### PR TITLE
feat(docs): write all 30 manual sections for user manual

### DIFF
--- a/docs/manual/agents/contract.md
+++ b/docs/manual/agents/contract.md
@@ -1,10 +1,145 @@
 # CONTRACT Agent
 
-!!! note "Coming Soon"
-    This section is under construction.
+**Version**: 1.0 | **Phase**: 2.5 | **Role**: Interface Designer
 
-API contract definition for fullstack work. CONTRACT-lite for simple changes.
+CONTRACT defines the API boundary between backend and frontend for fullstack work. It specifies endpoints, authentication, authorization, enum values, and frontend integration notes. CONTRACT is a spec-only agent -- it reads code and writes documentation, never modifying any source files.
 
+## When CONTRACT Runs
+
+CONTRACT is positioned between planning and implementation:
+
+```
+PLAN or MAP-PLAN  -->  CONTRACT  -->  PLAN-CHECK  -->  PATCH
+```
+
+| Condition | CONTRACT Required? |
+|-----------|--------------------|
+| Backend-only change | No |
+| Frontend-only change | No |
+| Fullstack change | **Yes** |
+
+!!! warning "PATCH Enforcement"
+    PATCH checks for a `contract-{issue}-*.md` artifact before starting any fullstack work. If the artifact is missing, PATCH stops immediately with `BLOCKED: CONTRACT artifact required for fullstack`.
+
+## The ENUM_VALUE Problem
+
+Before CONTRACT was mandatory, `ENUM_VALUE` accounted for 26% of all fullstack failures. The failure pattern:
+
+```python
+# Backend defines:
+class AccountMemberRole(str, Enum):
+    CO_OWNER = "CO-OWNER"    # Python NAME: CO_OWNER, VALUE: "CO-OWNER"
+```
+
+```javascript
+// Frontend incorrectly uses the Python NAME:
+role: "CO_OWNER"    // WRONG -- underscore
+
+// Frontend should use the VALUE:
+role: "CO-OWNER"    // CORRECT -- hyphen
+```
+
+CONTRACT forces explicit documentation of enum VALUES in a dedicated section, eliminating ambiguity about which string the frontend should send.
+
+## What CONTRACT Defines
+
+### 1. Scope
+
+Explicitly state which endpoints are in scope and which are out of scope.
+
+### 2. Authentication
+
+- Token type (Bearer JWT)
+- Which endpoints require authentication
+
+### 3. Authorization
+
+- Scoping model (e.g., `account_id` path prefix)
+- Access control dependencies (e.g., `require_account_access`)
+
+### 4. Endpoint Definitions
+
+For each endpoint, CONTRACT documents:
+
+```markdown
+### POST /accounts/{account_id}/members
+
+**Auth**: Required
+**Access**: require_account_owner
+
+**Request**:
+  { "email": "string (required)", "role": "OWNER | CO-OWNER | DEPENDENT" }
+
+**Response** (201):
+  { "id": 1, "email": "user@example.com", "role": "CO-OWNER" }
+
+**Errors**: 401, 403, 404, 422
+```
+
+### 5. Enum Definitions
+
+!!! note "Critical Section"
+    This section is the primary reason CONTRACT exists. Both PATCH (backend and frontend) and PROVE use this section to verify enum alignment.
+
+For each enum:
+
+| Python Name | Python VALUE | Valid API Values |
+|-------------|-------------|-----------------|
+| `OWNER` | `"OWNER"` | `"OWNER"` |
+| `CO_OWNER` | `"CO-OWNER"` | `"CO-OWNER"` |
+| `DEPENDENT` | `"DEPENDENT"` | `"DEPENDENT"` |
+
+### 6. Frontend Integration Notes
+
+- API call pattern (via `api.js`)
+- Account prefixing behavior
+- State management approach (React Query hooks, Zustand, etc.)
+
+## CONTRACT-lite
+
+Not every fullstack change needs a full CONTRACT agent. Small changes can use an inline contract within the MAP-PLAN artifact instead.
+
+### Decision Matrix
+
+| Condition | Result |
+|-----------|--------|
+| 0 new endpoints AND 2 or fewer frontend files | CONTRACT-lite (inline in MAP-PLAN) |
+| Any new endpoints OR 3+ frontend files | CONTRACT-full (dedicated agent) |
+
+CONTRACT-lite includes the same enum value documentation and API surface description, but is embedded as a section within the MAP-PLAN artifact rather than a separate file.
+
+## Output Template
+
+The artifact starts with YAML frontmatter:
+
+```yaml
 ---
+issue: 184
+agent: CONTRACT
+date: 2026-03-26
+scope: fullstack
+endpoints_modified: 2
+breaking_changes: NO
+---
+```
 
-*Content will be consolidated from existing documentation in Phase 2/3.*
+The body includes:
+
+| Section | Content |
+|---------|---------|
+| Summary | What API changes, backward compatibility |
+| Scope | In scope and out of scope endpoints |
+| Authentication | Token type and requirements |
+| Authorization | Scoping model and access control deps |
+| Endpoints | Full definition per endpoint |
+| Enum Definitions | NAME vs VALUE table for each enum |
+| Frontend Integration | API call patterns, state management |
+| Verification | Backend and frontend gate commands |
+
+The artifact ends with `AGENT_RETURN: contract-{issue}-{mmddyy}.md`.
+
+## Efficiency Rules
+
+- Use examples over prose -- a request/response pair communicates more than a paragraph
+- Target 180 lines, max 250
+- Focus on the API surface, not the implementation details behind it

--- a/docs/manual/agents/map-plan.md
+++ b/docs/manual/agents/map-plan.md
@@ -1,10 +1,167 @@
 # MAP-PLAN Agent
 
-!!! note "Coming Soon"
-    This section is under construction.
+**Version**: 1.0 | **Phase**: 1+2 | **Role**: Investigator + Architect
 
-Combined investigation and planning for TRIVIAL/SIMPLE issues.
+MAP-PLAN combines investigation and planning into a single agent for TRIVIAL and SIMPLE issues. It reads code, documents what it finds, and produces a file-by-file implementation plan -- but never modifies any code.
 
+## When to Use
+
+| Complexity | Use MAP-PLAN? | Alternative |
+|------------|---------------|-------------|
+| TRIVIAL | Yes | -- |
+| SIMPLE | Yes | -- |
+| COMPLEX | No | Use separate MAP + PLAN agents |
+
+If during investigation the issue turns out to be COMPLEX (new endpoints, migrations, cross-module changes), MAP-PLAN stops and reports to the orchestrator for reclassification.
+
+## Mandatory Verification Protocol
+
+!!! warning "This protocol prevents 63% of MAP-PLAN failures"
+    The most common agent failure is proceeding on assumptions without reading actual code. This checklist forces verification at every step.
+
+### 1. Specification Check
+
+If the issue references a spec:
+
+- Read the specification file first (before any code exploration)
+- Note spec version and status (DRAFT / FINAL / DEPRECATED)
+- Extract all requirements, not just the obvious ones
+- Check for related specs or ADRs in the `specs/` directory
+
+### 2. Assumption Verification
+
+- List all assumptions about code structure
+- Verify each assumption by reading actual code
+- Document what was verified and the result
+- Never assume structure -- always confirm by reading
+
+### 3. Ambiguity Resolution
+
+- If multiple valid approaches exist, pick one
+- Document rationale for the chosen approach
+- If truly unclear, ask the user
+- Never leave decisions for PATCH to resolve
+
+### 4. Impact Analysis
+
+For changes to calculations or formulas:
+
+- Identify all places where the result is used
+- Check if the result feeds into dependent engines
+- Document cache invalidation needs
+- List dependent calculations that may be affected
+
+### 5. Completeness Check
+
+- List all models and components touched
+- Check for related models via relationships
+- Verify consistency requirements across all affected areas
+- Document implicit requirements explicitly
+
+Every MAP-PLAN output must include a **Verification Steps** section documenting: what spec was read, what code was verified, which approach was chosen and why, what dependencies were checked, and all models/components identified.
+
+## Process Steps
+
+### 1. Classify Complexity
+
+| Level | Criteria |
+|-------|----------|
+| TRIVIAL | Docs, config, renames, deletions |
+| SIMPLE | 1-3 files, localized change |
+| COMPLEX | New endpoints, migrations, cross-module |
+
+### 2. Identify Stack
+
+Determine `backend`, `frontend`, or `fullstack`. If fullstack, a CONTRACT agent is required before PATCH.
+
+### 3. Find Affected Files
+
+Locate all files relevant to the change using search tools. Document each file and its role in the change.
+
+### 4. Document Component APIs
+
+!!! tip "COMPONENT_API accounts for 17% of failures"
+    When reusing frontend components, always extract and document the actual PropTypes or TypeScript interface from the source file.
+
+```markdown
+#### ComponentName
+**Props**: propA (string, required), propB (func, optional)
+**Example**: `<Component propA="x" />`
+```
+
+### 5. Document Enum Values
+
+!!! tip "ENUM_VALUE accounts for 26% of failures"
+    Always document the VALUE (right side of `=`), not the Python name.
+
+| Python Name | Python VALUE | Notes |
+|-------------|--------------|-------|
+| `CO_OWNER` | `"CO-OWNER"` | Hyphen in value, underscore in name |
+
+### 6. Data Model Analysis
+
+For CRUD operations, map every field to its owning model. List all models involved and note whether multi-model orchestration is needed.
+
+### 7. Find Pattern to Mirror
+
+Search for similar existing implementations in the codebase. Reference them by file path and line range rather than quoting code.
+
+### 8. Create File-by-File Plan
+
+For each file that needs changes:
+
+```markdown
+#### File: `path/to/file.py`
+**Changes**: Add new validation method
+**Pattern**: See `similar/file.py:45-67`
+```
+
+### 9. Define Acceptance Criteria
+
+Write a single checklist of criteria. PATCH and PROVE reference this list -- it is never duplicated across artifacts.
+
+```markdown
+- [ ] Criterion 1
+- [ ] Criterion 2
+- [ ] Criterion 3
+```
+
+## Output Template
+
+The artifact starts with YAML frontmatter:
+
+```yaml
 ---
+issue: 184
+agent: MAP-PLAN
+date: 2026-03-26
+complexity: SIMPLE
+stack: backend
+files_identified: 3
+---
+```
 
-*Content will be consolidated from existing documentation in Phase 2/3.*
+The body includes these sections:
+
+| Section | Content |
+|---------|---------|
+| Summary | 3-5 sentences: what, why, risks |
+| Verification Steps | Spec read, code verified, approach decided, impact analyzed, completeness confirmed |
+| Investigation | Affected files, component APIs, enum values, data model analysis, risks |
+| Plan | File-by-file steps, acceptance criteria, verification gates |
+
+The artifact ends with `AGENT_RETURN: map-plan-{issue}-{mmddyy}.md`.
+
+## Pre-Submission Checklist
+
+Before submitting the artifact:
+
+- Read the spec first (if referenced in the issue)
+- Verified assumptions by reading actual code
+- Documented enum VALUES (not names) if fullstack
+- Documented component APIs if reusing existing components
+- Picked one approach if multiple are valid
+- Included the Verification Steps section
+- Complexity classified correctly
+- Did not edit any code (MAP-PLAN is read-only)
+- Artifact is under 450 lines (target: 350)

--- a/docs/manual/agents/overview.md
+++ b/docs/manual/agents/overview.md
@@ -1,10 +1,136 @@
-# Agent Overview
+# Agent System Overview
 
-!!! note "Coming Soon"
-    This section is under construction.
+The orchestrate pipeline uses specialized agents that execute in sequence, each producing a named artifact consumed by the next. Only one agent writes code. The rest investigate, plan, validate, and verify.
 
-Agent roles, separation of concerns, pipeline flow, artifact chains.
+## Agent Roles
 
----
+| Agent | Phase | Role | Read-Only? | Target / Max Lines |
+|-------|-------|------|------------|-------------------|
+| MAP | 1 | Investigator (COMPLEX only) | Yes | 150 / 200 |
+| MAP-PLAN | 1+2 | Investigator + Architect (TRIVIAL/SIMPLE) | Yes | 400 / 500 |
+| PLAN | 2 | Architect (COMPLEX only) | Yes | 400 / 500 |
+| TEST-PLANNER | 2 | Test matrix designer | Yes | 250 / 350 |
+| CONTRACT | 2.5 | Interface designer (fullstack) | Yes | 200 / 300 |
+| PLAN-CHECK | 2.8 | Plan validator | Yes | 80 / 120 |
+| PATCH | 3 | Implementer | **No** | 300 / 400 |
+| PROVE | 4 | Verifier + outcome recorder | Metrics only | 250 / 350 |
 
-*Content will be consolidated from existing documentation in Phase 2/3.*
+!!! warning "Separation of Concerns"
+    Only PATCH writes code. Only PROVE records metrics. Investigation agents must never start implementing. Verification agents must never start fixing.
+
+## Pipeline Flow
+
+The pipeline route depends on complexity classification:
+
+```
+TRIVIAL:   MAP-PLAN ─────────────────────────────── PATCH ── PROVE-lite
+SIMPLE:    MAP-PLAN ── [TEST-PLANNER] ── CONTRACT* ── PLAN-CHECK ── PATCH ── PROVE
+COMPLEX:   MAP ── PLAN ── [TEST-PLANNER] ── CONTRACT* ── PLAN-CHECK ── PATCH ── PROVE
+
+* = mandatory for fullstack only
+[ ] = optional, enabled with --with-tests
+```
+
+```
+                  +----------------+
+                  | GitHub Issue   |
+                  +-------+--------+
+                          |
+                +---------+---------+
+                | Classify Complexity|
+                +---------+---------+
+           +----------+----------+----------+
+           v          v                     v
+       TRIVIAL     SIMPLE               COMPLEX
+       1-2 files   3-5 files            6+ files
+           |          |                     |
+       MAP-PLAN   MAP-PLAN             MAP -> PLAN
+           |          |                     |
+           |     CONTRACT* / PLAN-CHECK  CONTRACT / PLAN-CHECK
+           |          |                     |
+        PATCH      PATCH                 PATCH
+           |          |                     |
+      PROVE-lite   PROVE                 PROVE
+```
+
+## Artifact Chains and Validation
+
+Each agent produces a named artifact following the pattern `{agent}-{issue}-{mmddyy}.md` stored in `.agents/outputs/`. Every agent validates that its required predecessor artifact exists before starting work.
+
+| Agent | Required Predecessor | Stops If Missing? |
+|-------|---------------------|-------------------|
+| MAP / MAP-PLAN | None (first agent) | N/A |
+| PLAN | MAP artifact | Yes |
+| TEST-PLANNER | MAP or MAP-PLAN | Yes |
+| CONTRACT | PLAN or MAP-PLAN | Yes |
+| PLAN-CHECK | PLAN or MAP-PLAN; CONTRACT if fullstack | Yes |
+| PATCH | PLAN or MAP-PLAN; CONTRACT if fullstack; PLAN-CHECK | Yes |
+| PROVE | PATCH artifact | Yes |
+
+```
+map-plan-184-030826.md
+    |
+    +-- contract-184-030826.md (if fullstack)
+    |
+    +-- plan-check-184-030826.md
+            |
+            +-- patch-184-030826.md
+                    |
+                    +-- prove-184-030826.md
+```
+
+!!! note "Blocking on Missing Artifacts"
+    If PATCH detects fullstack work but cannot find a CONTRACT artifact, it stops immediately with `BLOCKED: CONTRACT artifact required for fullstack`. No assumptions, no proceeding without explicit input.
+
+## Shared Behaviors from _base.md
+
+All agents inherit from `_base.md` (v3.0), which provides:
+
+**Pre-flight checks** -- Before any work begins, agents load learned failure patterns (via MCP `failure_patterns()` or file fallback), search for similar past artifacts, and verify project constraints.
+
+**Artifact naming** -- `{agent}-{issue}-{mmddyy}.md` in `.agents/outputs/`.
+
+**Size compliance** -- Each agent has target and max line counts. Artifacts over max must be compressed before submission using a priority checklist: replace code quotes with line references, remove restated acceptance criteria, consolidate duplicates, remove appendices.
+
+**Verification commands** -- Standardized gates for backend (`ruff check . && pytest -q`) and frontend (`npm run lint && npm run build`).
+
+**AGENT_RETURN directive** -- Every agent must end output with `AGENT_RETURN: {filename}` to signal completion to the orchestrator.
+
+**Failure context awareness** -- When spawned with a `## Prior Failure` block, the agent applies the prevention recommendation before starting and explicitly verifies the prior failure point is addressed.
+
+**Escalation protocol** -- Agents stop and report to the orchestrator if complexity seems wrong, information is missing, constraints would be violated, or scope is ambiguous.
+
+## Agent Versioning
+
+All agents include `version: X.Y` in their YAML frontmatter.
+
+| Change Type | Version Bump | Examples |
+|-------------|-------------|----------|
+| Minor (1.0 to 1.1) | Pattern additions, wording changes | Add new enum check reminder |
+| Major (1.0 to 2.0) | Restructure, new sections, workflow changes | Add Mandatory Verification Protocol |
+
+Versions are recorded in `metrics.jsonl` via the `agent_versions` field, enabling correlation between agent versions and success rates through the `/metrics` command.
+
+```json
+"agent_versions": {"map-plan": "1.0", "patch": "1.2", "prove": "1.3"}
+```
+
+## Root Cause Classification
+
+When failures occur, they are classified using a canonical enum of 11 codes:
+
+| Code | Description |
+|------|-------------|
+| `ENUM_VALUE` | Used enum NAME instead of VALUE |
+| `COMPONENT_API` | Wrong props or hook usage |
+| `MULTI_MODEL` | Forgot model relationship |
+| `API_MISMATCH` | Frontend/backend contract violation |
+| `ACCESS_CONTROL` | Missing or wrong permission check |
+| `MISSING_TEST` | Untested code path |
+| `SQLITE_COMPAT` | PostgreSQL-only feature used |
+| `STRUCTURE_VIOLATION` | Violated project constraints |
+| `SCOPE_CREEP` | Changes beyond issue scope |
+| `VERIFICATION_GAP` | Assumptions not verified by reading code |
+| `OTHER` | Document specifics in details field |
+
+These codes feed back into the learning loop: `/learn` clusters failures by root cause, extracts prevention patterns, and updates agent definitions.

--- a/docs/manual/agents/patch.md
+++ b/docs/manual/agents/patch.md
@@ -1,10 +1,168 @@
 # PATCH Agent
 
-!!! note "Coming Soon"
-    This section is under construction.
+**Version**: 1.2 | **Phase**: 3 | **Role**: Implementer
 
-The only agent that writes code. Pre-flight checklists, deviation policy.
+PATCH is the only agent in the pipeline that writes code. It reads the plan, extracts requirements, implements changes, runs verification gates, and documents what changed. If any gate fails, PATCH fixes the issue in-place before submitting its artifact.
 
+## Pre-Flight Checklist
+
+Before writing a single line of code, PATCH must complete these checks:
+
+```
+- [ ] Read PLAN or MAP-PLAN artifact
+- [ ] Read CONTRACT artifact (MANDATORY if fullstack -- STOP if missing)
+- [ ] Read .claude/rules.md for project constraints
+- [ ] NOT on main branch (verified via git branch --show-current)
+- [ ] No new top-level directories planned
+- [ ] All changes are within scope of the PLAN
+```
+
+!!! warning "Branch Protection"
+    If PATCH detects it is on the `main` branch, it stops immediately with `BLOCKED: Cannot run PATCH on main branch`. This is a hard stop with no override.
+
+## Artifact Validation
+
+PATCH verifies predecessor artifacts exist before starting:
+
+```bash
+# Must exist
+ls .agents/outputs/{plan,map-plan}-${ISSUE}-*.md
+
+# Must exist if fullstack
+ls .agents/outputs/contract-${ISSUE}-*.md
+```
+
+If any required artifact is missing, PATCH reports `BLOCKED` and returns to the orchestrator.
+
+## Pre-Implementation Requirements Extraction
+
+Before writing code, PATCH extracts all requirements from the plan into a structured checklist:
+
+```markdown
+## Requirements Checklist
+
+### From Spec/PLAN
+- [ ] Field X maps to Model.field_x
+- [ ] Validation rule: email must be unique
+- [ ] Business logic: recalculate totals on update
+
+### Data Model Analysis
+- Models involved: Account, AccountMember
+- Multi-model operation: YES
+- Repository return type: ORM objects
+```
+
+This checklist ensures nothing is missed during implementation and provides a verification target for the completion check.
+
+## Implementation Conventions
+
+### Backend
+
+- Access control logic belongs in dependency injection, never inline in route handlers
+- Routers stay thin -- business logic lives in services
+- Tests must be SQLite-compatible
+- Format only modified files: `ruff format path/to/modified.py`
+
+### Frontend
+
+- All API calls go through `frontend/src/api.js`
+- Reuse established component patterns from the codebase
+- Verify component APIs by reading source before using them
+
+## Pre-Submission Gates
+
+!!! note "Fix Before Submitting"
+    If any gate fails, PATCH fixes the issue within the same session, re-runs the gate, and only proceeds when all gates pass. A failing artifact is never submitted.
+
+### Backend Gates
+
+```bash
+cd backend && ruff check . --fix && ruff format <modified_files>
+cd backend && pytest -q
+```
+
+### Frontend Gates
+
+```bash
+cd frontend && npm run lint
+cd frontend && npm run build
+```
+
+If a gate is unfixable within the current session, PATCH sets its artifact status to `Blocked`, documents the failure, and returns to the orchestrator.
+
+## Deviation Policy
+
+When implementation diverges from the plan, PATCH categorizes the deviation and takes the appropriate action:
+
+| Level | Examples | Action |
+|-------|----------|--------|
+| **TRIVIAL** | Naming, formatting, import order | Proceed silently |
+| **MINOR** | Different utility function, extra helper, slightly different signature | Note in Deviations section |
+| **SIGNIFICANT** | Different approach, extra endpoint, schema change | **STOP**. Document and return to orchestrator |
+| **SCOPE** | New feature, unplanned migration, unplanned module | **ABORT**. Return immediately |
+
+!!! tip "When in Doubt, Escalate"
+    If unsure whether a deviation is MINOR or SIGNIFICANT, always choose the higher level. It is better to pause and confirm than to proceed with an unauthorized change.
+
+## Completion Checklist
+
+Before marking the artifact as DONE:
+
+**Code Quality**
+
+- Every requirement from the checklist is implemented
+- No TODO, FIXME, or HACK comments remain
+- No stub implementations (`pass`, `return False`, `return []`)
+
+**Spec Compliance**
+
+- Implementation matches the spec exactly
+- All fields are implemented
+- All validations are implemented
+
+**Multi-Model (if applicable)**
+
+- All models updated in the same transaction
+- Relationships loaded correctly for serialization
+
+**Testing**
+
+- New code has tests
+- Success and error cases covered
+
+## Output Template
+
+The PATCH artifact includes a YAML frontmatter block:
+
+```yaml
 ---
+issue: 184
+agent: PATCH
+date: 2026-03-26
+status: Complete | Blocked | Gates-Failed
+files_modified: 3
+files_created: 1
+tests_added: 4
+---
+```
 
-*Content will be consolidated from existing documentation in Phase 2/3.*
+The body documents:
+
+| Section | Content |
+|---------|---------|
+| Summary | What was implemented (3-5 sentences) |
+| Pre-Flight | Checklist of what was read and verified |
+| Requirements Checklist | Extracted from the plan |
+| Files Changed | Per-file list of additions and modifications |
+| Component API Verification | Table matching PLAN spec to actual props (if frontend) |
+| Enum Alignment | Table matching frontend strings to backend VALUES (if fullstack) |
+| Verification | Gate results with pass/fail and output |
+| Deviations | Any divergence from PLAN with level and justification |
+
+The artifact ends with `AGENT_RETURN: patch-{issue}-{mmddyy}.md`.
+
+## Efficiency Rules
+
+- Do not re-quote code from the plan. Reference by file and line: "Implemented as planned in PLAN lines 45-67"
+- Keep the artifact under 350 lines (target: 250)
+- Focus on what changed and any issues encountered

--- a/docs/manual/agents/prove.md
+++ b/docs/manual/agents/prove.md
@@ -1,10 +1,202 @@
 # PROVE Agent
 
-!!! note "Coming Soon"
-    This section is under construction.
+**Version**: 1.3 | **Phase**: 4 | **Role**: Verifier + Outcome Recorder
 
-Verification levels (EXISTS, SUBSTANTIVE, WIRED, FUNCTIONAL) and outcome recording.
+PROVE is the final agent in the pipeline. It verifies that PATCH's implementation actually works, checks every acceptance criterion, records the outcome to structured data files, and classifies any failures by root cause. PROVE never fixes code -- it only reports.
 
