### PR TITLE
feat: expand Codex from reviewer to implementation partner

### DIFF
--- a/claude-config/rules/implementation-routing.md
+++ b/claude-config/rules/implementation-routing.md
@@ -1,40 +1,187 @@
-# Implementation Routing: Task Assessment → Workflow → Review
+# Implementation Routing: Task Assessment → Workflow → Codex Delegation → Review
 
-When given any task, assess complexity and route to the right workflow with the right review level. **Make the call yourself — do not ask the user which mode to use.**
+When given any task, assess complexity and route to the right workflow. Maximize use of Codex (GPT) for tasks within its capability — reviews, parallel implementation, debugging, and background work. **Make the call yourself — do not ask the user which mode to use.**
 
 ## Step 1: Assess and Route
 
 **Assess BEFORE entering any mode.** Read the issue/task, check files involved, then decide.
 
-| Complexity | Files | Criteria | Route To | Codex Review |
-|------------|-------|----------|----------|-------------|
-| **TRIVIAL** | 1 | Typo, config, rename, obvious fix | `/quick` | Skip |
-| **SIMPLE** | 1-3 | Clear requirements, single subsystem | Plan Mode | Offer after implementation |
-| **MODERATE** | 4-5 | Clear pattern, single subsystem | `/orchestrate` (SIMPLE tier) | Recommended |
-| **COMPLEX** | 6+ | Cross-cutting, architectural decisions | `/orchestrate` (COMPLEX tier) | Automatic |
-| **FULLSTACK** | Any | Backend + frontend changes | `/orchestrate` + CONTRACT | Automatic (focus: enums/API) |
-| **PRIOR FAIL** | Any | Re-attempt of a BLOCKED issue | `/orchestrate` + failure context, or `/codex:rescue` | Automatic |
+| Complexity | Files | Criteria | Route To | Codex Role |
+|------------|-------|----------|----------|-----------|
+| **TRIVIAL** | 1 | Typo, config, rename, obvious fix | `/quick` | None |
+| **SIMPLE** | 1-3 | Clear requirements, single subsystem | Plan Mode | Offer review after |
+| **MODERATE** | 4-5 | Clear pattern, single subsystem | `/orchestrate` (SIMPLE tier) | Review (recommended) |
+| **COMPLEX** | 6+ | Cross-cutting, architectural decisions | `/orchestrate` (COMPLEX tier) | Review (automatic) + delegate subtasks |
+| **FULLSTACK** | Any | Backend + frontend changes | `/orchestrate` + CONTRACT | Review (enum/API focus) + parallel implementation |
+| **PRIOR FAIL** | Any | Re-attempt of a BLOCKED issue | `/codex:rescue` first, then `/orchestrate` | Primary implementer (different model) |
 
 **Modifiers:**
 - **Multiple independent issues** → add `--parallel` (worktree isolation, separate tabs)
 - **Interrupted workflow** → add `--resume` (skip completed phases)
-- **Stuck after re-attempt** → try `/codex:rescue` before escalating to human
+- **Subtasks within an issue** → delegate independent subtasks to Codex via `/codex:rescue --background`
 
-## Step 2: Announce Your Decision
+## Step 2: Maximize Codex Delegation
 
-State the routing decision briefly before starting:
+After routing the primary workflow, identify work that Codex should handle. Codex (GPT) runs **in background** — Claude continues working in parallel.
 
-> **Quick** — typo in README, 1 file, obvious fix.
+### When to Delegate to Codex
 
