### PR TITLE
feat(docs): scaffold MkDocs user manual with Material theme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,5 +24,8 @@ venv/
 .agents/
 .claude/
 
+# MkDocs build output
+site/
+
 # Local-only settings (not symlinked)
 claude-config/settings.local.json

--- a/docs/manual/agents/contract.md
+++ b/docs/manual/agents/contract.md
@@ -1,0 +1,10 @@
+# CONTRACT Agent
+
+!!! note "Coming Soon"
+    This section is under construction.
+
+API contract definition for fullstack work. CONTRACT-lite for simple changes.
+
+---
+
+*Content will be consolidated from existing documentation in Phase 2/3.*

--- a/docs/manual/agents/map-plan.md
+++ b/docs/manual/agents/map-plan.md
@@ -1,0 +1,10 @@
+# MAP-PLAN Agent
+
+!!! note "Coming Soon"
+    This section is under construction.
+
+Combined investigation and planning for TRIVIAL/SIMPLE issues.
+
+---
+
+*Content will be consolidated from existing documentation in Phase 2/3.*

--- a/docs/manual/agents/overview.md
+++ b/docs/manual/agents/overview.md
@@ -1,0 +1,10 @@
+# Agent Overview
+
+!!! note "Coming Soon"
+    This section is under construction.
+
+Agent roles, separation of concerns, pipeline flow, artifact chains.
+
+---
+
+*Content will be consolidated from existing documentation in Phase 2/3.*

--- a/docs/manual/agents/patch.md
+++ b/docs/manual/agents/patch.md
@@ -1,0 +1,10 @@
+# PATCH Agent
+
+!!! note "Coming Soon"
+    This section is under construction.
+
+The only agent that writes code. Pre-flight checklists, deviation policy.
+
+---
+
+*Content will be consolidated from existing documentation in Phase 2/3.*

--- a/docs/manual/agents/prove.md
+++ b/docs/manual/agents/prove.md
@@ -1,0 +1,10 @@
+# PROVE Agent
+
+!!! note "Coming Soon"
+    This section is under construction.
+
+Verification levels (EXISTS, SUBSTANTIVE, WIRED, FUNCTIONAL) and outcome recording.
+
+---
+
+*Content will be consolidated from existing documentation in Phase 2/3.*

--- a/docs/manual/getting-started/installation.md
+++ b/docs/manual/getting-started/installation.md
@@ -1,0 +1,10 @@
+# Installation
+
+!!! note "Coming Soon"
+    This section is under construction.
+
+Clone the agents repo, run install.sh, prerequisites for macOS/WSL/Linux.
+
+---
+
+*Content will be consolidated from existing documentation in Phase 2/3.*

--- a/docs/manual/getting-started/multi-machine.md
+++ b/docs/manual/getting-started/multi-machine.md
@@ -1,0 +1,10 @@
+# Multi-Machine Sync
+
+!!! note "Coming Soon"
+    This section is under construction.
+
+Propagating changes across machines via git pull. Platform-specific handling.
+
+---
+
+*Content will be consolidated from existing documentation in Phase 2/3.*

--- a/docs/manual/getting-started/project-setup.md
+++ b/docs/manual/getting-started/project-setup.md
@@ -1,0 +1,10 @@
+# Project Setup
+
+!!! note "Coming Soon"
+    This section is under construction.
+
+Bootstrapping a new project with CLAUDE.md, .claude/ config, and .agents/ outputs.
+
+---
+
+*Content will be consolidated from existing documentation in Phase 2/3.*

--- a/docs/manual/git/contributing.md
+++ b/docs/manual/git/contributing.md
@@ -1,0 +1,10 @@
+# Contributing Policy
+
+!!! note "Coming Soon"
+    This section is under construction.
+
+Multi-agent development policy, worktree isolation, wave scheduling.
+
+---
+
+*Content will be consolidated from existing documentation in Phase 2/3.*

