### PR TITLE
feat: Merge learning system, spec workflow, and skills

### DIFF
--- a/claude-config/commands/agent-update.md
+++ b/claude-config/commands/agent-update.md
@@ -1,0 +1,243 @@
+---
+description: Apply suggested agent improvements from learning analysis
+argument-hint: [--dry-run] [--agent NAME] [--pattern PATTERN_NAME]
+---
+
+# Agent Update Command
+
+Applies suggested improvements to agent definitions based on learned patterns.
+
+## Usage
+
+```bash
+/agent-update              # Apply all suggestions interactively
+/agent-update --dry-run    # Preview changes without applying
+/agent-update --agent MAP  # Update specific agent only
+/agent-update --pattern ENUM_VALUE  # Apply fix for specific pattern
+```
+
+---
+
+## How It Works
+
+1. Reads `.claude/memory/patterns.md` for suggested updates
+2. Identifies patterns with 5+ occurrences (high impact)
+3. Generates specific text additions for agent definitions
+4. Applies changes with user confirmation
+
+---
+
+## Suggested Update Format
+
+From `/learn` output, updates are structured as:
+
+```markdown
+### Suggested Update: MAP Agent — Enum VALUE Check
+
+**Pattern**: ENUM_VALUE (12 occurrences, 26%)
+**Target file**: `.claude/agents/map.md`
+**Location**: After "Document Enums" section
+
+**Addition**:
+```markdown
+### Enum VALUE Verification (MANDATORY for fullstack)
+
+**⚠️ This check prevents 26% of failures**
+
+1. Find enum definition:
+   ```bash
+   grep -A 10 "class.*Enum" backend/backend/*/enums.py
+   ```
+
+2. For each enum, document:
+   | Python Name | Python VALUE |
+   |-------------|--------------|
+   
+3. Flag mismatches: NAME ≠ VALUE (e.g., `CO_OWNER = "CO-OWNER"`)
+
+4. Add to risks if any mismatch found
+```
+
+**Impact**: Would have prevented 12 failures
+```
+
+---
+
+## Interactive Mode
+
+```
+╔═══════════════════════════════════════════════════════════════╗
+║                    AGENT UPDATE                                ║
+╚═══════════════════════════════════════════════════════════════╝
+
+Found 3 suggested updates from patterns.md:
+
+1. MAP Agent — Enum VALUE Check
+   Pattern: ENUM_VALUE (12 occurrences)
+   Impact: High (26% of failures)
+
+2. PATCH Agent — Multi-Model Detection
+   Pattern: MULTI_MODEL (6 occurrences)
+   Impact: Medium (13% of failures)
+
+3. PROVE Agent — Component API Verification
+   Pattern: COMPONENT_API (8 occurrences)
+   Impact: High (17% of failures)
+
+Apply which updates? [all/1,2,3/none]: 
+```
+
+---
+
+## Process
+
+### Step 1: Load Suggestions
+
+```bash
+# Extract suggestions from patterns.md
+grep -A 20 "Suggested Update" .claude/memory/patterns.md
+```
+
+### Step 2: Validate Target Files
+
+```bash
+# Check agent files exist
+for AGENT in map plan patch prove; do
+  if [ ! -f ".claude/agents/${AGENT}.md" ]; then
+    echo "WARNING: Agent file not found: ${AGENT}.md"
+  fi
+done
+```
+
+### Step 3: Preview Changes
+
+For each suggestion:
+1. Show current section (if exists)
+2. Show proposed addition
+3. Show expected location
+
+```
+Preview: MAP Agent — Enum VALUE Check
+─────────────────────────────────────
+
+File: .claude/agents/map.md
+Location: Line 85 (after "Document Enums" section)
+
+Current content at location:
+│ ### 5. Document Enums (MANDATORY for fullstack)
+│ ...
+│ ### 6. Identify Pattern to Mirror
+
+Proposed addition:
+│ ### 5.5 Enum VALUE Verification (AUTO-ADDED)
+│ 
+│ **⚠️ This check prevents 26% of failures**
+│ ...
+
+Apply this change? [y/n]: 
+```
+
+### Step 4: Apply Changes
+
+Using `sed` or similar to insert at correct location:
+
+```bash
+# Insert after line N
+sed -i "${LINE}r addition.md" .claude/agents/map.md
+```
+
+### Step 5: Verify Changes
+
+```bash
+# Check file still valid markdown
+head -20 .claude/agents/map.md
+tail -20 .claude/agents/map.md
+```
+
+### Step 6: Commit Changes
+
+```bash
+# Create commit with clear message
+git add .claude/agents/
+git commit -m "feat(agents): apply learned patterns
+
+Applied automatic improvements from /learn analysis:
+- MAP: Added enum VALUE verification (ENUM_VALUE pattern)
+- PATCH: Added multi-model detection (MULTI_MODEL pattern)
+- PROVE: Added component API check (COMPONENT_API pattern)
+
+Based on analysis of 47 issues with 83% success rate.
+Patterns addressed account for 56% of failures."
+```
+
+---
+
+## Dry Run Mode
+
+With `--dry-run`:
+
+```
+╔═══════════════════════════════════════════════════════════════╗
+║                    AGENT UPDATE (DRY RUN)                      ║
+╚═══════════════════════════════════════════════════════════════╝
+
+Would apply 3 updates:
+
+1. MAP Agent — Enum VALUE Check
+   File: .claude/agents/map.md
+   Lines added: 15
+   Location: After line 85
+
+2. PATCH Agent — Multi-Model Detection
+   File: .claude/agents/patch.md
+   Lines added: 22
+   Location: After line 120
+
+3. PROVE Agent — Component API Verification
+   File: .claude/agents/prove.md
+   Lines added: 18
+   Location: After line 95
+
+Total lines added: 55
+Files modified: 3
+
+Run without --dry-run to apply changes.
+```
+
+---
+
+## Rollback
+
+If updates cause issues:
+
+```bash
+# Revert last agent update commit
+git revert HEAD
+
+# Or restore specific agent
+git checkout HEAD~1 .claude/agents/map.md
+```
+
+---
+
+## Update History
+
+Track applied updates in `.claude/memory/updates.jsonl`:
+
+```json
+{
+  "date": "2025-01-03",
+  "agent": "map",
+  "pattern": "ENUM_VALUE",
+  "lines_added": 15,
+  "commit": "abc123"
+}
+```
+
+---
+
+## Related Commands
+
+- `/learn` — Generate update suggestions
+- `/metrics` — View pattern impact
+- `/orchestrate` — Test updated agents

--- a/claude-config/commands/bug.md
+++ b/claude-config/commands/bug.md
@@ -1,0 +1,47 @@
+---
+description: Create a new bug report issue in GitHub
+argument-hint: [bug title]
+---
+
+## Reported Issue
+**What's broken**:
+-
+
+**Expected behavior**:
+-
+
+**Scope / Stack**:
+- [ ] Backend
+- [ ] Frontend
+- [ ] Fullstack
+
+**Severity**: Critical / High / Medium / Low
+
+## Error Details (if applicable)
+**Error type**:
+**Error message**:
+**Location (file:line)**:
+**Endpoint/route (method path)**:
+
+## Reproduction Steps
+1.
+2.
+3.
+
+## Notes / Logs
+```text
+
+```
+
+## Technical Constraints
+- [ ] No changes to monorepo structure (`backend/`, `frontend/` stay in place)
+- [ ] No backend `src/` layout
+- [ ] React Router changes follow migration guidelines (see `.claude/rules.md`)
+- [ ] See `.claude/rules.md` for full constraints
+
+## Acceptance Criteria
+- [ ] Repro confirmed + root cause identified
+- [ ] Fix is minimal and scoped
+- [ ] No project structure violations
+- [ ] If backend touched: tests updated + `cd backend && pytest -q` passes and `cd backend && ruff check .` passes
+- [ ] If frontend touched: `cd frontend && npm run lint` passes and `cd frontend && npm run build` passes; no console errors

--- a/claude-config/commands/codex-review.md
+++ b/claude-config/commands/codex-review.md
@@ -1,0 +1,72 @@
+---
+description: Get a second opinion from OpenAI Codex on a plan or proposal
+allowed-tools:
+  - Bash
+  - Read
+  - Glob
+---
+
+# Codex Review
+
+Get a second opinion from OpenAI Codex CLI on the current plan or specified file.
+
+## Instructions
+
+1. **Find the content to review:**
+   - If arguments provided: `$ARGUMENTS`
+   - Otherwise, find the most recent `.md` file in `.agents/outputs/` or look for a plan file
+
+2. **Load OPENAI_API_KEY:**
+   - First check `~/.claude/.env` (global config)
+   - Then check `.env` in current directory
+   - Or use the key from environment
+
+3. **Run Codex exec:**
+   ```bash
+   if [ -f ~/.claude/.env ]; then
+     export $(grep OPENAI_API_KEY ~/.claude/.env | xargs)
+   elif [ -f .env ]; then
+     export $(grep OPENAI_API_KEY .env | xargs)
+   fi
+
+   codex exec --skip-git-repo-check --sandbox read-only -o /tmp/codex-review-output.md "[PROMPT]"
+   ```
+
+4. **Read and summarize the output** from `/tmp/codex-review-output.md`
+
+5. **Present findings** with a clear recommendation on whether changes are needed
+
+## Review Prompt Template
+
+Use this prompt structure when calling Codex:
+
+```
+Review this plan/proposal and provide a second opinion:
+
+---
+[INSERT PLAN CONTENT]
+---
+
+Analyze for:
+1. Missed requirements or edge cases
+2. Potential risks or issues not addressed
+3. Alternative approaches worth considering
+4. Assumptions needing stakeholder validation
+
+Be specific and constructive. If the plan is solid, say so briefly.
+```
+
+## Output Format
+
+Present the results as:
+
+```
+## Codex Second Opinion
+
+**Assessment:** [One line summary]
+
+**Key Feedback:**
+- [Bullet points of main observations]
+
+**Recommended Action:** [None needed / Consider updating X / Discuss Y with stakeholders]
+```

