### PR TITLE
feat(obsidian-agent): real-time updates + cross-project rollups

### DIFF
--- a/obsidian-agent/docs/workflow-vision.html
+++ b/obsidian-agent/docs/workflow-vision.html
@@ -1,0 +1,754 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Obsidian Agent — Workflow Vision</title>
+<script src="https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js"></script>
+<style>
+  :root {
+    --bg: #0f1117;
+    --surface: #1a1d27;
+    --border: #2a2d3a;
+    --text: #e2e4e9;
+    --muted: #8b8fa3;
+    --accent-blue: #5b9cf6;
+    --accent-green: #4ade80;
+    --accent-amber: #fbbf24;
+    --accent-purple: #a78bfa;
+    --accent-red: #f87171;
+    --claude-bg: #d4a574;
+    --python-bg: #5b9cf6;
+    --user-bg: #4ade80;
+    --obsidian-bg: #a78bfa;
+  }
+
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+
+  body {
+    font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    background: var(--bg);
+    color: var(--text);
+    line-height: 1.6;
+    padding: 2rem;
+  }
+
+  .header {
+    text-align: center;
+    margin-bottom: 3rem;
+    padding-bottom: 2rem;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .header h1 {
+    font-size: 2.2rem;
+    font-weight: 700;
+    margin-bottom: 0.5rem;
+    background: linear-gradient(135deg, var(--accent-blue), var(--accent-purple));
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+  }
+
+  .header p {
+    color: var(--muted);
+    font-size: 1.1rem;
+  }
+
+  .legend {
+    display: flex;
+    justify-content: center;
+    gap: 2rem;
+    margin-bottom: 3rem;
+    flex-wrap: wrap;
+  }
+
+  .legend-item {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.9rem;
+  }
+
+  .legend-dot {
+    width: 14px;
+    height: 14px;
+    border-radius: 4px;
+  }
+
+  .dot-claude { background: var(--claude-bg); }
+  .dot-python { background: var(--python-bg); }
+  .dot-user { background: var(--user-bg); }
+  .dot-obsidian { background: var(--obsidian-bg); }
+  .dot-cron { background: var(--accent-amber); }
+
+  .workflow-section {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 16px;
+    padding: 2rem;
+    margin-bottom: 2.5rem;
+    overflow-x: auto;
+  }
+
+  .workflow-section h2 {
+    font-size: 1.5rem;
+    margin-bottom: 0.3rem;
+  }
+
+  .workflow-section .subtitle {
+    color: var(--muted);
+    font-size: 0.95rem;
+    margin-bottom: 1.5rem;
+  }
+
+  .badge {
+    display: inline-block;
+    padding: 2px 10px;
+    border-radius: 12px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    margin-left: 0.5rem;
+    vertical-align: middle;
+  }
+
+  .badge-auto { background: rgba(91,156,246,0.2); color: var(--accent-blue); }
+  .badge-manual { background: rgba(74,222,128,0.2); color: var(--accent-green); }
+  .badge-scheduled { background: rgba(251,191,36,0.2); color: var(--accent-amber); }
+
+  .mermaid {
+    display: flex;
+    justify-content: center;
+    margin: 1rem 0;
+  }
+
+  .mermaid svg {
+    max-width: 100%;
+  }
+
+  .timing-bar {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 1rem 1.5rem;
+    background: rgba(91,156,246,0.06);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    margin-top: 1.5rem;
+    font-size: 0.9rem;
+  }
+
+  .timing-bar .clock {
+    font-size: 1.3rem;
+    flex-shrink: 0;
+  }
+
+  .timing-bar strong {
+    color: var(--accent-amber);
+  }
+
+  .summary-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1.5rem;
+    margin-top: 2rem;
+  }
+
+  .summary-card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 1.5rem;
+    text-align: center;
+  }
+
+  .summary-card h3 {
+    font-size: 1rem;
+    margin-bottom: 0.5rem;
+  }
+
+  .summary-card .effort {
+    font-size: 2rem;
+    font-weight: 700;
+  }
+
+  .summary-card .effort-label {
+    color: var(--muted);
+    font-size: 0.85rem;
+  }
+
+  .effort-user { color: var(--accent-green); }
+  .effort-auto { color: var(--accent-blue); }
+
+  .outputs-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-top: 1rem;
+  }
+
+  .output-tag {
+    padding: 4px 12px;
+    border-radius: 8px;
+    font-size: 0.8rem;
+    font-weight: 500;
+  }
+
+  .output-auto {
+    background: rgba(91,156,246,0.15);
+    color: var(--accent-blue);
+    border: 1px solid rgba(91,156,246,0.3);
+  }
+
+  .output-manual {
+    background: rgba(74,222,128,0.15);
+    color: var(--accent-green);
+    border: 1px solid rgba(74,222,128,0.3);
+  }
+
+  .section-divider {
+    text-align: center;
+    margin: 3rem 0;
+    color: var(--muted);
+    font-size: 0.85rem;
+    position: relative;
+  }
+
+  .section-divider::before,
+  .section-divider::after {
+    content: '';
+    position: absolute;
+    top: 50%;
+    width: calc(50% - 80px);
+    height: 1px;
+    background: var(--border);
+  }
+
+  .section-divider::before { left: 0; }
+  .section-divider::after { right: 0; }
+
+  .data-flow {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    margin: 2rem 0;
+    flex-wrap: wrap;
+  }
+
+  .flow-node {
+    padding: 8px 16px;
+    border-radius: 8px;
+    font-size: 0.85rem;
+    font-weight: 600;
+  }
+
+  .flow-arrow {
+    color: var(--muted);
+    font-size: 1.2rem;
+  }
+
+  .fn-session { background: rgba(212,165,116,0.2); color: var(--claude-bg); border: 1px solid rgba(212,165,116,0.4); }
+  .fn-daily { background: rgba(91,156,246,0.15); color: var(--accent-blue); border: 1px solid rgba(91,156,246,0.3); }
+  .fn-weekly { background: rgba(167,139,250,0.15); color: var(--accent-purple); border: 1px solid rgba(167,139,250,0.3); }
+  .fn-monthly { background: rgba(251,191,36,0.15); color: var(--accent-amber); border: 1px solid rgba(251,191,36,0.3); }
+</style>
+</head>
+<body>
+
+<div class="header">
+  <h1>Obsidian Agent Workflow Vision</h1>
+  <p>Phases 1 & 2 — Automated multi-project tracking for work & personal vaults</p>
+</div>
+
+<div class="legend">
+  <div class="legend-item"><div class="legend-dot dot-claude"></div> Claude Code (generates session data)</div>
+  <div class="legend-item"><div class="legend-dot dot-python"></div> Python / obsidian-agent (automated)</div>
+  <div class="legend-item"><div class="legend-dot" style="background: var(--accent-amber)"></div> Cron (scheduled trigger)</div>
+  <div class="legend-item"><div class="legend-dot dot-obsidian"></div> Obsidian Vault (output)</div>
+  <div class="legend-item"><div class="legend-dot dot-user"></div> You (manual review)</div>
+</div>
+
+<!-- DATA FLOW OVERVIEW -->
+<div class="data-flow">
+  <div class="flow-node fn-session">Session Logs</div>
+  <div class="flow-arrow">&rarr;</div>
+  <div class="flow-node fn-daily">Daily Entries</div>
+  <div class="flow-arrow">&rarr;</div>
+  <div class="flow-node fn-weekly">Weekly Rollups</div>
+  <div class="flow-arrow">&rarr;</div>
+  <div class="flow-node fn-monthly">Monthly Summaries</div>
+</div>
+
+<!-- SESSION WORKFLOW -->
+<div class="workflow-section">
+  <h2>Session Workflow <span class="badge badge-auto">Automatic</span></h2>
+  <p class="subtitle">Triggered every time you finish a Claude Code session — captures what happened</p>
+
+  <div class="mermaid">
+%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#2a2d3a', 'primaryTextColor': '#e2e4e9', 'primaryBorderColor': '#5b9cf6', 'lineColor': '#5b9cf6', 'secondaryColor': '#1a1d27', 'tertiaryColor': '#1a1d27', 'edgeLabelBackground': '#1a1d27', 'clusterBkg': '#1a1d27', 'clusterBorder': '#2a2d3a' }}}%%
+flowchart LR
+    A["<b>You</b><br/>Work in Claude Code<br/>on any project"]
+    B["<b>Claude Code</b><br/>Writes session log<br/>.jsonl to ~/.claude/"]
+    C["<b>obsidian-agent</b><br/>Parses session log<br/>+ extracts state via Claude Haiku"]
+    D["<b>Git Helper</b><br/>Extracts today's commits<br/>(deterministic, no LLM)"]
+    E["<b>Vault Writer</b><br/>Writes to Obsidian vault"]
+    F["STATUS.md<br/><i>overwritten</i>"]
+    G["Daily Log<br/><i>appended</i>"]
+    H["DASHBOARD.md<br/><i>rebuilt</i>"]
+
+    A --> B
+    B --> C
+    C --> D
+    D --> E
+    E --> F
+    E --> G
+    E --> H
+
+    style A fill:#1a3a1a,stroke:#4ade80,color:#e2e4e9
+    style B fill:#3a2a1a,stroke:#d4a574,color:#e2e4e9
+    style C fill:#1a2a3a,stroke:#5b9cf6,color:#e2e4e9
+    style D fill:#1a2a3a,stroke:#5b9cf6,color:#e2e4e9
+    style E fill:#1a2a3a,stroke:#5b9cf6,color:#e2e4e9
+    style F fill:#2a1a3a,stroke:#a78bfa,color:#e2e4e9
+    style G fill:#2a1a3a,stroke:#a78bfa,color:#e2e4e9
+    style H fill:#2a1a3a,stroke:#a78bfa,color:#e2e4e9
+  </div>
+
+  <div class="timing-bar">
+    <span class="clock">&#9201;</span>
+    <span><strong>Trigger:</strong> Nightly cron at 11:00 PM &mdash; runs <code>--all-projects</code> to catch every session from the day. Your effort: <strong>zero</strong>.</span>
+  </div>
+</div>
+
+<!-- DAILY WORKFLOW -->
+<div class="workflow-section">
+  <h2>Daily Workflow <span class="badge badge-scheduled">Scheduled + 2 min review</span></h2>
+  <p class="subtitle">Consolidates all sessions into one daily view per project + cross-project rollup</p>
+
+  <div class="mermaid">
+%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#2a2d3a', 'primaryTextColor': '#e2e4e9', 'primaryBorderColor': '#5b9cf6', 'lineColor': '#5b9cf6', 'secondaryColor': '#1a1d27', 'tertiaryColor': '#1a1d27', 'edgeLabelBackground': '#1a1d27', 'clusterBkg': '#1a1d27', 'clusterBorder': '#2a2d3a' }}}%%
+flowchart TD
+    subgraph CRON ["Cron — 11:00 PM nightly"]
+        direction TB
+        A1["<b>obsidian-agent --all-projects</b><br/>Process every active project"]
+        A2["For each project:<br/>Parse latest session<br/>Extract state via Haiku<br/>Inject git commits"]
+        A3["Write per-project files:<br/>STATUS.md + Daily Log entry"]
+        A4["<b>obsidian-agent --daily-rollup</b><br/>Aggregate all project dailies<br/>into cross-project daily"]
+        A5["Rebuild DASHBOARD.md<br/>from all STATUS.md files"]
+
+        A1 --> A2 --> A3 --> A4 --> A5
+    end
+
+    subgraph VAULT ["Obsidian Vault Output"]
+        direction TB
+        V1["Projects/DocketIQ/STATUS.md"]
+        V2["Projects/Temper/STATUS.md"]
+        V3["Projects/DocketIQ/Log/Daily/2026-03-30.md"]
+        V4["Projects/Temper/Log/Daily/2026-03-30.md"]
+        V5["<b>Rollups/Daily/2026-03-30.md</b><br/><i>NEW — cross-project daily</i>"]
+        V6["DASHBOARD.md"]
+    end
+
+    subgraph YOU ["You — Next Morning (2 min)"]
+        direction TB
+        U1["Open Obsidian"]
+        U2["Scan DASHBOARD.md<br/><i>All projects at a glance</i>"]
+        U3["Check today's daily rollup<br/><i>What happened yesterday</i>"]
+        U4["Drill into any project<br/>STATUS.md if needed"]
+    end
+
+    A3 --> V1
+    A3 --> V2
+    A3 --> V3
+    A3 --> V4
+    A4 --> V5
+    A5 --> V6
+    V6 --> U1
+    U1 --> U2 --> U3 --> U4
+
+    style A1 fill:#2a2a1a,stroke:#fbbf24,color:#e2e4e9
+    style A2 fill:#1a2a3a,stroke:#5b9cf6,color:#e2e4e9
+    style A3 fill:#1a2a3a,stroke:#5b9cf6,color:#e2e4e9
+    style A4 fill:#1a2a3a,stroke:#5b9cf6,color:#e2e4e9
+    style A5 fill:#1a2a3a,stroke:#5b9cf6,color:#e2e4e9
+    style V1 fill:#2a1a3a,stroke:#a78bfa,color:#e2e4e9
+    style V2 fill:#2a1a3a,stroke:#a78bfa,color:#e2e4e9
+    style V3 fill:#2a1a3a,stroke:#a78bfa,color:#e2e4e9
+    style V4 fill:#2a1a3a,stroke:#a78bfa,color:#e2e4e9
+    style V5 fill:#2a1a3a,stroke:#a78bfa,color:#e2e4e9
+    style V6 fill:#2a1a3a,stroke:#a78bfa,color:#e2e4e9
+    style U1 fill:#1a3a1a,stroke:#4ade80,color:#e2e4e9
+    style U2 fill:#1a3a1a,stroke:#4ade80,color:#e2e4e9
+    style U3 fill:#1a3a1a,stroke:#4ade80,color:#e2e4e9
+    style U4 fill:#1a3a1a,stroke:#4ade80,color:#e2e4e9
+  </div>
+
+  <div class="timing-bar">
+    <span class="clock">&#9201;</span>
+    <span><strong>Your effort:</strong> ~2 min morning scan. Everything else is automated.</span>
+  </div>
+</div>
+
+<!-- WEEKLY WORKFLOW -->
+<div class="workflow-section">
+  <h2>Weekly Workflow <span class="badge badge-scheduled">Scheduled + 5 min review</span></h2>
+  <p class="subtitle">Sunday night auto-generates rollups from daily logs — you review Monday morning</p>
+
+  <div class="mermaid">
+%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#2a2d3a', 'primaryTextColor': '#e2e4e9', 'primaryBorderColor': '#5b9cf6', 'lineColor': '#5b9cf6', 'secondaryColor': '#1a1d27', 'tertiaryColor': '#1a1d27', 'edgeLabelBackground': '#1a1d27', 'clusterBkg': '#1a1d27', 'clusterBorder': '#2a2d3a' }}}%%
+flowchart TD
+    subgraph CRON ["Cron — Sunday 11:30 PM"]
+        direction TB
+        W1["<b>obsidian-agent --weekly</b><br/>For each project with daily logs this week"]
+        W2["Aggregate daily logs<br/>Mon-Sun into per-project weekly"]
+        W3["Deduplicate completed items,<br/>decisions, blockers, refs"]
+        W4["<b>obsidian-agent --weekly-rollup</b><br/>Generate cross-project weekly"]
+
+        W1 --> W2 --> W3 --> W4
+    end
+
+    subgraph OUTPUT ["Vault Output"]
+        direction TB
+        O1["Projects/DocketIQ/Log/Weekly/2026-W13.md"]
+        O2["Projects/Temper/Log/Weekly/2026-W13.md"]
+        O3["<b>Rollups/Weekly/2026-W13.md</b><br/><i>Cross-project weekly</i>"]
+    end
+
+    subgraph REVIEW ["You — Monday Morning (5 min)"]
+        direction TB
+        R1["Open cross-project weekly<br/><i>Rollups/Weekly/2026-W13.md</i>"]
+        R2["Review: highlights,<br/>carried blockers, decisions"]
+        R3["Adjust priorities for<br/>the coming week"]
+        R4["Optional: share weekly<br/>with stakeholders"]
+    end
+
+    W3 --> O1
+    W3 --> O2
+    W4 --> O3
+    O3 --> R1
+    R1 --> R2 --> R3 --> R4
+
+    style W1 fill:#2a2a1a,stroke:#fbbf24,color:#e2e4e9
+    style W2 fill:#1a2a3a,stroke:#5b9cf6,color:#e2e4e9
+    style W3 fill:#1a2a3a,stroke:#5b9cf6,color:#e2e4e9
+    style W4 fill:#1a2a3a,stroke:#5b9cf6,color:#e2e4e9
+    style O1 fill:#2a1a3a,stroke:#a78bfa,color:#e2e4e9
+    style O2 fill:#2a1a3a,stroke:#a78bfa,color:#e2e4e9
+    style O3 fill:#2a1a3a,stroke:#a78bfa,color:#e2e4e9
+    style R1 fill:#1a3a1a,stroke:#4ade80,color:#e2e4e9
+    style R2 fill:#1a3a1a,stroke:#4ade80,color:#e2e4e9
+    style R3 fill:#1a3a1a,stroke:#4ade80,color:#e2e4e9
+    style R4 fill:#1a3a1a,stroke:#4ade80,color:#e2e4e9
+  </div>
+
+  <div class="timing-bar">
+    <span class="clock">&#9201;</span>
+    <span><strong>Your effort:</strong> ~5 min Monday review. Optionally forward to stakeholders. Generation is fully automated.</span>
+  </div>
+</div>
+
+<!-- MONTHLY WORKFLOW -->
+<div class="workflow-section">
+  <h2>Monthly Workflow <span class="badge badge-scheduled">Scheduled + 10 min review</span></h2>
+  <p class="subtitle">Last day of month — portfolio health check with milestones, risks, and metrics</p>
+
+  <div class="mermaid">
+%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#2a2d3a', 'primaryTextColor': '#e2e4e9', 'primaryBorderColor': '#5b9cf6', 'lineColor': '#5b9cf6', 'secondaryColor': '#1a1d27', 'tertiaryColor': '#1a1d27', 'edgeLabelBackground': '#1a1d27', 'clusterBkg': '#1a1d27', 'clusterBorder': '#2a2d3a' }}}%%
+flowchart TD
+    subgraph CRON ["Cron — Last day of month, 11:30 PM"]
+        direction TB
+        M1["<b>obsidian-agent --monthly</b><br/>Aggregate all weekly rollups for the month"]
+        M2["Per-project monthly:<br/>Milestones hit, decisions,<br/>blockers resolved/carried"]
+        M3["<b>Cross-project monthly</b><br/>Portfolio status table<br/>+ risk matrix + metrics"]
+    end
+
+    subgraph OUTPUT ["Vault Output"]
+        direction TB
+        P1["Projects/DocketIQ/Log/Monthly/2026-03.md"]
+        P2["Projects/Temper/Log/Monthly/2026-03.md"]
+        P3["<b>Rollups/Monthly/2026-03.md</b><br/><i>Portfolio summary</i>"]
+    end
+
+    subgraph REVIEW ["You — 1st of Month (10 min)"]
+        direction TB
+        Q1["Open monthly portfolio<br/><i>Rollups/Monthly/2026-03.md</i>"]
+        Q2["Review project health<br/>on-track / at-risk / blocked"]
+        Q3["Check milestones:<br/>hit vs missed vs upcoming"]
+        Q4["Identify risks &<br/>adjust roadmap"]
+        Q5["Optional: use for<br/>client/stakeholder reporting"]
+    end
+
+    M1 --> M2 --> M3
+    M2 --> P1
+    M2 --> P2
+    M3 --> P3
+    P3 --> Q1
+    Q1 --> Q2 --> Q3 --> Q4 --> Q5
+
+    style M1 fill:#2a2a1a,stroke:#fbbf24,color:#e2e4e9
+    style M2 fill:#1a2a3a,stroke:#5b9cf6,color:#e2e4e9
+    style M3 fill:#1a2a3a,stroke:#5b9cf6,color:#e2e4e9
+    style P1 fill:#2a1a3a,stroke:#a78bfa,color:#e2e4e9
+    style P2 fill:#2a1a3a,stroke:#a78bfa,color:#e2e4e9
+    style P3 fill:#2a1a3a,stroke:#a78bfa,color:#e2e4e9
+    style Q1 fill:#1a3a1a,stroke:#4ade80,color:#e2e4e9
+    style Q2 fill:#1a3a1a,stroke:#4ade80,color:#e2e4e9
+    style Q3 fill:#1a3a1a,stroke:#4ade80,color:#e2e4e9
+    style Q4 fill:#1a3a1a,stroke:#4ade80,color:#e2e4e9
+    style Q5 fill:#1a3a1a,stroke:#4ade80,color:#e2e4e9
+  </div>
+
+  <div class="timing-bar">
+    <span class="clock">&#9201;</span>
+    <span><strong>Your effort:</strong> ~10 min on the 1st. This is your strategic review — are projects on track? Any course corrections?</span>
+  </div>
+</div>
+
+<div class="section-divider">YOUR TIME INVESTMENT</div>
+
+<!-- EFFORT SUMMARY -->
+<div class="summary-grid">
+  <div class="summary-card">
+    <h3>Session Capture</h3>
+    <div class="effort effort-auto">0 min</div>
+    <div class="effort-label">Fully automated via cron</div>
+  </div>
+  <div class="summary-card">
+    <h3>Daily Review</h3>
+    <div class="effort effort-user">2 min</div>
+    <div class="effort-label">Morning dashboard scan</div>
+  </div>
+  <div class="summary-card">
+    <h3>Weekly Review</h3>
+    <div class="effort effort-user">5 min</div>
+    <div class="effort-label">Monday rollup check</div>
+  </div>
+  <div class="summary-card">
+    <h3>Monthly Review</h3>
+    <div class="effort effort-user">10 min</div>
+    <div class="effort-label">Portfolio health check</div>
+  </div>
+  <div class="summary-card" style="border-color: var(--accent-green);">
+    <h3>Total Weekly</h3>
+    <div class="effort effort-user">~20 min</div>
+    <div class="effort-label">5 daily + weekly review</div>
+  </div>
+</div>
+
+<!-- FULL SYSTEM OVERVIEW -->
+<div class="workflow-section" style="margin-top: 3rem;">
+  <h2>Full System Overview</h2>
+  <p class="subtitle">How all the pieces connect — from coding session to monthly portfolio report</p>
+
+  <div class="mermaid">
+%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#2a2d3a', 'primaryTextColor': '#e2e4e9', 'primaryBorderColor': '#5b9cf6', 'lineColor': '#5b9cf6', 'secondaryColor': '#1a1d27', 'tertiaryColor': '#1a1d27', 'edgeLabelBackground': '#1a1d27', 'clusterBkg': 'transparent', 'clusterBorder': '#2a2d3a' }}}%%
+flowchart TB
+    subgraph INPUT ["Data Sources"]
+        direction TB
+        S1["Claude Code<br/>Session Logs (.jsonl)"]
+        S2["Git Commits<br/>(deterministic)"]
+        S3["GitHub Issues/PRs<br/><i>Phase 2: obsidian-github-tasks</i>"]
+    end
+
+    subgraph ENGINE ["obsidian-agent (Python)"]
+        direction TB
+        E1["Session Parser"]
+        E2["Claude Haiku Extractor<br/><i>status, phase, completed,<br/>decisions, blockers, next steps</i>"]
+        E3["Git Helper"]
+        E4["Daily Consolidator<br/><i>NEW: merge same-day sessions</i>"]
+        E5["Rollup Aggregator<br/><i>NEW: cross-project rollups</i>"]
+        E6["Vault Writer"]
+
+        E1 --> E2
+        E3 --> E4
+        E2 --> E4
+        E4 --> E5
+        E5 --> E6
+    end
+
+    subgraph VAULT ["Obsidian Vault"]
+        direction TB
+        V1["<b>DASHBOARD.md</b><br/>Portfolio overview"]
+        V2["Per-Project STATUS.md<br/><i>Current state</i>"]
+        V3["Per-Project Daily Logs<br/><i>Append-only history</i>"]
+        V4["Cross-Project Daily<br/><i>Rollups/Daily/</i>"]
+        V5["Cross-Project Weekly<br/><i>Rollups/Weekly/</i>"]
+        V6["Cross-Project Monthly<br/><i>Rollups/Monthly/</i>"]
+    end
+
+    subgraph OBSIDIAN ["Obsidian App (Phase 2)"]
+        direction TB
+        O1["Dataview Queries<br/><i>Live portfolio dashboard</i>"]
+        O2["Periodic Notes<br/><i>Auto-create daily/weekly</i>"]
+        O3["Templater<br/><i>Dynamic templates</i>"]
+        O4["GitHub Tasks Plugin<br/><i>Issue/PR sync</i>"]
+    end
+
+    subgraph SCHEDULE ["Cron Schedule"]
+        direction LR
+        C1["11:00 PM Daily<br/>--all-projects"]
+        C2["Sun 11:30 PM<br/>--weekly"]
+        C3["Last of Month<br/>--monthly"]
+    end
+
+    S1 --> E1
+    S2 --> E3
+    S3 -.-> O4
+
+    E6 --> V1
+    E6 --> V2
+    E6 --> V3
+    E6 --> V4
+    E6 --> V5
+    E6 --> V6
+
+    C1 -.-> ENGINE
+    C2 -.-> ENGINE
+    C3 -.-> ENGINE
+
+    V1 --> O1
+    V2 --> O1
+    V3 --> O2
+
+    style S1 fill:#3a2a1a,stroke:#d4a574,color:#e2e4e9
+    style S2 fill:#3a2a1a,stroke:#d4a574,color:#e2e4e9
+    style S3 fill:#3a2a1a,stroke:#d4a574,color:#e2e4e9
+    style E1 fill:#1a2a3a,stroke:#5b9cf6,color:#e2e4e9
+    style E2 fill:#1a2a3a,stroke:#5b9cf6,color:#e2e4e9
+    style E3 fill:#1a2a3a,stroke:#5b9cf6,color:#e2e4e9
+    style E4 fill:#1a2a3a,stroke:#5b9cf6,color:#e2e4e9
+    style E5 fill:#1a2a3a,stroke:#5b9cf6,color:#e2e4e9
+    style E6 fill:#1a2a3a,stroke:#5b9cf6,color:#e2e4e9
+    style V1 fill:#2a1a3a,stroke:#a78bfa,color:#e2e4e9
+    style V2 fill:#2a1a3a,stroke:#a78bfa,color:#e2e4e9
+    style V3 fill:#2a1a3a,stroke:#a78bfa,color:#e2e4e9
+    style V4 fill:#2a1a3a,stroke:#a78bfa,color:#e2e4e9
+    style V5 fill:#2a1a3a,stroke:#a78bfa,color:#e2e4e9
+    style V6 fill:#2a1a3a,stroke:#a78bfa,color:#e2e4e9
+    style O1 fill:#2a1a3a,stroke:#a78bfa,color:#e2e4e9
+    style O2 fill:#2a1a3a,stroke:#a78bfa,color:#e2e4e9
+    style O3 fill:#2a1a3a,stroke:#a78bfa,color:#e2e4e9
+    style O4 fill:#2a1a3a,stroke:#a78bfa,color:#e2e4e9
+    style C1 fill:#2a2a1a,stroke:#fbbf24,color:#e2e4e9
+    style C2 fill:#2a2a1a,stroke:#fbbf24,color:#e2e4e9
+    style C3 fill:#2a2a1a,stroke:#fbbf24,color:#e2e4e9
+  </div>
+</div>
+
+<!-- WHAT'S NEW SECTION -->
+<div class="workflow-section">
+  <h2>What Changes from Today</h2>
+  <p class="subtitle">Green = already working &nbsp;|&nbsp; Blue = new in Phase 1 &nbsp;|&nbsp; Purple = new in Phase 2</p>
+
+  <div class="outputs-list" style="margin-bottom: 1.5rem;">
+    <span class="output-tag" style="background:rgba(74,222,128,0.15);color:#4ade80;border:1px solid rgba(74,222,128,0.3);">Existing</span>
+    <span class="output-tag output-auto">Phase 1 (Python)</span>
+    <span class="output-tag" style="background:rgba(167,139,250,0.15);color:#a78bfa;border:1px solid rgba(167,139,250,0.3);">Phase 2 (Obsidian)</span>
+  </div>
+
+  <table style="width:100%;border-collapse:collapse;font-size:0.9rem;">
+    <thead>
+      <tr style="border-bottom:2px solid var(--border);text-align:left;">
+        <th style="padding:8px 12px;">Capability</th>
+        <th style="padding:8px 12px;">Status</th>
+        <th style="padding:8px 12px;">Phase</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr style="border-bottom:1px solid var(--border);">
+        <td style="padding:8px 12px;">Session parsing + Claude extraction</td>
+        <td style="padding:8px 12px;color:#4ade80;">Working</td>
+        <td style="padding:8px 12px;">Existing</td>
+      </tr>
+      <tr style="border-bottom:1px solid var(--border);">
+        <td style="padding:8px 12px;">Per-project STATUS.md + Daily logs</td>
+        <td style="padding:8px 12px;color:#4ade80;">Working</td>
+        <td style="padding:8px 12px;">Existing</td>
+      </tr>
+      <tr style="border-bottom:1px solid var(--border);">
+        <td style="padding:8px 12px;">DASHBOARD.md (basic table)</td>
+        <td style="padding:8px 12px;color:#4ade80;">Working</td>
+        <td style="padding:8px 12px;">Existing</td>
+      </tr>
+      <tr style="border-bottom:1px solid var(--border);">
+        <td style="padding:8px 12px;">Per-project weekly/monthly rollups</td>
+        <td style="padding:8px 12px;color:#4ade80;">Working</td>
+        <td style="padding:8px 12px;">Existing</td>
+      </tr>
+      <tr style="border-bottom:1px solid var(--border);background:rgba(91,156,246,0.05);">
+        <td style="padding:8px 12px;"><b>Cross-project daily rollup</b></td>
+        <td style="padding:8px 12px;color:var(--accent-blue);">New</td>
+        <td style="padding:8px 12px;color:var(--accent-blue);">Phase 1</td>
+      </tr>
+      <tr style="border-bottom:1px solid var(--border);background:rgba(91,156,246,0.05);">
+        <td style="padding:8px 12px;"><b>Cross-project weekly/monthly rollups</b></td>
+        <td style="padding:8px 12px;color:var(--accent-blue);">New (templates exist, unwired)</td>
+        <td style="padding:8px 12px;color:var(--accent-blue);">Phase 1</td>
+      </tr>
+      <tr style="border-bottom:1px solid var(--border);background:rgba(91,156,246,0.05);">
+        <td style="padding:8px 12px;"><b>Same-day session consolidation</b></td>
+        <td style="padding:8px 12px;color:var(--accent-blue);">New</td>
+        <td style="padding:8px 12px;color:var(--accent-blue);">Phase 1</td>
+      </tr>
+      <tr style="border-bottom:1px solid var(--border);background:rgba(91,156,246,0.05);">
+        <td style="padding:8px 12px;"><b>Dashboard: health, priority, type columns</b></td>
+        <td style="padding:8px 12px;color:var(--accent-blue);">New</td>
+        <td style="padding:8px 12px;color:var(--accent-blue);">Phase 1</td>
+      </tr>
+      <tr style="border-bottom:1px solid var(--border);background:rgba(91,156,246,0.05);">
+        <td style="padding:8px 12px;"><b>Cron automation (nightly/weekly/monthly)</b></td>
+        <td style="padding:8px 12px;color:var(--accent-blue);">New</td>
+        <td style="padding:8px 12px;color:var(--accent-blue);">Phase 1</td>
+      </tr>
+      <tr style="border-bottom:1px solid var(--border);background:rgba(167,139,250,0.05);">
+        <td style="padding:8px 12px;"><b>Dataview live queries in vault</b></td>
+        <td style="padding:8px 12px;color:var(--accent-purple);">New</td>
+        <td style="padding:8px 12px;color:var(--accent-purple);">Phase 2</td>
+      </tr>
+      <tr style="border-bottom:1px solid var(--border);background:rgba(167,139,250,0.05);">
+        <td style="padding:8px 12px;"><b>Frontmatter on STATUS.md (type, health, priority)</b></td>
+        <td style="padding:8px 12px;color:var(--accent-purple);">New</td>
+        <td style="padding:8px 12px;color:var(--accent-purple);">Phase 2</td>
+      </tr>
+      <tr style="border-bottom:1px solid var(--border);background:rgba(167,139,250,0.05);">
+        <td style="padding:8px 12px;"><b>Periodic Notes auto-creation</b></td>
+        <td style="padding:8px 12px;color:var(--accent-purple);">New</td>
+        <td style="padding:8px 12px;color:var(--accent-purple);">Phase 2</td>
+      </tr>
+      <tr style="border-bottom:1px solid var(--border);background:rgba(167,139,250,0.05);">
+        <td style="padding:8px 12px;"><b>GitHub Issues/PR sync to vault</b></td>
+        <td style="padding:8px 12px;color:var(--accent-purple);">New</td>
+        <td style="padding:8px 12px;color:var(--accent-purple);">Phase 2</td>
+      </tr>
+      <tr style="background:rgba(167,139,250,0.05);">
+        <td style="padding:8px 12px;"><b>Templater dynamic templates</b></td>
+        <td style="padding:8px 12px;color:var(--accent-purple);">New</td>
+        <td style="padding:8px 12px;color:var(--accent-purple);">Phase 2</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+<script>
+  mermaid.initialize({
+    startOnLoad: true,
+    theme: 'dark',
+    flowchart: {
+      useMaxWidth: true,
+      htmlLabels: true,
+      curve: 'basis',
+      padding: 15,
+      nodeSpacing: 30,
+      rankSpacing: 40
+    },
+    themeVariables: {
+      darkMode: true,
+      background: '#0f1117',
+      fontFamily: 'Inter, -apple-system, sans-serif',
+      fontSize: '13px'
+    }
+  });
+</script>
+
+</body>
+</html>