--- a/docs/manual/git/workflow.md
+++ b/docs/manual/git/workflow.md
@@ -1,0 +1,10 @@
+# Git Workflow
+
+!!! note "Coming Soon"
+    This section is under construction.
+
+Branch naming, commit conventions, PR process, main stays green.
+
+---
+
+*Content will be consolidated from existing documentation in Phase 2/3.*

--- a/docs/manual/hooks/custom-hooks.md
+++ b/docs/manual/hooks/custom-hooks.md
@@ -1,0 +1,10 @@
+# Custom Hooks
+
+!!! note "Coming Soon"
+    This section is under construction.
+
+Design principles and patterns for writing your own hooks.
+
+---
+
+*Content will be consolidated from existing documentation in Phase 2/3.*

--- a/docs/manual/hooks/lifecycle.md
+++ b/docs/manual/hooks/lifecycle.md
@@ -1,0 +1,10 @@
+# Lifecycle Hooks
+
+!!! note "Coming Soon"
+    This section is under construction.
+
+SessionStart, PreCompact, and Stop hooks — how they manage state and quality.
+
+---
+
+*Content will be consolidated from existing documentation in Phase 2/3.*

--- a/docs/manual/hooks/notifications.md
+++ b/docs/manual/hooks/notifications.md
@@ -1,0 +1,10 @@
+# Notifications
+
+!!! note "Coming Soon"
+    This section is under construction.
+
+macOS Notification Center alerts with iPhone Handoff relay.
+
+---
+
+*Content will be consolidated from existing documentation in Phase 2/3.*

--- a/docs/manual/hooks/state-manager.md
+++ b/docs/manual/hooks/state-manager.md
@@ -1,0 +1,10 @@
+# State Manager
+
+!!! note "Coming Soon"
+    This section is under construction.
+
+Centralized PERSISTENT_STATE.yaml management. --resume and --parallel support.
+
+---
+
+*Content will be consolidated from existing documentation in Phase 2/3.*

