### PR TITLE
feat: integrate MCP failure_patterns into agent pre-flight

### DIFF
--- a/claude-config/agents/_base.md
+++ b/claude-config/agents/_base.md
@@ -14,12 +14,30 @@ All agents inherit these behaviors. Read this FIRST before your agent-specific i
 
 **BEFORE investigating or planning**, load accumulated knowledge:
 
-### Always Load (Critical Patterns ~50 lines)
+### Preferred: MCP Tools (if vault-metrics MCP available)
+
+Use MCP tools for structured, up-to-date pattern data:
+
+```
+# Get failure patterns (structured, with frequency and recent examples)
+failure_patterns()
+
+# Get metrics overview (success rates by complexity/stack)
+agent_metrics(period="30d")
+```
+
+**Why MCP**: Returns parsed JSON with counts, percentages, and recent examples — more actionable than raw markdown files.
+
+### Fallback: File-Based Loading
+
+If MCP tools are not available (tool call fails or returns error), fall back to files:
+
+#### Always Load (Critical Patterns ~50 lines)
 ```bash
 cat .claude/memory/patterns-critical.md
 ```
 
-### Load If Needed (Full Patterns ~660 lines)
+#### Load If Needed (Full Patterns ~660 lines)
 Only load `.claude/memory/patterns-full.md` when:
 - Issue is COMPLEX classification
 - Issue involves pattern not in critical file

--- a/claude-config/agents/contract.md
+++ b/claude-config/agents/contract.md
@@ -33,7 +33,7 @@ ls .agents/outputs/{plan,map-plan}-${ISSUE_NUMBER}-*.md 2>/dev/null || echo "BLO
 
 1. Read PLAN artifact
 2. Read MAP artifact (if available)
-3. `cat .claude/memory/patterns.md` — Check for ENUM_VALUE pattern
+3. Load patterns via MCP `failure_patterns()` (fallback: `cat .claude/memory/patterns.md`) — Check for ENUM_VALUE pattern
 
 ---
 

--- a/claude-config/agents/map-plan.md
+++ b/claude-config/agents/map-plan.md
@@ -19,7 +19,7 @@ No predecessor required (MAP-PLAN is the first agent in the TRIVIAL/SIMPLE workf
 
 ## Pre-Flight (from _base.md)
 
-1. `cat .claude/memory/patterns.md` — Load learned patterns
+1. Load patterns via MCP `failure_patterns()` (fallback: `cat .claude/memory/patterns.md`)
 2. `grep -l "KEYWORD" .agents/outputs/*.md` — Find similar past work
 3. `cat .claude/rules.md | head -50` — Verify constraints
 

--- a/claude-config/agents/map.md
+++ b/claude-config/agents/map.md
@@ -19,7 +19,7 @@ No predecessor required (MAP is the first agent in the COMPLEX workflow).
 
 ## Pre-Flight (from _base.md)
 
-1. `cat .claude/memory/patterns.md` — Load learned patterns
+1. Load patterns via MCP `failure_patterns()` (fallback: `cat .claude/memory/patterns.md`)
 2. `grep -l "KEYWORD" .agents/outputs/*.md` — Find similar past work
 3. `cat .claude/rules.md | head -50` — Verify constraints
 

--- a/claude-config/agents/plan.md
+++ b/claude-config/agents/plan.md
@@ -23,7 +23,7 @@ ls .agents/outputs/map-${ISSUE_NUMBER}-*.md 2>/dev/null || echo "BLOCKED: MAP ar
 
 ## Pre-Flight (from _base.md)
 
-1. `cat .claude/memory/patterns.md` — Load learned patterns
+1. Load patterns via MCP `failure_patterns()` (fallback: `cat .claude/memory/patterns.md`)
 2. Read MAP artifact: `.agents/outputs/map-{issue}-{mmddyy}.md`
 3. `cat .claude/rules.md | head -50` — Verify constraints
 

--- a/claude-config/agents/prove.md
+++ b/claude-config/agents/prove.md
@@ -23,7 +23,7 @@ ls .agents/outputs/patch-${ISSUE_NUMBER}-*.md 2>/dev/null || echo "BLOCKED: PATC
 
 ## Pre-Flight (from _base.md)
 
-1. `cat .claude/memory/patterns.md` — Know common failure patterns
+1. Load patterns via MCP `failure_patterns()` (fallback: `cat .claude/memory/patterns.md`)
 2. Read PATCH artifact — Understand what changed
 
 ---

--- a/claude-config/agents/spec-reviewer.md
+++ b/claude-config/agents/spec-reviewer.md
@@ -24,7 +24,7 @@ max_lines: 400
 
 ## Pre-Flight (from _base.md)
 
-1. `cat .claude/memory/patterns.md` — Know common failure patterns
+1. Load patterns via MCP `failure_patterns()` (fallback: `cat .claude/memory/patterns.md`)
 2. Read the spec file completely
 3. Check for existing issues: `gh issue list --label "from-spec" --search "SPEC_NAME"`
 

--- a/claude-config/agents/test-planner.md
+++ b/claude-config/agents/test-planner.md
@@ -23,7 +23,7 @@ ls .agents/outputs/{map,map-plan}-${ISSUE_NUMBER}-*.md 2>/dev/null || echo "BLOC
 
 ## Pre-Flight (from _base.md)
 
-1. `cat .claude/memory/patterns.md` — Load learned patterns (identify past test failures)
+1. Load patterns via MCP `failure_patterns()` (fallback: `cat .claude/memory/patterns.md`) — Identify past test failures
 2. Read issue/spec — Extract ALL testable requirements
 3. Read MAP-PLAN artifact — Understand implementation scope
 

--- a/claude-config/settings.json
+++ b/claude-config/settings.json
@@ -50,6 +50,13 @@
   },
   "skipDangerousModePermissionPrompt": true,
   "mcpServers": {
+    "vault-metrics": {
+      "command": "python3",
+      "args": [
+        "~/agents/mcp-server/server.py",
+        "--mcp"
+      ]
+    },
     "apple-mcp": {
       "command": "bunx",
       "args": [


### PR DESCRIPTION
## Summary
- Add MCP `failure_patterns()` and `agent_metrics()` as preferred pre-flight pattern source
- All 8 agent files updated to MCP-first with file-based fallback
- `vault-metrics` MCP server added to `settings.json` for portability

## Files Changed
- `agents/_base.md` — MCP preferred pre-flight with fallback section
- `agents/map-plan.md`, `map.md`, `plan.md`, `prove.md`, `contract.md`, `spec-reviewer.md`, `test-planner.md` — one-line pre-flight update each
- `settings.json` — add vault-metrics MCP server config

## Test Plan
- [x] _base.md has MCP section before file-based fallback
- [x] All 7 agent files reference MCP-first loading
- [x] settings.json vault-metrics config matches settings.local.json format
- [ ] Verify `failure_patterns()` returns data in a project with failures.jsonl
- [ ] Verify agents fall back gracefully when MCP unavailable

Phase 4 of 4 — final phase of workflow improvements from agentic engineering audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)