--- a/obsidian-agent/obsidian_agent/__main__.py
+++ b/obsidian-agent/obsidian_agent/__main__.py
@@ -1,7 +1,12 @@
 """CLI entry point: python -m obsidian_agent"""
 import argparse
+import os
+import shutil
+import subprocess
 import sys
+import time
 from datetime import datetime
+from pathlib import Path
 
 from . import __version__
 from .config import load_config, init_config
@@ -15,6 +20,15 @@ from .session_finder import (
 )
 from .git_helper import get_recent_commits
 from .vault_writer import VaultWriter
+
+CACHE_DIR = Path.home() / ".cache" / "obsidian-agent"
+LAST_RUN_FILE = CACHE_DIR / "last-run"
+
+SYSTEMD_DIR = Path.home() / ".config" / "systemd" / "user"
+
+# Locate bundled systemd unit files
+_PACKAGE_DIR = Path(__file__).parent
+_SYSTEMD_SRC = _PACKAGE_DIR.parent / "systemd"
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -59,6 +73,14 @@ def _build_parser() -> argparse.ArgumentParser:
         metavar="YYYY-MM",
         help="Generate monthly rollup (default: current month)",
     )
+    parser.add_argument(
+        "--daily-rollup",
+        nargs="?",
+        const="",
+        default=None,
+        metavar="YYYY-MM-DD",
+        help="Generate cross-project daily rollup (default: today)",
+    )
 
     # Actions
     parser.add_argument(
@@ -70,6 +92,28 @@ def _build_parser() -> argparse.ArgumentParser:
         "--dry-run", "-n",
         action="store_true",
         help="Preview extraction without writing to vault",
+    )
+    parser.add_argument(
+        "--since-last-run",
+        action="store_true",
+        help="Only process sessions modified since last run (for timer/cron use)",
+    )
+
+    # Installation
+    parser.add_argument(
+        "--install-systemd",
+        action="store_true",
+        help="Install systemd user timer for near-real-time updates",
+    )
+    parser.add_argument(
+        "--install-launchd",
+        action="store_true",
+        help="Install macOS launchd agent for near-real-time updates + rollups",
+    )
+    parser.add_argument(
+        "--install-cron",
+        action="store_true",
+        help="Install cron entries for nightly/weekly/monthly rollups",
     )
 
     return parser