--- a/docs/manual/index.md
+++ b/docs/manual/index.md
@@ -1,0 +1,168 @@
+# Agentic Engineering Manual
+
+A comprehensive guide to building systematic, repeatable AI-assisted development workflows using Claude Code, OpenAI Codex, and Obsidian.
+
+---
+
+## What Is This System?
+
+This is a **multi-agent software engineering workflow** where AI agents autonomously handle investigation, planning, implementation, and verification of GitHub issues — with structured feedback loops that improve performance over time.
+
+```
+GitHub Issue → Classify → Branch → Agents → Verify → Record → PR
+                                      │
+                          ┌───────────┼───────────┐
+                          ▼           ▼           ▼
+                       MAP-PLAN    PATCH       PROVE
+                     (investigate) (implement) (verify)
+                          │           │           │
+                          ▼           ▼           ▼
+                       Artifact    Code        Metrics
+                       (.md)      Changes     (.jsonl)
+```
+
+It is **not** prompt engineering. It is the discipline of designing agent pipelines, artifact chains, verification gates, failure recording, and learning loops.
+
+## Key Capabilities
+
+<div class="grid cards" markdown>
+
+-   :material-robot:{ .lg .middle } **Multi-Agent Pipeline**
+
+    ---
+
+    MAP-PLAN → CONTRACT → PLAN-CHECK → PATCH → PROVE — each agent has a defined role, inputs, outputs, and verification gates.
+
+    [:octicons-arrow-right-24: Orchestrate Pipeline](workflow/orchestrate.md)
+
+-   :material-source-branch:{ .lg .middle } **Parallel Execution**
+
+    ---
+
+    Run 2-3 issues simultaneously using `--parallel` worktree isolation. macOS notifications alert when sessions complete.
+
+    [:octicons-arrow-right-24: Parallel Mode](workflow/parallel.md)
+
+-   :material-brain:{ .lg .middle } **Self-Learning Loop**
+
+    ---
+
+    Every issue outcome is recorded. `/learn --apply` extracts failure patterns and writes prevention directly into agent files.
+
+    [:octicons-arrow-right-24: Learning Loop](learning/self-learning-loop.md)
+
+-   :material-shield-check:{ .lg .middle } **Cross-Model Review**
+
+    ---
+
+    Claude writes code, OpenAI Codex reviews it. Different models catch different blind spots.
+
+    [:octicons-arrow-right-24: Codex Plugin](integrations/codex-plugin.md)
+
+-   :material-notebook:{ .lg .middle } **Obsidian Knowledge Capture**
+
+    ---
+
+    Sessions automatically become daily logs, weekly rollups, and project dashboards in your Obsidian vault.
+
+    [:octicons-arrow-right-24: Obsidian Agent](integrations/obsidian-agent.md)
+
+-   :material-sync:{ .lg .middle } **Portable Configuration**
+
+    ---
+
+    All config in one git repo, deployed via symlinks. `git pull` on any machine updates everything instantly.
+
+    [:octicons-arrow-right-24: Installation](getting-started/installation.md)
+
+</div>
+
+## System Architecture
+
+```
+~/agents/                              Source of truth (git repo)
+├── claude-config/                     Claude Code configuration
+│   ├── agents/     → ~/.claude/agents/    9 agent definitions
+│   ├── commands/   → ~/.claude/commands/  18 slash commands
+│   ├── hooks/      → ~/.claude/hooks/     6 lifecycle hooks + modules
+│   ├── rules/      → ~/.claude/rules/     4 conditional rules
+│   ├── skills/     → ~/.claude/skills/    3 workflow skills
+│   ├── templates/  agent prompt template  1 shared prompt template
+│   └── settings.json → ~/.claude/settings.json
+├── mcp-server/                        Custom MCP (metrics, vault access)
+├── obsidian-agent/                    Session → Obsidian vault writer
+└── docs/manual/                       This documentation (you are here)
+```
+
+All configuration is **symlinked** from `~/.claude/` to the repo. Changes propagate instantly. `install.sh` handles setup on any platform (macOS, WSL, Linux).
+
+## The Orchestrate Workflow
+
+Three complexity tiers, each with a different agent path:
+
+```
+TRIVIAL:  MAP-PLAN ──────────────────────────── PATCH → PROVE-lite
+SIMPLE:   MAP-PLAN → [CONTRACT*] → PLAN-CHECK → PATCH → PROVE
+COMPLEX:  MAP → PLAN → [CONTRACT*] → PLAN-CHECK → PATCH → PROVE
+```
+
+| Tier | Files | Agents | Example |
+|------|-------|--------|---------|
+| **TRIVIAL** | 1-2 | 3 (skip PLAN-CHECK, PROVE-lite) | Fix typo, update config |
+| **SIMPLE** | 3-5 | 4-6 | Add endpoint, wire component |
+| **COMPLEX** | 6+ | 6-8 | New module with schema + service + tests |
+
+Every issue gets outcome tracking in `metrics.jsonl`. Failures get root cause classification in `failures.jsonl`. The `/learn` command turns this data into prevention patterns.
+
+## Quick Start
+
+```bash
+# 1. Clone and install
+git clone https://github.com/jwj2002/agents.git ~/agents
+cd ~/agents/claude-config && ./install.sh
+
+# 2. Open any project
+cd ~/projects/myapp
+
+# 3. Start working
+claude                           # Launch Claude Code
+/orchestrate 184                 # Run full pipeline for issue #184
+/orchestrate 184 --parallel      # Run in isolated worktree
+/quick "fix the login redirect"  # Quick fix, no pipeline
+```
+
+## Daily Workflow
+
+| Time | Action | Command |
+|------|--------|---------|
+| **Morning** | Open project, context auto-restores | `claude` |
+| **Working** | Implement issues via pipeline | `/orchestrate <issue>` |
+| **Parallel** | Run multiple issues in separate tabs | `/orchestrate <issue> --parallel` |
+| **Quick fixes** | Small changes without pipeline | `/quick "description"` |
+| **Done** | Create PR with checklist | `/pr` |
+| **Automatic** | macOS notification when session completes | notify_completion.py |
+| **Automatic** | Sessions captured to Obsidian vault | obsidian-agent (cron) |
+
+## Weekly Maintenance
+
+| Day | Action | Command |
+|-----|--------|---------|
+| **Friday** | Extract patterns from failures | `/learn --apply` |
+| **Friday** | Review performance trends | `/metrics` |
+| **Friday** | Validate pattern effectiveness | `/learn --validate` |
+| **Sunday** | Cross-project pattern sharing | `/learn --cross-project` |
+| **Automatic** | Weekly rollups generated | obsidian-agent (cron) |
+
+## Navigation Guide
+
+| If you want to... | Go to... |
+|-------------------|----------|
+| Set up on a new machine | [Installation](getting-started/installation.md) |
+| Understand the pipeline | [Orchestrate Pipeline](workflow/orchestrate.md) |
+| See all available commands | [Command Reference](workflow/commands.md) |
+| Run issues in parallel | [Parallel Execution](workflow/parallel.md) |
+| Understand how agents work | [Agent Overview](agents/overview.md) |
+| Set up cross-model review | [Codex Plugin](integrations/codex-plugin.md) |
+| Configure Obsidian capture | [Obsidian Agent](integrations/obsidian-agent.md) |
+| Write effective project instructions | [Writing CLAUDE.md](rules/claude-md.md) |
+| Look up a term | [Glossary](reference/glossary.md) |