----
+## Artifact Validation
 
-*Content will be consolidated from existing documentation in Phase 2/3.*
+PROVE requires the PATCH artifact to exist:
+
+```bash
+ls .agents/outputs/patch-${ISSUE}-*.md
+```
+
+If the PATCH artifact is missing, PROVE stops with `BLOCKED: PATCH artifact not found`.
+
+## Four Verification Levels
+
+PROVE applies verification in layers, from basic existence checks through functional testing.
+
+### Level 1: EXISTS
+
+Verify every file listed in the PATCH artifact exists on disk.
+
+```bash
+for f in <files_from_patch>; do
+  [ -f "$f" ] || echo "MISSING: $f"
+done
+```
+
+**Fail condition**: Any file from the PATCH artifact is missing.
+
+### Level 2: SUBSTANTIVE
+
+Verify that no stubs, placeholders, or incomplete implementations remain in modified files.
+
+```bash
+# Backend stubs
+grep -rn "pass$\|return False$\|return \[\]$\|raise NotImplementedError" <files>
+
+# Frontend stubs
+grep -rn "onClick={() => {}}\|return null$" <files>
+
+# Universal markers
+grep -rn "TODO\|FIXME\|HACK\|PLACEHOLDER" <files>
+```
+
+**Fail condition**: Any stub, placeholder, or marker found in new or modified files.
+
+### Level 3: WIRED
+
+Verify that new code is actually integrated into the application, not sitting in isolated files.
+
+Checks include:
+
+- New components are imported somewhere
+- New endpoints are called from the frontend
+- New repositories are injected into services
+- Enum values in frontend match backend VALUES (ENUM_VALUE check)
+- Component prop usage matches actual API (COMPONENT_API check)
+
+**Fail condition**: Isolated artifacts with no integration, or mismatched enum values or props.
+
+### Level 4: FUNCTIONAL
+
+Run the standard verification gates:
+
+| Check | Command | Pass Criteria |
+|-------|---------|---------------|
+| Backend lint | `ruff check .` | No errors |
+| Backend tests | `pytest -q` | All pass |
+| Frontend lint | `npm run lint` | No errors |
+| Frontend build | `npm run build` | Success |
+
+## Focused Test Strategy
+
+PROVE runs tests in two passes for fast feedback:
+
+**Pass 1 -- Focused** (affected modules only):
+
+```bash
+MODULES=$(git diff --name-only HEAD~1 -- backend/ \
+  | grep -oP 'backend/backend/\K[^/]+' | sort -u)
+for mod in $MODULES; do
+  pytest "backend/${mod}/tests/" -q
+done
+```
+
+**Pass 2 -- Full suite** (safety net):
+
+```bash
+cd backend && pytest -q
+cd frontend && npm run lint && npm run build
+```
+
+Both results are reported in the artifact:
+
+```
+Focused: backend/accounts/tests/ -- 12/12 passing (2.1s)
+Full suite: pytest -q -- 45/45 passing (8.3s)
+```
+
+!!! tip "When to Skip Focused Mode"
+    Skip the focused pass for fullstack changes, refactoring, cross-module changes, or codebases with fewer than 50 total tests where the full suite is fast enough.
+
+## Acceptance Criteria Checking
+
+PROVE references the acceptance criteria from the MAP-PLAN or PLAN artifact and checks each one:
+
+| Criterion | Status |
+|-----------|--------|
+| New endpoint returns 201 on success | PASS |
+| Validation rejects empty email | PASS |
+| Frontend form submits to correct URL | FAIL -- sends to /api/members instead of /api/accounts/{id}/members |
+
+## Status Determination
+
+| Condition | Status |
+|-----------|--------|
+| All gates pass, all criteria met | **PASS** |
+| Any verification command fails | **BLOCKED** |
+| Any acceptance criterion unmet | **BLOCKED** |
+| Any pattern check fails (enum, component API) | **BLOCKED** |
+
+## Outcome Recording
+
+### On PASS
+
+Append to `.claude/memory/metrics.jsonl`:
+
+```json
+{
+  "issue": 184,
+  "date": "2026-03-26",
+  "status": "PASS",
+  "complexity": "SIMPLE",
+  "stack": "backend",
+  "agents_run": ["MAP-PLAN", "PATCH", "PROVE"],
+  "agent_versions": {"map-plan": "1.0", "patch": "1.2", "prove": "1.3"}
+}
+```
+
+### On BLOCKED
+
+Append to both `.claude/memory/failures.jsonl` and `.claude/memory/metrics.jsonl`:
+
+**failures.jsonl** records the specific failure:
+
+```json
+{
+  "issue": 184,
+  "agent": "PATCH",
+  "root_cause": "ENUM_VALUE",
+  "details": "Frontend used CO_OWNER instead of CO-OWNER",
+  "fix": "Changed string literal to match backend enum VALUE",
+  "prevention": "MAP should document enum VALUES explicitly"
+}
+```
+
+**metrics.jsonl** records the outcome:
+
+```json
+{
+  "issue": 184,
+  "status": "BLOCKED",
+  "root_cause": "ENUM_VALUE",
+  "blocking_agent": "PROVE"
+}
+```
+
+These records feed the self-learning loop: `/learn` clusters failures by root cause, extracts prevention patterns, and updates agent definitions.
+
+## Root Cause Classification
+
+When recording a BLOCKED outcome, PROVE classifies the failure using the canonical root cause enum. The three most common codes are:
+
+| Code | Frequency | Description |
+|------|-----------|-------------|
+| `VERIFICATION_GAP` | 63% | Assumptions not verified by reading code |
+| `ENUM_VALUE` | 26% | Used enum NAME instead of VALUE |
+| `COMPONENT_API` | 17% | Wrong props or hook usage |
+
+See [Agent Overview](overview.md) for the full list of 11 root cause codes.
+
+## PROVE-lite
+
+For TRIVIAL issues, PROVE runs in a lightweight mode:
+
+- Runs Level 4 (FUNCTIONAL) gates only
+- Skips Level 2 (SUBSTANTIVE) and Level 3 (WIRED) checks
+- Still records the outcome to `metrics.jsonl`
+
+## When BLOCKED
+
+PROVE includes four pieces of information when reporting a failure:
+
+1. **Root cause classification** from the canonical enum
+2. **Exact error output** from the failing command or check
+3. **Unblock steps** describing what needs to change
+4. **Prevention recommendation** for future runs
+
+PROVE never attempts to fix the problem. It returns to the orchestrator with its findings.

--- a/docs/manual/getting-started/installation.md
+++ b/docs/manual/getting-started/installation.md
@@ -1,10 +1,164 @@
 # Installation
 
-!!! note "Coming Soon"
-    This section is under construction.
+This guide walks through setting up the Claude Code configuration framework on a new machine.
 
-Clone the agents repo, run install.sh, prerequisites for macOS/WSL/Linux.
+## Prerequisites
 
----
+| Tool | Minimum Version | Purpose |
+|------|----------------|---------|
+| **Git** | 2.30+ | Version control, worktree support |
+| **Python 3** | 3.10+ | Hooks, MCP server, statusline |
+| **Node.js** | 18+ | MCP transports, frontend tooling |
+| **GitHub CLI** (`gh`) | 2.0+ | Issue and PR automation |
+| **Claude Code** | Latest | The CLI itself |
 
-*Content will be consolidated from existing documentation in Phase 2/3.*
+Optional but recommended:
+
+| Tool | Purpose |
+|------|---------|
+| **uv** | Fast Python package management (preferred over pip) |
+| **Bun** | Fast JS runtime for MCP servers |
+
+## Step 1: Clone the Repository
+
+```bash
+git clone https://github.com/your-org/agents.git ~/agents
+```
+
+This creates the central configuration repository at `~/agents/`.
+
+## Step 2: Run the Installer
+
+```bash
+cd ~/agents/claude-config && ./install.sh
+```
+
+The installer runs four phases automatically.
+
+### Phase 1: Symlinks
+
+Creates symlinks from `~/.claude/` to the repo so Claude Code reads your version-controlled configuration directly.
+
+| Source (in repo) | Target (Claude reads) |
+|------------------|-----------------------|
+| `claude-config/settings.json` | `~/.claude/settings.json` |
+| `claude-config/hooks/` | `~/.claude/hooks/` |
+| `claude-config/commands/` | `~/.claude/commands/` |
+| `claude-config/agents/` | `~/.claude/agents/` |
+| `claude-config/rules/` | `~/.claude/rules/` |
+| `claude-config/skills/` | `~/.claude/skills/` |
+| `claude-config/statusline.py` | `~/.claude/statusline.py` |
+
+!!! note "settings.local.json is never symlinked"
+    Machine-specific settings (`settings.local.json`) stay local. This file holds MCP server paths that vary by machine and is not tracked in git.
+
+### Phase 2: Dependencies
+
+The installer detects your Python package manager in priority order: active venv, `uv pip`, `pip3`, `pip`.
+
+**MCP server** -- installed into a dedicated virtual environment:
+
+```bash
+# Created automatically by install.sh
+~/agents/mcp-server/.venv/bin/pip install -e ~/agents/mcp-server
+```
+
+**PyYAML** -- required by session hooks for state persistence:
+
+```bash
+# install.sh checks if yaml is importable first
+python3 -c "import yaml" || pip install PyYAML
+```
+
+### Phase 2.5: Plugins
+
+If the `claude` CLI is available, the installer configures the Codex plugin:
+
+```bash
+claude plugin marketplace add openai/codex-plugin-cc
+claude plugin install codex@openai-codex
+```
+
+!!! tip "Codex plugin is optional"
+    The plugin enables `/codex-review` for second-opinion code reviews. Skip this if you do not have an OpenAI API key.
+
+### Phase 3: First-time Setup
+
+Creates the Obsidian vault directory and agent configuration:
+
+- **macOS**: Uses iCloud path (`~/Library/Mobile Documents/iCloud~md~obsidian/Documents/MyVault`)
+- **WSL**: Creates Windows-side directory with symlink
+- **Linux**: Uses `~/obsidian/MyVault`
+
+Generates `~/.config/obsidian-agent/config.toml` with vault path and extraction settings.
+
+### Phase 4: Verification
+
+The installer verifies all components:
+
+- All 7 symlinks resolve correctly
+- MCP server runs from its dedicated venv
+- PyYAML is importable by `python3`
+- `python3` command is available (hooks depend on it)
+
+## Platform Detection
+
+The installer auto-detects your platform:
+
+```
++---------------------------------------------+
+|  uname == Darwin?                           |
+|    YES --> macOS (iCloud vault path)        |
+|    NO  --> /proc/version contains microsoft?|
+|              YES --> WSL (Windows-side vault)|
+|              NO  --> Linux (local vault)     |
++---------------------------------------------+
+```
+
+On WSL, the installer resolves the Windows username via `cmd.exe` to locate the correct vault path under `/mnt/c/Users/`.
+
+## Verification
+
+After installation, confirm everything works:
+
+```bash
+# Check symlinks
+ls -la ~/.claude/settings.json
+ls -la ~/.claude/commands
+ls -la ~/.claude/agents
+
+# Check MCP server
+cd ~/agents/mcp-server && .venv/bin/python server.py --help
+
+# Check PyYAML
+python3 -c "import yaml; print('OK')"
+
+# Launch Claude Code
+claude
+```
+
+You should see all slash commands available (type `/` to list them).
+
+## Updating
+
+After pulling config changes from git:
+
+```bash
+cd ~/agents && git pull
+cd claude-config && ./install.sh
+```
+
+The installer is idempotent -- it skips existing correct symlinks and only updates what changed. Existing non-symlink files are backed up to `~/.claude/config-backup-{timestamp}/` before replacement.
+
+!!! warning "Always re-run install.sh after pulling"
+    New commands, agents, or hooks may have been added. The symlinks themselves persist, but dependency versions or new plugin requirements might need updating.
+
+## Troubleshooting
+
+| Problem | Solution |
+|---------|----------|
+| `python3 not found` | Install Python 3.10+ or create alias: `alias python3=python` |
+| `pip not found` | Install pip: `python3 -m ensurepip` or `apt install python3-pip` |
+| MCP server fails | Check venv: `~/agents/mcp-server/.venv/bin/python -c "import mcp"` |
+| PyYAML install fails (PEP 668) | The installer tries `--user --break-system-packages` automatically. If still failing: `apt install python3-yaml` |
+| Broken symlinks after git pull | Re-run `./install.sh` to repair |

--- a/docs/manual/getting-started/multi-machine.md
+++ b/docs/manual/getting-started/multi-machine.md
@@ -1,10 +1,139 @@
 # Multi-Machine Sync
 
-!!! note "Coming Soon"
-    This section is under construction.
+The configuration framework uses symlinks and git to keep Claude Code settings identical across every development machine. Pull once, and every machine updates.
 
-Propagating changes across machines via git pull. Platform-specific handling.
+## How Sync Works
 
----
+```
+Machine A (edit config)          Machine B (pull to sync)
+------------------------         ------------------------
+~/agents/claude-config/          ~/agents/claude-config/
+    |  git push                      |  git pull
+    v                                v
+GitHub repo ------------------> GitHub repo
+                                     |
+                                ./install.sh
+                                     |
+                                ~/.claude/ (symlinks updated)
+```
 
-*Content will be consolidated from existing documentation in Phase 2/3.*
+Because `~/.claude/` is symlinked to the repo, a `git pull` in `~/agents/` instantly updates all configuration. Run `./install.sh` after pulling only if new dependencies or plugins were added.
+
+## Shared vs Local
+
+### Shared (git-tracked, synced across machines)
+
+| Component | Path | Description |
+|-----------|------|-------------|
+| Agents | `claude-config/agents/` | MAP, PLAN, PATCH, PROVE definitions |
+| Commands | `claude-config/commands/` | All slash commands |
+| Hooks | `claude-config/hooks/` | SessionStart, PreCompact, Stop hooks |
+| Rules | `claude-config/rules/` | Conditional rule files |
+| Skills | `claude-config/skills/` | Multi-step workflow definitions |
+| Settings | `claude-config/settings.json` | Hooks, permissions, plugins, MCP |
+| Statusline | `claude-config/statusline.py` | Terminal status bar |
+
+### Local (never synced, machine-specific)
+
+| Component | Path | Why Local |
+|-----------|------|-----------|
+| `settings.local.json` | `~/.claude/settings.local.json` | MCP server paths vary by machine |
+| Memory | `~/.claude/memory/` | Per-machine learned patterns |
+| Projects | `~/.claude/projects/` | Session data per project |
+| History | `~/.claude/history.jsonl` | Conversation history |
+| Debug | `~/.claude/debug/` | Debug logs |
+| State | `.agents/outputs/claude_checkpoints/` | Session-local, recreated by hooks |
+
+!!! note "Project-level memory lives in the project repo"
+    Files under `<project>/.claude/memory/` (metrics, failures, patterns) are committed to each project's own repository, not to the agents repo. They sync with the project, not with the configuration.
+
+## Updating Shared Config
+
+When you edit configuration on one machine:
+
+```bash
+cd ~/agents
+git checkout -b config/add-new-command
+# ... make changes ...
+git add -A && git commit -m "feat(commands): add new slash command"
+git push
+```
+
+After the PR merges, on every other machine:
+
+```bash
+cd ~/agents
+git pull
+~/agents/claude-config/install.sh   # only if deps changed
+```
+
+## Platform-Specific Handling
+
+The installer adapts behavior per platform:
+
+| Behavior | macOS | WSL | Linux |
+|----------|-------|-----|-------|
+| Vault path | iCloud auto-detect | Windows-side + symlink | `~/obsidian/MyVault` |
+| Symlink creation | `ln -sf` | `ln -sf` | `ln -sf` |
+| pip strategy | uv preferred | System pip + `--user` | uv or pip3 |
+| Windows user | N/A | Auto-detected via `cmd.exe` | N/A |
+
+!!! tip "WSL users"
+    The vault directory is created on the Windows side (`/mnt/c/Users/<winuser>/obsidian/MyVault`) and symlinked into WSL. This lets Obsidian on Windows read the same vault.
+
+## Multi-Account GitHub Setup
+
+When working across multiple GitHub accounts on the same machine, use `gh auth` to manage account switching.
+
+### Account Mapping
+
+| GitHub Account | Used For | Git Email |
+|---------------|----------|-----------|
+| `personal-account` | Personal projects | personal@placeholder.com |
+| `work-account` | Work projects | work@placeholder.com |
+
+### Required Steps
+
+Before any git or `gh` operation:
+
+```bash
+# 1. Check active account
+gh auth status
+
+# 2. Switch if needed
+gh auth switch -u <correct_account>
+```
+
+For work repositories, always set the local git config after cloning:
+
+```bash
+git config user.name "Your Name"
+git config user.email "work@placeholder.com"
+```
+
+!!! warning "Never use global git config for email"
+    Always set email per-repo for work projects to avoid committing under the wrong identity.
+
+### Project-to-Account Mapping
+
+Maintain a mapping file (`claude-config/rules/github-accounts.md`) that maps each project path to the correct GitHub account. Agents read this file to verify the correct account is active before push operations.
+
+| Project Path | GitHub Account |
+|-------------|---------------|
+| `~/projects/app-a` | `personal-account` |
+| `~/projects/app-b` | `work-account` |
+| `~/agents` | `personal-account` |
+
+### Safety Rules
+
+- Never push to a work repo while logged in as your personal account (or vice versa)
+- Always verify with `gh auth status` before `git push` or `gh pr create`
+- The `/pr` command checks the active account automatically
+
+## Adding a New Machine
+
+1. Clone the repo: `git clone <repo-url> ~/agents`
+2. Run installer: `cd ~/agents/claude-config && ./install.sh`
+3. Create `~/.claude/settings.local.json` with machine-specific MCP paths
+4. Set up `gh auth` for your GitHub account(s)
+5. Verify: run `claude` and confirm all commands are available

--- a/docs/manual/getting-started/project-setup.md
+++ b/docs/manual/getting-started/project-setup.md
@@ -1,10 +1,199 @@
 # Project Setup
 
-!!! note "Coming Soon"
-    This section is under construction.
+Every project that uses Claude Code benefits from a local configuration structure. This guide covers bootstrapping a new project with the right files and directories.
 
-Bootstrapping a new project with CLAUDE.md, .claude/ config, and .agents/ outputs.
+## Quick Bootstrap
 
+Run the project bootstrap script from inside any git repository:
+
+```bash
+~/agents/claude-config/new-project-claude.sh /path/to/your/project
+```
+
+Or from within the project directory:
+
+```bash
+~/agents/claude-config/new-project-claude.sh
+```
+
+The script copies template files without overwriting anything that already exists.
+
+## What Gets Created
+
+```
+your-project/
+├── CLAUDE.md                        # Project instructions for Claude Code
+└── .claude/
+    ├── settings.json                # Project-level permissions
+    ├── commands/                    # Project-specific slash commands
+    │   └── .gitkeep
+    ├── context/
+    │   └── project-stack.md         # Tech stack reference
+    ├── memory/                      # Metrics, failures, patterns
+    │   └── .gitkeep
+    └── rules/
+        └── project-rules.md         # Project-specific rules
+```
+
+After bootstrap, the orchestrate workflow also uses:
+
+```
+your-project/
+├── .agents/
+│   └── outputs/                     # Workflow artifacts land here
+│       ├── archive/                 # Post-merge artifact storage
+│       └── claude_checkpoints/
+│           └── PERSISTENT_STATE.yaml
+└── .worktrees/                      # Parallel execution (gitignored)
+```
+
+!!! tip "Gitignore recommendations"
+    Add `.agents/outputs/` to `.gitignore` unless you want to track artifacts. Always gitignore `.worktrees/`.
+
+## CLAUDE.md Template
+
+The `CLAUDE.md` file at the project root is the primary instruction file Claude Code reads. Fill in each section:
+
+```markdown
+# CLAUDE.md
+
+This file provides project-specific guidance to Claude Code.
+
+## Project Overview
+
+- Purpose:
+- Users:
+- Non-goals:
+
+## Development Commands
+
+```bash
+# Setup
+
+# Run
+
+# Test
+
+# Lint/Format
+```
+
+## Architecture Constraints
+
+- Required patterns:
+- Forbidden changes:
+- Data/security constraints:
+
+## Delivery Rules
+
+- Definition of done:
+- Required test coverage:
+- Rollback expectations:
+```
+
+### What to Include
+
+| Section | Content | Example |
+|---------|---------|---------|
+| **Purpose** | One-line project description | "Financial planning SaaS" |
+| **Non-goals** | What Claude should never do | "Never create `src/` directory" |
+| **Development Commands** | Exact commands for setup, run, test, lint | `ruff check . && pytest -q` |
+| **Architecture Constraints** | Patterns that must be followed | "Layered: Router -> Service -> Repo" |
+| **Forbidden changes** | Files/dirs that must not be modified | "Never push to production branch" |
+| **Delivery Rules** | Definition of done, test requirements | "All tests pass, lint clean" |
+
+!!! warning "Be specific about forbidden actions"
+    Vague constraints like "be careful with the database" are ignored. Write "Never run DROP TABLE or DELETE without WHERE clause" instead.
+
+## Project Stack Context
+
+The `project-stack.md` file gives Claude Code quick context about your technology choices:
+
+```markdown
+# Project Stack
+
+- Language/runtime: Python 3.12, Node 20
+- Frameworks: FastAPI 0.115, React 19, Vite 6
+- Storage: PostgreSQL 16, Redis 7
+- Infra/deploy: Docker, AWS ECS
+- External services: Stripe, SendGrid
+```
+
+## Project-Level Settings
+
+The `.claude/settings.json` file controls permissions:
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "Bash(cd backend && ruff check .)",
+      "Bash(cd backend && pytest -q)"
+    ],
+    "deny": []
+  }
+}
+```
+
+Add frequently-used commands to `allow` so Claude Code does not prompt for permission each time.
+
+## Project-Specific Rules
+
+Add concrete, actionable rules to `.claude/rules/project-rules.md`:
+
+```markdown
+# Project Rules
+
+- All Python files use SQLAlchemy 2.0 style (Mapped[T], mapped_column)
+- Pydantic models use ConfigDict(from_attributes=True)
+- Repositories never call commit() -- services own the transaction
+- Frontend components use named exports, not default exports
+- Test database is SQLite in-memory -- avoid PostgreSQL-only syntax
+```
+
+## Project-Specific Commands
+
+Create project-specific slash commands in `.claude/commands/`:
+
+```markdown
+---
+description: Run the full test suite for this project
 ---
 