@@ -139,6 +183,238 @@ def _process_session(log_path, config, dry_run: bool):
     print(f"  DASHBOARD: {paths['dashboard']}")
 
 
+def _read_last_run() -> float:
+    """Read the last-run timestamp. Returns 0.0 if not found."""
+    try:
+        return float(LAST_RUN_FILE.read_text().strip())
+    except (OSError, ValueError):
+        return 0.0
+
+
+def _write_last_run():
+    """Write the current time as the last-run timestamp."""
+    CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    LAST_RUN_FILE.write_text(str(time.time()))
+
+
+def _install_systemd():
+    """Install systemd user timer for near-real-time session processing."""
+    SYSTEMD_DIR.mkdir(parents=True, exist_ok=True)
+
+    agent_dir = _PACKAGE_DIR.parent
+    python_bin = sys.executable
+
+    # Write service unit
+    service_content = f"""\
+[Unit]
+Description=Obsidian Agent - process recent Claude sessions
+
+[Service]
+Type=oneshot
+ExecStart={python_bin} -m obsidian_agent --all-projects --since-last-run
+WorkingDirectory={agent_dir}
+Environment=HOME={Path.home()}
+"""
+    service_path = SYSTEMD_DIR / "obsidian-agent-watcher.service"
+    service_path.write_text(service_content)
+    print(f"  Service: {service_path}")
+
+    # Write timer unit
+    timer_content = """\
+[Unit]
+Description=Run Obsidian Agent every 60 seconds
+
+[Timer]
+OnBootSec=60
+OnUnitActiveSec=60
+AccuracySec=5
+
+[Install]
+WantedBy=timers.target
+"""
+    timer_path = SYSTEMD_DIR / "obsidian-agent-watcher.timer"
+    timer_path.write_text(timer_content)
+    print(f"  Timer:   {timer_path}")
+
+    # Enable and start
+    subprocess.run(
+        ["systemctl", "--user", "daemon-reload"],
+        check=True,
+    )
+    subprocess.run(
+        ["systemctl", "--user", "enable", "--now", "obsidian-agent-watcher.timer"],
+        check=True,
+    )
+    print("\n  Timer enabled and started.")
+    subprocess.run(["systemctl", "--user", "status", "obsidian-agent-watcher.timer"])
+
+
+LAUNCHD_DIR = Path.home() / "Library" / "LaunchAgents"
+LAUNCHD_WATCHER_LABEL = "com.obsidian-agent.watcher"
+LAUNCHD_ROLLUP_LABEL = "com.obsidian-agent.rollups"
+
+
+def _install_launchd():
+    """Install macOS launchd agents for real-time updates and scheduled rollups."""
+    LAUNCHD_DIR.mkdir(parents=True, exist_ok=True)
+
+    python_bin = sys.executable
+    agent_dir = str(_PACKAGE_DIR.parent)
+    log_dir = Path.home() / "Library" / "Logs" / "obsidian-agent"
+    log_dir.mkdir(parents=True, exist_ok=True)
+
+    # --- Watcher agent (every 60 seconds) ---
+    watcher_plist = f"""\
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>{LAUNCHD_WATCHER_LABEL}</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>{python_bin}</string>
+        <string>-m</string>
+        <string>obsidian_agent</string>
+        <string>--all-projects</string>
+        <string>--since-last-run</string>
+    </array>
+    <key>WorkingDirectory</key>
+    <string>{agent_dir}</string>
+    <key>StartInterval</key>
+    <integer>60</integer>
+    <key>StandardOutPath</key>
+    <string>{log_dir}/watcher.log</string>
+    <key>StandardErrorPath</key>
+    <string>{log_dir}/watcher.err</string>
+    <key>RunAtLoad</key>
+    <true/>
+</dict>
+</plist>
+"""
+    watcher_path = LAUNCHD_DIR / f"{LAUNCHD_WATCHER_LABEL}.plist"
+    watcher_path.write_text(watcher_plist)
+    print(f"  Watcher plist: {watcher_path}")
+
+    # --- Rollup agent (daily at 11 PM, weekly Sunday 11:30 PM, monthly last day) ---
+    # launchd doesn't support "last day of month" natively, so we use a single
+    # daily job at 11 PM that runs all three rollup commands. The weekly and monthly
+    # commands are no-ops when there's nothing new to aggregate.
+    rollup_plist = f"""\
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>{LAUNCHD_ROLLUP_LABEL}</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>-c</string>
+        <string>{python_bin} -m obsidian_agent --daily-rollup; DOW=$(date +%u); [ "$DOW" = "7" ] &amp;&amp; {python_bin} -m obsidian_agent --weekly --all-projects; DOM=$(date -v+1d +%d); [ "$DOM" = "01" ] &amp;&amp; {python_bin} -m obsidian_agent --monthly --all-projects</string>
+    </array>
+    <key>WorkingDirectory</key>
+    <string>{agent_dir}</string>
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>23</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+    </dict>
+    <key>StandardOutPath</key>
+    <string>{log_dir}/rollups.log</string>
+    <key>StandardErrorPath</key>
+    <string>{log_dir}/rollups.err</string>
+</dict>
+</plist>
+"""
+    rollup_path = LAUNCHD_DIR / f"{LAUNCHD_ROLLUP_LABEL}.plist"
+    rollup_path.write_text(rollup_plist)
+    print(f"  Rollup plist:  {rollup_path}")
+
+    # Unload existing (ignore errors if not loaded)
+    for label in [LAUNCHD_WATCHER_LABEL, LAUNCHD_ROLLUP_LABEL]:
+        subprocess.run(
+            ["launchctl", "bootout", f"gui/{os.getuid()}", f"{LAUNCHD_DIR}/{label}.plist"],
+            capture_output=True,
+        )
+
+    # Load agents
+    for label, plist in [
+        (LAUNCHD_WATCHER_LABEL, watcher_path),
+        (LAUNCHD_ROLLUP_LABEL, rollup_path),
+    ]:
+        result = subprocess.run(
+            ["launchctl", "bootstrap", f"gui/{os.getuid()}", str(plist)],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode == 0:
+            print(f"  Loaded: {label}")
+        else:
+            # Fallback to legacy load for older macOS
+            result2 = subprocess.run(
+                ["launchctl", "load", str(plist)],
+                capture_output=True,
+                text=True,
+            )
+            if result2.returncode == 0:
+                print(f"  Loaded (legacy): {label}")
+            else:
+                print(f"  Warning: could not load {label}: {result.stderr.strip()}", file=sys.stderr)
+
+    print(f"\n  Logs: {log_dir}/")
+    print("  Check status: launchctl list | grep obsidian-agent")
+
+
+def _install_cron():
+    """Install cron entries for nightly/weekly/monthly rollups."""
+    python_bin = sys.executable
+    agent_dir = _PACKAGE_DIR.parent
+
+    marker = "# obsidian-agent managed entries"
+    entries = f"""{marker}
+# Nightly: cross-project daily rollup (11:00 PM)
+0 23 * * * cd {agent_dir} && {python_bin} -m obsidian_agent --daily-rollup >> /tmp/obsidian-agent-cron.log 2>&1
+# Sunday: weekly rollup (11:30 PM)
+30 23 * * 0 cd {agent_dir} && {python_bin} -m obsidian_agent --weekly --all-projects >> /tmp/obsidian-agent-cron.log 2>&1
+# Last day of month: monthly rollup (11:30 PM)
+30 23 28-31 * * [ "$$(date -d tomorrow +\\%d)" = "01" ] && cd {agent_dir} && {python_bin} -m obsidian_agent --monthly --all-projects >> /tmp/obsidian-agent-cron.log 2>&1
+{marker} END
+"""
+
+    # Read existing crontab
+    result = subprocess.run(
+        ["crontab", "-l"],
+        capture_output=True,
+        text=True,
+    )
+    existing = result.stdout if result.returncode == 0 else ""
+
+    # Check if already installed
+    if marker in existing:
+        # Replace existing block
+        import re
+        pattern = re.escape(marker) + r".*?" + re.escape(marker) + r" END\n?"
+        new_crontab = re.sub(pattern, entries, existing, flags=re.DOTALL)
+        print("  Updating existing cron entries...")
+    else:
+        new_crontab = existing.rstrip("\n") + "\n\n" + entries if existing.strip() else entries
+        print("  Adding cron entries...")
+
+    subprocess.run(
+        ["crontab", "-"],
+        input=new_crontab,
+        text=True,
+        check=True,
+    )
+    print("  Cron entries installed:")
+    print("    - Nightly daily rollup at 11:00 PM")
+    print("    - Weekly rollup Sunday at 11:30 PM")
+    print("    - Monthly rollup last day of month at 11:30 PM")
+
+
 def main(argv: list[str] | None = None):
     parser = _build_parser()
     args = parser.parse_args(argv)
@@ -148,7 +424,33 @@ def main(argv: list[str] | None = None):
         init_config()
         return
 
+    # --install-systemd
+    if args.install_systemd:
+        print("Installing systemd user timer...")
+        _install_systemd()
+        return
+
+    # --install-launchd
+    if args.install_launchd:
+        print("Installing macOS launchd agents...")
+        _install_launchd()
+        return
+
+    # --install-cron
+    if args.install_cron:
+        print("Installing cron entries...")
+        _install_cron()
+        return
+
     config = load_config()
+
+    # --daily-rollup: generate cross-project daily rollup
+    if args.daily_rollup is not None:
+        writer = VaultWriter(config)
+        date = args.daily_rollup or datetime.now().strftime("%Y-%m-%d")
+        path = writer.generate_daily_rollup(date)
+        print(f"Daily rollup: {path}")
+        return
 
     # --weekly / --monthly: generate rollups
     if args.weekly is not None or args.monthly is not None:
@@ -157,9 +459,13 @@ def main(argv: list[str] | None = None):
         if args.weekly is not None:
             week = args.weekly  # empty string means current week
             if args.all_projects or not args.project:
+                # Per-project rollups
                 paths = writer.generate_weekly_all(week)
                 for p in paths:
-                    print(f"Weekly: {p}")
+                    print(f"Weekly (project): {p}")
+                # Cross-project rollup
+                rollup_path = writer.generate_weekly_rollup(week)
+                print(f"Weekly (rollup):  {rollup_path}")
             else:
                 project_name = args.project.rstrip("/").split("/")[-1]
                 path = writer.generate_weekly(project_name, week)
@@ -170,7 +476,9 @@ def main(argv: list[str] | None = None):
             if args.all_projects or not args.project:
                 paths = writer.generate_monthly_all(month)
                 for p in paths:
-                    print(f"Monthly: {p}")
+                    print(f"Monthly (project): {p}")
+                rollup_path = writer.generate_monthly_rollup(month)
+                print(f"Monthly (rollup):  {rollup_path}")
             else:
                 project_name = args.project.rstrip("/").split("/")[-1]
                 path = writer.generate_monthly(project_name, month)
@@ -180,8 +488,13 @@ def main(argv: list[str] | None = None):
 
     # --all-projects: update every recent project
     if args.all_projects:
-        recent = list_recent_projects(config)
+        since = _read_last_run() if args.since_last_run else 0.0
+        recent = list_recent_projects(config, since_timestamp=since)
         if not recent:
+            if args.since_last_run:
+                # No new sessions — silent exit for timer
+                _write_last_run()
+                return
             print("No recent projects found.")
             return
         for name, log_path in recent:
@@ -189,6 +502,9 @@ def main(argv: list[str] | None = None):
                 _process_session(log_path, config, args.dry_run)
             except Exception as e:
                 print(f"  Error processing {name}: {e}", file=sys.stderr)
+
+        if args.since_last_run:
+            _write_last_run()
         return
 
     # Single session

--- a/obsidian-agent/obsidian_agent/extractor.py
+++ b/obsidian-agent/obsidian_agent/extractor.py
@@ -47,6 +47,11 @@ class SessionExtract:
     github_refs: list[str] = field(default_factory=list)  # Issue/PR numbers
     knowledge: list[str] = field(default_factory=list)  # [CAPTURE] tagged items
     notes: list[str] = field(default_factory=list)  # Freeform context worth capturing
+    # Metadata (preserved from existing STATUS.md frontmatter, not LLM-extracted)
+    meta_status: str = "active"  # active | maintenance | paused | archived
+    health: str = "on-track"  # on-track | at-risk | blocked
+    priority: str = "P2"  # P0 | P1 | P2
+    category: str = "work"  # work | personal
 
 
 def extract_captures(conversation_text: str) -> list[str]:

--- a/obsidian-agent/obsidian_agent/session_finder.py
+++ b/obsidian-agent/obsidian_agent/session_finder.py
@@ -62,8 +62,16 @@ def get_session_log_by_project(config: Config, project_path: str) -> Path:
     return _most_recent_jsonl(folder)
 
 
-def list_recent_projects(config: Config, limit: int = 10) -> list[tuple[str, Path]]:
+def list_recent_projects(
+    config: Config, limit: int = 10, since_timestamp: float = 0.0
+) -> list[tuple[str, Path]]:
     """List recently active projects by most-recent session mtime.
+
+    Args:
+        config: Agent configuration.
+        limit: Maximum number of projects to return.
+        since_timestamp: Only include projects with sessions modified after
+            this Unix timestamp. 0.0 means no filtering.
 
     Returns list of (project_name, most_recent_log_path) tuples.
     """
@@ -75,6 +83,12 @@ def list_recent_projects(config: Config, limit: int = 10) -> list[tuple[str, Pat
         if not jsonl_files:
             continue
         latest = max(jsonl_files, key=lambda p: p.stat().st_mtime)
+        mtime = latest.stat().st_mtime
+
+        # Skip if older than threshold
+        if since_timestamp and mtime < since_timestamp:
+            continue
+
         # Decode folder name back to project name
         # e.g., -home-jjob-projects-VE-RAG-System → VE-RAG-System
         name = folder.name.rsplit("-", 1)[-1] if "-" in folder.name else folder.name
@@ -82,7 +96,7 @@ def list_recent_projects(config: Config, limit: int = 10) -> list[tuple[str, Pat
         decoded = folder.name.replace("-", "/")
         if decoded.startswith("/"):
             name = Path(decoded).name
-        projects.append((name, latest, latest.stat().st_mtime))
+        projects.append((name, latest, mtime))
 
     projects.sort(key=lambda t: t[2], reverse=True)
     return [(name, path) for name, path, _ in projects[:limit]]

--- a/obsidian-agent/obsidian_agent/templates.py
+++ b/obsidian-agent/obsidian_agent/templates.py
@@ -5,6 +5,14 @@ from datetime import datetime
 # STATUS.md — overwritten each session (current state at a glance)
 # ---------------------------------------------------------------------------
 STATUS_TEMPLATE = """\
+---
+type: project
+status: {meta_status}
+health: {meta_health}
+priority: {meta_priority}
+category: {meta_category}
+---
+
 # {project_name}
 
 > Last updated: {updated}
@@ -45,8 +53,8 @@ DASHBOARD_TEMPLATE = """\
 
 > Auto-generated: {updated}
 
-| Project | Status | Phase | Next Step | Last Updated |
-|---------|--------|-------|-----------|--------------|
+| Project | Status | Health | Priority | Category | Phase | Next Step | Last Updated |
+|---------|--------|--------|----------|----------|-------|-----------|--------------|
 {rows}
 """
 
@@ -91,6 +99,43 @@ DAILY_ENTRY_TEMPLATE = """\
 # Header for a new daily log file
 DAILY_HEADER_TEMPLATE = """\
 # Daily Log: {date}
+"""
+
+# ---------------------------------------------------------------------------
+# Cross-project daily rollup — Rollups/Daily/YYYY-MM-DD.md
+# ---------------------------------------------------------------------------
+DAILY_ROLLUP_TEMPLATE = """\
+# Daily Rollup: {date}
+
+> Auto-generated: {generated}
+
+## Summary
+
+| Project | Status | Key Activity |
+|---------|--------|-------------|
+{summary_rows}
+
+{project_sections}
+"""
+
+DAILY_ROLLUP_PROJECT_SECTION = """\
+## {project_name}
+
+**Status**: {status}
+
+### Completed
+{completed}
+
+### Decisions
+{decisions}
+
+### Blockers
+{blockers}
+
+### Follow-up
+{next_steps}
+
+**GitHub Refs**: {github_refs}
 """
 
 # ---------------------------------------------------------------------------
@@ -153,6 +198,25 @@ MONTHLY_MULTI_PROJECT_TEMPLATE = """\
 > Generated: {generated}
 
 {project_sections}
+"""
+
+# ---------------------------------------------------------------------------
+# Shared rollup project section (used by multi-project weekly/monthly)
+# ---------------------------------------------------------------------------
+ROLLUP_PROJECT_SECTION = """\
+## {project_name}
+
+### Completed
+{completed}
+
+### Decisions
+{decisions}
+
+### Blockers
+{blockers}
+
+### GitHub References
+{github_refs}
 """
 
 
@@ -233,6 +297,10 @@ def render_status(project_name: str, extract, updated: str | None = None) -> str
         blockers=_bullet_list(extract.blockers),
         github_refs=_bullet_list(extract.github_refs),
         notes=_bullet_list(extract.notes),
+        meta_status=extract.meta_status,
+        meta_health=extract.health,
+        meta_priority=extract.priority,
+        meta_category=extract.category,
     )
 
 
@@ -241,7 +309,10 @@ def render_dashboard_row(project_name: str, extract, updated: str) -> str:
     status = extract.status or "—"
     phase = extract.phase or "—"
     next_step = _first_or(extract.next_steps)
-    return f"| {project_name} | {status} | {phase} | {next_step} | {updated} |"
+    health = extract.health
+    priority = extract.priority
+    category = extract.category
+    return f"| {project_name} | {status} | {health} | {priority} | {category} | {phase} | {next_step} | {updated} |"
 
 
 def render_dashboard(rows: list[str], updated: str | None = None) -> str:
@@ -249,7 +320,7 @@ def render_dashboard(rows: list[str], updated: str | None = None) -> str:
     updated = updated or datetime.now().strftime("%Y-%m-%d %H:%M")
     return DASHBOARD_TEMPLATE.format(
         updated=updated,
-        rows="\n".join(rows) if rows else "| _No projects yet_ | | | | |",
+        rows="\n".join(rows) if rows else "| _No projects yet_ | | | | | | | |",
     )
 
 
@@ -277,6 +348,58 @@ def render_daily_header(date: str) -> str:
     return DAILY_HEADER_TEMPLATE.format(date=date)
 
 
+def render_daily_rollup(
+    date: str,
+    summary_rows: list[str],
+    project_sections: list[str],
+) -> str:
+    """Render cross-project daily rollup."""
+    return DAILY_ROLLUP_TEMPLATE.format(
+        date=date,
+        generated=datetime.now().strftime("%Y-%m-%d %H:%M"),
+        summary_rows="\n".join(summary_rows) if summary_rows else "| _No activity_ | | |",
+        project_sections="\n".join(project_sections),
+    )
+
+
+def render_daily_rollup_project(
+    project_name: str,
+    status: str,
+    completed: list[str],
+    decisions: list[str],
+    blockers: list[str],
+    next_steps: list[str],
+    github_refs: list[str],
+) -> str:
+    """Render a single project section in the daily rollup."""
+    return DAILY_ROLLUP_PROJECT_SECTION.format(
+        project_name=project_name,
+        status=status or "—",
+        completed=_bullet_list(completed),
+        decisions=_bullet_list(decisions),
+        blockers=_bullet_list(blockers),
+        next_steps=_checkbox_list(next_steps),
+        github_refs=", ".join(github_refs) if github_refs else "_None_",
+    )
+
+
+def render_rollup_project_section(
+    project_name: str,
+    completed: list[str],
+    decisions: list[str],
+    blockers: list[str],
+    github_refs: list[str],
+) -> str:
+    """Render a project section for multi-project weekly/monthly rollups."""
+    return ROLLUP_PROJECT_SECTION.format(
+        project_name=project_name,
+        completed=_bullet_list(completed),
+        decisions=_bullet_list(decisions),
+        blockers=_bullet_list(blockers),
+        github_refs=_bullet_list(github_refs),
+    )
+
+
 def render_weekly(
     week: str,
     project_name: str,
@@ -297,6 +420,18 @@ def render_weekly(
     )
 
 
+def render_weekly_multi(
+    week: str,
+    project_sections: list[str],
+) -> str:
+    """Render a cross-project weekly rollup."""
+    return WEEKLY_MULTI_PROJECT_TEMPLATE.format(
+        week=week,
+        generated=datetime.now().strftime("%Y-%m-%d %H:%M"),
+        project_sections="\n".join(project_sections),
+    )
+
+
 def render_monthly(
     month: str,
     project_name: str,
@@ -314,4 +449,16 @@ def render_monthly(
         decisions=_bullet_list(decisions),
         blockers=_bullet_list(blockers),
         github_refs=_bullet_list(github_refs),
+    )
+
+
+def render_monthly_multi(
+    month: str,
+    project_sections: list[str],
+) -> str:
+    """Render a cross-project monthly rollup."""
+    return MONTHLY_MULTI_PROJECT_TEMPLATE.format(
+        month=month,
+        generated=datetime.now().strftime("%Y-%m-%d %H:%M"),
+        project_sections="\n".join(project_sections),
     )

--- a/obsidian-agent/obsidian_agent/vault_writer.py
+++ b/obsidian-agent/obsidian_agent/vault_writer.py
@@ -5,7 +5,9 @@ Design:
 - Daily logs are APPEND-ONLY (event history for rollups)
 - DASHBOARD.md is OVERWRITTEN (cross-project overview)
 - Weekly/Monthly are GENERATED on demand from daily logs
+- Rollups/ contains cross-project aggregations
 """
+import os
 import re
 from datetime import datetime
 from pathlib import Path
@@ -15,11 +17,16 @@ from .extractor import SessionExtract
 from .templates import (
     render_daily_entry,
     render_daily_header,
+    render_daily_rollup,
+    render_daily_rollup_project,
     render_dashboard,
     render_dashboard_row,
     render_monthly,
+    render_monthly_multi,
+    render_rollup_project_section,
     render_status,
     render_weekly,
+    render_weekly_multi,
 )
 
 
@@ -43,19 +50,46 @@ class VaultWriter:
         d.mkdir(parents=True, exist_ok=True)
         return d
 
+    def _rollup_dir(self, period: str) -> Path:
+        """Get (and create if needed) a cross-project rollup directory."""
+        d = self.vault / "Rollups" / period
+        d.mkdir(parents=True, exist_ok=True)
+        return d
+
     # ------------------------------------------------------------------
     # Core writes
     # ------------------------------------------------------------------
 
     def write_status(self, project_name: str, extract: SessionExtract) -> Path:
-        """Overwrite STATUS.md with current project state."""
+        """Overwrite STATUS.md with current project state.
+
+        Preserves user-edited frontmatter (health, priority, category) from
+        the existing STATUS.md before overwriting.
+        """
         path = self._project_dir(project_name) / "STATUS.md"
+
+        # Preserve existing frontmatter metadata
+        if path.exists():
+            existing_meta = self._parse_frontmatter(path)
+            if existing_meta.get("status"):
+                extract.meta_status = existing_meta["status"]
+            if existing_meta.get("health"):
+                extract.health = existing_meta["health"]
+            if existing_meta.get("priority"):
+                extract.priority = existing_meta["priority"]
+            if existing_meta.get("category"):
+                extract.category = existing_meta["category"]
+
         content = render_status(project_name, extract)
         path.write_text(content)
         return path
 
     def write_daily(self, project_name: str, extract: SessionExtract, date: str = "") -> Path:
-        """Append a session entry to the daily log (skips if duplicate)."""
+        """Append a session entry to the daily log.
+
+        If an entry for this project already exists for today, consolidates
+        by replacing the existing section with merged data.
+        """
         date = date or datetime.now().strftime("%Y-%m-%d")
         log_dir = self._log_dir(project_name, "Daily")
         path = log_dir / f"{date}.md"
@@ -65,14 +99,25 @@ class VaultWriter:
 
         entry = render_daily_entry(project_name, extract)
 
-        # Dedup: check if an entry with the same project + summary already exists
-        if path.exists():
-            existing = path.read_text()
-            summary_line = f"**Summary**: {extract.summary or '_No summary_'}"
-            project_header = f"— {project_name}"
-            if project_header in existing and summary_line in existing:
-                return path
+        # Check for existing entry for this project today
+        existing = path.read_text()
+        project_header = f"— {project_name}"
+        summary_line = f"**Summary**: {extract.summary or '_No summary_'}"
 
+        # Exact duplicate check (same project + same summary = skip)
+        if project_header in existing and summary_line in existing:
+            return path
+
+        # Consolidation: if project already has an entry today, replace it
+        if project_header in existing:
+            consolidated = self._consolidate_daily_entry(existing, project_name, extract)
+            # Atomic write: write to temp then replace
+            tmp = path.with_suffix(".tmp")
+            tmp.write_text(consolidated)
+            os.replace(tmp, path)
+            return path
+
+        # No existing entry — append
         with open(path, "a") as f:
             f.write(entry)
 
@@ -104,15 +149,11 @@ class VaultWriter:
         return dashboard
 
     # ------------------------------------------------------------------
-    # Rollup generation
+    # Rollup generation (per-project)
     # ------------------------------------------------------------------
 
     def generate_weekly(self, project_name: str, week: str = "") -> Path:
-        """Aggregate daily logs into a weekly rollup.
-
-        Args:
-            week: ISO week string like '2026-W06'. Defaults to current week.
-        """
+        """Aggregate daily logs into a weekly rollup for one project."""
         if not week:
             now = datetime.now()
             week = f"{now.year}-W{now.isocalendar()[1]:02d}"
@@ -129,11 +170,7 @@ class VaultWriter:
         return path
 
     def generate_monthly(self, project_name: str, month: str = "") -> Path:
-        """Aggregate daily logs into a monthly rollup.
-
-        Args:
-            month: Month string like '2026-02'. Defaults to current month.
-        """
+        """Aggregate daily logs into a monthly rollup for one project."""
         if not month:
             month = datetime.now().strftime("%Y-%m")
 
@@ -169,6 +206,137 @@ class VaultWriter:
         return paths
 
     # ------------------------------------------------------------------
+    # Cross-project rollups (NEW)
+    # ------------------------------------------------------------------
+
+    def generate_daily_rollup(self, date: str = "") -> Path:
+        """Generate a cross-project daily rollup aggregating all projects."""
+        date = date or datetime.now().strftime("%Y-%m-%d")
+        rollup_dir = self._rollup_dir("Daily")
+        path = rollup_dir / f"{date}.md"
+
+        summary_rows = []
+        project_sections = []
+
+        if self.projects.exists():
+            for project_dir in sorted(self.projects.iterdir()):
+                if not project_dir.is_dir():
+                    continue
+
+                daily_file = project_dir / "Log" / "Daily" / f"{date}.md"
+                status_file = project_dir / "STATUS.md"
+                if not daily_file.exists():
+                    continue
+
+                project_name = project_dir.name
+                content = daily_file.read_text()
+
+                # Get status from STATUS.md
+                status_text = "—"
+                if status_file.exists():
+                    status_extract = self._parse_status_file(status_file)
+                    status_text = status_extract.status or "—"
+
+                # Extract data from daily log
+                completed = _extract_section_bullets(content, "Completed")
+                decisions = _extract_section_bullets(content, "Decisions")
+                blockers = _extract_section_bullets(content, "Blockers")
+                next_steps = _extract_section_items(content, "Follow-up")
+                github_refs = _extract_github_refs(content)
+
+                # Summary row: first completed item as key activity
+                key_activity = completed[0] if completed else "—"
+                summary_rows.append(
+                    f"| {project_name} | {status_text} | {key_activity} |"
+                )
+
+                project_sections.append(render_daily_rollup_project(
+                    project_name=project_name,
+                    status=status_text,
+                    completed=_dedup(completed),
+                    decisions=_dedup(decisions),
+                    blockers=_dedup(blockers),
+                    next_steps=_dedup(next_steps),
+                    github_refs=_dedup(github_refs),
+                ))
+
+        content = render_daily_rollup(date, summary_rows, project_sections)
+        path.write_text(content)
+        return path
+
+    def generate_weekly_rollup(self, week: str = "") -> Path:
+        """Generate a cross-project weekly rollup."""
+        if not week:
+            now = datetime.now()
+            week = f"{now.year}-W{now.isocalendar()[1]:02d}"
+
+        rollup_dir = self._rollup_dir("Weekly")
+        path = rollup_dir / f"{week}.md"
+
+        project_sections = []
+        if self.projects.exists():
+            for project_dir in sorted(self.projects.iterdir()):
+                if not project_dir.is_dir():
+                    continue
+                daily_dir = project_dir / "Log" / "Daily"
+                if not daily_dir.exists():
+                    continue
+
+                completed, decisions, blockers, github_refs = self._aggregate_dailies(
+                    daily_dir, week=week
+                )
+                # Skip projects with no activity this week
+                if not any([completed, decisions, blockers, github_refs]):
+                    continue
+
+                project_sections.append(render_rollup_project_section(
+                    project_name=project_dir.name,
+                    completed=completed,
+                    decisions=decisions,
+                    blockers=blockers,
+                    github_refs=github_refs,
+                ))
+
+        content = render_weekly_multi(week, project_sections)
+        path.write_text(content)
+        return path
+
+    def generate_monthly_rollup(self, month: str = "") -> Path:
+        """Generate a cross-project monthly rollup."""
+        if not month:
+            month = datetime.now().strftime("%Y-%m")
+
+        rollup_dir = self._rollup_dir("Monthly")
+        path = rollup_dir / f"{month}.md"
+
+        project_sections = []
+        if self.projects.exists():
+            for project_dir in sorted(self.projects.iterdir()):
+                if not project_dir.is_dir():
+                    continue
+                daily_dir = project_dir / "Log" / "Daily"
+                if not daily_dir.exists():
+                    continue
+
+                completed, decisions, blockers, github_refs = self._aggregate_dailies(
+                    daily_dir, month=month
+                )
+                if not any([completed, decisions, blockers, github_refs]):
+                    continue
+
+                project_sections.append(render_rollup_project_section(
+                    project_name=project_dir.name,
+                    completed=completed,
+                    decisions=decisions,
+                    blockers=blockers,
+                    github_refs=github_refs,
+                ))
+
+        content = render_monthly_multi(month, project_sections)
+        path.write_text(content)
+        return path
+
+    # ------------------------------------------------------------------
     # Convenience: full update
     # ------------------------------------------------------------------
 
@@ -188,12 +356,41 @@ class VaultWriter:
     # ------------------------------------------------------------------
 
     @staticmethod
-    def _parse_status_file(path: Path) -> SessionExtract:
-        """Parse a STATUS.md back into a minimal SessionExtract for the dashboard.
+    def _parse_frontmatter(path: Path) -> dict[str, str]:
+        """Parse YAML frontmatter from a markdown file."""
+        try:
+            content = path.read_text()
+        except OSError:
+            return {}
 
-        This is intentionally loose — we just need status, phase, next_steps.
-        """
+        if not content.startswith("---"):
+            return {}
+
+        end = content.find("---", 3)
+        if end < 0:
+            return {}
+
+        frontmatter = {}
+        for line in content[3:end].strip().splitlines():
+            if ":" in line:
+                key, _, value = line.partition(":")
+                frontmatter[key.strip()] = value.strip()
+        return frontmatter
+
+    @staticmethod
+    def _parse_status_file(path: Path) -> SessionExtract:
+        """Parse a STATUS.md back into a minimal SessionExtract for the dashboard."""
         content = path.read_text()
+
+        # Parse frontmatter for metadata
+        meta = {}
+        if content.startswith("---"):
+            end = content.find("---", 3)
+            if end > 0:
+                for line in content[3:end].strip().splitlines():
+                    if ":" in line:
+                        key, _, value = line.partition(":")
+                        meta[key.strip()] = value.strip()
 
         def _section(header: str) -> list[str]:
             pattern = rf"## {header}\n(.*?)(?=\n## |\Z)"
@@ -203,7 +400,6 @@ class VaultWriter:
             text = m.group(1).strip()
             if text in ("_None_", "_Unknown_", "_Not specified_"):
                 return []
-            # Handle both "- " and "- [ ] " prefixed lines
             items = []
             for line in text.splitlines():
                 line = line.strip()
@@ -231,6 +427,10 @@ class VaultWriter:
             decisions=_section("Decisions"),
             blockers=_section("Blockers"),
             github_refs=_section("GitHub References"),
+            meta_status=meta.get("status", "active"),
+            health=meta.get("health", "on-track"),
+            priority=meta.get("priority", "P2"),
+            category=meta.get("category", "work"),
         )
 
     @staticmethod
@@ -238,6 +438,34 @@ class VaultWriter:
         """Get the last-modified date of a file as YYYY-MM-DD."""
         mtime = path.stat().st_mtime
         return datetime.fromtimestamp(mtime).strftime("%Y-%m-%d")
+
+    @staticmethod
+    def _consolidate_daily_entry(
+        existing_content: str, project_name: str, new_extract: SessionExtract
+    ) -> str:
+        """Replace existing project section in daily log with consolidated data.
+
+        Merges completed items, decisions, blockers etc. from the existing
+        section with the new extract, then replaces the section in place.
+        """
+        # Split on section dividers
+        sections = re.split(r"\n---\n", existing_content)
+
+        new_sections = []
+        replaced = False
+
+        for section in sections:
+            if f"— {project_name}" in section and not replaced:
+                # This is the section to replace — render fresh with new extract
+                new_entry = render_daily_entry(project_name, new_extract)
+                # Strip leading newlines since we re-join with \n---\n
+                new_entry = new_entry.lstrip("\n")
+                new_sections.append(new_entry)
+                replaced = True
+            else:
+                new_sections.append(section)
+
+        return "\n---\n".join(new_sections)
 
     @staticmethod
     def _aggregate_dailies(
@@ -281,13 +509,7 @@ class VaultWriter:
             blockers.extend(_extract_section_bullets(content, "Blockers"))
 
             # GitHub refs are comma-separated inline, not bullets
-            for line in content.splitlines():
-                if line.startswith("**GitHub Refs**:"):
-                    refs_text = line.split(":", 1)[1].strip()
-                    if refs_text and refs_text != "_None_":
-                        github_refs.extend(
-                            r.strip() for r in refs_text.split(",") if r.strip()
-                        )
+            github_refs.extend(_extract_github_refs(content))
 
         # Deduplicate while preserving order
         completed = _dedup(completed)
@@ -299,8 +521,10 @@ class VaultWriter:
 
 
 def _extract_section_bullets(content: str, header: str) -> list[str]:
-    """Extract bullet items from a **Header**: section in daily logs."""
+    """Extract bullet items from a **Header**: or ## Header section in daily logs."""
     items = []
+
+    # Try **Header**: format first (daily entry style)
     pattern = rf"\*\*{header}\*\*:\n(.*?)(?=\n\*\*|\n---|\n###|\Z)"
     match = re.search(pattern, content, re.DOTALL)
     if match:
@@ -308,7 +532,55 @@ def _extract_section_bullets(content: str, header: str) -> list[str]:
             line = line.strip()
             if line.startswith("- ") and line != "- _None_":
                 items.append(line[2:].strip())
+        return items
+
+    # Try ## Header format (daily entry sections)
+    # Don't stop at ### since completed items may be under ### sub-headings
+    pattern = rf"## {header}[^\n]*\n(.*?)(?=\n## [^#]|\n---|\Z)"
+    match = re.search(pattern, content, re.DOTALL)
+    if match:
+        for line in match.group(1).strip().splitlines():
+            line = line.strip()
+            if line.startswith("- _None_"):
+                continue
+            if line.startswith("- [x] "):
+                items.append(line[6:].strip())
+            elif line.startswith("- [ ] "):
+                items.append(line[6:].strip())
+            elif line.startswith("- "):
+                items.append(line[2:].strip())
+
     return items
+
+
+def _extract_section_items(content: str, header: str) -> list[str]:
+    """Extract items from a ## Header section, handling checkboxes."""
+    items = []
+    pattern = rf"## {header}[^\n]*\n(.*?)(?=\n## |\n---|\n###|\Z)"
+    match = re.search(pattern, content, re.DOTALL)
+    if match:
+        for line in match.group(1).strip().splitlines():
+            line = line.strip()
+            if line.startswith("- _None_"):
+                continue
+            if line.startswith("- [ ] "):
+                items.append(line[6:].strip())
+            elif line.startswith("- [x] "):
+                items.append(line[6:].strip())
+            elif line.startswith("- "):
+                items.append(line[2:].strip())
+    return items
+
+
+def _extract_github_refs(content: str) -> list[str]:
+    """Extract GitHub refs from **GitHub Refs**: lines."""
+    refs = []
+    for line in content.splitlines():
+        if line.startswith("**GitHub Refs**:"):
+            refs_text = line.split(":", 1)[1].strip()
+            if refs_text and refs_text != "_None_":
+                refs.extend(r.strip() for r in refs_text.split(",") if r.strip())
+    return refs
 
 
 def _dedup(items: list[str]) -> list[str]:

--- a/obsidian-agent/systemd/README.md
+++ b/obsidian-agent/systemd/README.md
@@ -1,0 +1,37 @@
+# Systemd Timer Setup
+
+The timer polls every 60 seconds for new Claude Code sessions. Only sessions
+modified since the last run are processed (zero wasted API calls when idle).
+
+## Automatic Install
+
+```bash
+python -m obsidian_agent --install-systemd
+```
+
+## Manual Install
+
+```bash
+cp systemd/*.service systemd/*.timer ~/.config/systemd/user/
+systemctl --user daemon-reload
+systemctl --user enable --now obsidian-agent-watcher.timer
+```
+
+## Check Status
+
+```bash
+systemctl --user status obsidian-agent-watcher.timer
+systemctl --user status obsidian-agent-watcher.service
+journalctl --user -u obsidian-agent-watcher.service -f
+```
+
+## Cron (Rollups)
+
+```bash
+python -m obsidian_agent --install-cron
+```
+
+Installs:
+- Nightly daily rollup at 11:00 PM
+- Weekly rollup Sunday 11:30 PM
+- Monthly rollup last day of month 11:30 PM

--- a/obsidian-agent/systemd/obsidian-agent-watcher.service
+++ b/obsidian-agent/systemd/obsidian-agent-watcher.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Obsidian Agent - process recent Claude sessions
+
+[Service]
+Type=oneshot
+ExecStart=%h/agents/obsidian-agent/.venv/bin/python -m obsidian_agent --all-projects --since-last-run
+WorkingDirectory=%h/agents/obsidian-agent
+Environment=HOME=%h

--- a/obsidian-agent/systemd/obsidian-agent-watcher.timer
+++ b/obsidian-agent/systemd/obsidian-agent-watcher.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Run Obsidian Agent every 60 seconds
+
+[Timer]
+OnBootSec=60
+OnUnitActiveSec=60
+AccuracySec=5
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Summary
- **Real-time session capture**: systemd timer (Linux) and launchd agent (macOS) poll every 60s for new Claude Code sessions, with mtime filtering to avoid redundant API calls
- **Cross-project rollups**: new `--daily-rollup`, enhanced `--weekly`/`--monthly` now generate both per-project and cross-project aggregations in `Rollups/` directory
- **Enhanced metadata**: STATUS.md gains YAML frontmatter (type, status, health, priority, category) preserved across overwrites; DASHBOARD.md expanded to 8 columns
- **Same-day consolidation**: multiple sessions per project per day are consolidated instead of duplicated
- **Platform installers**: `--install-systemd` (Linux), `--install-launchd` (macOS), `--install-cron` (rollup schedules)

## Test plan
- [x] All imports and basic functionality verified
- [x] Integration test: frontmatter preservation, daily consolidation, rollup generation
- [x] Section extraction regex handles grouped completions under ### sub-headings
- [x] Manual trigger `--all-projects` processed 10 projects successfully
- [x] systemd timer installed and active on Linux/WSL
- [x] Cron entries installed and verified
- [ ] Verify launchd install on macOS (not tested — Linux dev machine)

🤖 Generated with [Claude Code](https://claude.com/claude-code)