-> **Plan mode** — 2 files (entity_grid.py, config.py), clear requirements, high confidence.
+```
+┌──────────────────────────────────────────────────────────────┐
+│                  CODEX DELEGATION RULES                       │
+│                                                               │
+│  DELEGATE TO CODEX when:                                      │
+│  ├── Task is independent (doesn't block Claude's work)       │
+│  ├── Prior attempt by Claude was BLOCKED (try different model)│
+│  ├── Fullstack: frontend can run parallel to Claude's backend│
+│  ├── Debugging: test failures, regression investigation      │
+│  ├── Refactoring: mechanical changes (rename, extract, move) │
+│  └── Review: any MODERATE+ task after implementation         │
+│                                                               │
+│  KEEP IN CLAUDE when:                                         │
+│  ├── Task requires orchestrate pipeline state (MAP→PATCH)    │
+│  ├── Task needs MCP server access (vault-metrics, etc.)      │
+│  ├── Task involves project-specific rules/patterns           │
+│  ├── Task is the primary implementation thread                │
+│  └── Architectural decisions that need deep context           │
+└──────────────────────────────────────────────────────────────┘
+```
 
-> **Orchestrate (SIMPLE)** — 4 files, backend-only, clear pattern to follow. Codex review recommended.
+### Delegation Patterns
 
-> **Orchestrate (COMPLEX, fullstack)** — new module + schema + frontend integration. CONTRACT required. Codex adversarial review automatic.
+#### Pattern 1: Parallel Fullstack Split
+Claude handles backend (needs MCP, rules, patterns). Codex handles frontend in background.
 
-> **Parallel** — Issues 42 and 57 are independent. Recommending `--parallel` in separate tabs.
+```
+Claude: PATCH backend (services, models, routes)
+  │
+  └── /codex:rescue --background --write \
+        "Implement frontend component per CONTRACT:
+         - Component: PaymentForm at frontend/src/components/
+         - API endpoint: POST /api/payments (see contract artifact)
+         - Enum VALUES: STATUS='pending','completed','failed'
+         - Run: npm run lint && npm run build when done"
+  │
+  ├── Claude continues with backend tests
+  └── /codex:status → check when frontend is done
+```
 