--- a/claude-config/commands/feature-from-spec.md
+++ b/claude-config/commands/feature-from-spec.md
@@ -1,0 +1,90 @@
+---
+description: Create a feature request issue from specification analysis (used by /spec-review)
+argument-hint: [feature title]
+---
+
+## Specification Reference
+
+**Source**: `docs/features/[spec-file].md`
+**Section**: [Specific section in spec]
+**Requirement**:
+> [Exact requirement from spec - quote directly]
+
+## Implementation Gap
+
+**Current State**: [What exists now based on codebase analysis]
+**Required State**: [What spec requires]
+**Gap**: [What's missing / needs to change]
+
+## Feature Description
+[Clear 1-2 sentence description of what this issue will implement]
+
+## User Story
+**As a** <persona>
+**I want** <capability>
+**So that** <value>
+
+## Scope / Stack
+- [ ] Backend
+- [ ] Frontend
+- [ ] Fullstack
+
+## Requirements
+
+### Functional
+- [ ] [Specific requirement from spec]
+- [ ] [Another requirement]
+- [ ] [Another requirement]
+
+### Non-Functional
+- [ ] Minimal diffs / no drive-by refactors
+- [ ] Security / tenancy enforced via deps (backend)
+- [ ] SQLite in-memory tests supported (backend)
+- [ ] React Router migration-friendly changes (frontend)
+- [ ] See `.claude/rules.md` for structural constraints
+
+## Technical Context
+
+### Affected Areas
+
+**Backend (if applicable):**
+- Models: [file path or "None"]
+- Schemas: [file path or "Create new"]
+- Repositories: [file path or "Create new"]
+- Services: [file path or "Create new"]
+- Routers: [file path or "Create new"]
+- Deps / access control: [dependency to use, e.g., require_account_access]
+- Tests: [file path or "Create new"]
+
+**Frontend (if applicable):**
+- Components/pages: [file path or "Create new"]
+- Context/state: [what state management needed]
+- API layer: [file path or "Create new"]
+- Configs/constants: [if needed]
+- Navigation (App.jsx): [route to add]
+
+### Dependencies
+[List any dependencies on other features/issues]
+
+### Pattern to Follow
+[Which existing component/module to mirror - be specific with file path]
+
+Example:
+- Mirror `backend/account_members/` pattern for CRUD operations
+- Follow `frontend/src/components/accounts/AccountsList.jsx` for list component
+
+## Acceptance Criteria
+- [ ] [Specific testable criteria from spec]
+- [ ] [Another criteria]
+- [ ] No project structure violations
+- [ ] If backend touched: `cd backend && pytest -q` passes and `cd backend && ruff check .` passes
+- [ ] If frontend touched: `cd frontend && npm run lint` passes and `cd frontend && npm run build` passes
+- [ ] Loading / empty / error states handled in UI (if UI change)
+
+## Complexity: [TRIVIAL/SIMPLE/COMPLEX]
+
+**Justification**:
+[Why this complexity level - reference file count, pattern availability, etc.]
+
+## Related Issues
+[List related issues if part of larger spec, e.g., "Part of Invitation System - see #184, #185"]

--- a/claude-config/commands/feature.md
+++ b/claude-config/commands/feature.md
@@ -1,0 +1,67 @@
+---
+description: Create a new feature request issue in GitHub
+argument-hint: [feature title]
+---
+
+## Specification Reference (if applicable)
+**Source**: `docs/features/[spec-file].md` or "N/A (ad-hoc feature)"
+**Section**: [Specific section] or "N/A"
+
+## Feature Description
+[Clear 1-2 sentence description]
+
+## User Story
+**As a** <persona>  
+**I want** <capability>  
+**So that** <value>
+
+## Scope / Stack
+- [ ] Backend
+- [ ] Frontend
+- [ ] Fullstack
+
+## Requirements
+### Functional
+- [ ]
+- [ ]
+
+### Non-Functional
+- [ ] Minimal diffs / no drive-by refactors
+- [ ] Security / tenancy enforced via deps (backend)
+- [ ] SQLite in-memory tests supported (backend)
+- [ ] React Router migration-friendly changes (frontend)
+- [ ] See `.claude/rules.md` for structural constraints
+
+## Technical Context
+### Affected Areas
+**Backend (if applicable):**
+- Models:
+- Schemas:
+- Repositories:
+- Services:
+- Routers:
+- Deps / access control:
+- Tests:
+
+**Frontend (if applicable):**
+- Components/pages:
+- Context/state:
+- API layer:
+- Configs/constants:
+- Navigation (App.jsx):
+
+## Acceptance Criteria
+- [ ] Behavior works end-to-end
+- [ ] No project structure violations
+- [ ] If backend touched: `cd backend && pytest -q` passes and `cd backend && ruff check .` passes
+- [ ] If frontend touched: `cd frontend && npm run lint` passes and `cd frontend && npm run build` passes
+- [ ] Loading / empty / error states handled in UI (if UI change)
+
+## Complexity: [TRIVIAL/SIMPLE/COMPLEX]
+
+**Justification**:
+[Why this complexity level - reference file count, pattern availability, new vs existing patterns]
+
+- TRIVIAL: Config changes, docs, single-file edits
+- SIMPLE: 1-3 files, follows existing pattern exactly
+- COMPLEX: 4+ files, new patterns, database migrations, fullstack

--- a/claude-config/commands/learn.md
+++ b/claude-config/commands/learn.md
@@ -1,0 +1,286 @@
+---
+description: Analyze failure patterns and update learned knowledge base
+argument-hint: [--since YYYY-MM-DD] [--dry-run] [--verbose]
+---
+
+# Learn Command
+
+Analyzes accumulated failures and successes to extract patterns and update the knowledge base.
+
+## Usage
+
+```bash
+/learn                      # Analyze all recorded outcomes
+/learn --since 2025-01-01   # Analyze outcomes since date
+/learn --dry-run            # Preview changes without updating files
+/learn --verbose            # Show detailed analysis
+```
+
+---
+
+## What This Command Does
+
+1. **Loads outcome data** from `.claude/memory/`
+2. **Clusters failures** by root cause
+3. **Calculates metrics** (success rates, trends)
+4. **Extracts new patterns** from recurring failures
+5. **Updates patterns.md** with learned knowledge
+6. **Suggests agent updates** for high-frequency patterns
+
+---
+
+## Prerequisites
+
+- `.claude/memory/failures.jsonl` exists (can be empty)
+- `.claude/memory/metrics.jsonl` exists (can be empty)
+- Git repository (for agent update suggestions)
+
+---
+
+## Process
+
+### Step 1: Load Outcome Data
+
+```bash
+# Count available data
+FAILURE_COUNT=$(wc -l < .claude/memory/failures.jsonl 2>/dev/null || echo 0)
+METRIC_COUNT=$(wc -l < .claude/memory/metrics.jsonl 2>/dev/null || echo 0)
+
+echo "Loading outcomes..."
+echo "  Failures: $FAILURE_COUNT"
+echo "  Metrics:  $METRIC_COUNT"
+```
+
+If no data exists, report and exit:
+```
+No outcome data found. Run some issues through /orchestrate first.
+```
+
+### Step 2: Parse and Cluster Failures
+
+Read each failure record and group by `root_cause`:
+
+```bash
+# Extract root causes and count
+cat .claude/memory/failures.jsonl | \
+  jq -r '.root_cause' | \
+  sort | uniq -c | sort -rn
+```
+
+Expected output:
+```
+  12 ENUM_VALUE
+   8 COMPONENT_API
+   6 MULTI_MODEL
+   4 ACCESS_CONTROL
+   3 SQLITE_COMPAT
+   2 OTHER
+```
+
+### Step 3: Analyze Each Cluster
+
+For each root cause with 3+ occurrences:
+
+#### 3a. Extract Common Attributes
+
+```bash
+# Find common files affected
+cat .claude/memory/failures.jsonl | \
+  jq -r 'select(.root_cause == "ENUM_VALUE") | .files[]' | \
+  sort | uniq -c | sort -rn | head -5
+```
+
+#### 3b. Identify Trigger Conditions
+
+Look for patterns in:
+- Issue complexity (TRIVIAL/SIMPLE/COMPLEX)
+- Stack (backend/frontend/fullstack)
+- Affected domains (accounts, advisors, expenses)
+
+#### 3c. Find Preventive Agent
+
+Determine which agent SHOULD have caught this:
+- MAP: Investigation gaps
+- PLAN: Design gaps
+- CONTRACT: API specification gaps
+- PATCH: Implementation gaps
+- PROVE: Verification gaps
+
+### Step 4: Calculate Metrics
+
+```bash
+# Overall success rate
+PASS=$(cat .claude/memory/metrics.jsonl | jq -r 'select(.status == "PASS")' | wc -l)
+BLOCKED=$(cat .claude/memory/metrics.jsonl | jq -r 'select(.status == "BLOCKED")' | wc -l)
+TOTAL=$((PASS + BLOCKED))
+RATE=$((PASS * 100 / TOTAL))
+
+echo "Success rate: ${RATE}% ($PASS/$TOTAL)"
+```
+
+Calculate by dimension:
+- By complexity (TRIVIAL/SIMPLE/COMPLEX)
+- By stack (backend/frontend/fullstack)
+- By week (trend analysis)
+
+### Step 5: Generate Updated patterns.md
+
+Create new version of `.claude/memory/patterns.md`:
+
+```markdown
+# Learned Patterns
+
+**Last updated**: $(date +%Y-%m-%d)
+**Total issues analyzed**: $TOTAL
+**Success rate**: ${RATE}%
+
+## High-Frequency Failure Patterns
+
+[For each cluster with 3+ occurrences, generate section]
+
+### N. ROOT_CAUSE — Description
+
+**Frequency**: X% of failures (N occurrences)
+**Severity**: BLOCKED
+
+**Pattern**: [Description extracted from failure details]
+
+**Common files affected**:
+- [file patterns from analysis]
+
+**Trigger conditions**:
+- [conditions extracted from analysis]
+
+**Prevention checklist**:
+- [ ] [Agent]: [Action]
+
+**Responsible agents**: [List]
+```
+
+### Step 6: Identify Agent Update Candidates
+
+For patterns with 5+ occurrences:
+
+```markdown
+## Suggested Agent Updates
+
+### 1. MAP Agent — Add Enum VALUE Verification
+
+**Reason**: ENUM_VALUE pattern occurred 12 times (26%)
+
+**Suggested addition** to `.claude/agents/map.md`:
+
+```markdown
+### Enum Value Check (MANDATORY for fullstack)
+
+If issue is fullstack and involves role/status/type fields:
+
+1. Find enum definition:
+   ```bash
+   grep -r "class.*Enum" backend/backend/*/enums.py
+   ```
+
+2. Document VALUES explicitly:
+   | Python Name | Python VALUE |
+   |-------------|--------------|
+   
+3. Flag any NAME ≠ VALUE cases with ⚠️
+```
+
+**Impact**: Would have prevented 12 failures
+```
+
+### Step 7: Output Summary
+
+```
+═══════════════════════════════════════════════════════════
+                    LEARNING COMPLETE
+═══════════════════════════════════════════════════════════
+
+Data analyzed:
+  • Issues:     47
+  • Failures:   35 
+  • Successes:  39
+
+Patterns identified:
+  • Total:      7
+  • New:        2 (since last run)
+  • Updated:    3
+
+Success rate trend:
+  • Week 1:     75%
+  • Week 2:     81%
+  • Week 3:     85%
+  • Week 4:     91% ↑ Improving!
+
+Files updated:
+  ✓ .claude/memory/patterns.md
+
+Suggested agent updates (5+ occurrence patterns):
+  1. MAP agent:   Add enum VALUE verification (12 failures)
+  2. PATCH agent: Add multi-model detection (6 failures)
+
+Next steps:
+  • Review updated patterns.md
+  • Run `/agent-update` to apply suggestions
+  • Continue using /orchestrate to gather more data
+═══════════════════════════════════════════════════════════
+```
+
+---
+
+## Dry Run Mode
+
+With `--dry-run`, the command:
+- Performs all analysis
+- Shows what WOULD be updated
+- Does NOT modify any files
+
+```
+[DRY RUN] Would update: .claude/memory/patterns.md
+[DRY RUN] Changes:
+  + New pattern: SCOPE_CREEP (3 occurrences)
+  ~ Updated: ENUM_VALUE (12 → 15 occurrences)
+```
+
+---
+
+## When to Run
+
+**Recommended schedule**:
+- Weekly (Friday end of day)
+- After every 10 completed issues
+- After any COMPLEX issue completion
+- When success rate drops below 80%
+
+---
+
+## Troubleshooting
+
+### No data found
+```bash
+# Initialize empty files
+echo "" > .claude/memory/failures.jsonl
+echo "" > .claude/memory/metrics.jsonl
+```
+
+### jq not available
+```bash
+# Install jq
+apt-get install jq  # Linux
+brew install jq     # macOS
+```
+
+### Parse errors
+```bash
+# Validate JSONL format
+cat .claude/memory/failures.jsonl | jq -c '.' > /dev/null
+```
+
+---
+
+## Related Commands
+
+- `/metrics` — View performance dashboard
+- `/agent-update` — Apply suggested agent changes
+- `/orchestrate` — Run issues (generates outcome data)

--- a/claude-config/commands/metrics.md
+++ b/claude-config/commands/metrics.md
@@ -1,0 +1,271 @@
+---
+description: Display agent performance metrics and trends
+argument-hint: [--week] [--month] [--agent NAME] [--json]
+---
+
+# Metrics Command
+
+Displays performance metrics from accumulated outcome data.
+
+## Usage
+
+```bash
+/metrics              # Show all metrics (last 30 days)
+/metrics --week       # Last 7 days only
+/metrics --month      # Last 30 days (default)
+/metrics --all        # All time
+/metrics --agent MAP  # Filter by specific agent
+/metrics --json       # Output as JSON (for automation)
+```
+
+---
+
+## Dashboard Output
+
+```
+╔═══════════════════════════════════════════════════════════════╗
+║                 AGENT PERFORMANCE DASHBOARD                    ║
+║                   Period: Last 30 Days                         ║
+╚═══════════════════════════════════════════════════════════════╝
+
+┌─────────────────────────────────────────────────────────────────┐
+│ OVERALL METRICS                                                 │
+├─────────────────────────────────────────────────────────────────┤
+│ Issues completed:        47                                     │
+│ First-attempt success:   83% (39/47)                           │
+│ Avg recovery attempts:   1.2                                    │
+│ Avg time to completion:  24 min                                 │
+└─────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────┐
+│ BY COMPLEXITY                                                   │
+├─────────────────────────────────────────────────────────────────┤
+│ TRIVIAL:   95% success   ████████████████████░   (19/20)       │
+│ SIMPLE:    85% success   █████████████████░░░░   (17/20)       │
+│ COMPLEX:   43% success   ████████░░░░░░░░░░░░░   (3/7)         │
+└─────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────┐
+│ BY STACK                                                        │
+├─────────────────────────────────────────────────────────────────┤
+│ Backend:    91% success  ██████████████████░░░   (21/23)       │
+│ Frontend:   78% success  ███████████████░░░░░░   (14/18)       │
+│ Fullstack:  67% success  █████████████░░░░░░░░   (4/6)         │
+└─────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────┐
+│ TOP FAILURE CAUSES                                              │
+├─────────────────────────────────────────────────────────────────┤
+│ 1. ENUM_VALUE      26%  ██████████░░░░░░░░░░░   (12)           │
+│ 2. COMPONENT_API   17%  ██████░░░░░░░░░░░░░░░   (8)            │
+│ 3. MULTI_MODEL     13%  █████░░░░░░░░░░░░░░░░   (6)            │
+│ 4. ACCESS_CONTROL   9%  ███░░░░░░░░░░░░░░░░░░   (4)            │
+│ 5. SQLITE_COMPAT    7%  ██░░░░░░░░░░░░░░░░░░░   (3)            │
+└─────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────┐
+│ AGENT BLOCKING RATE                                             │
+├─────────────────────────────────────────────────────────────────┤
+│ MAP:        2%  █░░░░░░░░░░░░░░░░░░░░   (1 block)              │
+│ PLAN:       4%  █░░░░░░░░░░░░░░░░░░░░   (2 blocks)             │
+│ CONTRACT:   0%  ░░░░░░░░░░░░░░░░░░░░░   (0 blocks)             │
+│ PATCH:     11%  ██░░░░░░░░░░░░░░░░░░░   (5 blocks)             │
+│ PROVE:     83%  ████████████████░░░░░   (39 blocks) [expected] │
+└─────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────┐
+│ WEEKLY TREND                                                    │
+├─────────────────────────────────────────────────────────────────┤
+│ Week 1:  75%  ███████████████░░░░░░░░░░                        │
+│ Week 2:  81%  ████████████████░░░░░░░░░                        │
+│ Week 3:  85%  █████████████████░░░░░░░░                        │
+│ Week 4:  91%  ██████████████████░░░░░░░  ↑ Improving!          │
+└─────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────┐
+│ RECENT FAILURES                                                 │
+├─────────────────────────────────────────────────────────────────┤
+│ #201  ENUM_VALUE     fullstack  2025-01-02  (recovered in 1)   │
+│ #198  COMPONENT_API  frontend   2025-01-01  (recovered in 2)   │
+│ #195  MULTI_MODEL    backend    2024-12-30  (recovered in 1)   │
+└─────────────────────────────────────────────────────────────────┘
+
+╔═══════════════════════════════════════════════════════════════╗
+║ RECOMMENDATIONS                                                ║
+╠═══════════════════════════════════════════════════════════════╣
+║ • ENUM_VALUE at 26%: Consider adding enum check to MAP agent  ║
+║ • Fullstack at 67%: Always use CONTRACT agent for fullstack   ║
+║ • COMPLEX at 43%: Break into smaller issues when possible     ║
+╚═══════════════════════════════════════════════════════════════╝
+```
+
+---
+
+## Implementation
+
+### Step 1: Load Data
+
+```bash
+# Check for data files
+if [ ! -f ".claude/memory/metrics.jsonl" ]; then
+  echo "No metrics data found. Run /orchestrate to generate data."
+  exit 1
+fi
+
+# Count records
+TOTAL=$(wc -l < .claude/memory/metrics.jsonl)
+echo "Analyzing $TOTAL outcome records..."
+```
+
+### Step 2: Calculate Overall Metrics
+
+```bash
+# Success rate
+PASS=$(cat .claude/memory/metrics.jsonl | jq -r 'select(.status == "PASS")' | wc -l)
+BLOCKED=$(cat .claude/memory/metrics.jsonl | jq -r 'select(.status == "BLOCKED")' | wc -l)
+
+# Recovery attempts (for blocked issues that eventually passed)
+AVG_RECOVERY=$(cat .claude/memory/metrics.jsonl | \
+  jq -r 'select(.recovery_attempts != null) | .recovery_attempts' | \
+  awk '{sum+=$1; count++} END {print sum/count}')
+```
+
+### Step 3: Calculate by Dimension
+
+```bash
+# By complexity
+for COMPLEXITY in TRIVIAL SIMPLE COMPLEX; do
+  PASS=$(cat .claude/memory/metrics.jsonl | \
+    jq -r "select(.complexity == \"$COMPLEXITY\" and .status == \"PASS\")" | wc -l)
+  TOTAL=$(cat .claude/memory/metrics.jsonl | \
+    jq -r "select(.complexity == \"$COMPLEXITY\")" | wc -l)
+  echo "$COMPLEXITY: $PASS / $TOTAL"
+done
+
+# By stack
+for STACK in backend frontend fullstack; do
+  PASS=$(cat .claude/memory/metrics.jsonl | \
+    jq -r "select(.stack == \"$STACK\" and .status == \"PASS\")" | wc -l)
+  TOTAL=$(cat .claude/memory/metrics.jsonl | \
+    jq -r "select(.stack == \"$STACK\")" | wc -l)
+  echo "$STACK: $PASS / $TOTAL"
+done
+```
+
+### Step 4: Calculate Failure Causes
+
+```bash
+# Top failure causes
+cat .claude/memory/failures.jsonl | \
+  jq -r '.root_cause' | \
+  sort | uniq -c | sort -rn | head -5
+```
+
+### Step 5: Calculate Trends
+
+```bash
+# Weekly trend (last 4 weeks)
+for WEEK in 1 2 3 4; do
+  START_DATE=$(date -d "$WEEK weeks ago" +%Y-%m-%d)
+  END_DATE=$(date -d "$((WEEK-1)) weeks ago" +%Y-%m-%d)
+  
+  PASS=$(cat .claude/memory/metrics.jsonl | \
+    jq -r "select(.date >= \"$START_DATE\" and .date < \"$END_DATE\" and .status == \"PASS\")" | wc -l)
+  TOTAL=$(cat .claude/memory/metrics.jsonl | \
+    jq -r "select(.date >= \"$START_DATE\" and .date < \"$END_DATE\")" | wc -l)
+  
+  echo "Week $WEEK: $PASS / $TOTAL"
+done
+```
+
+---
+
+## JSON Output Mode
+
+With `--json` flag, output structured data for automation:
+
+```json
+{
+  "period": "30d",
+  "generated": "2025-01-03T10:00:00Z",
+  "overall": {
+    "total": 47,
+    "passed": 39,
+    "blocked": 8,
+    "success_rate": 0.83,
+    "avg_recovery": 1.2
+  },
+  "by_complexity": {
+    "TRIVIAL": {"passed": 19, "total": 20, "rate": 0.95},
+    "SIMPLE": {"passed": 17, "total": 20, "rate": 0.85},
+    "COMPLEX": {"passed": 3, "total": 7, "rate": 0.43}
+  },
+  "by_stack": {
+    "backend": {"passed": 21, "total": 23, "rate": 0.91},
+    "frontend": {"passed": 14, "total": 18, "rate": 0.78},
+    "fullstack": {"passed": 4, "total": 6, "rate": 0.67}
+  },
+  "top_failures": [
+    {"cause": "ENUM_VALUE", "count": 12, "percentage": 0.26},
+    {"cause": "COMPONENT_API", "count": 8, "percentage": 0.17}
+  ],
+  "trend": {
+    "week_1": 0.75,
+    "week_2": 0.81,
+    "week_3": 0.85,
+    "week_4": 0.91,
+    "direction": "improving"
+  }
+}
+```
+
+---
+
+## Agent Filter Mode
+
+With `--agent MAP`, show metrics for specific agent:
+
+```
+╔═══════════════════════════════════════════════════════════════╗
+║                    MAP AGENT METRICS                           ║
+╚═══════════════════════════════════════════════════════════════╝
+
+Invocations:     47
+Blocks caused:   1 (2%)
+Avg duration:    3 min
+
+Issues identified by MAP:
+• COMPONENT_API gaps:   8 (caught 6, missed 2)
+• ENUM_VALUE gaps:     12 (caught 9, missed 3)
+
+Common investigation patterns:
+• grep for models:      47 uses
+• grep for enums:       12 uses
+• PropTypes extraction: 18 uses
+
+Recommendations:
+• Add automatic enum VALUE check for fullstack issues
+• Increase PropTypes extraction for component reuse
+```
+
+---
+
+## Recommendations Engine
+
+Based on metrics, generate actionable recommendations:
+
+| Condition | Recommendation |
+|-----------|----------------|
+| ENUM_VALUE > 20% | "Add enum VALUE verification to MAP agent" |
+| Fullstack < 70% | "Always use CONTRACT agent for fullstack issues" |
+| COMPLEX < 50% | "Break COMPLEX issues into SIMPLE sub-issues" |
+| Trend declining | "Run /learn to update patterns" |
+| Agent blocking > 10% | "Review agent definition for gaps" |
+
+---
+
+## Related Commands
+
+- `/learn` — Update patterns from failures
+- `/orchestrate` — Run issues (generates metrics data)
+- `/agent-update` — Apply suggested improvements

--- a/claude-config/commands/postmortem-extract.md
+++ b/claude-config/commands/postmortem-extract.md
@@ -1,0 +1,210 @@
+---
+description: Extract learning data from postmortem files into memory system
+argument-hint: [--new-only] [--dry-run]
+---
+
+# Postmortem Extract Command
+
+Converts human-readable postmortem analyses into machine-readable failure records for the learning system.
+
+## Purpose
+
+Postmortems contain valuable failure analysis that should feed into:
+1. `memory/failures.jsonl` — Structured failure records
+2. `memory/patterns.md` — Aggregated prevention patterns
+
+This command bridges the gap between human documentation and automated learning.
+
+## Usage
+
+```bash
+/postmortem-extract              # Process all postmortems
+/postmortem-extract --new-only   # Only unprocessed files
+/postmortem-extract --dry-run    # Preview without writing
+```
+
+---
+
+## Process
+
+### Step 1: Find Postmortem Files
+
+```bash
+find ai_docs/postmortems -name "*.md" -type f | grep -v "TEMPLATE\|SUMMARY\|USER_TEMPLATES"
+```
+
+### Step 2: Parse Each Postmortem
+
+For each file, extract:
+
+| Field | Source | Example |
+|-------|--------|---------|
+| `date` | Frontmatter `date:` | "2025-12-24" |
+| `issue` | Frontmatter `issue:` or filename | "Enum Mismatch" |
+| `root_cause` | Analysis section | "ENUM_VALUE" |
+| `severity` | Frontmatter `severity:` | "HIGH" |
+| `details` | Executive Summary | "Frontend sent CO_OWNER..." |
+| `fix` | What Should Have Happened | "Use enum VALUES not names" |
+| `prevention` | Agent Improvement section | "Add enum check to PATCH" |
+| `files` | Affected files list | ["frontend/src/..."] |
+| `agents_involved` | Timeline section | ["CONTRACT", "PATCH", "PROVE"] |
+
+### Step 3: Classify Root Cause
+
+Map postmortem findings to standard root cause codes:
+
+| Pattern in Postmortem | Root Cause Code |
+|----------------------|-----------------|
+| "enum", "VALUE", "NAME" | `ENUM_VALUE` |
+| "component", "props", "PropTypes" | `COMPONENT_API` |
+| "hook", "return", "destructur" | `COMPONENT_API` |
+| "multi-model", "relationship", "update" | `MULTI_MODEL` |
+| "permission", "access", "403" | `ACCESS_CONTROL` |
+| "SQLite", "PostgreSQL" | `SQLITE_COMPAT` |
+| "structure", "directory", "src/" | `STRUCTURE_VIOLATION` |
+| "spec", "requirement", "missing" | `SPEC_DEVIATION` |
+
+### Step 4: Generate Failure Record
+
+```json
+{
+  "source": "postmortem",
+  "source_file": "ai_docs/postmortems/2025-12-enum-mismatch-errors.md",
+  "date": "2025-12-24",
+  "issue": "Enum Mismatch Analysis",
+  "root_cause": "ENUM_VALUE",
+  "severity": "HIGH",
+  "details": "Frontend sent CO_OWNER (underscore) but backend expected CO-OWNER (hyphen)",
+  "fix": "Changed role string to match backend enum VALUE",
+  "prevention": "PATCH agent must verify enum VALUES against CONTRACT",
+  "files": ["frontend/src/components/owners/OwnersList2.jsx"],
+  "agents_involved": ["CONTRACT", "PATCH", "PROVE"],
+  "extracted_at": "2025-01-03T10:00:00Z"
+}
+```
+
+### Step 5: Append to failures.jsonl
+
+```bash
+echo '$RECORD' >> .claude/memory/failures.jsonl
+```
+
+### Step 6: Mark as Processed
+
+Track processed files to avoid duplicates:
+
+```bash
+echo "ai_docs/postmortems/2025-12-enum-mismatch-errors.md" >> .claude/memory/processed_postmortems.txt
+```
+
+---
+
+## Output
+
+```
+╔═══════════════════════════════════════════════════════════════╗
+║                POSTMORTEM EXTRACTION COMPLETE                  ║
+╚═══════════════════════════════════════════════════════════════╝
+
+Files processed: 12
+Records extracted: 15
+
+By root cause:
+  ENUM_VALUE:     4 records
+  COMPONENT_API:  3 records
+  MULTI_MODEL:    2 records
+  ACCESS_CONTROL: 2 records
+  SPEC_DEVIATION: 2 records
+  OTHER:          2 records
+
+Output:
+  ✓ Appended 15 records to .claude/memory/failures.jsonl
+
+Next steps:
+  • Run /learn to update patterns.md
+  • Review patterns.md for new prevention rules
+```
+
+---
+
+## Handling Edge Cases
+
+### Multiple Issues per Postmortem
+
+Some postmortems (like `2024-12-27-issue-103-SUMMARY.md`) document multiple failures.
+
+**Approach**: Create one record per distinct root cause.
+
+### Missing Fields
+
+If postmortem lacks structured data:
+
+```json
+{
+  "source": "postmortem",
+  "source_file": "...",
+  "root_cause": "OTHER",
+  "details": "[First paragraph of file]",
+  "extraction_quality": "partial"
+}
+```
+
+### Already Processed
+
+With `--new-only` flag:
+```bash
+# Skip files in processed list
+grep -F "$FILE" .claude/memory/processed_postmortems.txt && continue
+```
+
+---
+
+## Integration with /learn
+
+After extraction:
+
+```bash
+/postmortem-extract
+/learn
+```
+
+The `/learn` command will:
+1. Read new records from failures.jsonl
+2. Cluster by root cause
+3. Update patterns.md with prevention rules
+
+---
+
+## Example Extraction
+
+**Input**: `ai_docs/postmortems/2025-12-enum-mismatch-errors.md`
+
+**Extracted**:
+```json
+{
+  "source": "postmortem",
+  "source_file": "ai_docs/postmortems/2025-12-enum-mismatch-errors.md",
+  "date": "2025-12-24",
+  "issue": "52",
+  "root_cause": "ENUM_VALUE",
+  "severity": "HIGH",
+  "details": "Frontend sent role: CO_OWNER (underscore) but backend expected role: CO-OWNER (hyphen). Caused 422 validation errors.",
+  "fix": "Changed frontend to use enum VALUE (CO-OWNER) not Python name (CO_OWNER)",
+  "prevention": "1. PATCH must read CONTRACT for enum specs. 2. PATCH must verify against backend enum file. 3. PROVE must grep frontend for enum strings.",
+  "files": [
+    "frontend/src/components/owners/OwnersList2.jsx",
+    "frontend/src/components/owners/AddEditMemberModal.jsx"
+  ],
+  "agents_involved": ["CONTRACT", "PATCH", "PROVE"],
+  "blocking_agent": "PROVE",
+  "extracted_at": "2025-01-03T10:00:00Z"
+}
+```
+
+---
+
+## Related Commands
+
+- `/learn` — Process failures into patterns
+- `/metrics` — View failure statistics
+- `/agent-update` — Apply prevention rules to agents

--- a/claude-config/commands/pr.md
+++ b/claude-config/commands/pr.md
@@ -1,0 +1,27 @@
+---
+description: Execute a "main stays green" PR workflow for this monorepo
+argument-hint: [pr-number]
+---
+
+# PR Workflow
+
+Goal: Execute a "main stays green" PR workflow for this monorepo.
+
+## Inputs
+- A PR number (e.g. `/pr 123`) or a diff/branch description.
+
+## Workflow
+1) Summarize scope: backend, frontend, or fullstack.
+2) If fullstack: generate/update the Contract Artifact before proposing code changes.
+3) Produce a patch plan broken into small commits.
+4) List the exact verification gates to run locally:
+   - backend pytest (scoped if possible)
+   - frontend lint/build/test
+5) Provide a PR description template:
+   - What / Why / How
+   - Contract changes (if any)
+   - How to verify
+   - Risks / Rollback
+
+## Output format
+- Checklist + suggested commit messages + commands.