-*Content will be consolidated from existing documentation in Phase 2/3.*
+# Run Tests
+
+```bash
+cd backend && pytest -q --timeout=60
+cd frontend && npm run test
+```
+```
+
+Save as `.claude/commands/test.md` to enable `/test` within this project.
+
+## Memory and Learning
+
+The `.claude/memory/` directory accumulates over time:
+
+| File | Created By | Purpose |
+|------|-----------|---------|
+| `patterns.md` | `/learn` | Auto-extracted failure patterns |
+| `patterns-critical.md` | `/learn` | Top patterns (loaded every session) |
+| `patterns-full.md` | `/learn` | Complete pattern database |
+| `metrics.jsonl` | PROVE agent | One line per completed issue |
+| `failures.jsonl` | PROVE agent | Failure details for learning |
+| `pattern-events.jsonl` | `/learn --apply` | Pattern application tracking |
+
+These files are committed to the project repository so patterns persist across machines.
+
+## Global vs Project Override
+
+Claude Code resolves configuration with project-first fallback:
+
+```
+1. .claude/agents/patch.md         (project override)
+2. ~/.claude/agents/patch.md       (global default)
+```
+
+This applies to agents, commands, and rules. To customize an agent for a specific project, copy it from `~/.claude/agents/` into the project's `.claude/agents/` and modify it.
+
+!!! note "Project overrides are rare"
+    Most projects use the global agents unchanged. Only override when a project has unique architectural patterns that require different agent behavior.

--- a/docs/manual/git/contributing.md
+++ b/docs/manual/git/contributing.md
@@ -1,10 +1,153 @@
 # Contributing Policy
 
-!!! note "Coming Soon"
-    This section is under construction.
+This policy governs how multiple AI agents work in parallel on the same codebase without breaking each other's work or polluting the git history.
 
-Multi-agent development policy, worktree isolation, wave scheduling.
+## Core Tenets
 
----
+1. **Main stays green at all times** --- main is always deployable, always passes all checks
+2. **One branch = one PR = one logical change** --- no branch reuse, no mega-commits
+3. **Agents own files, not branches** --- parallel work is safe when agents touch different files
+4. **Squash merge everything** --- clean linear history on main
+5. **No direct commits to main** --- all changes go through PRs with status checks
 
-*Content will be consolidated from existing documentation in Phase 2/3.*
+## Parallel Agent Work
+
+### File Ownership Model
+
+Before agents start parallel work, the orchestrator assigns **non-overlapping file sets** per agent:
+
+```
+Agent A: src/auth/login.py, src/auth/oauth.py
+Agent B: src/api/users.py, src/api/schemas.py
+Agent C: tests/test_auth.py, tests/test_users.py
+```
+
+Two agents must never edit the same file simultaneously. If overlap exists, **serialize** --- Agent B waits for Agent A's PR to merge.
+
+### Pre-Work Checks
+
+Every agent must run these checks before starting:
+
+```bash
+# 1. Sync main
+git fetch origin main
+
+# 2. Branch from latest main
+git checkout -b {branch} origin/main
+
+# 3. Verify no conflicts with in-flight PRs
+gh pr list --state open --json headRefName,files
+
+# 4. Confirm no open PR touches the same files
+```
+
+### Worktree Isolation
+
+Each agent works in its own git worktree:
+
+```bash
+# Create isolated worktree for agent
+git worktree add ../project-agent-A feature/issue-123-add-auth
+
+# Agent works in ../project-agent-A/
+# Changes are isolated from other agents
+
+# After PR merges, clean up
+git worktree remove ../project-agent-A
+```
+
+Claude Code agents use the `--parallel` flag on `/orchestrate`, which automatically creates and manages worktrees at `.worktrees/issue-{N}/`.
+
+### Wave Scheduling
+
+Group independent issues into parallel waves; dependent issues run sequentially:
+
+```
+Wave 1 (parallel): #630 (injection scanner), #631 (PII scanner), #633 (audit log)
+    -> No file overlap, all three run simultaneously
+
+Wave 2 (serial): #632 (taint tracking)
+    -> Depends on #630 and #631, starts after Wave 1 merges
+```
+
+### Rebase Before PR
+
+After other agents merge, remaining agents must rebase on the new main before creating their PR:
+
+```bash
+git fetch origin && git rebase origin/main
+```
+
+This catches semantic conflicts early --- two changes that pass CI independently may fail when combined.
+
+!!! note "Merge Queue"
+    Enable GitHub's merge queue on protected repositories. The queue tests each PR against the latest main plus all PRs ahead in the queue, preventing the race condition where two independently-passing PRs conflict when merged together.
+
+## The "Personal Probes Disaster"
+
+This real-world failure demonstrates why branch reuse is forbidden.
+
+### What Happened
+
+One branch (`feature/personal-probes`) was reused for 7 consecutive PRs over 2 hours:
+
+| PR | Type | Actual Content |
+|----|------|---------------|
+| #396 | feat | Add personal probes |
+| #397 | fix | Cache-busting for static assets |
+| #398 | fix | Skip HSTS on LAN IPs |
+| #399 | fix | Handle missing getUserMedia |
+| #400 | fix | Make save_memory proactive |
+| #401 | perf | Skip grid context scoring |
+| #402 | fix | STT digit filter |
+
+**Problems**: Could not revert one change without analyzing all seven. History showed 7 merges from the same branch. Impossible to determine which diff belonged to which PR.
+
+### What Should Have Happened
+
+```
+7 independent branches, 7 independent PRs
+    -> Each independently revertable
+    -> Each with clear, isolated diffs
+    -> No file overlap = all 7 run in parallel
+    -> Total time: ~30 minutes (parallel) vs ~2 hours (serial reuse)
+```
+
+!!! warning "Branch Reuse Is the Root Cause"
+    Branch reuse makes git history unusable. It prevents independent reverts, obscures which changes belong to which logical unit, and blocks parallel execution. One branch = one PR = one logical change.
+
+## Escalation Matrix
+
+| Situation | Action |
+|-----------|--------|
+| Two agents need the same file | Serialize: Agent B waits for Agent A's PR to merge |
+| Rebase conflict | Agent resolves conflict; if unsure, ask human |
+| CI fails on PR | Agent fixes the issue; never skip CI |
+| CI fails on main | Stop all merges. Hotfix immediately |
+| Large refactor needed | Open RFC/spec issue first; do not start coding |
+| PR too large (500+ lines) | Split into phased PRs |
+| Dependency between issues | Implement sequentially, not in parallel |
+
+## Anti-Patterns
+
+| Anti-Pattern | Why It Fails | Correct Approach |
+|-------------|-------------|-----------------|
+| Reuse one branch for multiple PRs | Cannot revert individual changes | One branch per PR |
+| Bundle multiple issues in one commit | Cannot bisect or blame individual issues | One issue per commit |
+| `debug:` commits on main | Noise in history, debug code in production | Remove before PR |
+| Implement then immediately revert | Wasted effort, cluttered history | Validate approach before coding |
+| Force push to shared branches | Destroys other agents' work | Rebase and push normally |
+| Long-lived feature branches | Diverge from main, painful merges | Keep branches under 24 hours |
+| Config flip-flops | Shows undecided architecture | Decide with data before implementing |
+
+## Repository Setup Checklist
+
+When onboarding a new project:
+
+- [ ] Branch protection on `main` (require status checks, linear history)
+- [ ] Enable merge queue (squash merge, required checks)
+- [ ] Allow only squash merging (disable merge commit and rebase options)
+- [ ] Auto-delete head branches after merge
+- [ ] Add CI workflow (`.github/workflows/ci.yml`)
+- [ ] Add `.gitignore` covering generated files, secrets, IDE configs
+- [ ] Create `CLAUDE.md` referencing this policy

--- a/docs/manual/git/workflow.md
+++ b/docs/manual/git/workflow.md
@@ -1,10 +1,182 @@
 # Git Workflow
 
-!!! note "Coming Soon"
-    This section is under construction.
+All agents follow a strict git workflow designed for multi-agent parallel development. The cardinal rule: **main stays green at all times**.
 
-Branch naming, commit conventions, PR process, main stays green.
+## Branch Naming
 
----
+Every branch follows the pattern `{type}/issue-{N}-{slug}`:
 
-*Content will be consolidated from existing documentation in Phase 2/3.*
+| Type | When |
+|------|------|
+| `feature/` | New feature or capability |
+| `fix/` | Bug fix |
+| `chore/` | Maintenance, dependency updates |
+| `docs/` | Documentation only |
+| `test/` | Adding or updating tests |
+| `perf/` | Performance improvement |
+
+```
+feature/issue-123-add-oauth-login
+fix/issue-456-null-pointer-crash
+chore/update-dependencies
+docs/update-api-reference
+```
+
+!!! warning "Never"
+    Never reuse a branch for multiple PRs. Never name a branch after a person or date. Never use `feat/` --- use `feature/` consistently.
+
+### Branch Creation
+
+Always branch from the latest `origin/main`:
+
+```bash
+git fetch origin && git checkout -b feature/issue-123-slug origin/main
+```
+
+### Branch Lifetime
+
+Branches should live less than **24 hours** (48 hours maximum). Short-lived branches reduce merge conflicts and keep work focused.
+
+## Commit Conventions
+
+All commits follow [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+type(scope): description
+```
+
+- **Imperative mood**, lowercase, no period, max 72 characters
+- Body explains **why**, not what (the diff shows what)
+- Reference the issue: `Closes #123` or `Fixes #456`
+
+| Type | When |
+|------|------|
+| `feat` | New feature |
+| `fix` | Bug fix |
+| `perf` | Performance improvement |
+| `chore` | Maintenance |
+| `docs` | Documentation only |
+| `test` | Test additions |
+| `refactor` | Code restructure, no behavior change |
+| `ci` | CI/CD configuration |
+| `style` | Formatting only |
+
+```
+feat(auth): add OAuth2 login flow
+
+Closes #123
+```
+
+!!! note "One Issue Per Commit"
+    Never bundle multiple issues in one commit message. `feat: various improvements (#100-#107)` is forbidden. Each issue gets its own commit.
+
+## Pre-PR Checklist
+
+Before creating any PR, run these steps in order:
+
+```bash
+# 1. Rebase on latest main
+git fetch origin && git rebase origin/main
+
+# 2. Run checks (Python projects)
+ruff check . && ruff format --check .
+pytest tests/ -x --timeout=60
+
+# 3. Verify only relevant files changed
+git diff --name-only origin/main
+```
+
+If any check fails, fix it before creating the PR. Never skip checks with `--no-verify`.
+
+## PR Creation
+
+```bash
+gh pr create --title "feat(scope): description" --body "$(cat <<'EOF'
+## Summary
+- What and why
+
+## Test Plan
+- [ ] Unit tests pass
+- [ ] Manual verification
+
+## Issue
+Closes #123
+EOF
+)"
+```
+
+| Requirement | Detail |
+|-------------|--------|
+| Title | Conventional Commits format |
+| Body | Summary, Test Plan, issue reference |
+| Merge strategy | Squash merge only |
+| After merge | Branch auto-deleted (repo setting) |
+
+## Merge Strategy
+
+**Squash merge only** --- all branches are squashed into a single commit on main. This produces a clean linear history where each commit maps to exactly one PR and one logical change.
+
+The squash commit message on main should be:
+
+```
+type(scope): PR title (#PR-number)
+```
+
+## Post-Merge Cleanup
+
+After every PR merge, run these cleanup steps:
+
+```bash
+# Prune stale remote refs
+git fetch --prune origin
+
+# Delete local branch
+git branch -d feature/issue-123-slug
+```
+
+Before starting new work, prune stale branches:
+
+```bash
+# List merged remote branches (candidates for deletion)
+git branch -r --merged origin/main | grep -v 'main\|HEAD'
+
+# Clean local branches that track deleted remotes
+git branch -vv | grep ': gone]' | awk '{print $1}' | xargs -r git branch -D
+```
+
+!!! tip "Enable Auto-Delete"
+    Set `Settings -> General -> Automatically delete head branches` on every repository. This handles 90% of stale branches automatically.
+
+## Large Features (500+ Lines)
+
+Split into phased PRs, each leaving main in a working state:
+
+| Phase | Content | Example Branch |
+|-------|---------|----------------|
+| 1 | Schema/model changes | `feature/issue-601-phase-1-schema` |
+| 2 | Service/business logic | `feature/issue-601-phase-2-service` |
+| 3 | API/integration | `feature/issue-601-phase-3-api` |
+| 4 | Tests | `feature/issue-601-phase-4-tests` |
+
+Each phase branches from the **updated main** (after the previous phase merges). Never stack branches on top of each other.
+
+## Emergency: Main is Broken
+
+```
+1. Stop all merges immediately
+2. Create fix/hotfix-{description} from last green commit
+3. Minimal fix only (smallest possible change)
+4. Fast-track PR -> merge
+5. Resume normal work
+```
+
+## Never-Do List
+
+- Reuse one branch for multiple PRs
+- Bundle multiple issues in one commit
+- Ship `debug:` commits to main
+- Implement then immediately revert (validate first)
+- Force push to shared branches
+- Skip CI with `--no-verify`
+- Merge without rebasing on latest main
+- Commit directly to main

--- a/docs/manual/hooks/custom-hooks.md
+++ b/docs/manual/hooks/custom-hooks.md
@@ -1,10 +1,192 @@
-# Custom Hooks
+# Writing Custom Hooks
 
-!!! note "Coming Soon"
-    This section is under construction.
+Hooks are Python scripts (or any executable) that run at specific moments in a Claude Code session. They let you inject context, persist state, enforce quality gates, and trigger external integrations.
 
-Design principles and patterns for writing your own hooks.
+## Available Events
 
----
+| Event | When It Fires | stdin Receives | stdout Goes To |
+|-------|--------------|----------------|----------------|
+| `SessionStart` | New session begins | `{"session_id": "..."}` | Injected into agent context |
+| `PreCompact` | Before context compression | `{"transcript_path": "...", "session_id": "...", "trigger": "..."}` | Logged only (not injected) |
+| `Stop` | Agent stops responding | `{}` | Injected into agent context |
+| `PreToolUse` | Before a tool call executes | Tool call details | Injected into agent context |
+| `PostToolUse` | After a tool call completes | Tool call result | Injected into agent context |
 
-*Content will be consolidated from existing documentation in Phase 2/3.*
+!!! note "stdout Injection"
+    Only SessionStart, Stop, PreToolUse, and PostToolUse output is injected into the agent's context. PreCompact stdout is logged but not visible to the agent. This means PreCompact hooks can be verbose for debugging without consuming context tokens.
+
+## Exit Codes
+
+| Exit Code | Meaning |
+|-----------|---------|
+| 0 | Success / allow the operation to proceed |
+| 2 | Block the operation and send stdout as feedback |
+
+!!! warning "Exit Code 2 on Stop"
+    Using exit code 2 on a Stop hook means the agent receives your stdout as feedback and continues working. Use this carefully to avoid infinite loops. The built-in `verify_completion.py` intentionally uses exit 0 (advisory only) rather than exit 2 (blocking) to prevent feedback loops.
+
+## settings.json Configuration
+
+Hooks are configured in `settings.json` (or `settings.local.json` for machine-specific hooks):
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ~/.claude/hooks/my_hook.py"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+The `matcher` field filters which events trigger the hook. An empty string `""` matches all events of that type. For `PreToolUse` and `PostToolUse`, you can match specific tools:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ~/.claude/hooks/audit_bash.py"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Multiple hooks on the same event run sequentially in the order they appear.
+
+## Design Principles
+
+### Fail Gracefully
+
+If your hook depends on an external package (like PyYAML), wrap the import and degrade rather than crash:
+
+```python
+try:
+    import yaml
+    HAS_YAML = True
+except ImportError:
+    HAS_YAML = False
+
+def load_config():
+    if not HAS_YAML:
+        return {}  # Graceful degradation
+    # ... normal logic
+```
+
+A crashing hook can break every session. A gracefully degrading hook just provides less functionality.
+
+### Log to File
+
+Hooks run silently. Without file-based logging, failures are invisible:
+
+```python
+import logging
+from pathlib import Path
+
+log_file = Path.home() / ".claude" / "hooks.log"
+logging.basicConfig(
+    filename=str(log_file),
+    level=logging.WARNING,
+    format="%(asctime)s [my_hook] %(levelname)s: %(message)s",
+)
+```
+
+### Keep Output Compact
+
+SessionStart and Stop hook output goes directly into the agent's context window. Every line costs tokens that could have been used for code context. Aim for the minimum viable context restoration.
+
+```python
+# Bad: dumping 200 lines of state
+print(full_state_dump)
+
+# Good: 5 lines of essential context
+print(f"Issue: #{issue}")
+print(f"Phase: {phase}")
+print(f"Branch: {branch}")
+```
+
+### Auto-Clean Old Data
+
+If your hook writes checkpoint files, include a cleanup routine:
+
+```python
+from datetime import datetime
+
+RETENTION_DAYS = 7
+
+def cleanup(directory: Path):
+    cutoff = datetime.now().timestamp() - (RETENTION_DAYS * 86400)
+    for f in directory.iterdir():
+        if f.stat().st_mtime < cutoff:
+            f.unlink()
+```
+
+## Example: Simple SessionStart Hook
+
+A minimal hook that prints the current git branch and last commit:
+
+```python
+#!/usr/bin/env python3
+"""Print current git context at session start."""
+
+import json
+import subprocess
+import sys
+
+
+def run(cmd: str) -> str:
+    result = subprocess.run(cmd, shell=True, capture_output=True, text=True)
+    return result.stdout.strip()
+
+
+def main() -> int:
+    # Read hook input (required even if unused)
+    _hook_input = json.load(sys.stdin)
+
+    branch = run("git branch --show-current")
+    last_commit = run("git log --oneline -1")
+
+    print("## Git Context\n")
+    print(f"- **Branch**: {branch}")
+    print(f"- **Last commit**: {last_commit}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+```
+
+Register it in `settings.json` under the `SessionStart` event with an empty `matcher` to run on every session start.
+
+## Testing Hooks
+
+Test hooks by piping sample JSON input through stdin:
+
+```bash
+# Test a SessionStart hook
+echo '{"session_id": "test-123"}' | python3 ~/.claude/hooks/my_hook.py
+echo $?  # Check exit code
+
+# Test a PreCompact hook
+echo '{"transcript_path": "/tmp/test.jsonl", "session_id": "test", "trigger": "manual"}' \
+  | python3 ~/.claude/hooks/precompact_checkpoint.py
+
+# Check for logged errors
+tail -20 ~/.claude/hooks.log
+```

--- a/docs/manual/hooks/lifecycle.md
+++ b/docs/manual/hooks/lifecycle.md
@@ -1,10 +1,156 @@
-# Lifecycle Hooks
+# Hook Lifecycle
 
-!!! note "Coming Soon"
-    This section is under construction.
+Claude Code hooks fire at specific moments during a session. Four hooks turn stateless chat sessions into stateful development workflows by persisting context across compactions, verifying completion quality, and sending notifications.
 
-SessionStart, PreCompact, and Stop hooks — how they manage state and quality.
+## Hook Execution Order
 
----
+```
++-- SessionStart ------------------------------------------------+
+|  sessionstart_restore_state.py                                  |
+|  +-- state_manager.get_active_work() -> restore active context  |
+|  +-- Load patterns (project -> global -> core-patterns.md)      |
+|  +-- Output ~500 tokens of restored context                     |
++-----------------------------------------------------------------+
+                          |
+                    [Session Work]
+                          |
++-- PreCompact ----------------------------------------------+
+|  precompact_checkpoint.py                                   |
+|  +-- Extract state from last 300 transcript lines           |
+|  +-- state_manager.update_from_extracted() -> save state    |
+|  +-- Save transcript checkpoint for recovery                |
+|  +-- Auto-delete checkpoints older than 7 days              |
++-----------------------------------------------------------------+
+                          |
+                    [Session Stop]
+                          |
++-- Stop (2 hooks, sequential) ---------------------------------+
+|  1. verify_completion.py                                       |
+|     +-- Check for uncommitted changes                          |
+|     +-- Scan for TODO/FIXME/HACK in diff                       |
+|     +-- Exit 0 to allow, advisory warning printed              |
+|                                                                |
+|  2. notify_completion.py                                       |
+|     +-- Platform guard (macOS only, no-op elsewhere)           |
+|     +-- state_manager.get_active_work() -> get context         |
+|     +-- osascript display notification -> Notification Center  |
+|     +-- Auto-forwards to iPhone via Handoff                    |
++-----------------------------------------------------------------+
+```
 
-*Content will be consolidated from existing documentation in Phase 2/3.*
+## SessionStart: Restore State
+
+**File**: `sessionstart_restore_state.py`
+
+When a new session begins, this hook restores context from the previous session:
+
+1. Loads `PERSISTENT_STATE.yaml` via `state_manager.get_active_work()`
+2. Loads critical failure patterns from `patterns-critical.md` (checks project-level first, then global, then `rules/core-patterns.md` as final fallback)
+3. Detects if an orchestrate workflow was in progress
+4. Outputs continuation instructions with issue number, phase, and branch
+
+!!! note "Token Budget"
+    SessionStart outputs approximately 500 tokens of restored context. This is an 85% reduction from the naive approach of dumping raw transcript summaries (~3,250 tokens). Every token of hook output competes with code context in the agent's working memory.
+
+## PreCompact: Extract and Save State
+
+**File**: `precompact_checkpoint.py`
+
+Before context compression, this hook extracts structured state from the conversation transcript:
+
+| Extracted Field | Source Pattern | Example |
+|----------------|---------------|---------|
+| `last_issue` | `Issue #NNN` in transcript | `775` |
+| `last_phase` | Phase keywords (MAP-PLAN, PATCH, etc.) | `PATCH` |
+| `artifacts_created` | `AGENT_RETURN: filename.md` | `["patch-775-032626.md"]` |
+| `files_modified` | Created/modified/updated mentions | `["backend/models.py"]` |
+| `pending_tasks` | `- [ ]` items (last 5) | `["Add frontend tests"]` |
+| `key_decisions` | Sentences with "decided", "chose" | `["Using Zustand for state"]` |
+
+The extracted state is written to `PERSISTENT_STATE.yaml` via `state_manager.update_from_extracted()`. A raw transcript copy is saved for recovery. Checkpoints older than 7 days are automatically deleted.
+
+## Stop: Verify Completion
+
+**File**: `verify_completion.py`
+
+!!! warning "Anti-Rationalization"
+    AI agents exhibit a specific failure mode: declaring a task complete when it is not. Common rationalizations include "functionally complete" (but uncommitted), "tests would require additional infrastructure" (but the issue says "add tests"), and "remaining TODOs are minor" (but they are in the acceptance criteria).
+
+This hook checks for signs of incomplete work:
+
+- **Uncommitted changes** in substantive files (ignoring lock files and config files like `.yaml`, `.yml`, `.toml`)
+- **TODO/FIXME/HACK markers** in added lines within the current diff
+
+The output is advisory -- it prints warnings visible to the user as context for whether to continue the conversation. The hook always exits 0 to avoid feedback loops.
+
+## Stop: Notify Completion
+
+**File**: `notify_completion.py`
+
+Sends a macOS Notification Center alert when the session finishes. See [Notifications](notifications.md) for details.
+
+## Configuration
+
+Hooks are configured in `settings.json`:
+
+```json
+{
+  "hooks": {
+    "PreCompact": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ~/.claude/hooks/precompact_checkpoint.py"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ~/.claude/hooks/sessionstart_restore_state.py"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ~/.claude/hooks/verify_completion.py"
+          },
+          {
+            "type": "command",
+            "command": "python3 ~/.claude/hooks/notify_completion.py"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+## How Hooks Create Statefulness
+
+Without hooks, every context compaction resets the agent. It loses track of the current issue, branch, phase, and what work has been done. The hook pair solves this:
+
+```
+Session 1:  Work on issue #775, PATCH phase
+               |
+            PreCompact fires -> saves issue=775, phase=PATCH to YAML
+               |
+            [Context compressed -- conversation history lost]
+               |
+            SessionStart fires -> restores issue=775, phase=PATCH
+               |
+Session 2:  Agent knows it was working on #775 PATCH, continues
+```
+
+The `--resume` flag in `/orchestrate` reads `completed_phases` from this same state file to skip phases that already finished, even across session restarts.

--- a/docs/manual/hooks/notifications.md
+++ b/docs/manual/hooks/notifications.md
@@ -1,10 +1,103 @@
 # Notifications
 
-!!! note "Coming Soon"
-    This section is under construction.
+`notify_completion.py` sends a macOS Notification Center alert when a Claude Code session finishes. This lets you step away from the terminal and get notified when the agent completes its work.
 
-macOS Notification Center alerts with iPhone Handoff relay.
+## How It Works
 
----
+The hook runs on the `Stop` event, after `verify_completion.py`. It follows this sequence:
 
-*Content will be consolidated from existing documentation in Phase 2/3.*
+1. **Platform guard** -- Check `sys.platform`. If not `darwin` (macOS), exit 0 immediately. The hook is a no-op on Linux, WSL, and Windows.
+2. **Read context** -- Call `state_manager.get_active_work()` to get the current issue number, phase, and last action.
+3. **Build message** -- Construct a notification message from the context.
+4. **Send notification** -- Execute `osascript -e 'display notification ...'` via subprocess.
+5. **Exit 0** -- Always exit successfully. Notification failure must never block a session.
+
+## Notification Content
+
+The message adapts to available context:
+
+| Context Available | Notification Message |
+|-------------------|---------------------|
+| Phase and issue number | `PATCH finished for issue #184` |
+| Last action only | `Session complete -- Implemented backend models` |
+| No context | `Session complete` |
+
+The notification title is always `Claude Code`.
+
+## Sound Alert
+
+The notification plays the `Glass` sound via the AppleScript `sound name "Glass"` parameter. This is a built-in macOS alert sound that is distinct enough to notice without being intrusive.
+
+```applescript
+display notification "PATCH finished for issue #184" with title "Claude Code" sound name "Glass"
+```
+
+## iPhone Relay via Handoff
+
+macOS Notification Center notifications automatically forward to paired iPhones through Apple's Handoff / Continuity features. No additional configuration is needed beyond having Handoff enabled on both devices and being signed into the same Apple ID.
+
+This means you can start a long-running orchestrate pipeline, leave your desk, and receive a notification on your phone when the session finishes.
+
+## AppleScript Injection Sanitization
+
+Since notification text is embedded in an AppleScript string, the `sanitize()` function prevents injection:
+
+```python
+def sanitize(text: str) -> str:
+    # Strip control characters
+    text = re.sub(r"[\x00-\x1f\x7f]", "", text)
+    # Escape backslashes, then double quotes
+    text = text.replace("\\", "\\\\").replace('"', '\\"')
+    # Truncate to 200 characters
+    return text[:200]
+```
+
+!!! warning "Why Sanitization Matters"
+    Without sanitization, a malicious or unexpected string in the state file (e.g., containing `"`) could break the AppleScript command or, in theory, execute arbitrary AppleScript. The `sanitize()` function strips control characters, escapes quotes and backslashes, and truncates to 200 characters.
+
+## Pairing with --parallel
+
+When running multiple issues in parallel (each in its own terminal tab with `--parallel`), each session sends its own notification on completion. The notification includes the issue number and phase, so you can tell which session finished:
+
+```
++-- Terminal Tab 1 --+    +-- Terminal Tab 2 --+
+| /orchestrate 184   |    | /orchestrate 185   |
+|   --parallel        |    |   --parallel        |
++--------+------------+    +--------+------------+
+         |                          |
+    [completes]                [completes]
+         |                          |
+  "PATCH finished            "PROVE finished
+   for issue #184"            for issue #185"
+```
+
+## Error Handling
+
+The hook is designed to never interfere with the session:
+
+- `osascript` call has a 5-second timeout
+- All exceptions are caught and logged to `~/.claude/hooks.log`
+- The hook always exits 0 regardless of whether the notification was sent
+- If `state_manager` import fails, the hook falls back to a generic "Session complete" message
+
+## Configuration
+
+The hook is registered as the second Stop hook in `settings.json`:
+
+```json
+{
+  "hooks": {
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {"type": "command", "command": "python3 ~/.claude/hooks/verify_completion.py"},
+          {"type": "command", "command": "python3 ~/.claude/hooks/notify_completion.py"}
+        ]
+      }
+    ]
+  }
+}
+```
+
+Order matters: `verify_completion.py` runs first (it may block the stop), then `notify_completion.py` sends the alert.

