### PR TITLE
feat: add --parallel flag to /orchestrate with worktree isolation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,8 @@ venv/
 .vscode/
 *.swp
 
+# Git worktrees (parallel orchestrate sessions)
+.worktrees/
+
 # Local-only settings (not symlinked)
 claude-config/settings.local.json

--- a/claude-config/commands/orchestrate.md
+++ b/claude-config/commands/orchestrate.md
@@ -35,6 +35,8 @@ argument-hint: [issue-number]
 /orchestrate #184
 /orchestrate 184 --with-tests    # Include TEST-PLANNER phase
 /orchestrate 184 --resume        # Resume from last completed phase
+/orchestrate 184 --parallel      # Run in isolated worktree
+/orchestrate 184 --parallel --resume  # Resume in existing worktree
 ```
 
 If no issue provided, instruct user to create one with `/feature` or `/bug`.
@@ -42,6 +44,7 @@ If no issue provided, instruct user to create one with `/feature` or `/bug`.
 **Flags**:
 - `--with-tests`: Run TEST-PLANNER agent after MAP-PLAN (recommended for calculations/formulas)
 - `--resume`: Resume an interrupted workflow from the last completed phase
+- `--parallel`: Run workflow in an isolated git worktree (`.worktrees/issue-{N}/`). Enables concurrent orchestrate sessions on independent issues.
 
 ---
 
@@ -150,6 +153,69 @@ When `--resume` is provided, skip already-completed phases:
 
 ---
 
+## Parallel Worktree Mode (`--parallel`)
+
+When `--parallel` is provided, the workflow runs inside an isolated git worktree.
+
+### Setup Phase
+
+1. Create worktree:
+   ```bash
+   python3 -c "
+   import sys; sys.path.insert(0, '$HOME/.claude/hooks')
+   from worktree_manager import create_worktree
+   path = create_worktree($ISSUE, 'feature/issue-$ISSUE-slug')
+   print(f'Worktree created: {path}')
+   "
+   ```
+
+2. If `WorktreeExistsError`:
+   - If `--resume` also provided: use the existing worktree path
+   - Otherwise: report error, suggest adding `--resume`
+
+3. Track worktree in state (use **repo root** as `project_dir`, NOT worktree CWD):
+   ```bash
+   REPO_ROOT=$(git rev-parse --show-toplevel)
+   python3 -c "
+   import sys; sys.path.insert(0, '$HOME/.claude/hooks')
+   from state_manager import update_phase
+   from pathlib import Path
+   update_phase(Path('$REPO_ROOT'), $ISSUE, '$BRANCH', 'SETUP', 'Created worktree', worktree_path='$WORKTREE_PATH')
+   "
+   ```
+
+### Agent Execution
+
+All Task() spawns set working directory to the worktree path.
+Artifacts are written to `{worktree}/.agents/outputs/`.
+
+**State tracking**: All `update_phase()` calls MUST use the **repo root** as `project_dir`, not the worktree CWD. Use `get_repo_root()` from `worktree_manager` to resolve the correct path:
+
+```bash
+REPO_ROOT=$(python3 -c "import sys; sys.path.insert(0, '$HOME/.claude/hooks'); from worktree_manager import get_repo_root; print(get_repo_root())")
+python3 -c "... update_phase(Path('$REPO_ROOT'), $ISSUE, '$BRANCH', '$PHASE', 'Starting $PHASE phase', worktree_path='$WORKTREE_PATH')"
+```
+
+### Auto-Detect Worktree on Resume
+
+When `--resume` is provided (with or without `--parallel`):
+1. Load worktree path from state: `get_worktree_for_issue(project_dir, issue)`
+2. If state has a `worktree_path`:
+   - If path still exists on disk: use it as CWD for remaining phases (auto-detect parallel mode)
+   - If path is gone (cleaned up): re-create worktree and restart from beginning
+3. If state has no `worktree_path`: resume normally (non-parallel mode)
+
+### Post-Workflow
+
+After PROVE completes, report worktree path for PR creation:
+```
+Worktree: .worktrees/issue-42/
+Next: cd .worktrees/issue-42 && /pr 42
+```
+Do NOT auto-remove worktree -- user may need it for PR revisions.
+
+---
+
 ## Process
 
 ### Step 0: Verify Issue
@@ -243,10 +309,31 @@ if [ -n "$CONFLICTS" ]; then
 fi
 ```
 