--- a/claude-config/commands/spec-draft.md
+++ b/claude-config/commands/spec-draft.md
@@ -1,0 +1,388 @@
+---
+description: Draft a feature specification with guided questions and codebase discovery
+argument-hint: "<feature title>"
+---
+
+# Spec Draft Command
+
+Guides you through creating a complete specification by asking structured questions and discovering relevant patterns in the codebase.
+
+## Usage
+
+```bash
+/spec-draft "Add advisor co-ownership feature"
+/spec-draft "Expense category filtering"
+```
+
+---
+
+## Process
+
+### Step 1: Classify Feature Type
+
+Ask user:
+```
+What type of feature is this?
+
+1. **CRUD** — Create/Read/Update/Delete for a resource
+2. **Integration** — Connect to external service or existing module
+3. **UI Component** — Frontend-only addition
+4. **Enhancement** — Modify existing behavior
+5. **Fullstack** — New end-to-end feature
+
+Type (1-5):
+```
+
+Based on answer, adjust required sections.
+
+---
+
+### Step 2: Discover Related Patterns
+
+```bash
+# Find similar features in codebase
+grep -rl "KEYWORD" backend/backend/*/router*.py | head -5
+grep -rl "KEYWORD" frontend/src/components/ | head -5
+
+# Find existing models that might be affected
+grep -l "account_id" backend/backend/*/models.py
+
+# Find existing enums
+grep -r "class.*Enum" backend/backend/*/enums.py
+```
+
+Report findings:
+```
+📁 Related Code Found:
+
+Backend:
+- backend/backend/advisors/router.py — Similar CRUD pattern
+- backend/backend/advisors/models.py — Advisor model
+
+Frontend:
+- frontend/src/components/advisors/AdvisorList.jsx
+- frontend/src/hooks/useAdvisors.js
+
+Enums:
+- FirmRole (backend/firms/enums.py): ADVISOR, SUPER_USER, ADMIN
+```
+
+---
+
+### Step 3: Guided Questions (by feature type)
+
+#### For CRUD Features:
+
+```markdown
+## Resource Definition
+
+**Resource name** (singular): 
+**Resource name** (plural): 
+**Parent resource** (if nested): Account / Firm / None
+
+## Fields
+
+| Field | Type | Required | Default | Notes |
+|-------|------|----------|---------|-------|
+| | | | | |
+
+## Enums (if any)
+
+| Enum Name | Values (comma-separated) | Notes |
+|-----------|--------------------------|-------|
+| | | |
+
+⚠️ IMPORTANT: List the actual VALUES that will be sent in JSON, not Python names.
+Example: "CO-OWNER" not "CO_OWNER"
+
+## Relationships
+
+| Related Model | Relationship | FK Location |
+|---------------|--------------|-------------|
+| | | |
+
+## Access Control
+
+Who can perform each action?
+
+| Action | Allowed Roles | Dep to Use |
+|--------|---------------|------------|
+| Create | | |
+| Read | | |
+| Update | | |
+| Delete | | |
+```
+
+#### For Fullstack Features:
+
+```markdown
+## Backend
+
+### Endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| | | |
+
+### Models Affected
+
+| Model | Changes |
+|-------|---------|
+| | |
+
+⚠️ If >1 model affected by single operation, flag as MULTI_MODEL risk.
+
+## Frontend
+
+### Components to Create
+
+| Component | Purpose | Reuses |
+|-----------|---------|--------|
+| | | |
+
+### Components to Reuse
+
+| Component | Current Location | Props/API |
+|-----------|------------------|-----------|
+| | | |
+
+⚠️ VERIFY component APIs before specifying. Don't assume.
+
+### State Management
+
+| Data | Hook/Query | Cache Key |
+|------|------------|-----------|
+| | | |
+```
+
+#### For UI Components:
+
+```markdown
+## Component Specification
+
+**Component name**: 
+**Location**: frontend/src/components/...
+
+### Props
+
+| Prop | Type | Required | Default |
+|------|------|----------|---------|
+| | | | |
+
+### State
+
+| State | Type | Initial |
+|-------|------|---------|
+| | | |
+
+### Events
+
+| Event | Handler | Notes |
+|-------|---------|-------|
+| | | |
+
+### Components to Reuse
+
+| Component | Import From |
+|-----------|-------------|
+| | |
+
+⚠️ Read PropTypes of reused components before assuming their API.
+```
+
+---
+
+### Step 4: Auto-Fill from Codebase
+
+Based on discovery, pre-fill what we can:
+
+```markdown
+## Auto-Discovered (verify these)
+
+### Existing Patterns to Mirror
+- CRUD pattern: See `backend/account_members/` (5 files)
+- Hook pattern: See `frontend/src/hooks/useAccountMembers.js`
+
+### Existing Enums (use these VALUES)
+- AccountMemberRole: "OWNER", "CO-OWNER", "DEPENDENT", "EXECUTOR"
+- FirmRole: "ADVISOR", "SUPER_USER", "ADMIN"
+
+### Existing Components (verify APIs)
+- HeaderActions: `frontend/src/components/common/HeaderActions.jsx`
+- DataTable: `frontend/src/components/common/DataTable.jsx`
+
+### Access Control Deps Available
+- require_account_access — Any account member
+- require_account_owner — Owner only
+- require_firm_member — Firm membership required
+```
+
+---
+
+### Step 5: Risk Flags (Auto-Generated)
+
+Based on spec content, flag risks:
+
+```markdown
+## ⚠️ Risk Flags
+
+### ENUM_VALUE Risk
+Spec defines enums. Ensure:
+- [ ] VALUES listed (not Python names)
+- [ ] Frontend will use exact VALUES
+
+### MULTI_MODEL Risk
+Operations affect multiple models:
+- [ ] Service coordinates all updates
+- [ ] Single transaction (atomic)
+- [ ] All relationships loaded for response
+
+### COMPONENT_API Risk
+Reusing existing components:
+- [ ] PropTypes verified (not assumed)
+- [ ] Hook return structures verified
+```
+
+---
+
+### Step 6: Completeness Check
+
+Before outputting, verify all required sections:
+
+```markdown
+## Completeness Checklist
+
+### Required for All
+- [ ] Feature title and summary
+- [ ] Scope (in/out)
+- [ ] Acceptance criteria
+
+### Required for Backend
+- [ ] Endpoints defined
+- [ ] Models/fields specified
+- [ ] Enum VALUES listed (not names)
+- [ ] Access control specified
+
+### Required for Frontend
+- [ ] Components listed
+- [ ] Reused component APIs verified
+- [ ] State management approach
+
+### Required for Fullstack
+- [ ] All backend sections
+- [ ] All frontend sections
+- [ ] API contract (request/response shapes)
+```
+
+If incomplete:
+```
+❌ Spec incomplete. Missing sections:
+- [ ] Enum VALUES not specified
+- [ ] Access control deps not chosen
+
+Please provide these before proceeding.
+```
+
+---
+
+### Step 7: Output Spec File
+
+**Location**: `docs/features/feature_{name}.md`
+
+```markdown
+---
+title: {Feature Title}
+status: draft
+created: {YYYY-MM-DD}
+author: {user}
+type: {CRUD|Integration|UI|Enhancement|Fullstack}
+complexity: {TRIVIAL|SIMPLE|COMPLEX}
+---
+
+# {Feature Title}
+
+## Summary
+{2-3 sentences describing the feature}
+
+## Goals
+- Goal 1
+- Goal 2
+
+## Scope
+
+### In Scope
+- Item 1
+
+### Out of Scope
+- Item 1
+
+## Technical Specification
+
+{Filled sections based on feature type}
+
+## Risk Flags
+
+{Auto-generated risk flags}
+
+## Acceptance Criteria
+
+- [ ] Criterion 1
+- [ ] Criterion 2
+
+## Open Questions
+
+- Question 1?
+
+---
+
+**Next Steps**:
+1. Review this spec
+2. Fill any [TODO] sections
+3. Run `/spec-review docs/features/feature_{name}.md`
+```
+
+---
+
+## Output
+
+```
+✓ Spec drafted: docs/features/feature_advisor_co_ownership.md
+
+Completeness: 85%
+Missing:
+- [ ] Acceptance criteria (3+ required)
+
+Risk flags detected:
+- ⚠️ ENUM_VALUE: FirmRole enum used
+- ⚠️ MULTI_MODEL: Touches User, Advisor, FirmUserMembership
+
+Next steps:
+1. Review and complete spec
+2. Run: /spec-review docs/features/feature_advisor_co_ownership.md
+```
+
+---
+
+## Integration with Workflow
+
+```
+/spec-draft "feature name"
+       ↓
+Human reviews, completes [TODO]s
+       ↓
+/spec-review docs/features/feature_X.md
+       ↓
+GitHub issues created
+       ↓
+/orchestrate <issue>
+```
+
+---
+
+## Tips
+
+- **Be specific early**: Vague specs create vague issues
+- **List enum VALUES**: This prevents 26% of failures
+- **Verify component APIs**: This prevents 17% of failures
+- **Map fields to models**: This prevents 13% of failures
+- **When unsure**: Mark as [TODO] and flag as Open Question