--- a/docs/manual/hooks/state-manager.md
+++ b/docs/manual/hooks/state-manager.md
@@ -1,10 +1,153 @@
 # State Manager
 
-!!! note "Coming Soon"
-    This section is under construction.
+`state_manager.py` is the centralized module for reading and writing `PERSISTENT_STATE.yaml`. It is the single source of truth for orchestrate workflow state, used by hooks, the orchestrate command, and the `--resume` / `--parallel` flags.
 
-Centralized PERSISTENT_STATE.yaml management. --resume and --parallel support.
+## Why Centralized
 
----
+Previously, three separate codepaths independently manipulated the same YAML file using inline `python3 -c` blocks embedded in shell commands. A quoting error, missing PyYAML, or malformed YAML would silently break state. Centralizing into one testable module with graceful fallbacks eliminated this fragility.
 
-*Content will be consolidated from existing documentation in Phase 2/3.*
+```
+Before:  orchestrate (inline) -+
+         precompact (inline)   +--> PERSISTENT_STATE.yaml (3 writers, no coordination)
+         sessionstart (inline) +
+
+After:   orchestrate  --+
+         precompact   --+--> state_manager.py --> PERSISTENT_STATE.yaml (1 writer)
+         sessionstart --+
+         notify       --+
+```
+
+## PERSISTENT_STATE.yaml Schema
+
+```yaml
+active_work:
+  issue: 775
+  branch: feature/issue-775-asset-form-fields
+  phase: PATCH
+  last_action: Implemented backend models
+  completed_phases:
+    - MAP-PLAN
+    - PLAN-CHECK
+  worktree_path: null    # Set when --parallel is used
+meta:
+  updated: '2026-03-26'
+```
+
+| Field | Type | Purpose |
+|-------|------|---------|
+| `issue` | int or null | Current issue number |
+| `branch` | string | Current git branch |
+| `phase` | string or null | Current pipeline phase |
+| `last_action` | string | Human-readable description of last action |
+| `completed_phases` | list[str] | Phases already finished (for `--resume`) |
+| `worktree_path` | string or null | Absolute path to worktree (for `--parallel`) |
+| `meta.updated` | date string | Last modification date |
+
+## Function Reference
+
+### load_state
+
+```python
+def load_state(project_dir: Path) -> dict
+```
+
+Read `PERSISTENT_STATE.yaml` and return its contents as a dict. Returns an empty dict if the file does not exist, YAML parsing fails, or PyYAML is not installed.
+
+### update_phase
+
+```python
+def update_phase(project_dir: Path, issue: int, branch: str,
+                 phase: str, action: str, worktree_path: str | None = None) -> None
+```
+
+Update `active_work` with the current phase. Called by the orchestrate command before spawning each agent.
+
+Key behaviors:
+
+- Tracks the previous phase as completed (appends to `completed_phases` when transitioning to a new phase)
+- Preserves existing `worktree_path` if not explicitly provided
+- Updates `meta.updated` timestamp
+
+```python
+# Example: transitioning from MAP-PLAN to PATCH
+update_phase(project_dir, issue=184, branch="feature/issue-184-fix",
+             phase="PATCH", action="Starting PATCH agent")
+# completed_phases now includes "MAP-PLAN"
+```
+
+### clear_active
+
+```python
+def clear_active(project_dir: Path, issue: int) -> None
+```
+
+Clear active workflow state after successful completion. Resets all fields to their defaults (`issue: None`, `branch: main`, `phase: None`, empty `completed_phases`). Sets `last_action` to `Completed issue #N`.
+
+### get_completed_phases
+
+```python
+def get_completed_phases(project_dir: Path, issue: int) -> list[str]
+```
+
+Return the list of completed phases for an issue. Used by `--resume` to determine which phases to skip. Returns an empty list if the state file does not exist or the active issue does not match the requested issue.
+
+### get_worktree_for_issue
+
+```python
+def get_worktree_for_issue(project_dir: Path, issue: int) -> str | None
+```
+
+Return the worktree path for an issue from persisted state. Used by `--resume` in combination with `--parallel` to find the correct worktree directory for resuming work.
+
+### get_active_work
+
+```python
+def get_active_work(project_dir: Path) -> dict
+```
+
+Return the `active_work` section of the state. Used by the SessionStart hook to restore context and by the notification hook to build contextual messages.
+
+### update_from_extracted
+
+```python
+def update_from_extracted(project_dir: Path, extracted: dict) -> None
+```
+
+Update state from precompact transcript extraction. Called by `precompact_checkpoint.py` after parsing the conversation transcript.
+
+Accepts a dict with optional keys:
+
+| Key | Effect |
+|-----|--------|
+| `last_issue` | Sets `active_work.issue` |
+| `last_phase` | Sets `active_work.phase` |
+| `artifacts_created` | Sets `last_action` to name of most recent artifact |
+
+## How --resume Uses State
+
+When `/orchestrate 184 --resume` is called:
+
+1. `get_completed_phases(project_dir, 184)` returns `["MAP-PLAN", "PLAN-CHECK"]`
+2. The orchestrate command skips MAP-PLAN and PLAN-CHECK
+3. Execution continues from the next incomplete phase (CONTRACT or PATCH)
+
+## How --parallel Uses State
+
+When `/orchestrate 184 --parallel` is called:
+
+1. A git worktree is created at `.worktrees/issue-184/`
+2. `update_phase()` is called with `worktree_path="/abs/path/.worktrees/issue-184/"`
+3. The path is persisted in `PERSISTENT_STATE.yaml`
+4. On `--resume`, `get_worktree_for_issue()` returns the path so work continues in the correct worktree
+
+## Graceful Fallbacks
+
+The module handles missing dependencies without crashing:
+
+- If PyYAML is not installed, all functions return empty dicts or silently no-op
+- If the state file does not exist, `load_state()` returns `{}`
+- If YAML parsing fails, the error is logged to `~/.claude/hooks.log` and an empty dict is returned
+- Write failures are caught and logged without interrupting the session
+
+!!! tip "Dependency"
+    PyYAML is the only external dependency. The `install.sh` script installs it automatically. If it is missing at runtime, state management degrades gracefully rather than crashing.

--- a/docs/manual/integrations/codex-plugin.md
+++ b/docs/manual/integrations/codex-plugin.md
@@ -1,10 +1,198 @@
 # Codex Plugin
 
-!!! note "Coming Soon"
-    This section is under construction.
+The Codex plugin brings OpenAI's Codex CLI inside Claude Code as a set of slash commands. This enables cross-model code review, adversarial design challenge, and task delegation -- all without leaving your Claude Code session.
 
-Cross-model review with OpenAI Codex inside Claude Code.
+## Installation
 
----
+### Step 1: Add the marketplace
 
-*Content will be consolidated from existing documentation in Phase 2/3.*
+The Codex plugin is distributed through a custom marketplace. Add it in `settings.json`:
+
+```json
+{
+  "extraKnownMarketplaces": {
+    "openai-codex": {
+      "source": {
+        "source": "github",
+        "repo": "openai/codex-plugin-cc"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "codex@openai-codex": true
+  }
+}
+```
+
+### Step 2: Install and setup
+
+```bash
+# Install the plugin from marketplace
+/codex:setup
+```
+
+The setup command validates that the Codex CLI is installed and authenticated, and configures the review gate toggle.
+
+### Step 3: Configure Codex
+
+Edit `~/.codex/config.toml` to set defaults:
+
+```toml
+[defaults]
+model = "o4-mini"
+approval_mode = "suggest"
+```
+
+## Commands
+
+### /codex:setup
+
+Validates Codex CLI installation and authentication. Toggles the review gate on or off.
+
+```bash
+/codex:setup              # Validate + configure
+```
+
+### /codex:review
+
+Runs a code review on current git state using Codex.
+
+```bash
+/codex:review                        # Review uncommitted changes
+/codex:review --base origin/main     # Review against specific base
+/codex:review --scope "backend/"     # Limit review scope
+/codex:review --background           # Run in background, check later
+/codex:review --wait                 # Block until review completes
+```
+
+| Flag | Description |
+|------|-------------|
+| `--wait` | Block until review completes (default for foreground) |
+| `--background` | Run asynchronously, retrieve with `/codex:result` |
+| `--base` | Git ref to diff against (default: HEAD) |
+| `--scope` | Limit review to specific paths |
+
+### /codex:adversarial-review
+
+A devil's advocate review that challenges design decisions rather than finding bugs. Codex evaluates architectural choices, naming conventions, and approach tradeoffs.
+
+```bash
+/codex:adversarial-review                           # Review full changes
+/codex:adversarial-review "database schema design"  # Focus on specific area
+```
+
+!!! tip "Cross-Model Blind Spots"
+    Claude and Codex have different training data and different failure modes. Using Codex to review Claude's output catches errors that Claude's own review would miss -- and vice versa.
+
+### /codex:rescue
+
+Delegates a task to Codex when Claude is stuck or when you want a second implementation attempt.
+
+```bash
+/codex:rescue                    # Delegate current task
+/codex:rescue --resume           # Continue a previous rescue
+/codex:rescue --fresh            # Start fresh (ignore prior context)
+/codex:rescue --model o4-mini    # Use specific model
+/codex:rescue --effort high      # Set effort level
+```
+
+| Flag | Description |
+|------|-------------|
+| `--resume` | Continue from where a previous rescue left off |
+| `--fresh` | Discard prior context and start clean |
+| `--model` | Override the default Codex model |
+| `--effort` | Set effort level (low, medium, high) |
+
+### /codex:status
+
+Shows running and recently completed Codex jobs.
+
+```bash
+/codex:status             # Show active jobs
+/codex:status --wait      # Block until current job completes
+/codex:status --all       # Include completed jobs
+```
+
+### /codex:result
+
+Displays the output of a finished Codex job.
+
+```bash
+/codex:result             # Show most recent result
+```
+
+### /codex:cancel
+
+Cancels an active Codex job.
+
+```bash
+/codex:cancel             # Cancel current job
+```
+
+## Cross-Model Adversarial Review Strategy
+
+The highest-value use of the Codex plugin is adversarial review: Claude writes code, Codex reviews it.
+
+```
+Claude Code (implementation)
+       |
+       v
+/codex:adversarial-review
+       |
+       v
+Codex challenges assumptions
+       |
+       v
+Claude addresses findings
+```
+
+**Why this works**: Different models have different blind spots. Claude might produce correct logic but miss an edge case in error handling. Codex might catch that edge case because its training distribution weights error handling differently. The reverse is also true -- Claude catches things Codex misses.
+
+## Integration with Orchestrate Workflow
+
+### Add to PROVE phase
+
+After PATCH completes, run a Codex review as part of verification:
+
+```bash
+# In PROVE phase, after running tests
+/codex:review --base origin/main --wait
+```
+
+This adds a cross-model verification layer to the standard PROVE checks (EXISTS, SUBSTANTIVE, WIRED, FUNCTIONAL).
+
+### Use rescue as PATCH fallback
+
+When PATCH is blocked and recovery attempts fail, delegate to Codex:
+
+```bash
+# After PATCH failure
+/codex:rescue --model o4-mini --effort high
+```
+
+This gives a fresh model perspective on the implementation problem without burning more Claude context on a failing approach.
+
+## Review Gate
+
+!!! warning "Experimental Feature"
+    The review gate is an experimental feature. Use it cautiously and monitor for false positives that block legitimate changes.
+
+When enabled via `/codex:setup`, the review gate runs an automatic Codex review before certain operations (e.g., commit, PR creation). If the review identifies critical issues, it blocks the operation until the issues are addressed.
+
+Enable or disable the gate:
+
+```bash
+/codex:setup    # Toggle review gate on/off
+```
+
+## Configuration
+
+Codex configuration lives at `~/.codex/config.toml`:
+
+```toml
+[defaults]
+model = "o4-mini"           # Default model for all commands
+approval_mode = "suggest"   # "suggest" or "auto-approve"
+```
+
+The plugin itself is configured in Claude Code's `settings.json` under `enabledPlugins` and `extraKnownMarketplaces`.

--- a/docs/manual/integrations/mcp-servers.md
+++ b/docs/manual/integrations/mcp-servers.md
@@ -1,10 +1,151 @@
 # MCP Servers
 
-!!! note "Coming Soon"
-    This section is under construction.
+Model Context Protocol (MCP) servers extend Claude Code with external tools. Instead of relying on file reads alone, agents can call structured tool APIs that return JSON data from Obsidian vaults, library documentation services, and platform integrations.
 
-vault-metrics, context7, apple-mcp — extending Claude with external tools.
+## What Is MCP
 
----
+MCP is a protocol that lets AI agents call external tools over a standardized interface. Each MCP server exposes named tools with typed parameters and structured responses. Claude Code discovers these tools at startup and makes them available alongside built-in tools like Read, Edit, and Bash.
 
-*Content will be consolidated from existing documentation in Phase 2/3.*
+The practical benefit: agents get structured data instead of parsing markdown files. An MCP call to `failure_patterns()` returns JSON with root cause codes, frequencies, and prevention steps. A file read of `patterns-critical.md` returns unstructured text that the agent must interpret.
+
+## Configured Servers
+
+Three MCP servers are configured in `settings.json`:
+
+### vault-metrics
+
+A custom Python server that provides access to the Obsidian vault and `.claude/memory/` files.
+
+```json
+{
+  "vault-metrics": {
+    "command": "python3",
+    "args": ["~/agents/mcp-server/server.py", "--mcp"]
+  }
+}
+```
+
+**Tools provided**:
+
+| Tool | Description |
+|------|-------------|
+| `vault_status` | Current project status from Obsidian vault |
+| `vault_search` | Search across vault content |
+| `vault_dashboard` | Cross-project overview |
+| `agent_metrics` | Performance metrics from `metrics.jsonl` (supports time ranges) |
+| `failure_patterns` | Learned failure patterns with root causes and prevention steps |
+
+!!! note "Machine-Local Configuration"
+    The vault-metrics server path varies by machine. Configure it in `settings.local.json` (not symlinked) rather than `settings.json` (symlinked) when the path differs across machines.
+
+### context7
+
+Injects current library documentation into agent context. This eliminates stale API hallucinations -- when an agent needs to use a library method, context7 provides the current docs instead of relying on training data that may be outdated.
+
+```json
+{
+  "context7": {
+    "command": "npx",
+    "args": ["-y", "@upstash/context7-mcp@latest"]
+  }
+}
+```
+
+### apple-mcp
+
+macOS platform integration providing access to system features like Calendar, Contacts, and other Apple services.
+
+```json
+{
+  "apple-mcp": {
+    "command": "bunx",
+    "args": ["--no-cache", "apple-mcp@latest"]
+  }
+}
+```
+
+## MCP-First Pattern Loading
+
+Agents use MCP tools as the preferred source for failure patterns during pre-flight. File reads serve as a fallback when MCP is unavailable.
+
+```
++---------------------+     +--------------------------+
+|  Agent Pre-Flight   |---->|  MCP: failure_patterns() |
+|                     |     |  MCP: agent_metrics(30d) |
+|  (all agents via    |     +----------+---------------+
+|   _base.md)         |                | fails?
+|                     |                v
+|                     |     +--------------------------+
+|                     |---->|  File: patterns-critical |
+|                     |     |  File: patterns-full.md  |
++---------------------+     +--------------------------+
+```
+
+**Why MCP-first**: The `failure_patterns()` tool returns structured JSON with root cause codes, frequencies, and prevention steps. This is more reliable than parsing a markdown file, and the MCP server can aggregate data from multiple sources (vault + memory files) in a single call.
+
+## settings.json Configuration
+
+All MCP servers are configured under the `mcpServers` key in `settings.json`:
+
+```json
+{
+  "mcpServers": {
+    "vault-metrics": {
+      "command": "python3",
+      "args": ["~/agents/mcp-server/server.py", "--mcp"]
+    },
+    "apple-mcp": {
+      "command": "bunx",
+      "args": ["--no-cache", "apple-mcp@latest"]
+    },
+    "context7": {
+      "command": "npx",
+      "args": ["-y", "@upstash/context7-mcp@latest"]
+    }
+  }
+}
+```
+
+Each server entry specifies:
+
+| Field | Description |
+|-------|-------------|
+| `command` | The executable to run (e.g., `python3`, `npx`, `bunx`) |
+| `args` | Arguments passed to the command |
+
+Claude Code starts each MCP server as a subprocess at session start and communicates with it over the MCP protocol.
+
+## Adding a New MCP Server
+
+To add a new MCP server:
+
+1. **Implement the server** following the MCP protocol specification. The server must handle tool discovery and tool execution requests.
+
+2. **Add the entry** to `settings.json` (or `settings.local.json` for machine-specific servers):
+
+    ```json
+    {
+      "mcpServers": {
+        "my-server": {
+          "command": "python3",
+          "args": ["/path/to/my_server.py", "--mcp"]
+        }
+      }
+    }
+    ```
+
+3. **Restart Claude Code** to pick up the new server. MCP servers are discovered at session start.
+
+4. **Test the tools** by asking Claude Code to list available MCP tools or by calling one directly.
+
+!!! tip "Local vs Global Servers"
+    Use `settings.json` (symlinked, version-controlled) for servers that work on all machines. Use `settings.local.json` (not symlinked, machine-specific) for servers with paths that vary by machine.
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| MCP tools not appearing | Restart Claude Code; check that the server command is in PATH |
+| Server crashes at startup | Run the command manually to see error output |
+| `failure_patterns()` returns empty | Verify `.claude/memory/failures.jsonl` exists and has data |
+| context7 slow on first call | Normal -- `npx` downloads the package on first run |

--- a/docs/manual/integrations/obsidian-agent.md
+++ b/docs/manual/integrations/obsidian-agent.md
@@ -1,10 +1,193 @@
 # Obsidian Agent
 
-!!! note "Coming Soon"
-    This section is under construction.
+The Obsidian Agent captures Claude Code sessions as project state in your Obsidian vault. It overwrites current status, appends daily logs, and generates weekly and monthly rollups -- transforming ephemeral coding sessions into a persistent knowledge base.
 
-Automated session capture, daily/weekly/monthly rollups, DASHBOARD.md.
+## What It Does
 
----
+```
+Claude Code session (.jsonl)
+       |
+       v
+obsidian-agent (extracts state via Claude Haiku)
+       |
+       +-- Projects/{name}/STATUS.md     (overwritten each run)
+       +-- Projects/{name}/Log/Daily/    (appended)
+       +-- DASHBOARD.md                  (cross-project overview)
+```
 
-*Content will be consolidated from existing documentation in Phase 2/3.*
+The agent finds the most recent session log, parses the conversation, sends it to Claude Haiku for structured extraction, and writes the results to your vault.
+
+## Vault Structure
+
+```
+MyVault/
++-- DASHBOARD.md                    # Cross-project overview (overwritten)
++-- Projects/
+    +-- {project-name}/
+        +-- STATUS.md               # Current state (overwritten each session)
+        +-- Log/
+            +-- Daily/
+            |   +-- 2026-03-26.md   # Append-only daily log
+            +-- Weekly/
+            |   +-- 2026-W13.md     # Generated on demand
+            +-- Monthly/
+                +-- 2026-03.md      # Generated on demand
+```
+
+| File | Update Mode | Purpose |
+|------|-------------|---------|
+| `DASHBOARD.md` | Overwritten | All projects at a glance |
+| `STATUS.md` | Overwritten | Current project state |
+| `Daily/*.md` | Appended | Chronological activity log |
+| `Weekly/*.md` | Generated | Weekly rollup summary |
+| `Monthly/*.md` | Generated | Monthly rollup summary |
+
+## What Gets Extracted
+
+The agent sends the conversation to Claude Haiku, which extracts structured state:
+
+| Field | Description |
+|-------|-------------|
+| `status` | Current project status (e.g., "Active", "Blocked") |
+| `phase` | Current development phase |
+| `completed_groups` | Groups of completed items with headings |
+| `issues` | GitHub issues with number, title, effort, and status |
+| `commits` | Recent git commits (injected from git log, not LLM) |
+| `decisions` | Architectural decisions made during the session |
+| `blockers` | Current blockers preventing progress |
+| `next_steps` | Planned next actions |
+| `knowledge` | Items tagged with `[CAPTURE]` during the session |
+
+!!! tip "Tagging Knowledge"
+    Tag items with `[CAPTURE]` during a Claude Code session to have them extracted into the daily log under a Knowledge section:
+    ```
+    [CAPTURE] Agents should be stored in ~/agents/ for cross-project use.
+    ```
+
+## CLI Commands
+
+### Session Processing
+
+```bash
+# Default: update current project (STATUS + Daily + DASHBOARD)
+python -m obsidian_agent
+
+# Specific project path
+python -m obsidian_agent --project /path/to/project
+
+# Specific session ID
+python -m obsidian_agent --session abc123-def456
+
+# Update all recently active projects
+python -m obsidian_agent --all-projects
+
+# Only process sessions modified since last run (for timers)
+python -m obsidian_agent --all-projects --since-last-run
+
+# Preview extraction without writing to vault
+python -m obsidian_agent --dry-run
+```
+
+### Rollup Generation
+
+```bash
+# Daily cross-project rollup
+python -m obsidian_agent --daily-rollup
+python -m obsidian_agent --daily-rollup 2026-03-25
+
+# Weekly rollup (current week or specific)
+python -m obsidian_agent --weekly
+python -m obsidian_agent --weekly 2026-W13
+
+# Monthly rollup
+python -m obsidian_agent --monthly
+python -m obsidian_agent --monthly 2026-03
+```
+
+### Setup
+
+```bash
+# Create config interactively
+python -m obsidian_agent --init
+```
+
+## Automation
+
+### macOS (launchd)
+
+```bash
+python -m obsidian_agent --install-launchd
+```
+
+Installs two launchd agents:
+
+- **Watcher**: Runs every 60 seconds, processes new sessions (`--all-projects --since-last-run`)
+- **Rollup**: Runs nightly at 11 PM, generates daily rollups. Weekly rollups on Sunday, monthly on the last day of the month.
+
+Logs are written to `~/Library/Logs/obsidian-agent/`.
+
+### Linux (systemd)
+
+```bash
+python -m obsidian_agent --install-systemd
+```
+
+Installs a systemd user timer that runs every 60 seconds, processing all projects with `--since-last-run`.
+
+### Cross-Platform (cron)
+
+```bash
+python -m obsidian_agent --install-cron
+```
+
+Installs three cron entries:
+
+| Schedule | Command |
+|----------|---------|
+| Nightly 11:00 PM | `--daily-rollup` |
+| Sunday 11:30 PM | `--weekly --all-projects` |
+| Last day of month 11:30 PM | `--monthly --all-projects` |
+
+## Configuration
+
+Config lives at `~/.config/obsidian-agent/config.toml`. Run `--init` to create it interactively.
+
+```toml
+[vault]
+path = "~/obsidian/MyVault"
+projects_folder = "Projects"
+
+[claude]
+projects_path = "~/.claude/projects"
+
+[extraction]
+model = "haiku"
+max_conversation_chars = 50000
+```
+
+| Section | Key | Description |
+|---------|-----|-------------|
+| `vault.path` | Obsidian vault root | Supports `~` expansion |
+| `vault.projects_folder` | Folder name for project subdirectories | Default: `Projects` |
+| `claude.projects_path` | Where Claude stores session data | Default: `~/.claude/projects` |
+| `extraction.model` | Claude model for extraction | Default: `haiku` |
+| `extraction.max_conversation_chars` | Max conversation size to send | Default: `50000` |
+
+**Precedence**: TOML config > environment variables (`OBSIDIAN_VAULT_PATH`, `CLAUDE_PROJECTS_PATH`) > platform defaults.
+
+## Effort Investment
+
+| Activity | Time | Frequency |
+|----------|------|-----------|
+| Capture (during coding) | 0 min | Automatic |
+| Daily review | 2 min | Daily |
+| Weekly rollup review | 5 min | Weekly |
+| Monthly summary review | 10 min | Monthly |
+
+The agent runs automatically via launchd/systemd/cron. Session capture requires zero manual effort. The only time investment is reviewing the generated summaries.
+
+## Dependencies
+
+- Python 3.11+ (uses stdlib `tomllib`)
+- Claude CLI (`claude` command in PATH)
+- No pip packages required