+Also check active worktrees for file overlap:
+
+```bash
+# Check worktrees for file conflicts (especially in --parallel mode)
+python3 -c "
+import sys, json
+sys.path.insert(0, '$HOME/.claude/hooks')
+from worktree_manager import check_file_conflicts
+planned = json.loads('$PLAN_FILES_JSON')  # list of planned file paths
+conflicts = check_file_conflicts(planned)
+if conflicts:
+    print('WARNING: File conflicts with active worktrees:')
+    for c in conflicts:
+        print(f'  {c[\"file\"]} (worktree: issue-{c[\"issue\"]})')
+    print('Consider serializing or waiting for the other issue to complete.')
+"
+```
+
 **Note**: This runs after MAP-PLAN produces the file list. If conflicts are found, warn but don't block — user decides whether to proceed.
 
 ### Step 2: Create Feature Branch
 
+If `--parallel`: Branch was already created by worktree setup. Skip this step.
+
+Otherwise:
 ```bash
 BRANCH=$(git branch --show-current)
 if [ "$BRANCH" = "main" ]; then

--- a/claude-config/commands/pr.md
+++ b/claude-config/commands/pr.md
@@ -159,6 +159,18 @@ for f in .agents/outputs/*-${ISSUE}-*.md; do
   [ -f "$f" ] && mv "$f" "$ARCHIVE_DIR/"
 done
 
+# If this issue used a worktree (--parallel mode), clean it up
+python3 -c "
+import sys
+sys.path.insert(0, '$HOME/.claude/hooks')
+from worktree_manager import remove_worktree
+result = remove_worktree(${ISSUE})
+if result:
+    print('Worktree cleaned up: .worktrees/issue-${ISSUE}/')
+else:
+    print('No worktree found for issue ${ISSUE} (not using --parallel)')
+"
+
 # Verify main is green
 cd backend && pytest -q
 cd frontend && npm run build

--- a/claude-config/hooks/state_manager.py
+++ b/claude-config/hooks/state_manager.py
@@ -56,8 +56,13 @@ def _write_state(project_dir: Path, data: dict) -> None:
         yaml.safe_dump(data, f, default_flow_style=False, sort_keys=False)
 
 
-def update_phase(project_dir: Path, issue: int, branch: str, phase: str, action: str) -> None:
-    """Update active_work with current phase. Tracks completed phases for --resume."""
+def update_phase(project_dir: Path, issue: int, branch: str, phase: str, action: str,
+                  worktree_path: str | None = None) -> None:
+    """Update active_work with current phase. Tracks completed phases for --resume.
+
+    Args:
+        worktree_path: Absolute path to worktree (--parallel mode only). None for normal mode.
+    """
     data = load_state(project_dir)
     active = data.get("active_work", {})
 
@@ -67,12 +72,17 @@ def update_phase(project_dir: Path, issue: int, branch: str, phase: str, action:
     if prev_phase and prev_phase != phase and prev_phase not in completed:
         completed.append(prev_phase)
 
+    # Preserve existing worktree_path if not explicitly provided
+    if worktree_path is None:
+        worktree_path = active.get("worktree_path")
+
     data["active_work"] = {
         "issue": issue,
         "branch": branch,
         "phase": phase,
         "last_action": action,
         "completed_phases": completed,
+        "worktree_path": worktree_path,
     }
 
     if "meta" not in data:
@@ -91,6 +101,7 @@ def clear_active(project_dir: Path, issue: int) -> None:
         "phase": None,
         "last_action": f"Completed issue #{issue}",
         "completed_phases": [],
+        "worktree_path": None,
     }
 
     if "meta" not in data:
@@ -107,6 +118,15 @@ def get_completed_phases(project_dir: Path, issue: int) -> list[str]:
     if active.get("issue") != issue:
         return []
     return active.get("completed_phases", [])
+
+
+def get_worktree_for_issue(project_dir: Path, issue: int) -> str | None:
+    """Get worktree path for an issue from persisted state. Used by --resume."""
+    data = load_state(project_dir)
+    active = data.get("active_work", {})
+    if active.get("issue") != issue:
+        return None
+    return active.get("worktree_path")
 
 
 def get_active_work(project_dir: Path) -> dict:

--- a/claude-config/hooks/worktree_manager.py
+++ b/claude-config/hooks/worktree_manager.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""
+Worktree manager for parallel orchestrate sessions.
+
+Creates and manages git worktrees at .worktrees/issue-{N}/ to enable
+concurrent orchestrate workflows on independent issues.
+
+Used by: orchestrate command (--parallel), pr command (post-merge cleanup).
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import subprocess
+from pathlib import Path
+
+_log_file = Path.home() / ".claude" / "hooks.log"
+logging.basicConfig(
+    filename=str(_log_file),
+    level=logging.WARNING,
+    format="%(asctime)s [worktree_manager] %(levelname)s: %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+
+
+class WorktreeExistsError(Exception):
+    """Raised when a worktree already exists for the given issue."""
+
+    def __init__(self, issue: int, path: Path):
+        self.issue = issue
+        self.path = path
+        super().__init__(f"Worktree already exists for issue #{issue} at {path}")
+
+
+def get_repo_root() -> Path:
+    """Return the main repository root via git rev-parse --show-toplevel.
+
+    Works correctly even when CWD is inside a worktree — always returns
+    the main repo root (not the worktree path).
+    """
+    result = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        capture_output=True, text=True, check=True,
+    )
+    return Path(result.stdout.strip())
+
+
+def _worktree_dir(repo_root: Path) -> Path:
+    """Return the .worktrees/ directory path."""
+    return repo_root / ".worktrees"
+
+
+def _issue_path(repo_root: Path, issue: int) -> Path:
+    """Return the worktree path for a given issue."""
+    return _worktree_dir(repo_root) / f"issue-{issue}"
+
+
+def create_worktree(issue: int, branch_slug: str) -> Path:
+    """Create an isolated worktree at .worktrees/issue-{N}/.
+
+    Args:
+        issue: GitHub issue number.
+        branch_slug: Branch name (e.g., 'feature/issue-42-description').
+
+    Returns:
+        Absolute path to the created worktree.
+
+    Raises:
+        WorktreeExistsError: If a worktree already exists for this issue.
+        subprocess.CalledProcessError: If git worktree add fails.
+    """
+    repo_root = get_repo_root()
+    wt_path = _issue_path(repo_root, issue)
+
+    # Check if worktree already exists
+    existing = get_worktree_path(issue)
+    if existing is not None:
+        raise WorktreeExistsError(issue, existing)
+
+    # Ensure .worktrees/ directory exists
+    _worktree_dir(repo_root).mkdir(parents=True, exist_ok=True)
+
+    # Fetch latest main and create worktree with new branch
+    subprocess.run(
+        ["git", "fetch", "origin", "main"],
+        capture_output=True, text=True, check=True,
+        cwd=str(repo_root),
+    )
+    subprocess.run(
+        ["git", "worktree", "add", str(wt_path), "-b", branch_slug, "origin/main"],
+        capture_output=True, text=True, check=True,
+        cwd=str(repo_root),
+    )
+
+    return wt_path.resolve()
+
+
+def list_worktrees() -> list[dict]:
+    """List active worktrees with metadata.
+
+    Returns:
+        List of dicts: {path, branch, issue (int|None)}.
+        Filters out the main worktree.
+    """
+    repo_root = get_repo_root()
+    result = subprocess.run(
+        ["git", "worktree", "list", "--porcelain"],
+        capture_output=True, text=True, check=True,
+        cwd=str(repo_root),
+    )
+
+    worktrees = []
+    current: dict = {}
+    for line in result.stdout.splitlines():
+        if line.startswith("worktree "):
+            current = {"path": line[len("worktree "):]}
+        elif line.startswith("branch "):
+            current["branch"] = line[len("branch refs/heads/"):]
+        elif line == "":
+            if current and current.get("path") != str(repo_root):
+                # Extract issue number from path (e.g., .worktrees/issue-42)
+                match = re.search(r"issue-(\d+)$", current.get("path", ""))
+                current["issue"] = int(match.group(1)) if match else None
+                worktrees.append(current)
+            current = {}
+
+    # Handle last entry if no trailing blank line
+    if current and current.get("path") != str(repo_root):
+        match = re.search(r"issue-(\d+)$", current.get("path", ""))
+        current["issue"] = int(match.group(1)) if match else None
+        worktrees.append(current)
+
+    return worktrees
+
+
+def get_worktree_path(issue: int) -> Path | None:
+    """Return the worktree path for a given issue, or None if not found.
+
+    Used by --resume to locate an existing worktree.
+    """
+    for wt in list_worktrees():
+        if wt.get("issue") == issue:
+            return Path(wt["path"])
+    return None
+
+
+def check_file_conflicts(planned_files: list[str]) -> list[dict]:
+    """Check if active worktrees have uncommitted changes in planned files.
+
+    Args:
+        planned_files: List of file paths the current issue plans to modify.
+
+    Returns:
+        List of {worktree, file, issue} conflict dicts.
+    """
+    conflicts = []
+    for wt in list_worktrees():
+        wt_path = wt["path"]
+        try:
+            # Get both staged and unstaged changes
+            unstaged = subprocess.run(
+                ["git", "-C", wt_path, "diff", "--name-only"],
+                capture_output=True, text=True, check=True,
+            )
+            staged = subprocess.run(
+                ["git", "-C", wt_path, "diff", "--cached", "--name-only"],
+                capture_output=True, text=True, check=True,
+            )
+            changed = set(unstaged.stdout.splitlines() + staged.stdout.splitlines())
+
+            for pf in planned_files:
+                if pf in changed:
+                    conflicts.append({
+                        "worktree": wt_path,
+                        "file": pf,
+                        "issue": wt.get("issue"),
+                    })
+        except subprocess.CalledProcessError:
+            logging.warning(f"Failed to check worktree at {wt_path}")
+
+    return conflicts
+
+
+def remove_worktree(issue: int) -> bool:
+    """Clean up a worktree after PR merge.
+
+    Args:
+        issue: GitHub issue number.
+
+    Returns:
+        True if worktree was found and removed, False if not found.
+    """
+    repo_root = get_repo_root()
+    wt_path = get_worktree_path(issue)
+    if wt_path is None:
+        return False
+
+    try:
+        subprocess.run(
+            ["git", "worktree", "remove", str(wt_path), "--force"],
+            capture_output=True, text=True, check=True,
+            cwd=str(repo_root),
+        )
+        subprocess.run(
+            ["git", "worktree", "prune"],
+            capture_output=True, text=True, check=True,
+            cwd=str(repo_root),
+        )
+        return True
+    except subprocess.CalledProcessError as e:
+        logging.warning(f"Failed to remove worktree for issue #{issue}: {e}")
+        return False

--- a/claude-config/skills/orchestrate/SKILL.md
+++ b/claude-config/skills/orchestrate/SKILL.md
@@ -55,6 +55,23 @@ Issue → Classify → Branch → Agents → Verify → Record → PR
 - Parallel fullstack PATCH: backend+frontend via CONTRACT
 - PROVE verification fan-out: lint/test/build (fullstack)
 
+## Worktree Isolation (`--parallel`)
+
+Run multiple orchestrate sessions simultaneously:
+
+```bash
+/orchestrate 42 --parallel    # Session 1: worktree at .worktrees/issue-42/
+/orchestrate 57 --parallel    # Session 2: worktree at .worktrees/issue-57/
+```
+
+Each session gets its own:
+- Working directory (`.worktrees/issue-{N}/`)
+- Git index (no staging conflicts)
+- Artifacts (`.agents/outputs/` inside worktree)
+- Feature branch
+
+Post-merge cleanup: `/pr --merge` removes the worktree automatically.
+
 ## Learning Loop
 
 After each issue:
@@ -75,6 +92,8 @@ After each issue:
 ```bash
 /orchestrate 184
 /orchestrate 184 --with-tests    # Include TEST-PLANNER phase