--- a/claude-config/commands/test-plan.md
+++ b/claude-config/commands/test-plan.md
@@ -1,0 +1,139 @@
+---
+description: Generate pre-implementation test plan with edge cases
+argument-hint: [issue-number or spec-path]
+---
+
+# Test Plan Command
+
+**Role**: Test Architect (TDD approach)
+
+---
+
+## Usage
+
+```bash
+/test-plan 239
+/test-plan #239
+/test-plan specs/engine-v2-proration-addendum.md
+```
+
+---
+
+## Process
+
+### Step 1: Identify Source
+
+**If issue number provided:**
+```bash
+gh issue view $ISSUE --json number,title,body
+```
+
+**If spec path provided:**
+```bash
+cat $SPEC_PATH
+```
+
+### Step 2: Find Related MAP-PLAN (if exists)
+
+```bash
+ls -la .agents/outputs/map-plan-$ISSUE-*.md 2>/dev/null | tail -1
+```
+
+If found, read it for implementation context.
+
+### Step 3: Spawn TEST-PLANNER Agent
+
+**CRITICAL**: Use Task tool to spawn the agent.
+
+```
+Task(
+  subagent_type='general-purpose',
+  description='TEST-PLANNER for issue N',
+  prompt='''You are the TEST-PLANNER agent.
+
+Read your agent definition: .claude/agents/test-planner.md
+
+Issue/Spec Context:
+[Insert issue body or spec content]
+
+MAP-PLAN Reference (if exists):
+[Insert MAP-PLAN artifact path]
+
+Generate a comprehensive test plan with:
+1. Testable requirements extracted from spec/issue
+2. Existing test coverage analysis
+3. Test matrix (happy path, boundary, error cases)
+4. Edge cases derived from formulas
+5. Test function signatures
+
+Write artifact to: .agents/outputs/test-plan-{issue}-{mmddyy}.md
+
+End with: AGENT_RETURN: test-plan-{issue}-{mmddyy}.md
+'''
+)
+```
+
+### Step 4: Validate Artifact
+
+```bash
+# Check file exists
+ls -la .agents/outputs/test-plan-$ISSUE-*.md
+
+# Check for AGENT_RETURN
+grep "AGENT_RETURN" .agents/outputs/test-plan-$ISSUE-*.md
+```
+
+### Step 5: Report
+
+```
+Test plan generated for issue #239
+
+Artifact: .agents/outputs/test-plan-239-011226.md
+
+Test cases identified: 12
+- P0 (critical): 4
+- P1 (important): 6
+- P2 (edge): 2
+
+Next steps:
+- Review test plan
+- Run /orchestrate 239 to implement (will use test plan)
+- Or run /patch 239 to implement manually
+```
+
+---
+
+## Output
+
+Artifact: `.agents/outputs/test-plan-{issue}-{mmddyy}.md`
+
+Contains:
+- Requirements analysis
+- Existing coverage gaps
+- Test matrix with priorities
+- Formula-derived edge cases
+- Test function signatures
+- Regression risks
+
+---
+
+## Integration
+
+### With Orchestrate
+
+Test plan is automatically used by PATCH agent when it exists:
+
+```bash
+# PATCH agent checks for test plan
+ls .agents/outputs/test-plan-$ISSUE-*.md
+```
+
+### Standalone
+
+Can be run independently before manual implementation:
+
+```bash
+/test-plan 239
+# Review output
+# Implement tests manually
+```