--- a/docs/manual/learning/failure-patterns.md
+++ b/docs/manual/learning/failure-patterns.md
@@ -1,10 +1,116 @@
 # Failure Patterns
 
-!!! note "Coming Soon"
-    This section is under construction.
+Three failure patterns account for over 50% of all agent failures. Each was discovered through structured failure data, not intuition, and each has systematic prevention encoded directly into agent definitions.
 
-VERIFICATION_GAP, ENUM_VALUE, COMPONENT_API — the top 3 patterns covering 89% of failures.
+## The Top 3 Patterns
 
----
+### VERIFICATION_GAP (63% of all failures)
 
-*Content will be consolidated from existing documentation in Phase 2/3.*
+**What happens**: The agent proceeds with implementation based on assumptions about code structure, spec requirements, or component APIs without actually reading the source.
+
+**Why agents make this mistake**: AI models have strong priors from training data. They "know" what a typical FastAPI endpoint looks like, what a typical React hook returns, what a typical schema includes. These priors are usually correct, but when they are wrong, the agent produces plausible-looking code that does not match your actual codebase.
+
+**Real example**: MAP-PLAN deferred a spec requirement ("add `after_tax_contributions` to cashflow summary") because a previous issue (#155) had a similar deferral. But the spec had been updated since #155. The agent assumed the old pattern still applied without reading the current spec.
+
+**Systematic prevention**:
+
+1. **Mandatory Verification Protocol** in MAP-PLAN agent -- explicit checklist requiring spec read, assumption verification, and ambiguity resolution
+2. **Pre-flight in PATCH** -- must read plan, contract, and rules before starting
+3. **`core-patterns.md`** loaded in every session -- "Verify by reading actual code, never assume"
+
+### ENUM_VALUE (26% of fullstack failures)
+
+**What happens**: Frontend sends the Python enum NAME (`CO_OWNER`, with underscore) when the backend expects the enum VALUE (`CO-OWNER`, with hyphen).
+
+**Why agents make this mistake**: In Python, `Role.CO_OWNER` is how you reference the enum member. The VALUE is `"CO-OWNER"`, assigned with `CO_OWNER = "CO-OWNER"`. Agents see the Python name in code and use it as the string value, not realizing the stored/transmitted value is different.
+
+**Real example**: Backend defines `CO_OWNER = "CO-OWNER"`. Agent writes `role: "CO_OWNER"` in frontend. API returns 422 or silently stores the wrong value.
+
+**Systematic prevention**:
+
+1. **CONTRACT agent** explicitly documents enum VALUES (not names) in a dedicated section
+2. **PATCH pre-flight** includes "Read backend enum definitions, use VALUE (right side of `=`)"
+3. **PROVE verification** checks that frontend strings match backend VALUES
+4. **`core-patterns.md`** with `grep` command: `grep -A 5 "class.*Enum" backend/*/enums.py`
+
+### COMPONENT_API (17% of frontend failures)
+
+**What happens**: Agent assumes a component's props or hook's return structure without reading the source.
+
+**Why agents make this mistake**: Common patterns from training data. Most `useSession()` hooks return `{ session, loading }`. But your hook might return the context directly. The agent generates code that destructures a non-existent property.
+
+**Real example**: `const { session } = useSession()` (wrong) vs `const session = useSession()` (correct -- hook returns context directly).
+
+**Systematic prevention**:
+
+1. **MAP agent** documents reusable component APIs with actual PropTypes
+2. **PATCH verification table** lists every reused component and its verified API
+3. **`core-patterns.md`** with `grep` command: `grep -A 15 "PropTypes" frontend/src/components/path/Component.jsx`
+
+## Full Root Cause Taxonomy
+
+Every failure is classified into exactly one canonical code. This enables automated pattern analysis via `/learn`.
+
+| Code | Description | Typical Cause | Detection Agent |
+|------|-------------|---------------|-----------------|
+| `VERIFICATION_GAP` | Proceeded without verifying spec/code | Skipped spec, assumed structure | MAP-PLAN |
+| `ENUM_VALUE` | Used enum NAME instead of VALUE | Python `CO_OWNER` vs string `"CO-OWNER"` | PATCH, PROVE |
+| `COMPONENT_API` | Wrong props or hook usage | Assumed API without reading source | PATCH |
+| `MULTI_MODEL` | Forgot to update related model | Changed User but not Advisor relationship | PATCH |
+| `API_MISMATCH` | Frontend/backend contract violation | Schema field type mismatch | PATCH, PROVE |
+| `ACCESS_CONTROL` | Missing/wrong permission dependency | Endpoint allows access without auth | PATCH |
+| `MISSING_TEST` | Code path not covered | New functionality with 0% coverage | PROVE |
+| `SQLITE_COMPAT` | PostgreSQL-only feature in tests | Used ARRAY type (SQLite incompatible) | PATCH |
+| `STRUCTURE_VIOLATION` | Violated project rules | Created `backend/src/` directory | PATCH |
+| `SCOPE_CREEP` | Beyond issue scope | Added feature not in issue | MAP-PLAN, PATCH |
+| `LINT_ERROR` | Code style violations | Unused imports, formatting | PROVE |
+| `OTHER` | Document specifics in details | Project-specific errors | Any |
+
+## How Patterns Are Encoded as Rules
+
+Patterns are encoded at three levels, each loaded conditionally to minimize context consumption:
+
+```
+core-patterns.md (Always loaded, ~12 lines)
+    +-- Fullstack with enums? -> Check VALUE vs NAME
+    +-- Reusing component?    -> Read PropTypes first
+    +-- References spec?      -> Read spec FIRST
+
+fastapi-layered-pattern.md (Loaded in backend contexts)
+    +-- Enum rules: member names = UPPER_SNAKE, values = stored in DB
+    +-- Layer rules: Repos never commit, Services never raise HTTPException
+
+orchestrate-workflow.md (Loaded in .agents contexts)
+    +-- CONTRACT mandatory for fullstack
+    +-- Artifact validation: each agent checks predecessors
+```
+
+!!! warning "core-patterns.md is always loaded"
+    This file is intentionally small (~12 lines). It contains only the three patterns that cause >50% of failures. Loading it costs fewer tokens than a single function definition.
+
+## The "Read Before Assuming" Principle
+
+Every agent in the pipeline has verification gates:
+
+| Agent | What It Verifies |
+|-------|-----------------|
+| MAP / MAP-PLAN | Reads spec, reads actual code, documents component APIs and enum values |
+| CONTRACT | Defines exact enum VALUES, endpoint schemas, auth requirements |
+| PLAN-CHECK | Validates plan covers all acceptance criteria, enum VALUES explicit |
+| PATCH | Pre-flight: reads plan + contract + rules. Pre-submission: runs ruff + pytest |
+| PROVE | Verification levels: EXISTS, SUBSTANTIVE, WIRED, FUNCTIONAL |
+
+## How These Patterns Were Discovered
+
+These three patterns were not discovered through intuition. They were extracted from structured failure data using `/learn`:
+
+```
+86 issues completed
+  -> 24 failures recorded
+    -> /learn clusters by root_cause
+      -> VERIFICATION_GAP: 63% -> Added Mandatory Verification Protocol to MAP-PLAN
+      -> ENUM_VALUE: 26%       -> Made CONTRACT mandatory for fullstack
+      -> COMPONENT_API: 17%    -> Added component API verification table to PATCH
+```
+
+Each prevention technique was added to the relevant agent definition, the agent version was incremented, and subsequent issues showed reduced failure rates. The loop continues indefinitely.

--- a/docs/manual/learning/metrics.md
+++ b/docs/manual/learning/metrics.md
@@ -1,10 +1,165 @@
 # Metrics Dashboard
 
-!!! note "Coming Soon"
-    This section is under construction.
+The `/metrics` command visualizes agent performance from accumulated outcome data in `.claude/memory/metrics.jsonl` and `.claude/memory/failures.jsonl`.
 
-The /metrics command, trend analysis, and recommendations engine.
+## Usage
 
----
+```bash
+/metrics              # Last 30 days (default)
+/metrics --week       # Last 7 days only
+/metrics --month      # Last 30 days
+/metrics --all        # All time
+/metrics --agent MAP  # Filter by specific agent
+/metrics --json       # Machine-readable JSON output
+```
 
-*Content will be consolidated from existing documentation in Phase 2/3.*
+## Dashboard Components
+
+The dashboard displays six panels, each calculated from the JSONL data files.
+
+### Overall Metrics
+
+Issues completed, first-attempt success rate, average recovery attempts, and average time to completion. Success rate is the primary KPI: `PASS / (PASS + BLOCKED)`.
+
+### Success by Complexity
+
+Breakdown across the three complexity tiers:
+
+| Complexity | Typical Rate | Implication |
+|------------|-------------|-------------|
+| TRIVIAL | 95% | Single-file, obvious changes |
+| SIMPLE | 85% | 1-3 files, clear requirements |
+| COMPLEX | 43% | 4+ files, cross-cutting, ambiguous |
+
+!!! tip "COMPLEX below 50%"
+    If COMPLEX success rate drops below 50%, the recommendations engine suggests breaking COMPLEX issues into SIMPLE sub-issues before execution.
+
+### Success by Stack
+
+Backend-only issues succeed at higher rates than fullstack issues because fullstack introduces cross-boundary failure modes (ENUM_VALUE, API_MISMATCH).
+
+| Stack | Typical Rate | Key Risk |
+|-------|-------------|----------|
+| Backend | 91% | SQLITE_COMPAT, STRUCTURE_VIOLATION |
+| Frontend | 78% | COMPONENT_API |
+| Fullstack | 67% | ENUM_VALUE, API_MISMATCH |
+
+### Top Failure Causes
+
+Ranked by frequency, showing the root cause code, percentage of all failures, and occurrence count. This panel directly feeds `/learn` analysis.
+
+### Agent Blocking Rate
+
+Shows which agents cause workflow blocks. PROVE blocking is expected (it is the verification gate). High blocking rates in MAP or PATCH indicate agent definition gaps.
+
+| Agent | Healthy Rate | Action if High |
+|-------|-------------|----------------|
+| MAP | < 5% | Improve investigation protocol |
+| PLAN | < 5% | Add acceptance criteria checks |
+| CONTRACT | < 2% | Review schema completeness |
+| PATCH | < 10% | Add pre-flight checklists |
+| PROVE | 80%+ | Expected (verification gate) |
+
+### Weekly Trend
+
+Four-week rolling trend showing success rate direction. An upward trend validates that `/learn --apply` updates are working.
+
+```
+Week 1:  75%  ===============
+Week 2:  81%  ================
+Week 3:  85%  =================
+Week 4:  91%  ==================  ^ Improving
+```
+
+## Recommendations Engine
+
+Based on current metrics, the dashboard generates actionable guidance:
+
+| Condition | Recommendation |
+|-----------|----------------|
+| ENUM_VALUE > 20% | "Add enum VALUE verification to MAP agent" |
+| Fullstack < 70% | "Always use CONTRACT agent for fullstack issues" |
+| COMPLEX < 50% | "Break COMPLEX issues into SIMPLE sub-issues" |
+| Trend declining | "Run `/learn` to update patterns" |
+| Agent blocking > 10% | "Review agent definition for gaps" |
+
+## Agent Version Correlation
+
+The dashboard correlates success rates with agent version numbers to detect whether updates help or hurt:
+
+```bash
+# Example output from version correlation
+  15 1.0 PASS
+   3 1.0 BLOCKED
+   8 1.1 PASS
+   0 1.1 BLOCKED    <-- v1.1 update was effective
+```
+
+This data answers the question: "Did the prevention checklist I added to PATCH v1.1 actually reduce ENUM_VALUE failures?"
+
+## Agent Filter Mode
+
+With `--agent`, the dashboard focuses on a single agent:
+
+```bash
+/metrics --agent MAP
+```
+
+Shows that agent's invocation count, blocks caused, average duration, issues identified (caught vs missed), common investigation patterns, and targeted recommendations.
+
+## JSON Output
+
+With `--json`, the dashboard outputs structured data for automation or external dashboards:
+
+```json
+{
+  "period": "30d",
+  "generated": "2026-03-26T10:00:00Z",
+  "overall": {
+    "total": 47,
+    "passed": 39,
+    "blocked": 8,
+    "success_rate": 0.83,
+    "avg_recovery": 1.2
+  },
+  "by_complexity": {
+    "TRIVIAL": {"passed": 19, "total": 20, "rate": 0.95},
+    "SIMPLE": {"passed": 17, "total": 20, "rate": 0.85},
+    "COMPLEX": {"passed": 3, "total": 7, "rate": 0.43}
+  },
+  "by_stack": {
+    "backend": {"passed": 21, "total": 23, "rate": 0.91},
+    "frontend": {"passed": 14, "total": 18, "rate": 0.78},
+    "fullstack": {"passed": 4, "total": 6, "rate": 0.67}
+  },
+  "top_failures": [
+    {"cause": "ENUM_VALUE", "count": 12, "percentage": 0.26},
+    {"cause": "COMPONENT_API", "count": 8, "percentage": 0.17}
+  ],
+  "trend": {
+    "week_1": 0.75, "week_2": 0.81,
+    "week_3": 0.85, "week_4": 0.91,
+    "direction": "improving"
+  }
+}
+```
+
+!!! note "Data Requirements"
+    `/metrics` requires `.claude/memory/metrics.jsonl` to exist. Run issues through `/orchestrate` to generate outcome data. The PROVE agent writes records automatically at the end of every workflow.
+
+## Schema Reference
+
+Metrics records follow the canonical schema from `_base.md`:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `issue` | integer | Yes | GitHub issue number |
+| `date` | string | Yes | ISO date (YYYY-MM-DD) |
+| `status` | string | Yes | `PASS` or `BLOCKED` |
+| `complexity` | string | Yes | `TRIVIAL`, `SIMPLE`, or `COMPLEX` |
+| `stack` | string | Yes | `backend`, `frontend`, or `fullstack` |
+| `agents_run` | array | Yes | List of agent names that executed |
+| `agent_versions` | object | Yes | Map of agent name to version string |
+| `root_cause` | string | No | Root cause code (null for PASS) |
+| `blocking_agent` | string | No | Agent that caused the block (null for PASS) |
+| `duration_minutes` | integer | No | Total execution time |

--- a/docs/manual/learning/self-learning-loop.md
+++ b/docs/manual/learning/self-learning-loop.md
@@ -1,10 +1,174 @@
 # Self-Learning Loop
 
-!!! note "Coming Soon"
-    This section is under construction.
+The self-learning loop is the mechanism that turns agent failures into systematic prevention. Every issue execution generates outcome data, which feeds pattern extraction, which updates agent definitions, which prevents future failures.
 
-How failures become patterns become prevention. The complete feedback cycle.
+## The Complete Feedback Cycle
 
----
+```
+/orchestrate (issue execution)
+       |
+       v
+PROVE records outcome
+       |-- metrics.jsonl  (PASS/BLOCKED, complexity, stack)
+       |-- failures.jsonl  (root cause, details, prevention)
+       |
+       v
+/learn --apply (weekly)
+       |-- Cluster failures by root_cause
+       |-- Write prevention checklists into agent .md files
+       |-- Bump agent versions automatically
+       |-- Record to pattern-events.jsonl
+       |
+       v
+/learn --validate (monthly)
+       |-- Compare success rates before/after each pattern
+       |
+       v
+Next /orchestrate loads updated agents
+       |-- MCP failure_patterns() (preferred)
+       |-- cat patterns-critical.md (fallback)
+       |
+       +----------- Loop repeats ------------------+
+```
 
-*Content will be consolidated from existing documentation in Phase 2/3.*
+## Data Schemas
+
+### metrics.jsonl
+
+One JSON line per completed issue, written automatically by the PROVE agent:
+
+```json
+{
+  "issue": 184,
+  "date": "2026-02-06",
+  "status": "PASS",
+  "complexity": "SIMPLE",
+  "stack": "fullstack",
+  "agents_run": ["MAP-PLAN", "CONTRACT", "PATCH", "PROVE"],
+  "agent_versions": {"map-plan": "1.0", "patch": "1.2", "prove": "1.3"},
+  "root_cause": null,
+  "blocking_agent": null,
+  "duration_minutes": 15
+}
+```
+
+**Required fields**: `issue`, `date`, `status`, `complexity`, `stack`, `agents_run`, `agent_versions`
+
+### failures.jsonl
+
+Recorded only when `status` is `BLOCKED`:
+
+```json
+{
+  "date": "2026-01-06",
+  "issue": 156,
+  "agent": "MAP-PLAN",
+  "root_cause": "VERIFICATION_GAP",
+  "details": "Plan deferred spec requirement without checking if spec was updated",
+  "fix": "Add after_tax_contributions to DataFrame",
+  "prevention": "Always validate spec version matches implementation pattern",
+  "files": ["backend/projections/models.py"]
+}
+```
+
+## The /learn Command
+
+### Steps
+
+| Step | Action | Detail |
+|------|--------|--------|
+| 1 | **Load outcome data** | Read `metrics.jsonl` + `failures.jsonl` from `.claude/memory/` |
+| 2 | **Cluster failures** | Group by `root_cause`, count occurrences |
+| 3 | **Analyze clusters** | For each cluster with 3+ occurrences, extract common files, trigger conditions, and the agent that should have caught the failure |
+| 4 | **Calculate metrics** | Success rates by complexity, stack, and week |
+| 5 | **Generate patterns.md** | Write prevention checklists for each high-frequency pattern |
+| 6 | **Identify candidates** | Patterns with 5+ occurrences become agent update candidates |
+
+### Usage
+
+```bash
+/learn                      # Standard analysis
+/learn --since 2026-01-01   # Analyze outcomes since date
+/learn --dry-run            # Preview changes without updating files
+/learn --verbose            # Show detailed analysis
+```
+
+### /learn --apply
+
+Closes the loop automatically. Instead of suggesting agent updates for manual application, `--apply` performs the full write cycle:
+
+1. Reads the target agent file (project-local first, then global)
+2. Finds the insertion point (after Pre-Flight, before Process)
+3. Generates a `## Learned Prevention: {ROOT_CAUSE}` section with failure count and date
+4. Shows a diff to the user for review
+5. Writes changes and bumps the agent minor version (e.g., `1.0` to `1.1`)
+6. Records the event to `pattern-events.jsonl`
+
+```bash
+/learn --apply              # Analyze + write prevention into agent files
+/learn --apply --dry-run    # Preview what --apply would write
+```
+
+!!! tip "Idempotency"
+    Before inserting, `/learn --apply` checks if a `## Learned Prevention: {ROOT_CAUSE}` section already exists. If so, it updates the count and date rather than duplicating.
+
+### /learn --validate
+
+Compares success rates before and after each pattern was added, using timestamps from `pattern-events.jsonl`:
+
+```
+Pattern Validation Results:
+  ENUM_VALUE:      74% -> 91% (+17%)  Effective
+  COMPONENT_API:   81% -> 85% (+4%)   Minor improvement
+  SCOPE_CREEP:     88% -> 86% (-2%)   No improvement -- review pattern
+```
+
+Patterns that do not improve outcomes get flagged for review or removal.
+
+### /learn --cross-project
+
+Aggregates failure patterns across all projects. Project paths are derived from `github-accounts.md`:
+
+```bash
+/learn --cross-project      # Scan all known projects
+```
+
+Scans each project for `.claude/memory/failures.jsonl`, merges same root causes across codebases, and writes results to global `~/.claude/memory/patterns.md`. This is how project-local patterns get promoted to global prevention.
+
+## Cadence Table
+
+| Cadence | Action | Command |
+|---------|--------|---------|
+| **After every issue** | PROVE auto-records outcome | Automatic |
+| **Weekly (Friday)** | Extract patterns, apply to agents | `/learn --apply` + `/metrics` |
+| **Monthly** | Validate pattern effectiveness | `/learn --validate` |
+| **Quarterly** | Cross-project pattern sharing | `/learn --cross-project` |
+| **When success rate < 80%** | Emergency pattern review | `/learn --verbose` |
+
+## Pattern Loading (MCP-First)
+
+Agents prefer MCP tools over file reads for pattern data during pre-flight:
+
+```
++---------------------+     +--------------------------+
+|  Agent Pre-Flight   |---->|  MCP: failure_patterns() |
+|                     |     |  MCP: agent_metrics(30d) |
+|  (all agents via    |     +----------+---------------+
+|   _base.md)         |                | fails?
+|                     |                v
+|                     |     +--------------------------+
+|                     |---->|  File: patterns-critical |
+|                     |     |  File: patterns-full.md  |
++---------------------+     +--------------------------+
+```
+
+## Real-World Results
+
+From one production project (86 issues analyzed over 5 weeks):
+
+- **Success rate**: 92% first-attempt pass
+- **Dominant failure**: VERIFICATION_GAP at 63% of all failures
+- **Result**: Added Mandatory Verification Protocol to MAP-PLAN agent
+- **Impact**: VERIFICATION_GAP dropped from 63% to 12% after agent update
+
+The loop works because every data point is recorded automatically by PROVE -- no manual tracking required.

--- a/docs/manual/reference/architecture-diagrams.md
+++ b/docs/manual/reference/architecture-diagrams.md
@@ -1,10 +1,199 @@
 # Architecture Diagrams
 
-!!! note "Coming Soon"
-    This section is under construction.
+All system diagrams collected in one reference. These diagrams show how the components connect, how data flows, and how lifecycle events are sequenced.
 
-All system diagrams collected in one place.
+## 1. Repository Structure
 
----
+```
+~/agents/                              # Single git repo
+  claude-config/                       # Claude Code configuration
+    agents/          (11 .md files)    # Agent definitions
+    commands/        (15 .md files)    # Slash commands
+    hooks/           (6 .py files)     # Lifecycle hooks + shared modules
+    rules/           (7 .md files)     # Conditional + always-loaded rules
+    skills/          (3 directories)   # Multi-step workflows
+    templates/       (2 entries)       # Prompt templates
+    settings.json                      # Global settings
+    statusline.py                      # Custom status bar
+    install.sh                         # Symlink installer
+  mcp-server/                          # Custom MCP server (5 tools)
+  obsidian-agent/                      # Session -> vault writer
+  code-review/                         # Pre-commit review agent
+  daily-standup/                       # Standup report generator
+  pr-changelog/                        # Post-merge changelog
+  doc-reader/                          # Document TTS reader
+  youtube-summarizer/                  # Video summarizer
+```
 
-*Content will be consolidated from existing documentation in Phase 2/3.*
+## 2. Symlink Deployment
+
+```
+~/agents/claude-config/                ~/.claude/
+  agents/          ---symlink--->        agents/
+  commands/        ---symlink--->        commands/
+  hooks/           ---symlink--->        hooks/
+  rules/           ---symlink--->        rules/
+  skills/          ---symlink--->        skills/
+  settings.json    ---symlink--->        settings.json
+  statusline.py    ---symlink--->        statusline.py
+
+  NOT symlinked (machine-local):
+                                         settings.local.json
+                                         memory/
+                                         projects/
+```
+
+Changes to the repo are live immediately --- symlinks mean no re-install is needed. Run `git pull` on another machine and updates propagate.
+
+## 3. Hook Lifecycle Flow
+
+```
+SESSION START
+  sessionstart_restore_state.py
+    +- Load PERSISTENT_STATE.yaml
+    +- Load patterns-critical.md
+    +- Output ~500 tokens restored context
+        |
+        v
+  [ SESSION WORK ]
+        |
+  Context limit? --YES--> PreCompact Hook
+        |                   +- Extract state from transcript
+        |                   +- Update PERSISTENT_STATE.yaml
+        |                   +- Auto-delete >7 day files
+        |<------------------+
+        |
+  Task complete? --YES--> Stop Hooks (sequential)
+        |                   1. verify_completion.py
+        |                      Exit 2 = block (uncommitted/TODOs)
+        |                   2. notify_completion.py
+        |                      macOS notification + iPhone
+        v
+  [continue working]
+```
+
+## 4. Orchestrate Pipeline Decision Tree
+
+```
+GitHub Issue --> Classify Complexity
+                    |
+    +---------------+---------------+
+    |               |               |
+  TRIVIAL         SIMPLE          COMPLEX
+  (1-2 files)     (3-5 files)     (6+ files)
+    |               |               |
+  MAP-PLAN        MAP-PLAN      MAP -> PLAN
+    |               |               |
+    |          fullstack? -----> CONTRACT(*)
+    |               |               |
+    |          PLAN-CHECK       PLAN-CHECK
+    |               |               |
+  PATCH           PATCH           PATCH
+    |               |               |
+  PROVE-lite      PROVE           PROVE
+    |               |               |
+    +------------- /pr -------------+
+
+(*) CONTRACT-lite if 0 new endpoints + <=2 frontend files
+```
+
+## 5. Parallel Worktree Sessions
+
+```
+Tab 1: /orchestrate 42 --parallel    Tab 2: /orchestrate 57 --parallel
+  .worktrees/issue-42/ (isolated)      .worktrees/issue-57/ (isolated)
+      |                                    |
+      v                                    v
+  PR from worktree branch              PR from worktree branch
+      |                                    |
+      v                                    v
+  Merge -> worktree removed            Merge -> worktree removed
+```
+
+Each worktree has its own files, git index, and `.agents/outputs/`. `PERSISTENT_STATE.yaml` lives in the main repo so `--resume` can locate the worktree.
+
+## 6. State Manager Functions
+
+```
+state_manager.py
+  load_state()            <- read PERSISTENT_STATE.yaml
+  update_phase()          <- orchestrate: before each agent
+  clear_active()          <- orchestrate: after completion
+  get_completed_phases()  <- --resume: skip finished phases
+  get_active_work()       <- sessionstart + notify hooks
+  get_worktree_for_issue()<- --parallel: find worktree path
+  update_from_extracted() <- precompact: save transcript state
+
+Callers: orchestrate (commands/), precompact, sessionstart, notify (hooks/)
+```
+
+## 7. Self-Learning Loop
+
+```
+/orchestrate --> PROVE --> metrics.jsonl + failures.jsonl
+                              |
+                              v
+                  /learn (weekly) --> patterns.md
+                     +--apply     --> agent .md files (prevention checklists)
+                     +--validate  --> before/after success rate comparison
+                     +--cross-project --> aggregate across all projects
+                              |
+                              v
+                  Next /orchestrate loads updated patterns via:
+                    1. MCP failure_patterns() (preferred)
+                    2. .claude/memory/patterns-critical.md (fallback)
+                              |
+                              v
+                        Cycle repeats
+```
+
+## 8. MCP Pattern Loading
+
+```
++---------------------+     +---------------------------+
+|  Agent Pre-Flight   |---->|  MCP: failure_patterns()  |
+|  (all agents via    |     |  MCP: agent_metrics(30d)  |
+|   _base.md section 1)|    +-------------+-------------+
+|                     |                   |
+|                     |                   | fails?
+|                     |                   v
+|                     |     +---------------------------+
+|                     |---->|  File: patterns-critical  |
+|                     |     |  File: patterns-full.md   |
++---------------------+     +---------------------------+
+```
+
+Agents prefer MCP tools over file reads for pattern data. MCP provides structured JSON responses. File-based loading is the fallback when MCP is unavailable.
+
+## 9. Obsidian Data Flow
+
+```
+Claude Code Sessions (.claude/projects/*/session.jsonl)
+        |
+        v
+obsidian-agent (Haiku) --+--> Obsidian Vault (STATUS.md, Daily, DASHBOARD)
+                         |       |
+                         |       +--> mcp-server (vault_status/search/dashboard)
+                         |       +--> daily-standup (reads vault)
+                         |       +--> pr-changelog (writes to vault)
+                         |
+                         +--> .claude/memory/ (metrics.jsonl, failures.jsonl)
+                                 +--> /learn, /metrics, mcp-server
+```
+
+## 10. Cross-Model Review
+
+```
+Claude Opus (Primary)          Claude Haiku (Review)
+  /orchestrate, /spec-draft      code-reviewer, obsidian-agent
+  Implementation, reasoning      Lightweight proactive review
+        |                              |
+        +----------+-------------------+
+                   v
+          Codebase (main branch)
+                   |
+                   v
+          Codex (OpenAI) -- Spec validation, secondary check
+```
+
+Claude Opus handles primary development. Claude Haiku runs lightweight proactive code reviews and extracts session data to the Obsidian vault. Codex provides an independent review perspective from a different model family.

--- a/docs/manual/reference/file-inventory.md
+++ b/docs/manual/reference/file-inventory.md
@@ -1,10 +1,128 @@
 # File Inventory
 
-!!! note "Coming Soon"
-    This section is under construction.
+Complete listing of all files in the `~/agents/claude-config/` repository, organized by category. All paths are relative to `~/agents/claude-config/` and symlinked to `~/.claude/` via `install.sh`.
 
-Complete listing of agents, commands, hooks, rules, skills, templates.
+## Agents (11 files)
 
----
+Symlinked to `~/.claude/agents/`. Agent definitions are markdown files that define role, constraints, input requirements, output format, and verification gates.
 
-*Content will be consolidated from existing documentation in Phase 2/3.*
+| File | Size | Purpose |
+|------|------|---------|
+| `_base.md` | 10.3 KB | Base agent inherited by all others: pre-flight, artifact naming, validation, AGENT_RETURN directive |
+| `map.md` | 3.6 KB | Investigator for COMPLEX issues (read-only, phase 1) |
+| `map-plan.md` | 6.5 KB | Combined investigator + architect for TRIVIAL/SIMPLE issues (read-only, phase 1+2) |
+| `plan.md` | 4.1 KB | Architect for COMPLEX issues (read-only, phase 2) |
+| `contract.md` | 3.3 KB | Interface designer for fullstack issues (read-only, phase 2.5) |
+| `plan-checker.md` | 3.1 KB | Plan validator (read-only, phase 2.8) |
+| `patch.md` | 5.8 KB | Implementer --- the only agent that modifies code (phase 3) |
+| `prove.md` | 7.3 KB | Reviewer and outcome recorder (phase 4) |
+| `test-planner.md` | 7.9 KB | Test architect for `--with-tests` flag (optional, phase 1.5) |
+| `spec-reviewer.md` | 6.1 KB | Spec analyst and GitHub issue creator (pre-pipeline) |
+| `code-reviewer.md` | 1.3 KB | Proactive lightweight review (runs on Haiku model) |
+
+## Commands (15 files)
+
+Symlinked to `~/.claude/commands/`. Slash commands invokable by the user during a session.
+
+| File | Size | Purpose |
+|------|------|---------|
+| `orchestrate.md` | 18.4 KB | Full agent pipeline for GitHub issues (`/orchestrate`) |
+| `learn.md` | 8.5 KB | Pattern extraction from failures (`/learn`) |
+| `metrics.md` | 15.8 KB | Performance dashboard (`/metrics`) |
+| `pr.md` | 3.1 KB | PR creation with checklist (`/pr`) |
+| `spec-review.md` | 3.4 KB | Spec analysis and issue creation (`/spec-review`) |
+| `spec-draft.md` | 7.5 KB | Interactive specification creation (`/spec-draft`) |
+| `feature.md` | 2.8 KB | Feature request issue creation (`/feature`) |
+| `feature-from-spec.md` | 2.7 KB | Create issues from spec gaps (`/feature-from-spec`) |
+| `bug.md` | 2.3 KB | Bug report with investigation (`/bug`) |
+| `test-plan.md` | 2.5 KB | Pre-implementation test planning (`/test-plan`) |
+| `scaffold-project.md` | 22.4 KB | Full FastAPI project scaffolding (`/scaffold-project`) |
+| `scaffold-module.md` | 7.5 KB | Domain module addition (`/scaffold-module`) |
+| `quick.md` | 2.0 KB | Ad-hoc fix without orchestrate (`/quick`) |
+| `review.md` | 0.4 KB | Code review of staged changes (`/review`) |
+| `frontend-design.md` | --- | Frontend design plugin integration (`/frontend-design`) |
+
+## Rules (7 files)
+
+Symlinked to `~/.claude/rules/`. Conditional and always-loaded instruction files.
+
+| File | Size | Trigger | Purpose |
+|------|------|---------|---------|
+| `core-patterns.md` | 0.7 KB | Always | Top 3 failure patterns (89% coverage) |
+| `git-workflow.md` | 3.2 KB | Always | Branch, commit, and PR conventions |
+| `implementation-routing.md` | 2.1 KB | Always | Plan mode vs orchestrate decision matrix |
+| `github-accounts.md` | 1.0 KB | Always | Multi-account GitHub configuration |
+| `fastapi-layered-pattern.md` | 23.6 KB | `**/backend/**`, `**/api/**`, `**/services/**` | Full layered architecture reference |
+| `orchestrate-workflow.md` | 16.7 KB | `.agents/**/*.md` | Agent efficiency, artifact naming, CONTRACT rules |
+| `spec-review-workflow.md` | 12.0 KB | `**/specs/**`, `**/.agents/**` | Spec finalization gate and issue creation |
+
+## Hooks (6 files)
+
+Symlinked to `~/.claude/hooks/`. Python scripts attached to Claude Code lifecycle events.
+
+| File | Size | Event | Purpose |
+|------|------|-------|---------|
+| `sessionstart_restore_state.py` | 4.8 KB | SessionStart | Restore PERSISTENT_STATE and critical patterns (~500 tokens) |
+| `precompact_checkpoint.py` | 7.5 KB | PreCompact | Extract state from transcript, update YAML, auto-clean old files |
+| `verify_completion.py` | 3.3 KB | Stop | Anti-rationalization: block if uncommitted changes or TODOs exist |
+| `notify_completion.py` | 3.5 KB | Stop | macOS Notification Center alert with iPhone relay via Handoff |
+| `state_manager.py` | 4.5 KB | (shared module) | Centralized PERSISTENT_STATE.yaml read/write operations |
+| `worktree_manager.py` | 6.5 KB | (shared module) | Git worktree lifecycle for `--parallel` flag |
+
+## Skills (3 directories)
+
+Symlinked to `~/.claude/skills/`. Multi-step workflow definitions with reference documentation.
+
+| Directory | Files | Purpose |
+|-----------|-------|---------|
+| `orchestrate/` | SKILL.md (2.4 KB), ORCHESTRATE_REFERENCE.md (7.5 KB) | Multi-agent pipeline execution |
+| `test-plan/` | SKILL.md (2.1 KB) | Test matrix generation with edge cases |
+| `spec-review/` | SKILL.md (1.2 KB) | Spec analysis and gap identification |
+
+## Templates (2 entries)
+
+Not symlinked --- referenced by orchestrate and other commands directly.
+
+| File | Size | Purpose |
+|------|------|---------|
+| `agent-prompt.md` | 2.5 KB | Shared prompt template with variable substitution for all agents |
+| `github-actions/` | --- | GitHub Actions workflow templates (Copilot review setup) |
+
+## Config Files
+
+| File | Size | Purpose |
+|------|------|---------|
+| `settings.json` | 2.1 KB | Global settings: hooks, MCP servers, permissions, plugins (symlinked) |
+| `statusline.py` | 1.2 KB | Custom ANSI status bar: hostname, user, date, context usage (symlinked) |
+| `install.sh` | 11.5 KB | Idempotent symlink installer (macOS/WSL/Linux aware) |
+| `project-template/` | --- | Starter `CLAUDE.md` and `.claude/rules/` for new projects |
+
+## Per-Project Files (Not in Repo)
+
+These files live in each project repository, not in `~/agents/claude-config/`:
+
+```
+~/projects/<project>/
+  CLAUDE.md                              # Project-specific agent instructions
+  .claude/
+    settings.json                        # Project permissions
+    memory/
+      patterns.md                        # Project-specific learned patterns
+      patterns-full.md                   # Extended patterns (~660 lines)
+      metrics.jsonl                      # Issue outcome tracking
+      failures.jsonl                     # Failure details
+      pattern-events.jsonl               # /learn --apply tracking
+  .agents/
+    outputs/
+      map-plan-{issue}-{mmddyy}.md      # Agent artifacts
+      patch-{issue}-{mmddyy}.md
+      prove-{issue}-{mmddyy}.md
+      archive/                           # Post-merge artifact archive
+      claude_checkpoints/
+        PERSISTENT_STATE.yaml            # Workflow state
+  .worktrees/                            # Worktree isolation (gitignored)
+    issue-{N}/                           # Full repo copy on own branch
+```
+
+!!! note "Machine-Local Files"
+    `~/.claude/settings.local.json` and `~/.claude/memory/` are machine-specific and not symlinked from the repo. Each machine configures its own MCP server paths and maintains its own global pattern files.

--- a/docs/manual/reference/glossary.md
+++ b/docs/manual/reference/glossary.md
@@ -1,10 +1,106 @@
 # Glossary
 
-!!! note "Coming Soon"
-    This section is under construction.
+Terms used throughout this documentation, defined in the context of the agentic engineering workflow.
 
-All terms defined — agent, artifact, CONTRACT, hook, MCP, pattern, rule, skill.
+## A
 
----
+**Agent**
+A specialized AI role with a defined purpose, input requirements, output format, and verification gates. Each agent in the pipeline (MAP, PLAN, PATCH, PROVE) performs one phase of work and produces a named artifact. Agent definitions are markdown files in `~/.claude/agents/`. All agents inherit from `_base.md` which provides pre-flight checklists, artifact naming, and the AGENT_RETURN directive.
 
-*Content will be consolidated from existing documentation in Phase 2/3.*
+**Artifact**
+A markdown file produced by an agent during the orchestrate pipeline. Named with the pattern `{agent}-{issue}-{mmddyy}.md` and stored in `.agents/outputs/`. Each agent validates that its required predecessor artifacts exist before starting. After PR merge, artifacts are moved to the `archive/` subdirectory.
+
+**Anti-Rationalization**
+A failure mode where AI agents declare a task complete when it is not. The `verify_completion.py` Stop hook combats this by checking for uncommitted changes and TODO/FIXME markers before allowing session completion.
+
+## C
+
+**Context Window**
+The agent's working memory --- everything it can "see" at once, including instructions, conversation history, file contents, and tool results. When the context fills up, older content gets compressed or dropped. Every token of instructions competes with code context.
+
+**CONTRACT**
+An agent phase (phase 2.5) that defines the interface between frontend and backend before implementation begins. Specifies endpoint schemas, enum VALUES, authentication requirements, and authorization patterns. Mandatory for fullstack issues.
+
+**CONTRACT-lite**
+An inline version of CONTRACT used for simple fullstack issues (0 new endpoints, 2 or fewer frontend files). Skips spawning a separate agent and documents the contract within the MAP-PLAN artifact instead.
+
+**Complexity Classification**
+The system for categorizing issues before routing them through the pipeline. TRIVIAL (1-2 files, obvious change), SIMPLE (3-5 files, clear pattern), or COMPLEX (6+ files, architectural decisions). The MAP agent determines complexity after investigating the codebase.
+
+## F
+
+**Failure Taxonomy**
+The set of 12 canonical root cause codes used to classify agent failures: VERIFICATION_GAP, ENUM_VALUE, COMPONENT_API, MULTI_MODEL, SQLITE_COMPAT, ACCESS_CONTROL, API_MISMATCH, MISSING_TEST, STRUCTURE_VIOLATION, SCOPE_CREEP, LINT_ERROR, and OTHER. Every failure is classified into exactly one code, enabling automated pattern analysis.
+
+## H
+
+**Hook**
+A Python script attached to a Claude Code lifecycle event. Hooks fire at specific moments --- SessionStart, PreCompact, Stop --- to manage state persistence, inject context, and enforce quality gates. Configured in `settings.json`.
+
+## L
+
+**Learning Loop**
+The continuous improvement cycle: `/orchestrate` executes issues, PROVE records outcomes to `metrics.jsonl` and `failures.jsonl`, `/learn` extracts patterns from failures, `/learn --apply` writes prevention checklists into agent files, and the next `/orchestrate` session loads the updated agents. This cycle runs weekly.
+
+## M
+
+**MAP**
+The investigation agent for COMPLEX issues (phase 1). Read-only --- it explores the codebase, reads specs, and documents component APIs, enum values, and file structures. Produces a 150-200 line artifact used by the PLAN agent.
+
+**MAP-PLAN**
+A combined investigation and planning phase for TRIVIAL and SIMPLE issues. Merges the MAP (investigation) and PLAN (architecture) phases into a single agent pass, reducing overhead for straightforward changes. Produces a 350-450 line artifact.
+
+**MCP (Model Context Protocol)**
+A protocol for providing AI agents with structured access to external data sources. In this system, the custom `vault-metrics` MCP server exposes five tools: `vault_status`, `vault_search`, `vault_dashboard`, `agent_metrics`, and `failure_patterns`.
+
+**Metrics**
+Structured outcome data recorded as JSON lines in `metrics.jsonl`. Each completed issue gets one record containing: issue number, date, status (PASS/BLOCKED), complexity, stack type, agents run, agent versions, root cause (if failed), and duration. Analyzed by `/learn` and `/metrics`.
+
+## O
+
+**Orchestrate**
+The primary workflow command (`/orchestrate`) that takes a GitHub issue number and executes a multi-agent pipeline: MAP, PLAN, CONTRACT, PATCH, PROVE. Supports flags for test planning (`--with-tests`), session resumption (`--resume`), and parallel execution (`--parallel`).
+
+## P
+
+**PATCH**
+The implementation agent (phase 3) and the only agent in the pipeline that modifies code. Reads the plan and contract artifacts, runs pre-flight checklists, implements changes, and runs pre-submission gates (lint, format, tests). If fullstack work is detected without a CONTRACT artifact, PATCH stops immediately.
+
+**Pattern**
+A documented failure mode with trigger conditions and prevention steps. Patterns are extracted from `failures.jsonl` by the `/learn` command and stored in tiered files: `patterns-critical.md` (always loaded, ~50 lines), `patterns-full.md` (loaded for COMPLEX issues, ~660 lines), and `core-patterns.md` (always-loaded rule, 12 lines).
+
+**PERSISTENT_STATE**
+A YAML file (`.agents/outputs/claude_checkpoints/PERSISTENT_STATE.yaml`) that tracks the current workflow state: active issue, branch, phase, completed phases, and worktree path. Managed by `state_manager.py` and used by hooks, orchestrate, `--resume`, and `--parallel`.
+
+**PROVE**
+The final agent phase (phase 4) that verifies implementation, records outcomes to `metrics.jsonl` and `failures.jsonl`, and classifies any failures by root cause code. Uses multi-level verification: EXISTS, SUBSTANTIVE, WIRED, FUNCTIONAL.
+
+**PROVE-lite**
+A reduced verification pass for TRIVIAL issues. Runs only the basic verification gates (file exists, lint passes, tests pass) without the full multi-level review that PROVE performs on SIMPLE and COMPLEX issues.
+
+**Prompt Template**
+A markdown file with variable placeholders used to generate agent spawn prompts. The shared template at `templates/agent-prompt.md` accepts variables like `{AGENT_ROLE}`, `{ISSUE_NUMBER}`, and `{PREDECESSOR_ARTIFACTS}` to produce consistent prompts across all agents.
+
+## R
+
+**Rule**
+A markdown file in `~/.claude/rules/` that provides instructions to agents. Rules can be always-loaded (`alwaysApply: true`) or conditionally loaded based on file path globs. Rules encode failure prevention, architectural patterns, and workflow constraints.
+
+## S
+
+**Skill**
+A multi-step workflow defined in `~/.claude/skills/`. Skills are more complex than single commands and include their own reference documentation. Current skills: `orchestrate` (multi-agent pipeline), `test-plan` (test matrix generation), and `spec-review` (spec analysis and issue creation).
+
+**Slash Command**
+A user-invokable command defined as a markdown file in `~/.claude/commands/`. Examples: `/orchestrate`, `/pr`, `/learn`, `/metrics`, `/scaffold-project`. Commands encode workflow logic and can spawn agents, create PRs, or analyze data.
+
+**State Manager**
+The centralized Python module (`hooks/state_manager.py`) that handles all reads and writes to `PERSISTENT_STATE.yaml`. Used by orchestrate (update phase), precompact hook (save transcript state), sessionstart hook (restore context), and the `--resume`/`--parallel` flags.
+
+## W
+
+**Worktree**
+A git worktree created for parallel issue processing. The `--parallel` flag on `/orchestrate` creates an isolated worktree at `.worktrees/issue-{N}/` branched from `origin/main`. Each worktree has its own files, git index, and artifacts. Managed by `worktree_manager.py`.
+
+**Worktree Manager**
+The Python module (`hooks/worktree_manager.py`) that handles git worktree lifecycle: creation, branch setup, file overlap detection, and cleanup after PR merge. Called by `/orchestrate --parallel` and `/pr`.

--- a/docs/manual/rules/claude-md.md
+++ b/docs/manual/rules/claude-md.md
@@ -1,10 +1,190 @@
-# Writing CLAUDE.md
+# Writing CLAUDE.md Files
 
-!!! note "Coming Soon"
-    This section is under construction.
+Every project should have a `CLAUDE.md` at the root. This file is the primary instruction set for AI agents working in your codebase. It tells agents what the project is, how to build and test it, what patterns to follow, and what to never do.
 
-What to include, forbidden patterns, actionable architecture documentation.
+## What to Include
 
----
+A production-quality CLAUDE.md covers seven sections. Each section serves a specific purpose --- skip one and agents will guess (often wrong).
 
-*Content will be consolidated from existing documentation in Phase 2/3.*
+### 1. Project Overview
+
+What the project is, who uses it, and what it is not.
+
+```markdown
+## Overview
+Multi-tenant financial planning platform. Firm -> Advisor -> Client hierarchy.
+Not a general-purpose accounting tool.
+```
+
+### 2. Development Commands
+
+How to set up, run, test, and lint. Agents execute these commands directly, so they must be copy-paste accurate.
+
+```markdown
+## Development
+cd backend && ruff check . && pytest -q          # Backend checks
+cd frontend && npm run check                     # Frontend (format + lint + test + build)
+```
+
+### 3. Architecture
+
+The layered pattern, module structure, and data flow. This must be actionable, not abstract.
+
+```markdown
+## Architecture
+Layered: Router -> Service -> Repository -> DB
+Module layout: models.py, schemas.py, repository.py, services.py, deps.py, router.py
+```
+
+### 4. Technology Stack
+
+Versions and key dependencies. Agents use this to avoid deprecated APIs and version mismatches.
+
+```markdown
+## Stack
+- Backend: FastAPI, SQLAlchemy 2.0, Pydantic v2, PostgreSQL
+- Frontend: React 19, Vite, Tailwind CSS, React Query
+```
+
+### 5. Project Structure
+
+Directory layout with descriptions. Mark directories that must not be reorganized.
+
+```markdown
+## Structure (IMMUTABLE -- do not reorganize)
+backend/backend/    # Flat layout -- NEVER create backend/src/
+frontend/src/       # React application
+```
+
+### 6. Forbidden Changes
+
+Things agents must never do. Explicit prohibitions are the most effective entries in any CLAUDE.md.
+
+```markdown
+## Forbidden
+- NEVER create src/, lib/, or pkg/ directories
+- NEVER push to production branch without explicit request
+- NEVER use PostgreSQL-specific syntax in tests (SQLite only)
+```
+
+### 7. Key Configuration
+
+Environment variables, defaults, and test credentials.
+
+```markdown
+## Config
+- DATABASE_URL defaults to sqlite:///test.db in tests
+- JWT_SECRET must be set for auth endpoints
+```
+
+## The Template
+
+A starter template is provided at `claude-config/project-template/CLAUDE.md`:
+
+```markdown
+# CLAUDE.md
+
+## Project Overview
+- Purpose:
+- Users:
+- Non-goals:
+
+## Development Commands
+# Setup / Run / Test / Lint
+
+## Architecture Constraints
+- Required patterns:
+- Forbidden changes:
+- Data/security constraints:
+
+## Delivery Rules
+- Definition of done:
+- Required test coverage:
+- Rollback expectations:
+```
+
+## Forbidden Patterns and Guardrails
+
+The most effective CLAUDE.md entries are explicit prohibitions that prevent known failure modes:
+
+| Guardrail | Prevents |
+|-----------|----------|
+| `NEVER create backend/src/` | STRUCTURE_VIOLATION --- agents reorganize if not told otherwise |
+| `Always filter by account_id` | ACCESS_CONTROL --- multi-tenant data leaks |
+| `Use require_account_owner from deps` | Inline permission checks with inconsistent enforcement |
+| `Tests use SQLite in-memory only` | SQLITE_COMPAT --- PostgreSQL-only features breaking test suite |
+| `Single source of truth: pyproject.toml` | Version drift from agents creating new version files |
+| `NEVER push to production branch` | Accidental production deployments |
+
+!!! warning "Agents Do Anything Not Explicitly Forbidden"
+    AI agents will reorganize directories, create new configuration files, add dependencies, and push to protected branches unless you tell them not to. Every known failure mode should become an explicit prohibition in CLAUDE.md.
+
+## Actionable vs Vague Documentation
+
+Architecture documentation must be actionable --- it tells the agent exactly what pattern to follow.
+
+**Good** (actionable):
+
+```markdown
+## Module Structure
+module/
+  models.py      # SQLAlchemy 2.0 (UUID PK, TimestampMixin)
+  schemas.py     # Pydantic v2 (ConfigDict, from_attributes=True)
+  repository.py  # Never commits -- service calls commit()
+  services.py    # Business logic -- raises AppError, not HTTPException
+  deps.py        # Access control via Depends()
+  router.py      # Thin -- calls service, returns response
+```
+
+**Bad** (vague):
+
+```markdown
+We use a layered architecture with separation of concerns.
+```
+
+The good example gives the agent a concrete file-by-file reference. The bad example forces the agent to guess what "separation of concerns" means in your specific project.
+
+## The "Read Before Assuming" Principle
+
+This single principle prevents 63% of all agent failures. Encode it in your CLAUDE.md:
+
+```markdown
+## Critical Rule
+Before using any existing component, hook, enum, or service:
+1. Read the actual source file
+2. Verify the API (props, return type, accepted values)
+3. Never assume -- always confirm
+```
+
+This matters because AI agents have training data about common patterns, but your codebase has specific implementations that may differ. An agent "knows" that `useSession()` typically returns `{ session, loading }` --- but your hook might return the session directly.
+
+## Per-Project Overrides
+
+The global rules in `~/.claude/rules/` apply to all projects. Per-project rules live in the project repository:
+
+```
+~/projects/myapp/
+  CLAUDE.md                          # Project-level instructions
+  .claude/
+    rules/
+      project-rules.md               # Project-specific rules
+    memory/
+      patterns.md                    # Learned patterns for this project
+      patterns-full.md               # Extended patterns (COMPLEX issues)
+      metrics.jsonl                  # Issue outcome tracking
+      failures.jsonl                 # Failure details
+```
+
+!!! tip "Layered Configuration"
+    Global rules handle cross-cutting concerns (git workflow, failure patterns). Project CLAUDE.md handles project-specific architecture and conventions. Project rules handle project-specific implementation patterns. This layering avoids duplicating global guidance in every project.
+
+## Maintenance
+
+Review your CLAUDE.md when:
+
+- A new failure pattern emerges that is project-specific
+- The tech stack changes (new dependency versions, new tools)
+- The directory structure changes (new modules, renamed directories)
+- An agent makes a mistake that a CLAUDE.md entry would have prevented
+
+Keep the file under 200 lines. If it grows beyond that, extract domain-specific sections into `.claude/rules/` as conditional rule files.

--- a/docs/manual/rules/conditional-rules.md
+++ b/docs/manual/rules/conditional-rules.md
@@ -1,10 +1,134 @@
 # Conditional Rules
 
-!!! note "Coming Soon"
-    This section is under construction.
+Rules in this system follow a tiered loading strategy: load the minimum context needed for the current task. Every token of rules competes with code context in the agent's working memory, so unnecessary rules waste capacity that could be spent reading source files.
 
-FastAPI layered pattern, orchestrate workflow, spec review — loaded by path match.
+## How Conditional Loading Works
 
+Claude Code evaluates rule files based on **path-based triggers** defined in each file's YAML frontmatter. When the agent is working in a directory that matches a trigger glob, the corresponding rule is loaded. When no match occurs, the rule stays unloaded and costs zero tokens.
+
+```yaml
+---
+description: "FastAPI layered architecture rules"
+globs: ["**/backend/**", "**/api/**", "**/services/**"]
+---
+```
+
+Rules with `alwaysApply: true` bypass the path matching and load into every session. Only `core-patterns.md`, `git-workflow.md`, `implementation-routing.md`, and `github-accounts.md` use this setting.
+
+## Complete Rule Inventory
+
+| Rule File | Size | Loaded When | Purpose |
+|-----------|------|-------------|---------|
+| `core-patterns.md` | 0.7 KB (12 lines) | **Always** (`alwaysApply: true`) | Top 3 failure patterns covering 89% of failures |
+| `git-workflow.md` | 3.2 KB | **Always** (`alwaysApply: true`) | Branch naming, commit conventions, PR process |
+| `implementation-routing.md` | 2.1 KB | **Always** (`alwaysApply: true`) | Plan mode vs orchestrate decision matrix |
+| `github-accounts.md` | 1.0 KB | **Always** (`alwaysApply: true`) | Multi-account git configuration |
+| `fastapi-layered-pattern.md` | 23.6 KB (767 lines) | `**/backend/**`, `**/api/**`, `**/services/**` | Full layered architecture reference: router, service, repository, models, schemas, deps |
+| `orchestrate-workflow.md` | 16.7 KB (588 lines) | `.agents/**/*.md` | Agent efficiency rules, artifact naming, size compliance, CONTRACT requirements |
+| `spec-review-workflow.md` | 12.0 KB (361 lines) | `**/specs/**`, `**/.agents/**` | Spec finalization gate, review process, issue creation rules |
+
+## Token Budget Analysis
+
+Loading all rules simultaneously would consume approximately 43 KB of context. With conditional loading, a typical session loads only what it needs:
+
+| Scenario | Rules Loaded | Approximate Size |
+|----------|-------------|-----------------|
+| Backend bugfix | core-patterns + git-workflow + implementation-routing + fastapi-layered | ~28 KB |
+| Frontend-only change | core-patterns + git-workflow + implementation-routing | ~6 KB |
+| Orchestrate pipeline | core-patterns + git-workflow + orchestrate-workflow | ~21 KB |
+| Spec review | core-patterns + git-workflow + spec-review-workflow | ~16 KB |
+| Documentation update | core-patterns + git-workflow + implementation-routing | ~6 KB |
+
+!!! note "Savings Compound"
+    A frontend-only session saves ~37 KB of context by not loading `fastapi-layered-pattern.md` or `orchestrate-workflow.md`. That recovered space is equivalent to reading two additional source files --- which directly improves implementation accuracy.
+
+## When Each Rule Loads
+
+### Always-Loaded Rules
+
+These four rules load into every session regardless of working directory:
+
+- **core-patterns.md** --- Three failure patterns that apply to all codebases
+- **git-workflow.md** --- Branch, commit, and PR conventions used on every project
+- **implementation-routing.md** --- Decision matrix for choosing plan mode vs orchestrate
+- **github-accounts.md** --- Maps projects to the correct GitHub account
+
+### Backend Context
+
+When the agent reads or writes files matching `**/backend/**`, `**/api/**`, or `**/services/**`:
+
+- **fastapi-layered-pattern.md** loads with the full architecture reference: layer responsibilities, module structure, enum conventions, access control patterns, and SQLAlchemy/Pydantic usage rules
+
+### Orchestrate Context
+
+When the agent operates on files matching `.agents/**/*.md` (typically during `/orchestrate` workflows):
+
+- **orchestrate-workflow.md** loads with artifact naming conventions, agent size compliance targets, and CONTRACT enforcement rules
+
+### Spec Context
+
+When the agent operates on files matching `**/specs/**` or `**/.agents/**`:
+
+- **spec-review-workflow.md** loads with the spec finalization gate, draft-to-final workflow, and issue creation rules
+
+## Design Principles
+
+1. **Minimum context for current task** --- Only load rules relevant to the files being touched
+2. **Always-loaded stays tiny** --- The always-loaded rules total ~7 KB combined; any growth here costs every session
+3. **Conditional rules can be large** --- `fastapi-layered-pattern.md` at 767 lines is acceptable because it only loads for backend work
+4. **Path globs must be specific** --- Broad globs like `**/*.py` would defeat the purpose; use directory-based patterns that match project structure
+5. **No duplication across rules** --- Each rule owns its domain; cross-references use "see `core-patterns.md`" rather than repeating content
+
+## Rule File Anatomy
+
+Every rule file follows the same structure:
+
+```markdown
+---
+description: "Human-readable description for tooling"
+alwaysApply: true                # or omit for conditional
+globs: ["**/backend/**"]         # path triggers (conditional only)
 ---
 
-*Content will be consolidated from existing documentation in Phase 2/3.*
+# Rule Title
+
+Content that agents read and follow.
+```
+
+The frontmatter is parsed by Claude Code to determine loading behavior. The body is injected into the agent's context when the rule is active. Keep the body focused --- avoid tutorial-style explanations and focus on actionable instructions.
+
+## What Each Conditional Rule Contains
+
+### fastapi-layered-pattern.md (23.6 KB)
+
+The largest rule file. Contains the complete FastAPI layered architecture reference:
+
+- Layer responsibilities (router, service, repository, models, schemas, deps)
+- Module file structure with per-file conventions
+- Enum rules (member names = UPPER_SNAKE, values = stored in DB)
+- Access control patterns (always via dependencies, never inline)
+- SQLAlchemy 2.0 conventions (Mapped types, select() syntax)
+- Pydantic v2 conventions (ConfigDict, from_attributes)
+- Error handling (AppError subclasses, not HTTPException in services)
+
+### orchestrate-workflow.md (16.7 KB)
+
+Loaded during agent pipeline execution:
+
+- Artifact naming convention (`{agent}-{issue}-{mmddyy}.md`)
+- Agent output size targets with compression checklists
+- CONTRACT enforcement (mandatory for fullstack, PATCH stops without it)
+- Parallel execution rules (which phases can overlap)
+- State management integration points
+
+### spec-review-workflow.md (12.0 KB)
+
+Loaded during spec analysis and issue creation:
+
+- Spec finalization gate (status must be `final` before issues are created)
+- Draft-to-final lifecycle with review rounds
+- Gap classification (Implemented, Partial, Missing, Differs)
+- Issue creation format and dependency ordering
+
+!!! tip "Adding New Rules"
+    When creating a new rule file, choose the narrowest glob that covers the relevant files. Measure the file size and consider whether the content could be added to an existing rule instead. Rules under 1 KB can often be merged with an existing always-loaded rule; rules over 5 KB should always be conditional.

--- a/docs/manual/rules/core-patterns.md
+++ b/docs/manual/rules/core-patterns.md
@@ -1,10 +1,98 @@
-# Core Patterns
+# Core Failure Patterns
 
-!!! note "Coming Soon"
-    This section is under construction.
+The `core-patterns.md` rule file is always loaded into every agent session, regardless of project or context. At 12 lines, it is the most concise and highest-impact rule in the system.
 
-The always-loaded 12-line rule covering 89% of failures.
+## Why It Exists
 
----
+Analysis of 86 completed issues across production projects revealed that **three failure patterns account for over 50% of all agent failures**. Rather than loading hundreds of lines of prevention guidance every session, the core patterns file encodes the minimum viable prevention in a compact format that fits within any context budget.
 
-*Content will be consolidated from existing documentation in Phase 2/3.*
+The three patterns covered here have a combined occurrence rate of 89% across all recorded failures. Encoding them as an always-loaded rule means every agent --- MAP, PLAN, PATCH, PROVE --- applies these checks proactively without needing to load project-specific pattern files.
+
+## The Three Patterns
+
+| Pattern | Frequency | Trigger | Prevention |
+|---------|-----------|---------|------------|
+| **ENUM_VALUE** | 26% of fullstack failures | Issue involves role, status, or type fields across frontend and backend | Read the backend enum definition. Use the VALUE string (right side of `=`), not the Python name (left side). `"CO-OWNER"` not `"CO_OWNER"`. |
+| **COMPONENT_API** | 17% of frontend failures | Reusing an existing React component or custom hook | Read the actual source file. Extract PropTypes or function signature before using. Never invent props. |
+| **VERIFICATION_GAP** | 63% of all failures | Any assumption about code structure, spec content, or API shape | Verify by reading actual code with the Read tool. Never assume a file exists, a function signature matches, or a schema field is present. |
+
+### ENUM_VALUE in Detail
+
+Backend Python enums define members with a NAME and a VALUE:
+
+```python
+class AdvisorRole(str, Enum):
+    CO_OWNER = "CO-OWNER"      # NAME: CO_OWNER, VALUE: "CO-OWNER"
+    ASSOCIATE = "ASSOCIATE"    # NAME: ASSOCIATE, VALUE: "ASSOCIATE"
+```
+
+The database stores the VALUE. The API sends and receives the VALUE. Frontend code must use the VALUE. The NAME is only used in Python code to reference the enum member. When an agent uses `"CO_OWNER"` in a frontend fetch call or API request body, it silently fails validation because the backend expects `"CO-OWNER"`.
+
+The CONTRACT agent now documents enum VALUES explicitly in a dedicated section, and the PROVE agent verifies that frontend strings match backend VALUES during its verification pass.
+
+### COMPONENT_API in Detail
+
+Agents have training data about common React patterns, but your project's hooks and components may differ. For example:
+
+```javascript
+// Training data says:
+const { session, loading } = useSession();
+
+// But your project actually does:
+const session = useSession();  // returns value directly
+```
+
+The fix is mechanical: read the actual source file before using any component or hook. The MAP agent documents reusable component APIs in its artifact so that PATCH does not need to re-discover them.
+
+### VERIFICATION_GAP in Detail
+
+This is the most common pattern because it is the most general. Any time an agent proceeds based on an assumption rather than reading actual code, it risks a VERIFICATION_GAP failure. Common triggers include:
+
+- Assuming a spec requirement was already implemented
+- Assuming a file exists at an expected path
+- Assuming a function accepts certain parameters
+- Assuming a database column has a particular type
+
+## Decision Matrix
+
+When starting any issue, agents evaluate these triggers:
+
+| Condition | Action |
+|-----------|--------|
+| Issue references a spec | Read the spec file FIRST before planning |
+| Issue involves enums across stack boundary | Read backend enum, extract VALUE strings |
+| Issue reuses existing component or hook | Read source file, extract actual API |
+| Any assumption about code structure | Read the actual file to confirm |
+
+!!! warning "Single Source of Truth"
+    `core-patterns.md` is the canonical definition of these three patterns. All other files --- agent definitions, training docs, workflow docs --- **reference** these patterns but do not redefine them. When updating a pattern, edit `core-patterns.md` only. Duplicating definitions across files leads to drift where one copy gets updated and others become stale.
+
+## Quick Gotchas
+
+These additional failure modes appear frequently enough to warrant awareness, even though they are not in the always-loaded file:
+
+| Gotcha | What Goes Wrong | Prevention |
+|--------|----------------|------------|
+| **Directory structure** | Agent creates `backend/src/` or reorganizes folders | CLAUDE.md must list forbidden directory changes explicitly |
+| **React hook return shape** | Agent assumes `const { data } = useHook()` when hook returns value directly | Read the hook source; destructuring patterns vary per project |
+| **Access control** | Agent adds endpoint without `account_id` scoping | Use `require_account_owner` or equivalent from `deps.py`; never inline permission checks |
+| **SQLite compatibility** | Agent uses PostgreSQL-only syntax in test fixtures | Tests run against SQLite in-memory; avoid `ARRAY`, `JSONB`, or `ON CONFLICT` syntax |
+| **Multi-model updates** | Agent changes one model but forgets related models | When modifying a model, grep for all foreign key references and relationship definitions |
+
+## How Agents Load It
+
+The rule file uses `alwaysApply: true` in its frontmatter, which means Claude Code loads it into every session automatically. No conditional trigger is needed. The file lives at:
+
+```
+~/.claude/rules/core-patterns.md  (symlink)
+    -> ~/agents/claude-config/rules/core-patterns.md  (source)
+```
+
+!!! tip "Full Patterns for Complex Issues"
+    For COMPLEX issues (6+ files, architectural decisions), agents load the extended pattern file at `.claude/memory/patterns-full.md` (~660 lines). This contains detailed prevention checklists with examples for all 12 root cause codes. The core patterns file handles the common cases; the full file handles edge cases.
+
+## Relationship to the Learning Loop
+
+Core patterns are the output of the self-learning system. The `/learn` command analyzes `metrics.jsonl` and `failures.jsonl`, clusters failures by root cause, and updates pattern files. When a pattern reaches 5+ occurrences, `/learn --apply` writes prevention checklists directly into agent definition files and bumps agent versions.
+
+The core patterns file is updated manually and rarely --- only when a new failure pattern reaches sufficient frequency to warrant always-loaded status. The current three patterns have been stable since early 2026.

--- a/docs/manual/workflow/commands.md
+++ b/docs/manual/workflow/commands.md
@@ -1,10 +1,239 @@
 # Command Reference
 
-!!! note "Coming Soon"
-    This section is under construction.
+All slash commands are defined in `claude-config/commands/` and available globally via symlink. Project-specific commands can be added in `.claude/commands/` within any project.
 
-Complete reference for all slash commands.
+## Workflow Commands
 
----
+| Command | Usage | Purpose |
+|---------|-------|---------|
+| `/orchestrate` | `/orchestrate 184 [flags]` | Full agent pipeline for a GitHub issue |
+| `/quick` | `/quick Fix typo in README` | Direct execution for small, scoped tasks |
+| `/pr` | `/pr [number] [--merge]` | PR creation, review, and merge workflow |
+| `/review` | `/review` | Pre-commit code review of staged changes |
 
-*Content will be consolidated from existing documentation in Phase 2/3.*
+### /orchestrate
+
+Runs the MAP - PLAN - PATCH - PROVE pipeline for a GitHub issue.
+
+```bash
+/orchestrate 184                      # Standard
+/orchestrate 184 --with-tests         # Add TEST-PLANNER phase
+/orchestrate 184 --resume             # Resume interrupted workflow
+/orchestrate 184 --parallel           # Isolated worktree execution
+```
+
+See [Orchestrate Workflow](orchestrate.md) for full documentation.
+
+### /quick
+
+Executes small tasks directly without sub-agents, artifacts, or GitHub issues.
+
+```bash
+/quick Fix typo in README
+/quick Add missing import in accounts/services.py
+/quick Update env example with new variable
+```
+
+See [Quick Mode](quick-mode.md) for decision criteria and process.
+
+### /pr
+
+Creates, reviews, or merges pull requests with a pre-flight checklist.
+
+```bash
+/pr                   # Create PR from current branch
+/pr 123               # Review existing PR #123
+/pr --merge 123       # Merge PR #123 after checks pass
+```
+
+The PR workflow includes:
+
+- Branch verification (must not be on main)
+- Backend/frontend lint and test gates
+- Auto-generated PR body with scope, verification, and test plan
+- Post-merge cleanup (branch deletion, artifact archival, worktree removal)
+
+### /review
+
+Runs a lightweight code review on staged changes using the Haiku model.
+
+```bash
+/review
+```
+
+## Issue Management Commands
+
+| Command | Usage | Purpose |
+|---------|-------|---------|
+| `/feature` | `/feature "Add payment module"` | Create feature request issue |
+| `/bug` | `/bug "Login fails on Safari"` | Create bug report with investigation |
+| `/spec-draft` | `/spec-draft payments` | Interactive specification creation |
+| `/spec-review` | `/spec-review specs/payments.md` | Analyze spec vs codebase |
+| `/feature-from-spec` | `/feature-from-spec specs/payments.md` | Create issues from spec gaps |
+
+### /feature
+
+Creates a GitHub feature issue with automatic scope classification and labels.
+
+```bash
+/feature "Add payment processing module"
+```
+
+Runs `gh issue create` with a structured template including scope, stack detection, and complexity estimate.
+
+### /bug
+
+Creates a GitHub bug report with context investigation.
+
+```bash
+/bug "Login fails on Safari with 403 error"
+```
+
+Investigates the codebase for relevant context before creating the issue.
+
+### /spec-draft
+
+Interactive multi-step specification creation with codebase discovery.
+
+```bash
+/spec-draft payments
+```
+
+Guides through requirements gathering, discovers existing code patterns, and flags risks.
+
+### /spec-review
+
+Analyzes a specification against the current codebase to find gaps and inconsistencies.
+
+```bash
+/spec-review specs/payments.md
+/spec-review specs/payments.md --create-issues
+```
+
+With `--create-issues`, automatically creates GitHub issues for each gap found.
+
+### /feature-from-spec
+
+Creates GitHub issues from specification analysis. Used by the spec-reviewer agent.
+
+```bash
+/feature-from-spec specs/payments.md
+```
+
+## Testing Commands
+
+| Command | Usage | Purpose |
+|---------|-------|---------|
+| `/test-plan` | `/test-plan 184` | Pre-implementation test planning |
+
+### /test-plan
+
+Runs the TEST-PLANNER agent to generate a test matrix with edge cases and priority levels.
+
+```bash
+/test-plan 184
+/test-plan specs/payments.md
+```
+
+Generates a test plan artifact with test signatures that the PATCH agent follows during implementation.
+
+## Learning and Metrics Commands
+
+| Command | Usage | Purpose |
+|---------|-------|---------|
+| `/learn` | `/learn [flags]` | Extract patterns from failures |
+| `/metrics` | `/metrics [--week] [--json]` | Performance dashboard |
+
+### /learn
+
+Analyzes `metrics.jsonl` and `failures.jsonl` to extract failure patterns and update prevention knowledge.
+
+```bash
+/learn                     # Analyze current project
+/learn --since 2026-01-01  # From specific date
+/learn --cross-project     # Aggregate across all projects
+/learn --validate          # Compare before/after success rates
+/learn --apply             # Write prevention into agent files
+/learn --apply --dry-run   # Preview changes without writing
+```
+
+| Flag | Purpose |
+|------|---------|
+| `--since DATE` | Analyze failures from a specific date |
+| `--cross-project` | Aggregate patterns across all projects |
+| `--validate` | Compare success rates before/after pattern addition |
+| `--apply` | Write prevention checklists into agent .md files |
+| `--dry-run` | Preview without modifying files |
+
+### /metrics
+
+Displays an agent performance dashboard with success rates and trends.
+
+```bash
+/metrics              # Current week
+/metrics --week       # Last 7 days
+/metrics --month      # Last 30 days
+/metrics --json       # Machine-readable output
+```
+
+## Scaffolding Commands
+
+| Command | Usage | Purpose |
+|---------|-------|---------|
+| `/scaffold-project` | `/scaffold-project myapp` | Generate full project skeleton |
+| `/scaffold-module` | `/scaffold-module items` | Add module to existing project |
+
+### /scaffold-project
+
+Generates a complete FastAPI project with 30+ files including auth, migrations, and tests.
+
+```bash
+/scaffold-project myapp
+/scaffold-project myapp --with-auth
+```
+
+### /scaffold-module
+
+Adds a domain module to an existing project with all layers.
+
+```bash
+/scaffold-module items
+/scaffold-module items -f "name:str, amount:Decimal"
+```
+
+Generates: `models.py`, `schemas.py`, `repository.py`, `services.py`, `deps.py`, `router.py`.
+
+## External Agent Commands
+
+| Command | Usage | Purpose |
+|---------|-------|---------|
+| `/obsidian` | `/obsidian [--dry-run]` | Capture session to Obsidian vault |
+| `/standup` | `/standup` | Generate daily standup from vault |
+| `/changelog` | `/changelog` | Update changelog from merged PRs |
+| `/codex-review` | `/codex-review` | Second opinion from OpenAI Codex |
+
+!!! note "External commands require additional setup"
+    `/obsidian` requires the obsidian-agent module. `/codex-review` requires an OpenAI API key and the Codex plugin.
+
+## All Commands at a Glance
+
+| Command | Category | Requires Issue | Creates Files |
+|---------|----------|---------------|---------------|
+| `/orchestrate` | Workflow | Yes | Artifacts in `.agents/outputs/` |
+| `/quick` | Workflow | No | Modified source files only |
+| `/pr` | Workflow | No | PR on GitHub |
+| `/review` | Workflow | No | None |
+| `/feature` | Issue Mgmt | No | GitHub issue |
+| `/bug` | Issue Mgmt | No | GitHub issue |
+| `/spec-draft` | Issue Mgmt | No | Spec file |
+| `/spec-review` | Issue Mgmt | No | Optional GitHub issues |
+| `/feature-from-spec` | Issue Mgmt | No | GitHub issues |
+| `/test-plan` | Testing | Optional | Test plan artifact |
+| `/learn` | Learning | No | Updates patterns.md |
+| `/metrics` | Learning | No | None (read-only) |
+| `/scaffold-project` | Scaffolding | No | 30+ project files |
+| `/scaffold-module` | Scaffolding | No | 6 module files |
+| `/obsidian` | External | No | Vault entries |
+| `/standup` | External | No | Report output |
+| `/changelog` | External | No | CHANGELOG.md |
+| `/codex-review` | External | No | None |

--- a/docs/manual/workflow/orchestrate.md
+++ b/docs/manual/workflow/orchestrate.md
@@ -1,10 +1,261 @@
-# Orchestrate Pipeline
+# Orchestrate Workflow
 
-!!! note "Coming Soon"
-    This section is under construction.
+The `/orchestrate` command runs a multi-agent pipeline to implement GitHub issues. It classifies complexity, spawns specialized agents in sequence, tracks state across context compactions, and records outcomes for the learning system.
 
-The full MAP -> PLAN -> PATCH -> PROVE pipeline with TRIVIAL/SIMPLE/COMPLEX routing.
+## Usage
 
----
+```bash
+/orchestrate 184                        # Standard execution
+/orchestrate #184                       # With hash prefix
+/orchestrate 184 --with-tests           # Include TEST-PLANNER phase
+/orchestrate 184 --resume               # Resume from last completed phase
+/orchestrate 184 --parallel             # Run in isolated worktree
+/orchestrate 184 --parallel --resume    # Resume in existing worktree
+```
 
-*Content will be consolidated from existing documentation in Phase 2/3.*
+If no issue number is provided, you will be prompted to create one with `/feature` or `/bug`.
+
+## Flags
+
+| Flag | Purpose |
+|------|---------|
+| `--with-tests` | Adds TEST-PLANNER agent after MAP-PLAN. Recommended for calculations, formulas, or complex business logic. |
+| `--resume` | Skips already-completed phases. Reads state from `PERSISTENT_STATE.yaml`. |
+| `--parallel` | Creates an isolated git worktree (`.worktrees/issue-{N}/`). Enables concurrent orchestrate sessions on independent issues. |
+
+## Pipeline Overview
+
+```
+GitHub Issue
+     |
+     +-- TRIVIAL --> MAP-PLAN --> PATCH --> PROVE-lite
+     |
+     +-- SIMPLE ---> MAP-PLAN --> [TEST-PLANNER] --> CONTRACT* --> PLAN-CHECK --> PATCH --> PROVE
+     |
+     +-- COMPLEX --> MAP --> PLAN --> [TEST-PLANNER] --> CONTRACT* --> PLAN-CHECK --> PATCH --> PROVE
+
+     * CONTRACT is MANDATORY for fullstack (PATCH will STOP without it)
+       CONTRACT-lite (inline) for simple fullstack (0 new endpoints, <=2 frontend files)
+     [ ] = Optional (requires --with-tests flag)
+```
+
+## Complexity Classification
+
+### Decision Flow
+
+```
+                    +---------------+
+                    | GitHub Issue  |
+                    +-------+-------+
+                            |
+                 +----------+----------+
+                 | Classify Complexity |
+                 +----------+----------+
+                            |
+           +----------------+----------------+
+           |                |                |
+      +---------+     +----------+     +----------+
+      | TRIVIAL |     |  SIMPLE  |     | COMPLEX  |
+      | 1-2 file|     | 3-5 file |     | 6+ files |
+      +----+----+     +----+-----+     +----+-----+
+           |               |                |
+           v               v                v
+      MAP-PLAN         MAP-PLAN        MAP --> PLAN
+           |               |                |
+           |          +----+----+      +----+----+
+           |          |fullstack|      |fullstack|
+           |          +----+----+      +----+----+
+           |          yes  | no        yes  | no
+           |               v                v
+           |          CONTRACT(*)       CONTRACT
+           |               |                |
+           |          PLAN-CHECK       PLAN-CHECK
+           |               |                |
+           v               v                v
+        PATCH            PATCH            PATCH
+           |               |                |
+           v               v                v
+      PROVE-lite         PROVE            PROVE
+      (gates only)         |                |
+           |               v                v
+           +------------- /pr --------------+
+
+     (*) CONTRACT-lite if 0 new endpoints + <=2 frontend files
+         CONTRACT-full otherwise
+```
+
+### Classification Criteria
+
+| Level | Files | Criteria | Workflow |
+|-------|-------|----------|----------|
+| **TRIVIAL** | 1-2 | Docs, config, obvious fixes | MAP-PLAN, skips PLAN-CHECK, PROVE-lite |
+| **SIMPLE** | 3-5 | Clear pattern, single subsystem | MAP-PLAN with full verification |
+| **COMPLEX** | 6+ | Endpoints, migrations, architectural | Separate MAP and PLAN phases |
+
+## Step-by-Step Process
+
+### Step 0: Verify Issue
+
+```bash
+gh issue view $ISSUE --json number,title,body
+```
+
+If the issue does not exist, the workflow stops.
+
+### Step 1: Classify and Detect Stack
+
+The orchestrator reads the issue body and classifies complexity. After MAP-PLAN (or MAP) completes, it auto-detects the stack by scanning the plan artifact for `backend/` and `frontend/` references:
+
+- Both present: `fullstack` (CONTRACT becomes mandatory)
+- Only one: `backend` or `frontend`
+
+### Step 1.6: CONTRACT Weight Assessment
+
+For fullstack issues, decide between inline and full contract:
+
+| Signal | CONTRACT-lite (inline) | CONTRACT-full (agent) |
+|--------|------------------------|-----------------------|
+| New endpoints | 0 | 1+ |
+| Enum changes | 0-1 | 2+ |
+| Breaking API changes | No | Yes |
+| Frontend files touched | 1-2 | 3+ |
+
+CONTRACT-lite embeds the contract directly in the PATCH prompt. CONTRACT-full spawns a dedicated agent that produces its own artifact.
+
+### Step 1.7: Conflict Check
+
+Before branching, checks for file conflicts with open PRs and active worktrees:
+
+```bash
+# Files from open PRs
+gh pr list --state open --json files --jq '.[].files[].path'
+
+# Compare against planned files from MAP-PLAN artifact
+```
+
+If conflicts are found, the orchestrator warns but does not block. You decide whether to proceed or wait.
+
+### Step 2: Create Feature Branch
+
+```bash
+git fetch origin && git checkout -b feature/issue-$ISSUE-description origin/main
+```
+
+Skipped when `--parallel` is used (the worktree setup handles branch creation).
+
+### Step 3: Spawn Agents
+
+Each agent is spawned via the Task tool with inherited context:
+
+```markdown
+## Inherited Context (DO NOT re-read these files)
+- Issue: #184 - Add payment module
+- Branch: feature/issue-184-payment-module
+- Stack: backend
+- Complexity: SIMPLE
+
+## Prior Artifacts
+- map-plan-184-032626.md
+```
+
+Every agent validates that predecessor artifacts exist before starting. If an artifact is missing, the agent stops immediately.
+
+### Step 4: Report Status
+
+```
+Workflow complete for issue #184
+
+Artifacts:
+- map-plan-184-032626.md
+- patch-184-032626.md
+- prove-184-032626.md
+
+PROVE status: PASS
+
+Next: /pr 184 to create pull request
+```
+
+## Agent Roles
+
+| Agent | Phase | Read-Only | Purpose |
+|-------|-------|-----------|---------|
+| **MAP** | 1 | Yes | Investigate codebase (COMPLEX only) |
+| **MAP-PLAN** | 1+2 | Yes | Investigate + plan (TRIVIAL/SIMPLE) |
+| **PLAN** | 2 | Yes | File-by-file implementation plan (COMPLEX) |
+| **TEST-PLANNER** | 1.5 | Yes | Test matrix with edge cases (optional) |
+| **CONTRACT** | 2.5 | Yes | Backend/frontend API contract (fullstack) |
+| **PLAN-CHECK** | 2.8 | Yes | Validate plan completeness |
+| **PATCH** | 3 | No | Implement changes |
+| **PROVE** | 4 | No | Verify and record outcome |
+
+!!! warning "CONTRACT is mandatory for fullstack"
+    If the detected stack is `fullstack`, PATCH will refuse to proceed without a CONTRACT artifact. This prevents enum value mismatches and API contract violations.
+
+## State Tracking
+
+State persists in `.agents/outputs/claude_checkpoints/PERSISTENT_STATE.yaml`:
+
+```yaml
+active_work:
+  issue: 184
+  branch: feature/issue-184-payment-module
+  phase: PATCH
+  last_action: Starting PATCH phase
+  completed_phases: [MAP-PLAN, PLAN-CHECK]
+  worktree_path: null
+meta:
+  updated: '2026-03-26'
+```
+
+The `state_manager.py` module provides:
+
+| Function | Used By |
+|----------|---------|
+| `update_phase()` | Orchestrate (before each agent) |
+| `clear_active()` | Orchestrate (after completion) |
+| `get_completed_phases()` | `--resume` flag |
+| `get_active_work()` | SessionStart hook |
+| `get_worktree_for_issue()` | `--parallel` flag |
+
+## Resume Mode
+
+When `--resume` is provided:
+
+1. Loads state from `PERSISTENT_STATE.yaml`
+2. Reads `completed_phases` to determine where to continue
+3. Verifies artifacts exist for all completed phases
+4. Resumes from the next incomplete phase
+
+| Last Completed | Next Phase |
+|----------------|------------|
+| (none) | MAP-PLAN or MAP |
+| MAP-PLAN | PLAN-CHECK (or CONTRACT if fullstack) |
+| PLAN-CHECK | PATCH |
+| PATCH | PROVE |
+| PROVE | Done |
+
+## Failure Handling
+
+If any agent fails:
+
+1. Workflow stops immediately
+2. Reports which agent failed and the expected artifact path
+3. Does not proceed to the next phase
+
+!!! note "Prior failures are injected"
+    If an issue was previously attempted and PROVE recorded BLOCKED, the failure context (root cause, details, prevention) is injected into the next PATCH prompt to avoid repeating the same mistake.
+
+## Artifacts
+
+All outputs go to `.agents/outputs/` with the naming pattern `{agent}-{issue}-{mmddyy}.md`:
+
+| Artifact | Agent |
+|----------|-------|
+| `map-plan-184-032626.md` | MAP-PLAN |
+| `test-plan-184-032626.md` | TEST-PLANNER |
+| `contract-184-032626.md` | CONTRACT |
+| `plan-check-184-032626.md` | PLAN-CHECK |
+| `patch-184-032626.md` | PATCH |
+| `prove-184-032626.md` | PROVE |
+
+Each agent validates the chain: PROVE checks for PATCH, PATCH checks for MAP-PLAN (and CONTRACT if fullstack), and so on.

--- a/docs/manual/workflow/parallel.md
+++ b/docs/manual/workflow/parallel.md
@@ -1,10 +1,232 @@
 # Parallel Execution
 
-!!! note "Coming Soon"
-    This section is under construction.
+Parallel execution operates at two levels: agent-level parallelism within a single session, and worktree-level parallelism across multiple terminal sessions.
 
-Running multiple issues simultaneously with --parallel worktree isolation.
+## Two Levels of Parallelism
 
----
+```
+Level 1: Agent-Level (within one session)
++-------------------------------------------+
+| /orchestrate 42                           |
+|                                           |
+|   MAP fan-out:                            |
+|     Task(explore backend)  ---+           |
+|     Task(explore frontend) ---+-- parallel|
+|     Task(explore tests)    ---+           |
+|                                           |
+|   Speculative PATCH:                      |
+|     Task(PLAN-CHECK) ---+                 |
+|     Task(PATCH)      ---+-- parallel      |
++-------------------------------------------+
 
-*Content will be consolidated from existing documentation in Phase 2/3.*
+Level 2: Worktree-Level (across sessions)
++--------------------+  +--------------------+
+| Terminal Tab 1     |  | Terminal Tab 2     |
+| /orchestrate 42    |  | /orchestrate 57    |
+|   --parallel       |  |   --parallel       |
+|        |           |  |        |           |
+|        v           |  |        v           |
+| .worktrees/        |  | .worktrees/        |
+|   issue-42/        |  |   issue-57/        |
+|   (isolated copy)  |  |   (isolated copy)  |
++--------------------+  +--------------------+
+```
+
+## Agent-Level Parallelism
+
+Within a single orchestrate session, certain agents can run concurrently when they share input but produce independent outputs.
+
+### Parallel Patterns
+
+| Pattern | Agents | Condition |
+|---------|--------|-----------|
+| MAP fan-out | Explore backend + frontend + tests | COMPLEX issues |
+| MAP + TEST-PLANNER | MAP + TEST-PLANNER | COMPLEX with `--with-tests` |
+| PLAN-CHECK + TEST-PLANNER | PLAN-CHECK + TEST-PLANNER | `--with-tests` flag |
+| Speculative PATCH | PLAN-CHECK + PATCH | SIMPLE backend-only |
+| Fullstack PATCH | Backend PATCH + Frontend PATCH | Fullstack with CONTRACT |
+
+### MAP Fan-Out
+
+For COMPLEX issues, the MAP phase can spawn parallel exploration agents:
+
+```
++-- Task(Explore backend/)  --> file paths, functions, current behavior
+|
++-- Task(Explore frontend/) --> components, hooks, API calls, state
+|
++-- Task(Explore tests/)    --> test coverage, patterns, gaps
+|
+v
+MAP agent synthesizes all findings into single artifact
+```
+
+Skip fan-out for TRIVIAL/SIMPLE issues (MAP-PLAN handles exploration inline) or when only one subsystem is involved.
+
+### Speculative PATCH
+
+PLAN-CHECK passes approximately 90% of the time. Instead of waiting for validation, PATCH can start speculatively in parallel:
+
+```
+Spawn in parallel:
+  Task(PLAN-CHECK for issue 42)    <-- validation
+  Task(PATCH for issue 42)         <-- speculative implementation
+
+  PLAN-CHECK passes  --> PATCH result is valid, proceed to PROVE
+  PLAN-CHECK fails   --> roll back PATCH, revise plan, re-run
+```
+
+!!! warning "When NOT to speculate"
+    Disable speculative PATCH for COMPLEX issues, fullstack changes, or issues that were previously BLOCKED. The plan rejection rate is higher in these cases.
+
+### Fullstack PATCH Split
+
+When a CONTRACT artifact exists, PATCH can split into backend and frontend tasks:
+
+```
+CONTRACT artifact
+       |
+       +-- Task(PATCH backend/)   -- runs ruff + pytest
+       |
+       +-- Task(PATCH frontend/)  -- runs lint + build
+       |
+       v
+  Merge into single patch artifact for PROVE
+```
+
+Skip the split when shared utility files appear in both plans or when fewer than 3 files per side are affected.
+
+## Worktree-Level Parallelism
+
+The `--parallel` flag isolates the entire workflow in a git worktree, enabling multiple orchestrate sessions to run concurrently on different issues.
+
+### How It Works
+
+```bash
+/orchestrate 42 --parallel
+```
+
+1. Creates `.worktrees/issue-42/` as a full copy of the repository on its own branch
+2. Runs all agents with the worktree as working directory
+3. Writes artifacts to `{worktree}/.agents/outputs/`
+4. Tracks state in the main repo's `PERSISTENT_STATE.yaml` (not the worktree's)
+
+### The worktree_manager.py Module
+
+Located in `claude-config/hooks/`, this module manages the worktree lifecycle:
+
+| Function | Purpose |
+|----------|---------|
+| `create_worktree(issue, branch)` | Create `.worktrees/issue-{N}/` with feature branch |
+| `remove_worktree(issue)` | Clean up after PR merge |
+| `get_repo_root()` | Resolve main repo root (not worktree CWD) |
+| `check_file_conflicts(planned_files)` | Check for overlap with other active worktrees |
+| `get_worktree_for_issue(project_dir, issue)` | Find existing worktree path from state |
+
+### State Tracking with Repo Root
+
+!!! warning "State uses repo root, not worktree CWD"
+    All `update_phase()` calls must use the **repo root** as `project_dir`, not the worktree path. The state file lives in the main repository so all parallel sessions share a single source of truth.
+
+```bash
+REPO_ROOT=$(python3 -c "
+import sys; sys.path.insert(0, '$HOME/.claude/hooks')
+from worktree_manager import get_repo_root
+print(get_repo_root())
+")
+```
+
+### Conflict Check (Step 1.7)
+
+Before the workflow proceeds, it checks for file overlap at two levels:
+
+**Open PRs:**
+
+```bash
+gh pr list --state open --json files --jq '.[].files[].path'
+```
+
+**Active worktrees:**
+
+```python
+from worktree_manager import check_file_conflicts
+conflicts = check_file_conflicts(planned_files)
+```
+
+```
+Planned files for issue 42:
+  backend/accounts/services.py
+  backend/accounts/schemas.py
+
+Active worktree issue-57 touches:
+  backend/accounts/services.py    <-- CONFLICT
+
+WARNING: File conflicts with active worktrees.
+Consider serializing or waiting for issue 57 to complete.
+```
+
+The conflict check warns but does not block. You decide whether to proceed.
+
+### Resume in Worktree
+
+When `--resume` is used:
+
+1. Loads worktree path from state (`get_worktree_for_issue()`)
+2. If the worktree still exists on disk: resumes inside it
+3. If the worktree was cleaned up: re-creates it and starts from the beginning
+
+When `--resume` is used without `--parallel`, it checks state for a `worktree_path` field and auto-detects whether the issue was running in parallel mode.
+
+### Post-Merge Cleanup
+
+After a PR merges, the `/pr` command handles cleanup:
+
+```bash
+# Archive artifacts
+mv .agents/outputs/*-42-*.md .agents/outputs/archive/
+
+# Remove worktree
+python3 -c "
+from worktree_manager import remove_worktree
+remove_worktree(42)
+"
+# Result: .worktrees/issue-42/ deleted
+```
+
+!!! note "Worktrees are not auto-removed after PROVE"
+    The orchestrator reports the worktree path after completion but does not delete it. You may need the worktree for PR revisions. Cleanup happens during `/pr --merge`.
+
+## macOS Notifications
+
+When a session completes (via the Stop hook), `notify_completion.py` sends a macOS Notification Center alert:
+
+- Includes issue number and current phase from `state_manager`
+- Auto-forwards to iPhone via Handoff
+- Particularly useful when running parallel sessions in background terminal tabs
+
+## When NOT to Parallelize
+
+| Situation | Reason |
+|-----------|--------|
+| Issues share files | Merge conflicts are likely |
+| Issue B depends on Issue A | B needs A's changes in main first |
+| Single-file changes | Worktree overhead exceeds benefit |
+| Limited machine resources | Each worktree is a full repo copy |
+
+## Recommended Pattern: Wave Scheduling
+
+Group independent issues into parallel waves. Dependent issues run in later waves after predecessors merge.
+
+```
+Wave 1 (parallel -- no file overlap):
+  /orchestrate 42 --parallel   # accounts module
+  /orchestrate 57 --parallel   # reports module
+
+      |  both merge to main  |
+
+Wave 2 (after Wave 1 merges):
+  /orchestrate 63 --parallel   # depends on #42 changes
+  /orchestrate 71 --parallel   # independent of #63
+```
+
+This pattern maximizes throughput while preventing merge conflicts. Always rebase on the latest main before creating a PR from a worktree.