--- a/docs/manual/integrations/codex-plugin.md
+++ b/docs/manual/integrations/codex-plugin.md
@@ -1,0 +1,10 @@
+# Codex Plugin
+
+!!! note "Coming Soon"
+    This section is under construction.
+
+Cross-model review with OpenAI Codex inside Claude Code.
+
+---
+
+*Content will be consolidated from existing documentation in Phase 2/3.*

--- a/docs/manual/integrations/mcp-servers.md
+++ b/docs/manual/integrations/mcp-servers.md
@@ -1,0 +1,10 @@
+# MCP Servers
+
+!!! note "Coming Soon"
+    This section is under construction.
+
+vault-metrics, context7, apple-mcp — extending Claude with external tools.
+
+---
+
+*Content will be consolidated from existing documentation in Phase 2/3.*

--- a/docs/manual/integrations/obsidian-agent.md
+++ b/docs/manual/integrations/obsidian-agent.md
@@ -1,0 +1,10 @@
+# Obsidian Agent
+
+!!! note "Coming Soon"
+    This section is under construction.
+
+Automated session capture, daily/weekly/monthly rollups, DASHBOARD.md.
+
+---
+
+*Content will be consolidated from existing documentation in Phase 2/3.*

--- a/docs/manual/learning/failure-patterns.md
+++ b/docs/manual/learning/failure-patterns.md
@@ -1,0 +1,10 @@
+# Failure Patterns
+
+!!! note "Coming Soon"
+    This section is under construction.
+
+VERIFICATION_GAP, ENUM_VALUE, COMPONENT_API — the top 3 patterns covering 89% of failures.
+
+---
+
+*Content will be consolidated from existing documentation in Phase 2/3.*

--- a/docs/manual/learning/metrics.md
+++ b/docs/manual/learning/metrics.md
@@ -1,0 +1,10 @@
+# Metrics Dashboard
+
+!!! note "Coming Soon"
+    This section is under construction.
+
+The /metrics command, trend analysis, and recommendations engine.
+
+---
+
+*Content will be consolidated from existing documentation in Phase 2/3.*