-The user can override: "just do it" (downgrade to quick/plan) or "orchestrate this" (upgrade).
+#### Pattern 2: Debug Delegation
+Claude is implementing issue A. Tests for issue B start failing. Delegate debugging to Codex.
+
+```
+Claude: working on issue A...
+  │
+  └── /codex:rescue --background \
+        "Investigate why tests in backend/auth/tests/ are failing.
+         Started failing after commit abc123. Find root cause and fix."
+  │
+  ├── Claude continues issue A
+  └── /codex:result → review Codex's fix when done
+```
+
+#### Pattern 3: Prior Failure Escalation
+Claude's PATCH was BLOCKED. Instead of re-running Claude with failure context, try Codex first (different model = different approach).
+
+```
+PROVE: BLOCKED (root cause: MULTI_MODEL — forgot to update related model)
+  │
+  ├── OLD: re-run Claude PATCH with failure context
+  │
+  └── NEW: /codex:rescue --write --effort high \
+        "Fix issue #184. Prior attempt failed with MULTI_MODEL error:
+         forgot to update Advisor model when changing User.
+         See .agents/outputs/patch-184-032626.md for what was tried.
+         Fix the multi-model coordination."
+```
+
+#### Pattern 4: Mechanical Refactoring
+Large rename, extract, or move operations that don't require architectural judgment.
+
+```
+Claude: planning the refactor...
+  │
+  └── /codex:rescue --background --write \
+        "Rename all occurrences of 'UserAccount' to 'Account' across
+         backend/backend/ directory. Update imports, type hints, and
+         test references. Run ruff check . when done."
+  │
+  ├── Claude works on the architectural changes
+  └── /codex:status → merge Codex's renames with Claude's work
+```
+
+#### Pattern 5: Test Writing
+Claude implements the feature. Codex writes the tests.
+
+```
+Claude: PATCH completes feature implementation
+  │
+  └── /codex:rescue --background --write \
+        "Write tests for the new payment processing module.
+         Source: backend/backend/payments/services.py
+         Test file: backend/backend/payments/tests/test_services.py
+         Use pytest + pytest-asyncio. SQLite in-memory only.
+         Cover: success cases, validation errors, edge cases.
+         Run: cd backend && pytest -q when done."
+  │
+  ├── Claude continues to PROVE phase
+  └── /codex:result → incorporate tests before commit
+```
+
+## Step 3: Announce Your Decision
+
+State the routing decision AND any Codex delegation briefly:
+
+> **Quick** — typo in README, 1 file. No Codex.
+
+> **Plan mode** — 2 files, clear requirements. Will offer Codex review after.
+
+> **Orchestrate (MODERATE)** — 4 files, backend-only. Codex review after PROVE.
+
+> **Orchestrate (COMPLEX, fullstack)** — new module + frontend. Claude handles backend, delegating frontend to Codex in background. Adversarial review automatic.
+
+> **Codex-first** — issue 184 failed twice. Sending to `/codex:rescue` before re-attempting with Claude.
+
+> **Parallel** — Issues 42 and 57 independent. `--parallel` in separate tabs. Codex reviews both in background.
+
+The user can override any routing or delegation decision.
+
+## Step 4: Apply Codex Review
+
+After implementation (regardless of workflow), apply review based on risk:
+
+| Risk Level | Codex Action | Command |
+|------------|-------------|---------|
+| **TRIVIAL** | Skip entirely | — |
+| **SIMPLE** | Offer (don't force) | "Want a cross-model review?" |
+| **MODERATE** | Run after implementation | `/codex:review --background` |
+| **COMPLEX** | Run adversarial after PROVE | `/codex:adversarial-review --background` |
+| **FULLSTACK** | Run with enum/API focus | `/codex:adversarial-review --background "Focus on: enum value mismatches, API contract compliance, access control"` |
+| **PRIOR FAIL** | Run before commit | `/codex:adversarial-review --wait "Focus on: {prior root cause}"` |
+
+### Review Integration with Orchestrate
+
+For MODERATE+ tasks, Codex review runs **after PROVE passes**:
+
+```
+PATCH → PROVE passes → /codex:adversarial-review --background
+                               │
+                          findings?
+                          ├── No  → /pr
+                          └── Yes → fix → re-run PROVE → /pr
+```
+
+## Codex Model Selection Guide
+
+| Task Type | Recommended Model | Effort | Why |
+|-----------|------------------|--------|-----|
+| Quick review | `gpt-5.4-mini` | `medium` | Fast, cheap, sufficient for review |
+| Adversarial review | `gpt-5.4` | `high` | Needs reasoning depth to challenge decisions |
+| Bug investigation | `gpt-5.4-mini` | `medium` | Read-only diagnosis, speed matters |
+| Feature implementation | `gpt-5.4` | `high` | Write-capable, needs quality |
+| Mechanical refactoring | `gpt-5.4-mini` | `low` | Repetitive, pattern-following |
+| Test writing | `gpt-5.4` | `medium` | Needs understanding of code but not deep reasoning |
+| Prior failure rescue | `gpt-5.4` | `xhigh` | Maximum reasoning for stuck problems |
 
 ## Workflow Flows
 
@@ -63,72 +210,40 @@ Options:
 3. "Revise plan" — Adjust the approach before implementing
 ```
 
-5. After implementation, **offer** Codex review: "Want a cross-model review? I can run `/codex:adversarial-review`."
+5. After implementation, **offer** Codex review.
 
 ### Orchestrate
 
 For MODERATE, COMPLEX, and FULLSTACK tasks. Full agent pipeline.
 
 ```
-TRIVIAL tier:  MAP-PLAN → PATCH → PROVE-lite
-SIMPLE tier:   MAP-PLAN → [CONTRACT*] → PLAN-CHECK → PATCH → PROVE
-COMPLEX tier:  MAP → PLAN → [CONTRACT*] → PLAN-CHECK → PATCH → PROVE
+TRIVIAL pipeline:  MAP-PLAN → PATCH → PROVE-lite
+SIMPLE pipeline:   MAP-PLAN → [CONTRACT*] → PLAN-CHECK → PATCH → PROVE
+COMPLEX pipeline:  MAP → PLAN → [CONTRACT*] → PLAN-CHECK → PATCH → PROVE
 ```
 
 Use `/orchestrate <issue-number>` with optional flags: `--with-tests`, `--resume`, `--parallel`.
 
-## Step 3: Apply Codex Review
-
-After the task is implemented (regardless of workflow), apply review based on risk:
-
-| Risk Level | Codex Action | Command |
-|------------|-------------|---------|
-| **TRIVIAL** | Skip entirely | — |
-| **SIMPLE** | Offer (don't force) | "Want a cross-model review?" |
-| **MODERATE** | Run after implementation | `/codex:review --background` |
-| **COMPLEX** | Run adversarial after PROVE | `/codex:adversarial-review --background` |
-| **FULLSTACK** | Run with enum/API focus | `/codex:adversarial-review --background "Focus on: enum value mismatches, API contract compliance, access control"` |
-| **PRIOR FAIL** | Run before commit | `/codex:adversarial-review --wait "Focus on: {prior root cause}"` |
-
-### Codex Review Integration with Orchestrate
-
-For MODERATE+ tasks routed through `/orchestrate`, Codex review runs **after PROVE passes**:
-
-```
-PATCH completes → PROVE passes → /codex:adversarial-review --background
-                                         │
-                                    findings?
-                                    ├── No  → /pr
-                                    └── Yes → fix issues → re-run PROVE → /pr
-```
-
-### Codex Rescue (Fallback)
-
-When a task has been attempted and BLOCKED:
-
-1. First re-attempt: `/orchestrate` with failure context injection (standard)
-2. Still BLOCKED: `/codex:rescue "investigate and fix {description}"` (different model, different approach)
-3. Still BLOCKED: escalate to human
+During PATCH phase, identify subtasks to delegate to Codex (see Delegation Patterns above).
 
 ## Examples
 
 ### Quick
-- "Fix the typo in the README" → **Quick**, skip review
-- "Update the env example with new variable" → **Quick**, skip review
+- "Fix the typo in the README" → **Quick**, no Codex
 
 ### Plan Mode
-- "Add feature flag to config.py" → **Plan mode**, offer review
-- "Wire resolve_fact_key() into upsert_fact()" → **Plan mode**, offer review
+- "Add feature flag to config.py" → **Plan mode**, offer review after
 
-### Orchestrate
-- "Add validation endpoint with tests" → **Orchestrate SIMPLE**, recommended review
-- "Create fact_vocabulary table + service + seed data + tests" → **Orchestrate COMPLEX**, automatic adversarial review
-- "Implement payment form with backend API" → **Orchestrate FULLSTACK**, automatic review with enum/API focus
+### Orchestrate + Codex Delegation
+- "Add validation endpoint with tests" → **Orchestrate MODERATE**. Claude implements endpoint, `/codex:rescue --background` writes tests. Codex review after.
+- "Create fact_vocabulary table + service + seed data + tests" → **Orchestrate COMPLEX**. Claude handles all (single subsystem). Automatic adversarial review.
+- "Implement payment form with backend API" → **Orchestrate FULLSTACK**. Claude does backend, Codex does frontend in background via `/codex:rescue`. Automatic review with enum/API focus.
 
-### Parallel
-- "Implement issues 42, 57, and 63" → Assess independence:
+### Codex-First (Prior Failure)
+- "Issue 184 has failed twice" → `/codex:rescue --effort xhigh` first. If Codex succeeds, review with Claude. If not, escalate to human.
+
+### Parallel + Codex
+- "Implement issues 42, 57, and 63":
   - 42 and 57 independent → `--parallel` in separate tabs
+  - Both get Codex adversarial review in background
   - 63 depends on 42 → sequential after 42 merges
-
-### Rescue
-- "Issue 184 has failed twice" → `/codex:rescue` before re-attempting with Claude

--- a/docs/manual/integrations/codex-plugin.md
+++ b/docs/manual/integrations/codex-plugin.md
@@ -129,73 +129,143 @@ Cancels an active Codex job.
 /codex:cancel             # Cancel current job
 ```
 
-## Cross-Model Adversarial Review Strategy
+## Codex as Implementation Partner (Not Just Reviewer)
 
-The highest-value use of the Codex plugin is adversarial review: Claude writes code, Codex reviews it.
+Codex is a **write-capable implementation engine**, not just a reviewer. It can create files, modify code, run tests, and implement features — using GPT in the background while Claude continues working.
 
-```
-Claude Code (implementation)
-       |
-       v
-/codex:adversarial-review
-       |
-       v
-Codex challenges assumptions
-       |
-       v
-Claude addresses findings
-```
-
-**Why this works**: Different models have different blind spots. Claude might produce correct logic but miss an edge case in error handling. Codex might catch that edge case because its training distribution weights error handling differently. The reverse is also true -- Claude catches things Codex misses.
-
-## Automatic Review via Implementation Routing
-
-Codex review is **automatically applied based on task complexity** — you don't need to remember to run it. The [implementation routing rule](../workflow/orchestrate.md#implementation-routing) handles this:
-
-| Task Complexity | Codex Review | What Happens |
-|-----------------|-------------|-------------|
-| **TRIVIAL** | Skip | Not worth the overhead |
-| **SIMPLE** | Offer | "Want a cross-model review?" after implementation |
-| **MODERATE** | Recommended | `/codex:review --background` runs after implementation |
-| **COMPLEX** | Automatic | `/codex:adversarial-review --background` runs after PROVE |
-| **FULLSTACK** | Automatic + focused | Review focuses on enum value mismatches and API contract compliance |
-| **PRIOR FAILURE** | Automatic + targeted | Review focuses on the prior root cause |
-
-### How It Works With Orchestrate
-
-For MODERATE+ tasks, the review runs after PROVE passes:
+### Two Roles for Codex
 
 ```
-PATCH completes
+┌──────────────────────────────────────────────────────────────┐
+│                    CODEX ROLES                                │
+│                                                               │
+│  1. REVIEWER (after implementation)                          │
+│     └── /codex:review, /codex:adversarial-review             │
+│         Read-only. Catches blind spots Claude misses.        │
+│                                                               │
+│  2. IMPLEMENTER (parallel to Claude)                         │
+│     └── /codex:rescue --background --write                   │
+│         Write-capable. Builds features, fixes bugs,          │
+│         writes tests — all in background.                    │
+└──────────────────────────────────────────────────────────────┘
+```
+
+### Delegation Patterns
+
+#### Parallel Fullstack Split
+Claude handles backend (needs MCP, rules, patterns). Codex handles frontend in background.
+
+```bash
+# Claude is implementing backend...
+/codex:rescue --background --write \
+  "Implement frontend component per CONTRACT:
+   - Component: PaymentForm at frontend/src/components/
+   - API endpoint: POST /api/payments
+   - Enum VALUES: STATUS='pending','completed','failed'
+   - Run: npm run lint && npm run build when done"
+```
+
+#### Test Writing
+Claude implements the feature. Codex writes the tests in parallel.
+
+```bash
+# Claude finished PATCH, moving to PROVE...
+/codex:rescue --background --write \
+  "Write tests for backend/backend/payments/services.py
+   Test file: backend/backend/payments/tests/test_services.py
+   Use pytest + pytest-asyncio. SQLite in-memory only.
+   Cover: success cases, validation errors, edge cases.
+   Run: cd backend && pytest -q when done."
+```
+
+#### Debug Delegation
+Claude is implementing issue A. Tests for issue B start failing.
+
+```bash
+/codex:rescue --background \
+  "Investigate why tests in backend/auth/tests/ are failing.
+   Started failing after commit abc123. Find root cause and fix."
+```
+
+#### Prior Failure Rescue
+Claude's PATCH was BLOCKED twice. Try a different model first.
+
+```bash
+/codex:rescue --write --effort xhigh \
+  "Fix issue #184. Prior Claude attempt failed with MULTI_MODEL error:
+   forgot to update Advisor model when changing User.
+   See .agents/outputs/patch-184-032626.md for what was tried."
+```
+
+#### Mechanical Refactoring
+Large rename/extract/move operations that don't require judgment.
+
+```bash
+/codex:rescue --background --write --model gpt-5.4-mini --effort low \
+  "Rename all occurrences of 'UserAccount' to 'Account' across
+   backend/backend/. Update imports, type hints, test references.
+   Run ruff check . when done."
+```
+
+### When to Delegate vs Keep in Claude
+
+| Delegate to Codex | Keep in Claude |
+|-------------------|---------------|
+| Independent subtask (doesn't block Claude) | Primary implementation thread |
+| Prior failure (different model = different approach) | Tasks needing MCP servers |
+| Frontend during fullstack (Claude does backend) | Tasks needing project rules/patterns |
+| Test writing (mechanical, parallel) | Architectural decisions |
+| Bug investigation (parallel debugging) | Orchestrate pipeline state management |
+| Mechanical refactoring (rename, extract) | Complex multi-model coordination |
+
+### Model Selection
+
+| Task Type | Model | Effort | Why |
+|-----------|-------|--------|-----|
+| Quick review | `gpt-5.4-mini` | `medium` | Fast, cheap |
+| Adversarial review | `gpt-5.4` | `high` | Needs reasoning depth |
+| Bug investigation | `gpt-5.4-mini` | `medium` | Speed matters |
+| Feature implementation | `gpt-5.4` | `high` | Needs quality |
+| Mechanical refactoring | `gpt-5.4-mini` | `low` | Repetitive |
+| Test writing | `gpt-5.4` | `medium` | Needs understanding |
+| Prior failure rescue | `gpt-5.4` | `xhigh` | Maximum reasoning |
+
+## Automatic Routing (Review + Delegation)
+
+Both review and delegation are **automatically applied based on task complexity** — you don't need to remember to run them. The [implementation routing rule](../workflow/orchestrate.md#implementation-routing) handles this:
+
+| Task Complexity | Codex Review | Codex Delegation |
+|-----------------|-------------|-----------------|
+| **TRIVIAL** | Skip | None |
+| **SIMPLE** | Offer after | None |
+| **MODERATE** | Recommended | None (single subsystem) |
+| **COMPLEX** | Automatic | Delegate independent subtasks |
+| **FULLSTACK** | Automatic (enum/API focus) | Delegate frontend to Codex |
+| **PRIOR FAIL** | Automatic | Codex-first implementation |
+
+### Orchestrate Integration
+
+```
+MAP-PLAN identifies subtasks
+     │
+     ├── Backend work → Claude PATCH (primary)
+     │       │
+     │       └── /codex:rescue --background (frontend/tests/refactoring)
      │
      ▼
-PROVE passes (all 4 levels)
-     │
-     ▼
-/codex:adversarial-review --background
-  "Focus on: enum value mismatches, API contract
-   compliance, access control, transaction integrity"
+PROVE passes → /codex:adversarial-review --background
      │
      ├── No findings → /pr
-     └── Findings → fix issues → re-run PROVE → /pr
+     └── Findings → fix → re-run PROVE → /pr
 ```
 
 !!! tip "You don't trigger this manually"
-    Claude reads the routing rule, assesses your task, and decides whether to run Codex review. You just describe what you want done.
+    Claude reads the routing rule, assesses your task, and decides what to delegate. You just describe what you want done.
 
-### Rescue as PATCH Fallback
+### Escalation Path (Prior Failures)
 
-When PATCH is BLOCKED and re-attempting with failure context doesn't fix it:
-
-```bash
-# Different model, different approach to the same problem
-/codex:rescue "investigate and fix: {description of the stuck issue}"
-```
-
-The escalation path:
-
-1. Re-run PATCH with failure context (standard)
-2. `/codex:rescue` (different model perspective)
+1. Re-run Claude PATCH with failure context (standard)
+2. `/codex:rescue --effort xhigh` (different model perspective)
 3. Escalate to human
 
 ## Review Gate

--- a/docs/manual/workflow/orchestrate.md
+++ b/docs/manual/workflow/orchestrate.md
@@ -296,18 +296,22 @@ Claude automatically assesses every task and routes to the right workflow. You d
 └──────────────────────────────────────────────────────────────┘
 ```
 
-| Complexity | Files | Route | Codex Review |
-|------------|-------|-------|-------------|
-| **TRIVIAL** | 1 | `/quick` | Skip |
-| **SIMPLE** | 1-3 | Plan Mode | Offer |
-| **MODERATE** | 4-5 | `/orchestrate` SIMPLE | Recommended |
-| **COMPLEX** | 6+ | `/orchestrate` COMPLEX | Automatic |
-| **FULLSTACK** | Any | `/orchestrate` + CONTRACT | Automatic (enum/API focus) |
-| **PRIOR FAIL** | Any | `/orchestrate` + context or `/codex:rescue` | Automatic |
+| Complexity | Files | Route | Codex Role |
+|------------|-------|-------|-----------|
+| **TRIVIAL** | 1 | `/quick` | None |
+| **SIMPLE** | 1-3 | Plan Mode | Offer review |
+| **MODERATE** | 4-5 | `/orchestrate` SIMPLE | Review (recommended) |
+| **COMPLEX** | 6+ | `/orchestrate` COMPLEX | Review (automatic) + delegate subtasks |
+| **FULLSTACK** | Any | `/orchestrate` + CONTRACT | Review (enum/API) + parallel frontend |
+| **PRIOR FAIL** | Any | `/codex:rescue` first | Primary implementer |
 
-## Codex Review Integration
+## Codex Integration (Review + Delegation)
 
-After PROVE passes on MODERATE+ tasks, a cross-model review runs automatically:
+Codex serves two roles: **reviewer** (after implementation) and **implementer** (parallel to Claude during PATCH).
+
+### Automatic Review
+
+After PROVE passes on MODERATE+ tasks:
 
 ```
 PATCH → PROVE passes → /codex:adversarial-review --background
@@ -317,5 +321,24 @@ PATCH → PROVE passes → /codex:adversarial-review --background
                           └── Yes → fix → re-run PROVE → /pr
 ```
 
-!!! tip "Why cross-model review matters"
-    Claude and GPT have different blind spots. ENUM_VALUE errors (26% of fullstack failures) are caught more reliably when a different model reviews the code. Claude writes it, Codex reviews it — genuinely adversarial, not the same model checking its own work.
+### Parallel Delegation During PATCH
+
+For COMPLEX and FULLSTACK tasks, Claude delegates independent subtasks to Codex in background:
+
+```
+MAP-PLAN identifies subtasks
+     │
+     ├── Backend → Claude PATCH (primary thread)
+     │       │
+     │       ├── /codex:rescue --background --write (frontend)
+     │       ├── /codex:rescue --background --write (tests)
+     │       └── Claude continues implementing...
+     │
+     ▼
+/codex:status → collect results → PROVE → review → /pr
+```
+
+!!! tip "Why cross-model delegation matters"
+    Claude and GPT have different strengths. Claude excels at architectural reasoning and orchestration. GPT handles mechanical implementation, test writing, and debugging well. Using both in parallel maximizes throughput without sacrificing quality.
+
+See [Codex Plugin](../integrations/codex-plugin.md) for all delegation patterns and model selection guide.


### PR DESCRIPTION
## Summary
- Expand implementation routing to use Codex as write-capable implementation partner, not just reviewer
- 5 delegation patterns: parallel fullstack, test writing, debug delegation, mechanical refactoring, prior failure rescue
- Model selection guide (gpt-5.4 vs gpt-5.4-mini vs spark by task type)
- Codex-first escalation for prior failures

## Files Changed
- `claude-config/rules/implementation-routing.md` — full rewrite with delegation rules
- `docs/manual/integrations/codex-plugin.md` — delegation patterns, when-to-delegate matrix, model guide
- `docs/manual/workflow/orchestrate.md` — parallel delegation diagram during PATCH

## Test Plan
- [x] MkDocs build clean
- [x] Routing rule covers all delegation scenarios
- [x] Codex plugin page documents write capabilities