### PR TITLE
chore: centralize patterns, extract state manager, add PR hygiene

### DIFF
--- a/claude-config/agents/_base.md
+++ b/claude-config/agents/_base.md
@@ -165,28 +165,20 @@ This signals successful completion to the orchestrator.
 
 ## 8. High-Frequency Failure Prevention
 
-These patterns cause >50% of failures. Check proactively:
+**Canonical definitions**: See `~/.claude/rules/core-patterns.md` (auto-loaded).
 
-### ENUM_VALUE (26% of failures)
-**Trigger**: Fullstack issue with role/status/type fields
-**Check**: Read backend enum, verify VALUES not names
+Use these verification commands when patterns apply:
+
 ```bash
+# ENUM_VALUE: verify VALUES not names
 grep -A 10 "class.*Enum" backend/backend/*/enums.py
-```
-**Prevention**: Frontend must use VALUE string (e.g., `"CO-OWNER"` not `"CO_OWNER"`)
 
-### COMPONENT_API (17% of failures)
-**Trigger**: Reusing existing frontend component/hook
-**Check**: Read actual source, extract PropTypes/return type
-```bash
+# COMPONENT_API: extract PropTypes/return type
 grep -A 20 "PropTypes" frontend/src/components/path/Component.jsx
-```
-**Prevention**: Document API explicitly before using
 