--- a/docs/manual/learning/self-learning-loop.md
+++ b/docs/manual/learning/self-learning-loop.md
@@ -1,0 +1,10 @@
+# Self-Learning Loop
+
+!!! note "Coming Soon"
+    This section is under construction.
+
+How failures become patterns become prevention. The complete feedback cycle.
+
+---
+
+*Content will be consolidated from existing documentation in Phase 2/3.*

--- a/docs/manual/reference/architecture-diagrams.md
+++ b/docs/manual/reference/architecture-diagrams.md
@@ -1,0 +1,10 @@
+# Architecture Diagrams
+
+!!! note "Coming Soon"
+    This section is under construction.
+
+All system diagrams collected in one place.
+
+---
+
+*Content will be consolidated from existing documentation in Phase 2/3.*

--- a/docs/manual/reference/file-inventory.md
+++ b/docs/manual/reference/file-inventory.md
@@ -1,0 +1,10 @@
+# File Inventory
+
+!!! note "Coming Soon"
+    This section is under construction.
+
+Complete listing of agents, commands, hooks, rules, skills, templates.
+
+---
+
+*Content will be consolidated from existing documentation in Phase 2/3.*

--- a/docs/manual/reference/glossary.md
+++ b/docs/manual/reference/glossary.md
@@ -1,0 +1,10 @@
+# Glossary
+
+!!! note "Coming Soon"
+    This section is under construction.
+
+All terms defined — agent, artifact, CONTRACT, hook, MCP, pattern, rule, skill.
+
+---
+
+*Content will be consolidated from existing documentation in Phase 2/3.*

--- a/docs/manual/rules/claude-md.md
+++ b/docs/manual/rules/claude-md.md
@@ -1,0 +1,10 @@
+# Writing CLAUDE.md
+
+!!! note "Coming Soon"
+    This section is under construction.
+
+What to include, forbidden patterns, actionable architecture documentation.
+
+---
+
+*Content will be consolidated from existing documentation in Phase 2/3.*

--- a/docs/manual/rules/conditional-rules.md
+++ b/docs/manual/rules/conditional-rules.md
@@ -1,0 +1,10 @@
+# Conditional Rules
+
+!!! note "Coming Soon"
+    This section is under construction.
+
+FastAPI layered pattern, orchestrate workflow, spec review — loaded by path match.
+
+---
+
+*Content will be consolidated from existing documentation in Phase 2/3.*

--- a/docs/manual/rules/core-patterns.md
+++ b/docs/manual/rules/core-patterns.md
@@ -1,0 +1,10 @@
+# Core Patterns
+
+!!! note "Coming Soon"
+    This section is under construction.
+
+The always-loaded 12-line rule covering 89% of failures.
+
+---
+
+*Content will be consolidated from existing documentation in Phase 2/3.*

--- a/docs/manual/workflow/commands.md
+++ b/docs/manual/workflow/commands.md
@@ -1,0 +1,10 @@
+# Command Reference
+
+!!! note "Coming Soon"
+    This section is under construction.
+
+Complete reference for all slash commands.
+
+---
+
+*Content will be consolidated from existing documentation in Phase 2/3.*

--- a/docs/manual/workflow/orchestrate.md
+++ b/docs/manual/workflow/orchestrate.md
@@ -1,0 +1,10 @@
+# Orchestrate Pipeline
+
+!!! note "Coming Soon"
+    This section is under construction.
+
+The full MAP -> PLAN -> PATCH -> PROVE pipeline with TRIVIAL/SIMPLE/COMPLEX routing.
+
+---
+
+*Content will be consolidated from existing documentation in Phase 2/3.*

--- a/docs/manual/workflow/parallel.md
+++ b/docs/manual/workflow/parallel.md
@@ -1,0 +1,10 @@
+# Parallel Execution
+
+!!! note "Coming Soon"
+    This section is under construction.
+
+Running multiple issues simultaneously with --parallel worktree isolation.
+
+---
+
+*Content will be consolidated from existing documentation in Phase 2/3.*