--- a/claude-config/install.sh
+++ b/claude-config/install.sh
@@ -66,6 +66,24 @@ fi
 ln -sf "$SCRIPT_DIR/rules" "$CLAUDE_DIR/rules"
 echo "  ✓ Linked rules/"
 
+# Backup and symlink skills directory
+if [ -d "$CLAUDE_DIR/skills" ] && [ ! -L "$CLAUDE_DIR/skills" ]; then
+    mkdir -p "$BACKUP_DIR"
+    mv "$CLAUDE_DIR/skills" "$BACKUP_DIR/"
+    echo "  Backed up skills/"
+fi
+ln -sf "$SCRIPT_DIR/skills" "$CLAUDE_DIR/skills"
+echo "  ✓ Linked skills/"
+
+# Backup and symlink statusline.py
+if [ -f "$CLAUDE_DIR/statusline.py" ] && [ ! -L "$CLAUDE_DIR/statusline.py" ]; then
+    mkdir -p "$BACKUP_DIR"
+    mv "$CLAUDE_DIR/statusline.py" "$BACKUP_DIR/"
+    echo "  Backed up statusline.py"
+fi
+ln -sf "$SCRIPT_DIR/statusline.py" "$CLAUDE_DIR/statusline.py"
+echo "  ✓ Linked statusline.py"
+
 echo ""
 if [ -d "$BACKUP_DIR" ]; then
     echo "Backups saved to: $BACKUP_DIR"
@@ -74,8 +92,12 @@ echo ""
 echo "Installation complete!"
 echo ""
 echo "Installed:"
-echo "  - settings.local.json (hooks config)"
+echo "  - settings.local.json (hooks + statusline config)"
 echo "  - hooks/ (PreCompact, SessionStart scripts)"
 echo "  - commands/ (slash commands)"
 echo "  - agents/ (agent instructions)"
 echo "  - rules/ (global rules)"
+echo "  - skills/ (orchestrate, test-plan)"
+echo "  - statusline.py (custom status line)"
+echo ""
+echo "Note: settings.json (plugins, credentials) stays local and is not overwritten."