--- a/docs/manual/workflow/quick-mode.md
+++ b/docs/manual/workflow/quick-mode.md
@@ -1,10 +1,145 @@
 # Quick Mode
 
-!!! note "Coming Soon"
-    This section is under construction.
+The `/quick` command handles small, well-scoped tasks without the overhead of the full orchestrate pipeline. No sub-agents, no artifacts, no GitHub issue required.
 
-Ad-hoc fixes without the full orchestrate pipeline.
+## Usage
 
----
+```bash
+/quick Fix typo in README
+/quick Add missing import in accounts/services.py
+/quick Update env example with new variable
+```
 
-*Content will be consolidated from existing documentation in Phase 2/3.*
+The argument is a plain-text description of the task.
+
+## When to Use /quick vs /orchestrate
+
+| Criteria | `/quick` | `/orchestrate` |
+|----------|----------|----------------|
+| Scope | 1-2 files, obvious fix | Multi-file, needs planning |
+| Tracking | No GitHub issue needed | Requires GitHub issue |
+| Branching | Stays on current branch | Creates feature branch |
+| Artifacts | None generated | Full MAP - PATCH - PROVE chain |
+| Sub-agents | None spawned | Specialized agents per phase |
+| Patterns | Critical patterns only | Full patterns for COMPLEX |
+| Time | Seconds to minutes | Minutes to longer |
+
+!!! tip "Rule of thumb"
+    If you hesitate about whether it fits `/quick`, use `/orchestrate` instead. Quick mode is for changes you could describe in one sentence and verify in one command.
+
+## Decision Criteria
+
+Use `/quick` when ALL of these are true:
+
+- The change touches 3 files or fewer
+- The fix is obvious (no investigation needed)
+- No schema changes or migrations
+- No cross-cutting concerns (pure backend OR pure frontend)
+- You can verify the change with a single command
+
+Use `/orchestrate` when ANY of these are true:
+
+- You need to investigate the codebase first
+- The change spans multiple subsystems
+- There are enum values, API contracts, or shared types involved
+- You want tracked artifacts for the implementation
+- The change requires a dedicated feature branch and PR
+
+## Process
+
+### 1. Load Critical Patterns
+
+Before executing, `/quick` loads the critical failure patterns:
+
+```bash
+cat .claude/memory/patterns-critical.md
+```
+
+The three core checks are applied:
+
+| Pattern | Check |
+|---------|-------|
+| VERIFICATION_GAP | Verify assumptions by reading actual code |
+| ENUM_VALUE | Use enum VALUE string, not Python name |
+| COMPONENT_API | Read component source before using props |
+
+### 2. Classify Scope
+
+Determine which area is affected:
+
+- **Backend**: `backend/` directory
+- **Frontend**: `frontend/src/` directory
+- **Config**: `.claude/`, root files, documentation
+
+### 3. Execute Directly
+
+Make changes directly -- no sub-agents are spawned. All project rules from `.claude/rules/` still apply.
+
+### 4. Verify
+
+Run the appropriate verification commands for the area touched:
+
+```bash
+# Backend changes
+cd backend && ruff check . && pytest -q
+
+# Frontend changes
+cd frontend && npm run lint && npm run build
+```
+
+### 5. Report
+
+```
+Quick task complete:
+- Files changed: backend/accounts/services.py
+- Verification: PASS
+- Summary: Added missing import for AccountSchema
+```
+
+## Optional Metrics Recording
+
+Quick tasks can optionally record to `metrics.jsonl` for tracking:
+
+```bash
+echo '{"date":"2026-03-26","source":"quick","task":"Fix missing import","status":"PASS","files_changed":1}' >> .claude/memory/metrics.jsonl
+```
+
+This is not required but helps when running `/metrics` for a complete picture of development activity.
+
+## What /quick Does NOT Do
+
+| Behavior | Why |
+|----------|-----|
+| Create feature branches | Stays on current branch to minimize overhead |
+| Create GitHub issues | The task is too small to warrant formal tracking |
+| Spawn sub-agents | Direct execution is faster for small changes |
+| Write artifacts | No MAP-PLAN, PATCH, or PROVE files generated |
+| Run full PROVE | Only runs lint and test gates, not the full verification matrix |
+
+## Examples
+
+Good candidates for `/quick`:
+
+```bash
+/quick Fix typo in CLAUDE.md header
+/quick Add CORS origin for staging environment
+/quick Update Python version in pyproject.toml
+/quick Remove unused import in router.py
+/quick Add missing field to env.example
+```
+
+Bad candidates (use `/orchestrate` instead):
+
+```bash
+# Too broad -- needs investigation
+/quick Refactor the auth module
+
+# Cross-cutting -- touches backend and frontend
+/quick Add role field to user profile
+
+# Needs planning -- schema change
+/quick Add payment_status column to orders table
+```
+
+!!! warning "3-file limit"
+    If `/quick` would need to touch more than 3 files, it recommends switching to `/orchestrate` instead. This is a hard boundary to prevent scope creep in untracked work.


### PR DESCRIPTION
## Summary
- All 30 section stubs replaced with full content (5,324 lines total)
- 4 parallel agents wrote sections simultaneously from 199K+ of source docs
- Covers: getting started, workflow, agents, hooks, learning, integrations (Codex + Obsidian), rules, git, reference
- MkDocs build clean, no warnings, no stubs remaining

Phases 2-3 of 4 for issue #12. Phase 4: Cloudflare Pages deployment.

Ref #12

## Test Plan
- [x] `mkdocs build` succeeds with no errors
- [x] All 31 files have content (zero "Coming Soon" stubs)
- [x] No real email addresses exposed
- [x] All nav sections render with content