--- a/docs/manual/workflow/quick-mode.md
+++ b/docs/manual/workflow/quick-mode.md
@@ -1,0 +1,10 @@
+# Quick Mode
+
+!!! note "Coming Soon"
+    This section is under construction.
+
+Ad-hoc fixes without the full orchestrate pipeline.
+
+---
+
+*Content will be consolidated from existing documentation in Phase 2/3.*

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,124 @@
+site_name: Agentic Engineering Manual
+site_description: A comprehensive guide to building systematic, repeatable AI-assisted development workflows
+site_author: Jason Job
+site_url: https://agents-manual.pages.dev
+
+repo_url: https://github.com/jwj2002/agents
+repo_name: jwj2002/agents
+
+theme:
+  name: material
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: indigo
+      accent: deep purple
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: indigo
+      accent: deep purple
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.expand
+    - navigation.path
+    - navigation.top
+    - navigation.footer
+    - search.suggest
+    - search.highlight
+    - content.code.copy
+    - content.code.annotate
+    - toc.follow
+  icon:
+    repo: fontawesome/brands/github
+
+plugins:
+  - search
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.mark
+  - pymdownx.keys
+  - tables
+  - attr_list
+  - md_in_html
+  - def_list
+  - footnotes
+  - toc:
+      permalink: true
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/jwj2002
+
+docs_dir: docs/manual
+
+nav:
+  - Home: index.md
+
+  - Getting Started:
+    - Installation: getting-started/installation.md
+    - Multi-Machine Sync: getting-started/multi-machine.md
+    - Project Setup: getting-started/project-setup.md
+
+  - Workflow:
+    - Orchestrate Pipeline: workflow/orchestrate.md
+    - Command Reference: workflow/commands.md
+    - Quick Mode: workflow/quick-mode.md
+    - Parallel Execution: workflow/parallel.md
+
+  - Agents:
+    - Agent Overview: agents/overview.md
+    - MAP-PLAN: agents/map-plan.md
+    - PATCH: agents/patch.md
+    - PROVE: agents/prove.md
+    - CONTRACT: agents/contract.md
+
+  - Hooks:
+    - Lifecycle Hooks: hooks/lifecycle.md
+    - State Manager: hooks/state-manager.md
+    - Notifications: hooks/notifications.md
+    - Custom Hooks: hooks/custom-hooks.md
+
+  - Self-Learning:
+    - Learning Loop: learning/self-learning-loop.md
+    - Failure Patterns: learning/failure-patterns.md
+    - Metrics Dashboard: learning/metrics.md
+
+  - Integrations:
+    - Codex Plugin: integrations/codex-plugin.md
+    - MCP Servers: integrations/mcp-servers.md
+    - Obsidian Agent: integrations/obsidian-agent.md
+
+  - Rules:
+    - Core Patterns: rules/core-patterns.md
+    - Conditional Rules: rules/conditional-rules.md
+    - Writing CLAUDE.md: rules/claude-md.md
+
+  - Git:
+    - Git Workflow: git/workflow.md
+    - Contributing Policy: git/contributing.md
+
+  - Reference:
+    - Glossary: reference/glossary.md
+    - File Inventory: reference/file-inventory.md
+    - Architecture Diagrams: reference/architecture-diagrams.md


### PR DESCRIPTION
## Summary
- MkDocs + Material theme scaffold for comprehensive user manual
- 31 markdown files: full home page + 30 section stubs across 9 content areas
- Verified: `mkdocs build` and `mkdocs serve` work locally

Phase 1 of 4 for issue #12. Phases 2-3 fill in content, Phase 4 deploys to Cloudflare Pages.

Ref #12

## Test Plan
- [x] `mkdocs build` succeeds
- [x] `mkdocs serve` renders with correct title
- [x] Nav structure shows all 9 sections with subsections
- [x] Dark/light mode toggle works
- [x] site/ added to .gitignore