-### MULTI_MODEL (13% of failures)
-**Trigger**: CRUD operation with 5+ fields
-**Check**: Map each field to its owning model
-**Prevention**: Service layer must coordinate all model updates atomically
+# MULTI_MODEL: map fields to owning models
+grep -rn "class.*Model" backend/backend/*/models.py
+```
 
 ---
 

--- a/claude-config/commands/orchestrate.md
+++ b/claude-config/commands/orchestrate.md
@@ -92,20 +92,7 @@ COMPLEX:        MAP → PLAN → [TEST-PLANNER] → CONTRACT* → PLAN-CHECK →
 **MUST** run this command BEFORE spawning each agent:
 
 ```bash
-python3 -c "
-import yaml
-from pathlib import Path
-state_file = Path('.agents/outputs/claude_checkpoints/PERSISTENT_STATE.yaml')
-if state_file.exists():
-    data = yaml.safe_load(state_file.read_text())
-    data['active_work'] = {
-        'issue': $ISSUE,
-        'branch': '$BRANCH',
-        'phase': '$PHASE',
-        'last_action': 'Starting $PHASE phase'
-    }
-    state_file.write_text(yaml.safe_dump(data, default_flow_style=False, sort_keys=False))
-"
+python3 -c "import sys; sys.path.insert(0, '$HOME/.claude/hooks'); from state_manager import update_phase; from pathlib import Path; update_phase(Path('.'), $ISSUE, '$BRANCH', '$PHASE', 'Starting $PHASE phase')"
 ```
 
 Replace variables:
@@ -118,20 +105,7 @@ Replace variables:
 After workflow completes successfully:
 
 ```bash
-python3 -c "
-import yaml
-from pathlib import Path
-state_file = Path('.agents/outputs/claude_checkpoints/PERSISTENT_STATE.yaml')
-if state_file.exists():
-    data = yaml.safe_load(state_file.read_text())
-    data['active_work'] = {
-        'issue': None,
-        'branch': 'main',
-        'phase': None,
-        'last_action': 'Completed issue #$ISSUE'
-    }
-    state_file.write_text(yaml.safe_dump(data, default_flow_style=False, sort_keys=False))
-"
+python3 -c "import sys; sys.path.insert(0, '$HOME/.claude/hooks'); from state_manager import clear_active; from pathlib import Path; clear_active(Path('.'), $ISSUE)"
 ```
 
 ---
@@ -187,6 +161,28 @@ CONTRACT agent will run before PLAN-CHECK.
 
 **Override**: If user initially classified as backend-only but plan touches frontend, escalate to fullstack.
 
+### Step 1.7: Check for File Conflicts with Open PRs
+
+Before branching, check if open PRs touch files this issue will affect:
+
+```bash
+# Get files from open PRs
+OPEN_PR_FILES=$(gh pr list --state open --json files --jq '.[].files[].path' 2>/dev/null | sort -u)
+
+# After MAP-PLAN, compare planned files against open PR files
+PLAN_FILES=$(grep -oP '`[^`]+\.(py|jsx?|tsx?|md|json)`' .agents/outputs/{map-plan,plan}-${ISSUE}-*.md 2>/dev/null | tr -d '`' | sort -u)
+
+CONFLICTS=$(comm -12 <(echo "$OPEN_PR_FILES") <(echo "$PLAN_FILES"))
+
+if [ -n "$CONFLICTS" ]; then
+  echo "WARNING: File conflicts with open PRs:"
+  echo "$CONFLICTS"
+  echo "Consider serializing or rebasing after those PRs merge."
+fi
+```
+
+**Note**: This runs after MAP-PLAN produces the file list. If conflicts are found, warn but don't block — user decides whether to proceed.
+
 ### Step 2: Create Feature Branch
 
 ```bash
@@ -213,9 +209,8 @@ All agent prompts MUST include this inherited context block to reduce re-reading
 - Complexity: {TRIVIAL|SIMPLE|COMPLEX}
 
 ## Critical Patterns (Always Apply)
-1. VERIFICATION_GAP: Verify assumptions by reading actual code
-2. ENUM_VALUE: Use VALUES not Python names ("CO-OWNER" not "CO_OWNER")
-3. COMPONENT_API: Read PropTypes before using components
+Loaded from rules/core-patterns.md (auto-loaded by Claude Code).
+Apply VERIFICATION_GAP, ENUM_VALUE, and COMPONENT_API checks as relevant.
 
 ## Prior Artifacts
 - {list any prior artifacts for this issue}

--- a/claude-config/commands/pr.md
+++ b/claude-config/commands/pr.md
@@ -152,6 +152,13 @@ git checkout main && git pull
 # Delete local feature branch
 git branch -d feature/issue-${ISSUE}-description
 
+# Archive artifacts for the merged issue
+ARCHIVE_DIR=".agents/outputs/archive"
+mkdir -p "$ARCHIVE_DIR"
+for f in .agents/outputs/*-${ISSUE}-*.md; do
+  [ -f "$f" ] && mv "$f" "$ARCHIVE_DIR/"
+done
+
 # Verify main is green
 cd backend && pytest -q
 cd frontend && npm run build

--- a/claude-config/hooks/precompact_checkpoint.py
+++ b/claude-config/hooks/precompact_checkpoint.py
@@ -111,41 +111,15 @@ def extract_state_from_transcript(transcript_lines: list[str]) -> dict:
     return state
 
 
-def update_persistent_state(state_file: Path, extracted: dict) -> None:
-    """Update PERSISTENT_STATE.yaml with extracted info."""
-    import yaml  # Only import if needed
-
-    if not state_file.exists():
-        return
-
+def update_persistent_state(project_dir: Path, extracted: dict) -> None:
+    """Update PERSISTENT_STATE.yaml with extracted info via state_manager."""
     try:
-        content = state_file.read_text(encoding="utf-8")
-        data = yaml.safe_load(content) or {}
-
-        # Update active_work section
-        if "active_work" not in data:
-            data["active_work"] = {}
-
-        if extracted["last_issue"]:
-            data["active_work"]["issue"] = extracted["last_issue"]
-        if extracted["last_phase"]:
-            data["active_work"]["phase"] = extracted["last_phase"]
-
-        # Update with last action description
-        if extracted["artifacts_created"]:
-            data["active_work"]["last_action"] = f"Created {extracted['artifacts_created'][-1]}"
-
-        # Update timestamp
-        if "meta" not in data:
-            data["meta"] = {}
-        data["meta"]["updated"] = datetime.now().strftime("%Y-%m-%d")
-
-        # Write back
-        with state_file.open("w", encoding="utf-8") as f:
-            yaml.safe_dump(data, f, default_flow_style=False, sort_keys=False)
-
+        from state_manager import update_from_extracted
+        update_from_extracted(project_dir, extracted)
+    except ImportError:
+        # state_manager not on path, skip
+        print("[precompact] Warning: state_manager not found, skipping state update", file=sys.stderr)
     except Exception as e:
-        # Don't fail the hook if YAML update fails
         print(f"[precompact] Warning: Could not update PERSISTENT_STATE.yaml: {e}", file=sys.stderr)
 
 
@@ -221,13 +195,11 @@ def main() -> int:
     md_dst.write_text(summary, encoding="utf-8")
 
     # 4) Update PERSISTENT_STATE.yaml with extracted info
-    state_yaml = out_dir / "PERSISTENT_STATE.yaml"
     try:
-        update_persistent_state(state_yaml, extracted)
-        print(f"[precompact] Updated PERSISTENT_STATE.yaml")
-    except ImportError:
-        # PyYAML not available, skip update
-        print(f"[precompact] Skipped PERSISTENT_STATE.yaml update (PyYAML not installed)")
+        update_persistent_state(project_dir, extracted)
+        print("[precompact] Updated PERSISTENT_STATE.yaml")
+    except Exception as e:
+        print(f"[precompact] Skipped PERSISTENT_STATE.yaml update: {e}")
 
     # 5) Cleanup old checkpoints
     try:

--- a/claude-config/hooks/sessionstart_restore_state.py
+++ b/claude-config/hooks/sessionstart_restore_state.py
@@ -31,9 +31,16 @@ try:
 except ImportError:
     HAS_YAML = False
 
+# Try to import centralized state manager
+try:
+    from state_manager import get_active_work as _sm_get_active_work
+    HAS_STATE_MANAGER = True
+except ImportError:
+    HAS_STATE_MANAGER = False
+
 
 def get_active_work(yaml_content: str) -> dict:
-    """Extract active_work from YAML content."""
+    """Extract active_work from YAML content (fallback when state_manager unavailable)."""
     if not HAS_YAML:
         return {}
     try:
@@ -62,7 +69,10 @@ def main() -> int:
     active_work = {}
     if yaml_state.exists():
         yaml_content = yaml_state.read_text(encoding="utf-8")
-        active_work = get_active_work(yaml_content)
+        if HAS_STATE_MANAGER:
+            active_work = _sm_get_active_work(project_dir)
+        else:
+            active_work = get_active_work(yaml_content)
         print("### Project State\n")
         print("```yaml")
         print(yaml_content)
@@ -82,13 +92,20 @@ def main() -> int:
         print(patterns_critical.read_text(encoding="utf-8"))
         print()
     else:
-        # Fallback: print inline critical patterns
-        print("### Critical Patterns\n")
-        print("1. **VERIFICATION_GAP**: Read spec/code before assuming")
-        print("2. **ENUM_VALUE**: Use VALUES not Python names (CO-OWNER not CO_OWNER)")
-        print("3. **COMPONENT_API**: Read PropTypes before using components")
-        print()
-        print("Full patterns: `.claude/memory/patterns-full.md`\n")
+        # Fallback: try reading rules/core-patterns.md (canonical source)
+        core_patterns = global_claude_dir / "rules" / "core-patterns.md"
+        if core_patterns.exists():
+            print("### Critical Patterns (Always Apply)\n")
+            print(core_patterns.read_text(encoding="utf-8"))
+            print()
+        else:
+            # Last resort: minimal inline reminder
+            print("### Critical Patterns\n")
+            print("1. **VERIFICATION_GAP**: Read spec/code before assuming")
+            print("2. **ENUM_VALUE**: Use VALUES not Python names (CO-OWNER not CO_OWNER)")
+            print("3. **COMPONENT_API**: Read PropTypes before using components")
+            print()
+            print("Full patterns: `.claude/memory/patterns-full.md`\n")
 
     # 3. Check for active orchestrate workflow and provide continue instructions
     issue = active_work.get("issue")

--- a/claude-config/hooks/state_manager.py
+++ b/claude-config/hooks/state_manager.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""
+Centralized state manager for PERSISTENT_STATE.yaml.
+
+Used by: orchestrate command (inline), precompact hook, sessionstart hook.
+Single source of truth for reading/writing orchestrate workflow state.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from pathlib import Path
+
+_log_file = Path.home() / ".claude" / "hooks.log"
+logging.basicConfig(
+    filename=str(_log_file),
+    level=logging.WARNING,
+    format="%(asctime)s [state_manager] %(levelname)s: %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+
+try:
+    import yaml
+    HAS_YAML = True
+except ImportError:
+    HAS_YAML = False
+
+
+def _state_path(project_dir: Path) -> Path:
+    return project_dir / ".agents" / "outputs" / "claude_checkpoints" / "PERSISTENT_STATE.yaml"
+
+
+def load_state(project_dir: Path) -> dict:
+    """Read PERSISTENT_STATE.yaml and return its contents as a dict."""
+    if not HAS_YAML:
+        return {}
+    path = _state_path(project_dir)
+    if not path.exists():
+        return {}
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+        return data if isinstance(data, dict) else {}
+    except Exception as e:
+        logging.warning(f"Failed to load state: {e}")
+        return {}
+
+
+def _write_state(project_dir: Path, data: dict) -> None:
+    """Write state dict back to PERSISTENT_STATE.yaml."""
+    if not HAS_YAML:
+        return
+    path = _state_path(project_dir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as f:
+        yaml.safe_dump(data, f, default_flow_style=False, sort_keys=False)
+
+
+def update_phase(project_dir: Path, issue: int, branch: str, phase: str, action: str) -> None:
+    """Update active_work with current phase. Tracks completed phases for --resume."""
+    data = load_state(project_dir)
+    active = data.get("active_work", {})
+
+    # Track the previous phase as completed (if transitioning)
+    prev_phase = active.get("phase")
+    completed = active.get("completed_phases", [])
+    if prev_phase and prev_phase != phase and prev_phase not in completed:
+        completed.append(prev_phase)
+
+    data["active_work"] = {
+        "issue": issue,
+        "branch": branch,
+        "phase": phase,
+        "last_action": action,
+        "completed_phases": completed,
+    }
+
+    if "meta" not in data:
+        data["meta"] = {}
+    data["meta"]["updated"] = datetime.now().strftime("%Y-%m-%d")
+
+    _write_state(project_dir, data)
+
+
+def clear_active(project_dir: Path, issue: int) -> None:
+    """Clear active workflow state after successful completion."""
+    data = load_state(project_dir)
+    data["active_work"] = {
+        "issue": None,
+        "branch": "main",
+        "phase": None,
+        "last_action": f"Completed issue #{issue}",
+        "completed_phases": [],
+    }
+
+    if "meta" not in data:
+        data["meta"] = {}
+    data["meta"]["updated"] = datetime.now().strftime("%Y-%m-%d")
+
+    _write_state(project_dir, data)
+
+
+def get_completed_phases(project_dir: Path, issue: int) -> list[str]:
+    """Get list of completed phases for an issue. Used by --resume."""
+    data = load_state(project_dir)
+    active = data.get("active_work", {})
+    if active.get("issue") != issue:
+        return []
+    return active.get("completed_phases", [])
+
+
+def get_active_work(project_dir: Path) -> dict:
+    """Get the active_work section. Used by sessionstart hook."""
+    data = load_state(project_dir)
+    return data.get("active_work", {})
+
+
+def update_from_extracted(project_dir: Path, extracted: dict) -> None:
+    """Update state from precompact transcript extraction."""
+    data = load_state(project_dir)
+
+    if "active_work" not in data:
+        data["active_work"] = {}
+
+    if extracted.get("last_issue"):
+        data["active_work"]["issue"] = extracted["last_issue"]
+    if extracted.get("last_phase"):
+        data["active_work"]["phase"] = extracted["last_phase"]
+    if extracted.get("artifacts_created"):
+        data["active_work"]["last_action"] = f"Created {extracted['artifacts_created'][-1]}"
+
+    if "meta" not in data:
+        data["meta"] = {}
+    data["meta"]["updated"] = datetime.now().strftime("%Y-%m-%d")
+
+    _write_state(project_dir, data)


### PR DESCRIPTION
## Summary
- Deduplicate failure pattern definitions to single source (`rules/core-patterns.md`)
- Extract `state_manager.py` from inline YAML manipulation in orchestrate/hooks
- Add file conflict check (Step 1.7) before branching in orchestrate workflow
- Add post-merge artifact archival to `/pr` command

## Files Changed
- `agents/_base.md` — replace pattern definitions with reference
- `commands/orchestrate.md` — pattern ref, state manager calls, conflict check
- `commands/pr.md` — artifact archive in post-merge cleanup
- `hooks/state_manager.py` — **new** centralized state module
- `hooks/precompact_checkpoint.py` — delegate to state_manager
- `hooks/sessionstart_restore_state.py` — delegate to state_manager

## Test Plan
- [x] `state_manager.py` imports successfully
- [x] Only Phase 1 files staged (no unrelated changes)
- [x] Hooks use hardlinks — edits propagate to installed location

Phase 1 of 4 — workflow improvements from agentic engineering audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)