--- a/claude-config/rules/orchestrate-workflow.md
+++ b/claude-config/rules/orchestrate-workflow.md
@@ -1,0 +1,540 @@
+---
+paths: ".agents/**/*.md"
+---
+
+# Orchestrate Workflow & Agent Efficiency Guidelines
+
+This rule applies to all agent outputs in .agents/outputs/.
+
+## Workflow Overview
+
+The orchestrate workflow implements a **MAP → PLAN → PATCH → PROVE** pattern for issue-driven development.
+
+```
+GitHub Issue → MAP-PLAN → PATCH → PROVE → PR → Merge
+```
+
+### When to Use
+
+Use the orchestrate workflow when:
+- ✅ You have a GitHub issue (bug or feature)
+- ✅ Change spans backend, frontend, or both
+- ✅ You need automated verification and artifact tracking
+- ✅ Issue requires multi-step implementation
+
+**Primary command**: `/orchestrate <issue_number>`
+
+---
+
+## Workflow Phases
+
+### Phase 1: MAP-PLAN (Investigation + Planning)
+
+**Agent**: `.claude/agents/map-plan.md`
+**Output**: `.agents/outputs/map-plan-{issue}-{mmddyy}.md`
+
+**Purpose**:
+- Investigate codebase and understand current state
+- Design implementation approach
+- Create file-by-file plan
+- List acceptance criteria
+
+**For SIMPLE/TRIVIAL issues**: Use combined MAP-PLAN agent
+**For COMPLEX issues**: Use separate MAP + PLAN agents
+
+**Key Sections**:
+- Executive Summary (3-5 sentences)
+- Investigation findings
+- File-by-file implementation steps
+- Acceptance criteria (checklist format)
+- Verification gates for PROVE
+
+**Target Length**: 500-600 lines
+
+---
+
+### Phase 1.5 (Optional): TEST-PLANNER (Pre-Implementation Test Planning)
+
+**Agent**: `.claude/agents/test-planner.md`
+**Output**: `.agents/outputs/test-plan-{issue}-{mmddyy}.md`
+
+**When to use**: When `--with-tests` flag is provided, recommended for:
+- Issues involving calculations or formulas
+- Complex business rules with edge cases
+- Bug fixes requiring regression tests
+- TDD approach
+
+**Purpose**:
+- Extract testable requirements from spec/issue
+- Analyze existing test coverage gaps
+- Generate systematic test matrix (happy, boundary, error)
+- Derive edge cases from formulas
+- Provide test function signatures for PATCH
+
+**Key Sections**:
+- Requirements analysis
+- Existing coverage gaps
+- Test matrix with priorities (P0, P1, P2)
+- Formula-derived edge cases
+- Test signatures (stubs, not full code)
+
+**Target Length**: 250-350 lines
+
+**Timing**: Run AFTER MAP-PLAN, BEFORE CONTRACT/PATCH
+
+---
+
+### Phase 2 (Optional): CONTRACT (API Contract Definition)
+
+**Agent**: `.claude/agents/contract.md`
+**Output**: `.agents/outputs/contract-{issue}-{mmddyy}.md`
+
+**When to use**: **MANDATORY for fullstack changes** (backend + frontend)
+
+**Purpose**:
+- Define backend ↔ frontend API contract
+- Specify request/response schemas
+- Document validation rules and error codes
+- Clarify enum values (backend VALUE vs NAME)
+- Examples for integration
+
+**Key Sections**:
+- Executive Summary
+- Endpoint definitions (request/response)
+- Enum definitions (backend VALUE must match frontend usage)
+- Frontend integration notes
+- Backward compatibility analysis
+
+**Target Length**: 200-300 lines
+
+**Timing**: Run AFTER PLAN, BEFORE PATCH
+
+---
+
+### Phase 3: PATCH (Implementation)
+
+**Agent**: `.claude/agents/patch.md`
+**Output**: `.agents/outputs/patch-{issue}-{mmddyy}.md`
+
+**Purpose**:
+- Implement changes exactly as planned
+- Update tests
+- Document issues encountered
+- Verify implementation
+
+**Key Sections**:
+- Executive Summary
+- Metrics table (files changed, tests added, lines modified)
+- Files changed (with references to MAP-PLAN, NOT full code re-quotes)
+- Issues encountered (CRITICAL - keep detailed)
+- Verification performed (linting, tests)
+- Deviations from PLAN
+- Acceptance criteria status (reference MAP-PLAN, don't repeat)
+
+---
+
+### Phase 4: PROVE (Verification)
+
+**Agent**: `.claude/agents/prove.md`
+**Output**: `.agents/outputs/prove-{issue}-{mmddyy}.md`
+
+**Purpose**:
+- Run verification commands (linting, tests)
+- Validate acceptance criteria
+- Check for regressions
+- Verify compliance with project rules
+- Final sign-off for PR
+
+**Key Sections**:
+- Executive Summary with PASS/BLOCKED status
+- Verification results (tests, linting)
+- Acceptance criteria (simple pass/fail table)
+- Comparison with PATCH (exceptions only)
+- Compliance checklist
+- Issues found (if any)
+- Recommendation (APPROVED or BLOCKED)
+
+---
+
+## Agent Efficiency Guidelines (Phase 1 - Implemented Dec 2025)
+
+### Critical Rules for ALL Agents
+
+**DO**:
+- ✅ Use YAML frontmatter for metadata
+- ✅ Keep reports concise - focus on signal, not noise
+- ✅ Include Executive Summary (3-5 sentences) in all reports
+- ✅ Document issues encountered (high-value learning)
+- ✅ Use consistent status indicators (✅/❌)
+
+**DON'T**:
+- ❌ Be verbose - avoid redundancy
+- ❌ Include low-value appendices
+- ❌ Create excessive subsections (max 3 heading levels)
+- ❌ Repeat information across phases
+
+---
+
+### MAP-PLAN Agent Efficiency Rules
+
+**Output Target**: 500-600 lines (currently averaging 698)
+
+**DO**:
+- ✅ Use YAML frontmatter:
+  ```yaml
+  ---
+  issue: 26
+  agent: MAP-PLAN
+  date: 2025-12-23
+  complexity: SIMPLE
+  stack: backend
+  ---
+  ```
+- ✅ Keep Executive Summary to 3-5 sentences
+- ✅ List acceptance criteria as simple checklist (don't repeat in PATCH)
+- ✅ Reference file line numbers instead of quoting existing code
+
+**DON'T**:
+- ❌ Quote full existing code (use: "See models.py:45-67")
+- ❌ Create "Future Enhancements" sections (out of scope)
+- ❌ Duplicate risk sections (consolidate to one)
+- ❌ Include API documentation examples (reference Swagger `/docs`)
+
+**Target Reduction**: 17% (698 → 580 lines)
+
+---
+
+### PATCH Agent Efficiency Rules
+
+**Output Target**: 280-300 lines (currently averaging 475)
+
+**DO**:
+- ✅ Use YAML frontmatter with metrics:
+  ```yaml
+  ---
+  issue: 26
+  agent: PATCH
+  date: 2025-12-23
+  status: Complete
+  files_modified: 2
+  files_created: 1
+  tests_added: 6
+  lines_added: 241
+  lines_removed: 4
+  ---
+  ```
+- ✅ Include Metrics table after Executive Summary
+- ✅ Reference MAP-PLAN for code details:
+  ```markdown
+  ### `accounts/schemas.py`
+  - Added: AccountMemberRead schema (lines 18-39)
+  - See map-plan-26-122225.md lines 102-127 for details
+  ```
+- ✅ Summarize test implementations:
+  ```markdown
+  Created 3 router tests: test_success, test_not_found, test_unauthorized (117 lines)
+  ```
+- ✅ **Document issues encountered in detail** (HIGH VALUE!)
+
+**DON'T**:
+- ❌ Re-quote code already in MAP-PLAN (biggest waste - 15% of content)
+- ❌ Repeat acceptance criteria (reference MAP-PLAN instead)
+- ❌ Include full test code listings (summarize)
+- ❌ Enumerate every single change (git diff provides this)
+
+**Acceptance Criteria Section**:
+```markdown
+## Acceptance Criteria Status
+All criteria met. See MAP-PLAN for full list.
+
+(If any failed, list specific failures here)
+```
+
+**Target Reduction**: 41% (475 → 280 lines)
+
+---
+
+### PROVE Agent Efficiency Rules
+
+**Output Target**: 370-400 lines MAX (currently averaging 642)
+
+**DO**:
+- ✅ Use YAML frontmatter with test metrics:
+  ```yaml
+  ---
+  issue: 26
+  agent: PROVE
+  date: 2025-12-23
+  status: PASS
+  tests_passed: 6
+  tests_failed: 0
+  regressions: 0
+  ---
+  ```
+- ✅ Use exceptions-only reporting:
+  ```markdown
+  ## Comparison with PATCH
+  All PATCH claims verified. No discrepancies found.
+  ```
+- ✅ Simple acceptance criteria table (10 lines max):
+  ```markdown
+  | Criterion | Status |
+  |-----------|--------|
+  | Schema created | ✅ |
+  | Tests passing | ✅ |
+  ```
+- ✅ Focus on PASS/FAIL and exceptions
+
+**DON'T**:
+- ❌ Create detailed verification for each criterion (120 lines → 15 lines)
+- ❌ Document PATCH comparison when all confirmed (use one-liner)
+- ❌ Create appendices ("Appendix A: Test Output", etc.)
+- ❌ Include redundant test output (reference PATCH if already documented)
+- ❌ Exceed 400 lines total
+
+**Comparison Section**:
+```markdown
+## Comparison with PATCH
+All PATCH claims verified. No discrepancies found.
+
+**OR if issues found:**
+- Discrepancy 1: [detailed description]
+- Discrepancy 2: [detailed description]
+```
+
+**Target Reduction**: 42% (642 → 370 lines)
+
+---
+
+## Output File Naming
+
+**Pattern**: `{phase}-{issue_number}-{mmddyy}.md`
+
+**Examples**:
+- `map-plan-26-122225.md`
+- `test-plan-26-122225.md` (if --with-tests)
+- `patch-26-122225.md`
+- `prove-26-122225.md`
+- `contract-26-122225.md` (for fullstack coordination)
+
+**Location**: `.agents/outputs/`
+
+---
+
+## Fullstack Coordination
+
+If change touches both backend and frontend:
+1. PLAN defines implementation approach
+2. **CONTRACT agent (Phase 2)** defines API surface (MANDATORY)
+3. PATCH implements both sides using CONTRACT as authoritative spec
+
+**Workflow for fullstack**:
+```
+MAP-PLAN → CONTRACT → PATCH → PROVE
+```
+
+**Contract Agent**: `.claude/agents/contract.md`
+**Output**: `.agents/outputs/contract-{issue}-{mmddyy}.md`
+**Timing**: After PLAN, before PATCH
+
+---
+
+## Verification Gates
+
+### Backend Verification (PROVE)
+```bash
+cd backend && ruff check .
+cd backend && pytest -q
+```
+
+### Frontend Verification (PROVE)
+```bash
+cd frontend && npm run lint
+cd frontend && npm run build
+```
+
+**Status**: If any command fails, set overall status to **BLOCKED**
+
+---
+
+## Complexity Classification
+
+**TRIVIAL**: docs, config tweaks, small renames, deleting unused code
+→ Use MAP-PLAN (single phase)
+
+**SIMPLE**: 1-3 files, straightforward bug fix or UI tweak
+→ Use MAP-PLAN (single phase)
+
+**COMPLEX**: new endpoints, DB migrations, cross-module refactors, fullstack changes
+→ Use MAP + PLAN (two phases)
+
+---
+
+## Success Metrics (Phase 1 Targets)
+
+### Document Length Targets
+
+| Agent | Current Avg | Phase 1 Target | Reduction |
+|-------|-------------|----------------|-----------|
+| MAP-PLAN | 698 lines | 580 lines | -17% |
+| PATCH | 475 lines | 280 lines | -41% |
+| PROVE | 642 lines | 370 lines | -42% |
+| **Total** | **1,815 lines** | **1,230 lines** | **-32%** |
+
+### Quality Metrics
+
+- ✅ Zero code re-quotes in PATCH
+- ✅ Acceptance criteria NOT repeated across phases
+- ✅ PROVE reports under 400 lines
+- ✅ No appendices in PROVE reports
+- ✅ All high-value content preserved (Issues Encountered, Test Results, etc.)
+
+### Token Savings
+
+- Current: ~8,408 tokens per issue
+- Target: ~5,525 tokens per issue
+- **Savings**: 2,883 tokens/issue (34% reduction)
+
+---
+
+## Example Sessions
+
+### Standard Workflow
+```
+User: /orchestrate 26
+Skill: Verifying issue #26...
+Skill: Issue verified: "Add account_members to ClientProfileRead schema"
+Skill: Classifying as SIMPLE
+Skill: Running MAP-PLAN agent...
+Skill: MAP-PLAN artifact: .agents/outputs/map-plan-26-122225.md
+Skill: Running PATCH agent...
+Skill: PATCH artifact: .agents/outputs/patch-26-122225.md
+Skill: Running PROVE agent...
+Skill: PROVE artifact: .agents/outputs/prove-26-122225.md
+Skill: ✓ Workflow complete - Ready for PR
+```
+
+### With Test Planning (Recommended for Calculations)
+```
+User: /orchestrate 239 --with-tests
+Skill: Verifying issue #239...
+Skill: Issue verified: "Income start-year proration + bug fix"
+Skill: Classifying as SIMPLE (backend)
+Skill: Running MAP-PLAN agent...
+Skill: MAP-PLAN artifact: .agents/outputs/map-plan-239-011226.md
+Skill: Running TEST-PLANNER agent...
+Skill: TEST-PLAN artifact: .agents/outputs/test-plan-239-011226.md
+Skill: Test cases identified: 12 (P0: 4, P1: 6, P2: 2)
+Skill: Running PATCH agent...
+Skill: PATCH artifact: .agents/outputs/patch-239-011226.md
+Skill: Running PROVE agent...
+Skill: PROVE artifact: .agents/outputs/prove-239-011226.md
+Skill: ✓ Workflow complete - Ready for PR
+```
+
+---
+
+## Post-Workflow Actions
+
+Once PROVE passes:
+1. Review artifacts in `.agents/outputs/`
+2. Use `/pr` skill to create pull request
+3. Keep `main` branch green
+4. Merge after review
+
+---
+
+## Monitoring & Improvement
+
+Track these metrics for each issue:
+
+```yaml
+metrics:
+  issue: 29
+  map_plan_lines: 580
+  patch_lines: 280
+  patch_code_requotes: 0  # Should be zero
+  prove_lines: 370
+  prove_appendices: 0     # Should be zero
+  total_lines: 1230
+  reduction_pct: 32
+```
+
+**Performance Reviews**:
+- Quarterly review: `.agents/outputs/agent-performance-review-{date}.md`
+- Implementation summaries: `.agents/outputs/phase{N}-implementation-summary-{date}.md`
+
+---
+
+## References
+
+- **Detailed orchestrate guide**: `.claude/commands/orchestrate.md`
+- **Agent definitions**: `.claude/agents/`
+- **Performance review**: `.agents/outputs/agent-performance-review-122325.md`
+- **Phase 1 implementation**: `.agents/outputs/phase1-implementation-summary-122325.md`
+- **Project rules**: `.claude/rules.md`
+- **Project stack**: `.claude/context/project_stack.md`
+
+---
+
+## Phase 1 Efficiency Improvements Summary
+
+**Date**: December 2025
+**Status**: Implemented
+
+**Changes**:
+1. ✅ YAML frontmatter for all agents
+2. ✅ Eliminated code re-quoting in PATCH (41% reduction)
+3. ✅ Consolidated acceptance criteria (10% reduction across all phases)
+4. ✅ Removed PROVE appendices (5% reduction)
+5. ✅ Implemented exceptions-only PROVE reporting (42% reduction in PROVE)
+
+**Expected Results**:
+- 32% reduction in total documentation (1,815 → 1,230 lines)
+- 34% token savings (8,408 → 5,525 tokens/issue)
+- Zero quality loss - all high-value content preserved
+
+**Next Phases**:
+- Phase 2: Cross-reference system, standardized status indicators
+- Phase 3: Structured JSON output, smart content reuse library
+
+---
+
+## Critical Fix: Task Tool Invocation (December 31, 2025)
+
+**Issue**: Orchestrate workflow failed to produce artifacts (issue #116, 40+ minutes, zero output)
+
+**Root Cause**: Orchestrate SKILL.md described WHAT to do ("Run MAP-PLAN agent") but not HOW to do it (use Task tool)
+
+**Impact**: Complete workflow failure - agents never spawned, no artifacts created
+
+**Fix Applied**: Updated `.claude/skills/orchestrate/SKILL.md` with:
+1. ✅ Explicit Task tool invocation instructions for each agent
+2. ✅ Artifact validation after each phase
+3. ✅ Error handling and failure reporting
+4. ✅ Clear "CRITICAL" markers for required steps
+
+**Key Changes**:
+```markdown
+### Step 2: Spawn Agents Using Task Tool
+
+**CRITICAL**: You MUST use the Task tool to spawn each agent.
+
+Use the Task tool to spawn the MAP-PLAN agent:
+Task(
+  subagent_type='general-purpose',
+  description='MAP-PLAN analysis for issue <number>',
+  prompt='''You are acting as the MAP-PLAN agent.
+  Read your agent definition at: `.claude/agents/map-plan.md`
+  ...'''
+)
+
+**Validate artifact**:
+- Check file exists
+- Check file size > 0 bytes
+- Check file contains "AGENT_RETURN:" directive
+```
+
+**Documentation**: See `.agents/outputs/orchestrate-rca-123125.md` for full root cause analysis
+
+**Status**: Fixed and ready for testing with issue #116

--- a/claude-config/rules/spec-review-workflow.md
+++ b/claude-config/rules/spec-review-workflow.md
@@ -1,0 +1,356 @@
+# Spec Review Workflow & Best Practices
+
+This document defines the **specification review and issue creation workflow** based on lessons learned from the flow-of-funds specification process (December 2025).
+
+## Overview
+
+The spec review workflow ensures specifications are **finalized and validated** before creating GitHub issues, preventing wasted effort and maintaining consistency between specs and implementation work.
+
+## Workflow Pattern
+
+### ✅ CORRECT: Spec Finalization Gate
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ 1. Initial Spec Review                                      │
+│    - Analyze spec against codebase                          │
+│    - Identify gaps, inconsistencies, missing prerequisites  │
+│    - Document findings in review artifact                   │
+└─────────────────────────────────────────────────────────────┘
+                            ↓
+┌─────────────────────────────────────────────────────────────┐
+│ 2. Senior Engineer / Stakeholder Feedback                   │
+│    - Code review findings                                   │
+│    - Identify architectural gaps                            │
+│    - Clarify business requirements                          │
+└─────────────────────────────────────────────────────────────┘
+                            ↓
+┌─────────────────────────────────────────────────────────────┐
+│ 3. Make Decisions & Update Spec                             │
+│    - Document all stakeholder decisions                     │
+│    - Fix inconsistencies                                    │
+│    - Add prerequisites and dependencies                     │
+│    - Update effort estimates                                │
+└─────────────────────────────────────────────────────────────┘
+                            ↓
+                    ┌───────────────┐
+                    │ Spec Final?   │
+                    └───────┬───────┘
+                            │
+                ┌───────────┴────────────┐
+                │                        │
+              NO                        YES
+                │                        │
+                └──► Repeat 1-3          │
+                                         ↓
+                        ┌────────────────────────────────┐
+                        │ 4. Commit Final Spec to Git    │
+                        │    - Single version (vX)       │
+                        │    - Mark as FINAL             │
+                        │    - Tag commit                │
+                        └────────────────────────────────┘
+                                         ↓
+                        ┌────────────────────────────────┐
+                        │ 5. Create GitHub Issues        │
+                        │    - Reference spec + commit   │
+                        │    - All issues consistent     │
+                        └────────────────────────────────┘
+```
+
+### ❌ INCORRECT: Create Issues Before Finalizing Spec
+
+```
+Spec Review → Decisions → Create Issues → Fix Spec
+                              ↓
+                    ⚠️ Issues now inconsistent with spec
+                    ⚠️ Must update all issues manually
+                    ⚠️ Wasted effort
+```
+
+---
+
+## Single Source of Truth Pattern
+
+### Specification Versioning
+
+**DO:**
+- ✅ Use **one spec file** with clear version in filename (e.g., `feature-name-v3.md`)
+- ✅ Use **git commits** to track version history
+- ✅ Use **git tags** for major versions (e.g., `spec-flow-of-funds-v3.0`)
+- ✅ Mark final version as **FINAL** in title and status
+
+**DON'T:**
+- ❌ Keep multiple version files (v1.md, v2.md, v3.md)
+- ❌ Use timestamps in filenames (spec-123125.md)
+- ❌ Maintain outdated versions in main branch
+
+### Review Document Management
+
+**DO:**
+- ✅ Keep **only the final review document** in `.agents/outputs/`
+- ✅ Name clearly: `spec-review-FINAL-{feature-name}-{mmddyy}.md`
+- ✅ Archive intermediate reviews if needed
+
+**DON'T:**
+- ❌ Keep multiple review iterations (creates confusion)
+- ❌ Reference outdated reviews in issues
+
+---
+
+## Spec Finalization Checklist
+
+Before creating GitHub issues, ensure:
+
+### Content Completeness
+- [ ] All prerequisites documented with evidence
+- [ ] Current behavior accurately reflects codebase state
+- [ ] All stakeholder decisions documented
+- [ ] Implementation phases defined with dependencies
+- [ ] Effort estimates realistic and approved
+- [ ] Risk assessment complete
+- [ ] Open questions resolved
+
+### Internal Consistency
+- [ ] No contradictions between sections
+- [ ] Terminology used consistently
+- [ ] Dependencies correctly sequenced
+- [ ] Acceptance criteria align with goals
+
+### Stakeholder Approval
+- [ ] Engineering lead approval
+- [ ] Product team approval (timeline, scope)
+- [ ] Architecture team approval (if applicable)
+- [ ] Security team approval (if applicable)
+
+### Documentation Quality
+- [ ] Status marked as "FINAL - Ready for Implementation"
+- [ ] Version number in frontmatter and title
+- [ ] Document history table updated
+- [ ] References to other docs accurate
+
+---
+
+## Issue Creation Best Practices
+
+### Issue Template Requirements
+
+Every issue created from a spec MUST include:
+
+```markdown
+## Reference
+Spec: `specs/{spec-name}-v{X}.md` (lines Y-Z)
+**Spec Version**: v{X}.0 (commit {hash})
+
+## Overview
+[Clear description of what this issue implements]
+
+## Problem
+**Current State**: [What exists now]
+**Required**: [What spec requires]
+
+## Implementation
+[Detailed implementation steps from spec]
+
+## Acceptance Criteria
+[Checklist from spec - do not duplicate, reference spec lines]
+
+## Dependencies
+**Depends on**: Issue #X, Issue #Y
+**Blocks**: Issue #Z
+
+## Effort Estimate
+**X-Y days** (COMPLEXITY_LEVEL)
+```
+
+### Spec Version Reference Format
+
+**Required fields:**
+1. **Spec file path** with version: `specs/flow-of-funds-v3.md`
+2. **Line numbers** for relevant sections: `(lines 76-88, 243-258)`
+3. **Spec version**: `v3.0`
+4. **Git commit hash**: `(commit abc1234)`
+
+**Example:**
+```markdown
+## Reference
+Spec: `specs/flow-of-funds-v3.md` (lines 434-448)
+**Spec Version**: v3.0 (commit 97bc25e)
+```
+
+**Why this matters:**
+- Ensures implementers reference correct version
+- Git commit provides immutable reference
+- Line numbers help locate exact requirements
+- Version number prevents confusion with outdated specs
+
+---
+
+## Git Workflow for Specs
+
+### 1. Create Initial Spec
+
+```bash
+# Create spec in specs/ directory
+# Naming: feature-name-v1.md (start with v1)
+
+# Commit initial version
+git add specs/feature-name-v1.md
+git commit -m "feat: Add feature-name specification v1"
+git push
+```
+
+### 2. Iterate Based on Feedback
+
+```bash
+# Update spec file IN PLACE
+# DO NOT create v2, v3 files yet
+
+# Commit each iteration
+git commit -am "docs: Update feature-name spec with senior feedback"
+git push
+```
+
+### 3. Finalize Spec
+
+```bash
+# Update status to FINAL
+# Update version number in frontmatter
+# Rename file if moving to final version number
+
+git mv specs/feature-name-v1.md specs/feature-name-v3.md  # If jumped versions
+# OR just update content if keeping v1
+
+# Commit final version
+git add specs/feature-name-v3.md
+git commit -m "docs: Finalize feature-name specification v3 (FINAL)"
+
+# Tag the commit
+git tag -a spec-feature-name-v3.0 -m "Feature Name Specification v3.0 FINAL"
+git push && git push --tags
+```
+
+### 4. Create Issues
+
+```bash
+# Now that spec is finalized, create issues
+# Each issue references: specs/feature-name-v3.md (commit abc1234)
+
+# If spec needs updates after issues created
+# Update the SAME file (v3.md)
+# Increment version in frontmatter (v3.1, v3.2)
+# Update affected issues
+```
+
+---
+
+## Version Control Strategy
+
+### Semantic Versioning for Specs
+
+- **v1.0**: Initial draft
+- **v2.0**: Major revision (after senior review)
+- **v3.0**: Final approved version (ready for implementation)
+- **v3.1**: Minor updates after finalization (bug fixes, clarifications)
+- **v3.2**: Additional minor updates
+
+### Git Tags
+
+**Format**: `spec-{feature-name}-v{X}.{Y}`
+
+**Examples**:
+- `spec-flow-of-funds-v3.0` - Final approved version
+- `spec-rbac-v2.0` - Second major revision
+- `spec-invitation-v1.0` - Initial version
+
+**When to tag**:
+- ✅ When spec status changes to FINAL
+- ✅ Before creating GitHub issues
+- ✅ Before starting implementation
+- ❌ Not for every minor update
+
+---
+
+## Lessons Learned: Flow-of-Funds Case Study
+
+### What Went Wrong
+
+**Problem**: Created GitHub issues from v2 spec, then found Phase 3 inconsistencies, created v3 spec.
+
+**Impact**:
+- Had to manually update issues #125 and #126
+- Had 3 spec files (v1, v2, v3) causing confusion
+- Had 3 review documents with overlapping content
+- Wasted time cleaning up afterward
+
+### What Would Have Been Better
+
+**Improved Flow**:
+1. ✅ Spec review → senior feedback → UPDATE spec v1 → iterate
+2. ✅ Make all decisions → UPDATE spec v1 → mark as FINAL → rename to v3
+3. ✅ Commit final spec
+4. ✅ Create all issues referencing v3 + commit hash
+5. ✅ No cleanup needed
+
+**Time Saved**: 2-3 hours of manual issue updates and cleanup
+
+---
+
+## Quick Reference
+
+### Before Creating Issues
+
+1. Is spec marked FINAL? → If NO, keep iterating
+2. Are all decisions documented? → If NO, get decisions
+3. Is spec committed to git? → If NO, commit it
+4. Is commit tagged? → If NO, tag it
+5. Ready to create issues? → YES
+
+### Issue Creation Checklist
+
+- [ ] Spec is FINAL and committed
+- [ ] Have git commit hash
+- [ ] Issue template includes spec reference with commit
+- [ ] Issue references specific line numbers
+- [ ] Issue dependencies align with spec phases
+- [ ] Issue effort estimates match spec
+
+### Cleanup After Finalization
+
+1. Delete old spec versions (if any)
+2. Delete intermediate review documents
+3. Keep only: final spec + final review
+4. Commit cleanup
+5. Push to remote
+
+---
+
+## Related Documentation
+
+- **Orchestrate Workflow**: `.claude/rules/orchestrate-workflow.md`
+- **Spec-Reviewer Agent**: `.claude/agents/spec-reviewer.md`
+- **Feature Command**: `.claude/commands/feature-from-spec.md`
+- **Backend Patterns**: `.claude/rules/backend-patterns.md`
+
+---
+
+## Summary
+
+**Golden Rules**:
+
+1. **Finalize spec BEFORE creating issues** (not after)
+2. **One spec file** (use git for history, not filenames)
+3. **Tag the commit** when finalizing spec
+4. **Reference commit hash** in every issue
+5. **Delete old versions** after finalization
+
+Following this workflow prevents:
+- ❌ Inconsistent issues
+- ❌ Manual issue updates
+- ❌ Confusion about canonical version
+- ❌ Wasted cleanup effort
+
+And ensures:
+- ✅ Single source of truth
+- ✅ Immutable references (git commits)
+- ✅ Clear version history
+- ✅ Efficient workflow

--- a/claude-config/settings.local.json
+++ b/claude-config/settings.local.json
@@ -14,10 +14,6 @@
           {
             "type": "command",
             "command": "python3 ~/.claude/hooks/precompact_checkpoint.py"
-          },
-          {
-            "type": "command",
-            "command": "python3 ~/agents/obsidian-agent/update_vault.py 2>&1 | tee -a /tmp/obsidian-agent.log"
           }
         ]
       }
@@ -33,5 +29,9 @@
         ]
       }
     ]
+  },
+  "statusLine": {
+    "type": "command",
+    "command": "python3 ~/.claude/statusline.py"
   }
 }

--- a/claude-config/skills/orchestrate/ORCHESTRATE_REFERENCE.md
+++ b/claude-config/skills/orchestrate/ORCHESTRATE_REFERENCE.md
@@ -1,0 +1,227 @@
+# Orchestrate Command — Complete Reference
+
+This is the detailed reference for the orchestrate workflow. The main skill definition is in [SKILL.md](./SKILL.md).
+
+## Workflow Overview
+
+**ORCHESTRATION ONLY**: You are a **conductor**, not a performer.
+
+### Conditional Workflow Paths
+- **TRIVIAL/SIMPLE tasks**: **MAP-PLAN → PATCH → PROVE** (3-agent)
+- **COMPLEX tasks**: **MAP → PLAN → PATCH → PROVE** (4-agent)
+
+## Repo Structure
+- **Monorepo root**: `mymoney-dev/`
+- **Backend repo root**: `backend/` (FastAPI + SQLAlchemy + pytest)
+- **Frontend repo root**: `frontend/` (Vite + React)
+
+## Tech Stack Snapshot
+- **Backend**: FastAPI, SQLAlchemy, Alembic, pytest (SQLite in-memory), ruff
+- **Frontend**: Vite, React, Tailwind, `react-router-dom` (migration in progress), axios wrapper in `frontend/src/api.js`, ESLint/Vitest
+
+---
+
+## Critical Rules
+
+**YOU MUST:**
+- Require a **GitHub Issue** as source of truth (issue number = build number)
+- Extract/verify the issue via GitHub CLI
+- Coordinate agents sequentially
+- Require each agent to write a `.agents/outputs/...` artifact
+- Summarize between phases and carry forward filenames
+- Enforce `.claude/rules.md`
+
+**YOU MUST NEVER:**
+- Implement the feature/bug yourself
+- Edit code directly
+- Bypass the MAP/PLAN/PATCH/PROVE sequence
+
+---
+
+## Output Files (Mandatory)
+
+All outputs are written to:
+
+`mymoney-dev/.agents/outputs/`
+
+Naming convention:
+
+`{skill}-{issue_number}-{mmddyy}.md`
+
+**TRIVIAL/SIMPLE (MAP-PLAN workflow):**
+- `map-plan-{issue}-{date}.md`
+- `patch-{issue}-{date}.md`
+- `prove-{issue}-{date}.md`
+
+**COMPLEX (Full workflow):**
+- `map-{issue}-{date}.md`
+- `plan-{issue}-{date}.md`
+- `patch-{issue}-{date}.md`
+- `prove-{issue}-{date}.md`
+
+Each agent MUST end with:
+
+`AGENT_RETURN: <filename>`
+
+---
+
+## Usage
+
+```
+/orchestrate gh issue #184
+/orchestrate #184
+/orchestrate https://github.com/<org>/<repo>/issues/184
+```
+
+If the user does not provide an issue, instruct them to create one with:
+- `bug "..."` or
+- `feature "..."`
+
+---
+
+## Step 0 — Verify Issue Exists (authoritative)
+
+Extract `ISSUE_NUMBER`, then:
+
+```bash
+gh issue view $ISSUE_NUMBER --json number,title,body -q '.number'
+```
+
+Capture context to pass into MAP/MAP-PLAN:
+
+```bash
+gh issue view $ISSUE_NUMBER --json title,body -q '.title + "\n\n" + .body'
+```
+
+---
+
+## Step 1 — Initialize Run Date + Filenames
+
+Set:
+- `RUN_DATE = $(date +%m%d%y)`
+- Ensure: `mkdir -p .agents/outputs`
+
+Filenames:
+- `MAP_FILE        = .agents/outputs/map-${ISSUE_NUMBER}-${RUN_DATE}.md`
+- `PLAN_FILE       = .agents/outputs/plan-${ISSUE_NUMBER}-${RUN_DATE}.md`
+- `MAP_PLAN_FILE   = .agents/outputs/map-plan-${ISSUE_NUMBER}-${RUN_DATE}.md`
+- `CONTRACT_FILE   = .agents/outputs/contract-${ISSUE_NUMBER}-${RUN_DATE}.md`
+- `PATCH_FILE      = .agents/outputs/patch-${ISSUE_NUMBER}-${RUN_DATE}.md`
+- `PROVE_FILE      = .agents/outputs/prove-${ISSUE_NUMBER}-${RUN_DATE}.md`
+
+---
+
+## Step 1.5 — Classify Task Complexity (MANDATORY)
+
+Classification criteria:
+
+**TRIVIAL:** docs, config tweaks, small renames, deleting unused code
+
+**SIMPLE:** single-area changes, 1–3 files, straightforward bug fix or UI tweak
+
+**COMPLEX:** new endpoints, DB migrations, cross-module refactors, multi-step UI features, changes spanning backend + frontend
+
+Routing:
+- TRIVIAL/SIMPLE → MAP-PLAN
+- COMPLEX → MAP then PLAN
+
+---
+
+## Step 2 — Run Agents
+
+### Path A: TRIVIAL/SIMPLE
+1) Run **MAP-PLAN agent** (`.claude/agents/map-plan.md`) → `MAP_PLAN_FILE`
+2) If the task is **fullstack** (backend + frontend), run **CONTRACT agent** (`.claude/agents/contract.md`) → `CONTRACT_FILE`
+3) Run **PATCH agent** (`.claude/agents/patch.md`) → `PATCH_FILE`
+4) Run **PROVE agent** (`.claude/agents/prove.md`) → `PROVE_FILE`
+
+### Path B: COMPLEX
+1) Run **MAP agent** (`.claude/agents/map.md`) → `MAP_FILE`
+2) Run **PLAN agent** (`.claude/agents/plan.md`) → `PLAN_FILE`
+3) If the task is **fullstack** (backend + frontend), run **CONTRACT agent** (`.claude/agents/contract.md`) → `CONTRACT_FILE`
+4) Run **PATCH agent** (`.claude/agents/patch.md`) → `PATCH_FILE`
+5) Run **PROVE agent** (`.claude/agents/prove.md`) → `PROVE_FILE`
+
+---
+
+## Step 3 — Fullstack Coordination Rule (MANDATORY CONTRACT)
+
+If the change impacts **both** backend and frontend:
+- Backend changes define the contract (routes, request/response, error semantics)
+- Frontend must follow the contract
+
+**MANDATORY contract artifact for any fullstack change:**
+- `.agents/outputs/contract-{issue}-{date}.md`
+
+PATCH must treat the Contract Artifact as **authoritative** for:
+- Route paths, request/response schemas
+- Error semantics (401/403/404/422) and payload shapes
+- Account scoping (path prefix vs query param)
+- Frontend integration notes (how to call via `fetchData`)
+
+---
+
+## Step 4 — Verification Gates
+
+PROVE must run only the relevant commands, based on what changed:
+
+**Backend touched:**
+```bash
+cd backend && ruff check .
+cd backend && pytest -q
+```
+
+**Frontend touched:**
+```bash
+cd frontend && npm run lint
+cd frontend && npm run build
+```
+
+If a command fails, PROVE status is **BLOCKED** and must include error output + unblock steps.
+
+---
+
+## PR Workflow
+- Keep `main` green. If this change is non-trivial, use `/pr <number>` to produce a PR-ready plan, contract artifact (if fullstack), and verification checklist.
+
+---
+
+## Agent Communication
+
+Each agent receives:
+1. **Issue context** (title, body, number)
+2. **Previous artifacts** (MAP/MAP-PLAN, PLAN if applicable)
+3. **Project constraints** (`.claude/rules.md`)
+4. **Tech stack context** (`.claude/context/project_stack.md`)
+
+Each agent produces:
+1. **Markdown artifact** in `.agents/outputs/`
+2. **AGENT_RETURN: <filename>** at the end
+3. **Summary** of work completed
+4. **Handoff notes** for next agent (if applicable)
+
+---
+
+## Troubleshooting
+
+**Issue not found:**
+```bash
+gh issue view <number>
+# Error: Could not resolve to an issue
+```
+→ Verify issue exists, check repo access
+
+**Agent fails:**
+- Review agent artifact for error details
+- Check if constraints were violated
+- Verify all prerequisites met
+
+**PROVE blocked:**
+- Review linting/test output in PROVE artifact
+- Fix issues before proceeding
+- May need to run PATCH again with fixes
+
+**Fullstack confusion:**
+- Always generate CONTRACT artifact for backend + frontend changes
+- Backend defines API contract
+- Frontend implements to contract

--- a/claude-config/skills/orchestrate/SKILL.md
+++ b/claude-config/skills/orchestrate/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: orchestrate
+version: 3.0
+description: Multi-agent workflow with self-learning capabilities
+---
+
+# Orchestrate Skill (v3.0)
+
+Issue-driven workflow with pattern learning and outcome tracking.
+
+## What's New in v3.0
+
+- **Self-learning**: Agents read patterns.md before each run
+- **Outcome tracking**: PROVE records success/failure to memory/
+- **Slimmed agents**: 50% smaller, faster context loading
+- **Shared behaviors**: All agents inherit from _base.md
+
+## Workflow
+
+```
+Issue → Classify → Branch → Agents → Verify → Record → PR
+```
+
+## Agent Sequence
+
+**TRIVIAL/SIMPLE**:
+1. MAP-PLAN → `.agents/outputs/map-plan-{issue}-{date}.md`
+2. TEST-PLANNER (if `--with-tests`) → `.agents/outputs/test-plan-{issue}-{date}.md`
+3. CONTRACT (if fullstack) → `.agents/outputs/contract-{issue}-{date}.md`
+4. PATCH → `.agents/outputs/patch-{issue}-{date}.md`
+5. PROVE → `.agents/outputs/prove-{issue}-{date}.md`
+
+**COMPLEX**:
+1. MAP → `.agents/outputs/map-{issue}-{date}.md`
+2. PLAN → `.agents/outputs/plan-{issue}-{date}.md`
+3. TEST-PLANNER (if `--with-tests`) → `.agents/outputs/test-plan-{issue}-{date}.md`
+4. CONTRACT (if fullstack)
+5. PATCH
+6. PROVE
+
+**Recommended**: Use `--with-tests` for issues involving calculations, formulas, or complex business rules.
+
+## Learning Loop
+
+After each issue:
+1. PROVE records outcome to `.claude/memory/metrics.jsonl`
+2. If BLOCKED, records failure to `.claude/memory/failures.jsonl`
+3. Weekly `/learn` extracts patterns
+4. Agents read `patterns.md` on next run
+
+## Key Files
+
+- `.claude/agents/_base.md` — Shared agent behaviors
+- `.claude/memory/patterns.md` — Learned patterns
+- `.claude/memory/failures.jsonl` — Failure log
+- `.claude/memory/metrics.jsonl` — Success metrics
+
+## Usage
+
+```bash
+/orchestrate 184
+/orchestrate 184 --with-tests    # Include TEST-PLANNER phase
+```
+
+See `.claude/commands/orchestrate.md` for full details.

--- a/claude-config/skills/test-plan/SKILL.md
+++ b/claude-config/skills/test-plan/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: test-plan
+version: 1.0
+description: Generate test plan with edge cases before implementation
+argument-hint: [issue-number]
+---
+
+# Test Plan Skill (v1.0)
+
+Pre-implementation test planning with systematic edge case generation.
+
+## When to Use
+
+- Before implementing features with calculations/formulas
+- When spec defines business rules that need test coverage
+- For complex bug fixes with multiple edge cases
+- When you want TDD approach
+
+## Workflow Position
+
+```
+MAP-PLAN → TEST-PLANNER → PATCH → PROVE
+```
+
+TEST-PLANNER runs AFTER planning, BEFORE implementation.
+
+## Usage
+
+```bash
+# Generate test plan for an issue
+/test-plan 239
+
+# Generate test plan from a spec (without issue)
+/test-plan specs/engine-v2-proration-addendum.md
+```
+
+## Process
+
+1. **Extract requirements** — Parse spec/issue for testable behavior
+2. **Analyze coverage** — Find existing tests, identify gaps
+3. **Generate matrix** — Derive cases (happy, boundary, error)
+4. **Formula edge cases** — Systematically derive from calculations
+5. **Test signatures** — Provide function stubs for PATCH to implement
+
+## Output
+
+- Artifact: `.agents/outputs/test-plan-{issue}-{date}.md`
+- Test matrix with priorities (P0, P1, P2)
+- Test function signatures (not full implementations)
+- Regression risk list
+
+## Example Output
+
+```markdown
+## Test Matrix - Income Proration
+
+| Test Case | Input | Expected | Priority |
+|-----------|-------|----------|----------|
+| July start | start_month=7 | 0.5 | P0 |
+| Null month | start_month=None | 1.0 | P0 |
+| Invalid range | start=9, end=3 | ValidationError | P1 |
+
+## Test Signatures
+
+def test_income_july_start_prorates_half():
+    """Income starting July = 6/12 of annual"""
+    # Arrange: income with start_month=7
+    # Act: project_values()
+    # Assert: result == annual * 0.5
+```
+
+## Integration with Orchestrate
+
+When `/orchestrate` is run with `--with-tests` flag:
+```
+/orchestrate 239 --with-tests
+```
+
+The TEST-PLANNER agent runs automatically after MAP-PLAN.
+
+## See Also
+
+- `.claude/agents/test-planner.md` — Agent definition
+- `.claude/rules/testing.md` — Testing patterns

--- a/claude-config/statusline.py
+++ b/claude-config/statusline.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+import json
+import sys
+import getpass
+from datetime import datetime
+
+def main():
+    # Read JSON input from stdin
+    input_data = json.load(sys.stdin)
+
+    # ANSI color codes
+    BLUE = "\033[34m"
+    PINK = "\033[95m"
+    ORANGE = "\033[38;5;214m"
+    GREEN = "\033[32m"
+    RESET = "\033[0m"
+
+    # Server name simplified to DELLPRO (blue)
+    server = f"{BLUE}DELLPRO{RESET}"
+
+    # Get username (pink)
+    username = f"{PINK}{getpass.getuser()}{RESET}"
+
+    # Get current date in MM/DD format (orange)
+    current_date = f"{ORANGE}{datetime.now().strftime('%m/%d')}{RESET}"
+
+    # Get context used percentage (green)
+    context_window = input_data.get("context_window", {})
+    used_percentage = context_window.get("used_percentage")
+
+    # Format context display
+    if used_percentage is not None:
+        context_display = f"{GREEN}{used_percentage:.1f}%{RESET}"
+    else:
+        context_display = f"{GREEN}0.0%{RESET}"
+
+    # Build status line
+    status_line = f"{server} | {username} | {current_date} | {context_display} ctx"
+
+    print(status_line)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
Merges additional commands, rules, and skills from local Claude configuration.

### Added Commands (11)
- `/learn`, `/metrics`, `/postmortem-extract`, `/agent-update` - Learning system
- `/codex-review` - OpenAI second opinion
- `/spec-draft`, `/feature-from-spec` - Spec workflow
- `/pr`, `/bug`, `/feature`, `/test-plan` - GitHub workflow

### Added Rules (2)
- `spec-review-workflow.md` - Spec finalization before issues
- `orchestrate-workflow.md` - MAP → PLAN → PATCH → PROVE reference

### Added Skills (2)
- `orchestrate/` - Orchestration skill with reference docs
- `test-plan/` - Test planning skill

### Added
- `statusline.py` - Custom status line display
- Updated `install.sh` to handle skills and statusline
- Updated `settings.local.json` with statusLine configuration

🤖 Generated with [Claude Code](https://claude.ai/code)