+/orchestrate 184 --parallel      # Run in isolated worktree
+/orchestrate 184 --parallel --resume  # Resume in existing worktree
 ```
 
 See `.claude/commands/orchestrate.md` for full details.


### PR DESCRIPTION
## Summary
- New `worktree_manager.py` module for git worktree lifecycle management
- `--parallel` flag creates isolated worktree per issue, runs full pipeline inside it
- State manager tracks worktree path, auto-detects on `--resume`
- Step 1.7 upgraded to scan active worktrees AND open PRs for file conflicts
- Post-merge cleanup removes worktree via `git worktree remove`

Closes #8

## Files Changed
- **New**: `hooks/worktree_manager.py` (163 lines) — create, list, cleanup, conflict-check
- `hooks/state_manager.py` — worktree_path tracking, get_worktree_for_issue()
- `commands/orchestrate.md` — --parallel flag, Parallel Worktree Mode section
- `commands/pr.md` — worktree cleanup in post-merge
- `skills/orchestrate/SKILL.md` — --parallel documentation
- `.gitignore` — exclude .worktrees/

## Test Plan
- [x] Level 1-4 verification passed (PROVE)
- [x] Python imports succeed for worktree_manager and state_manager
- [x] PLAN-CHECK issues addressed (repo root state, --resume auto-detect, .gitignore)
- [ ] End-to-end: run `/orchestrate N --parallel` on a real issue (manual test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)