### PR TITLE
feat: machine profiles + email helper with proper threading

### DIFF
--- a/email-helper/graph_email.py
+++ b/email-helper/graph_email.py
@@ -1,0 +1,236 @@
+"""Microsoft Graph email helper for VitalAILabs agent communication.
+
+Handles both sending new emails and threaded replies correctly.
+Uses the /messages/{id}/reply endpoint for replies (not sendMail with RE: prefix).
+
+Usage:
+    from graph_email import GraphMailClient
+
+    client = GraphMailClient()  # loads credentials from env or defaults
+
+    # New email
+    client.send_email(
+        to="ai-coder@vital-enterprises.com",
+        subject="jbox6 status update",
+        body="<p>Setup complete.</p>",
+    )
+
+    # Threaded reply
+    client.reply_email(
+        to="ai-coder@vital-enterprises.com",
+        body="<p>Thanks, confirmed.</p>",
+        original_subject="jbox6 status update",
+    )
+
+    # Read inbox
+    messages = client.read_inbox(top=10)
+    for m in messages:
+        print(f"{m['from']['emailAddress']['address']}: {m['subject']}")
+"""
+import json
+import os
+
+import httpx
+from azure.identity import ClientSecretCredential
+
+# Credentials loaded from environment variables only.
+# Set these in ~/.claude/.env or export them in your shell:
+#   GRAPH_TENANT_ID, GRAPH_CLIENT_ID, GRAPH_CLIENT_SECRET, GRAPH_SENDER
+
+
+class GraphMailClient:
+    """Microsoft Graph API email client with proper threading support."""
+
+    def __init__(
+        self,
+        tenant_id: str = "",
+        client_id: str = "",
+        client_secret: str = "",
+        sender: str = "",
+    ):
+        self.tenant_id = tenant_id or os.environ.get("GRAPH_TENANT_ID", "")
+        self.client_id = client_id or os.environ.get("GRAPH_CLIENT_ID", "")
+        self.client_secret = client_secret or os.environ.get("GRAPH_CLIENT_SECRET", "")
+        self.sender = sender or os.environ.get("GRAPH_SENDER", "")
+
+        if not all([self.tenant_id, self.client_id, self.client_secret, self.sender]):
+            raise ValueError(
+                "Missing Graph API credentials. Set environment variables: "
+                "GRAPH_TENANT_ID, GRAPH_CLIENT_ID, GRAPH_CLIENT_SECRET, GRAPH_SENDER"
+            )
+        self._token = None
+
+    def _get_token(self) -> str:
+        """Get or refresh the bearer token."""
+        cred = ClientSecretCredential(
+            tenant_id=self.tenant_id,
+            client_id=self.client_id,
+            client_secret=self.client_secret,
+        )
+        self._token = cred.get_token("https://graph.microsoft.com/.default").token
+        return self._token
+
+    def _headers(self) -> dict:
+        return {
+            "Authorization": f"Bearer {self._get_token()}",
+            "Content-Type": "application/json",
+        }
+
+    def _base_url(self) -> str:
+        return f"https://graph.microsoft.com/v1.0/users/{self.sender}"
+
+    # ------------------------------------------------------------------
+    # Send new email (no existing thread)
+    # ------------------------------------------------------------------
+
+    def send_email(
+        self,
+        to: str | list[str],
+        subject: str,
+        body: str,
+        cc: str | list[str] | None = None,
+        content_type: str = "HTML",
+    ) -> int:
+        """Send a new email. Returns HTTP status code (202 = success)."""
+        if isinstance(to, str):
+            to = [to]
+        to_recipients = [{"emailAddress": {"address": a}} for a in to]
+
+        message = {
+            "subject": subject,
+            "body": {"contentType": content_type, "content": body},
+            "toRecipients": to_recipients,
+        }
+
+        if cc:
+            if isinstance(cc, str):
+                cc = [cc]
+            message["ccRecipients"] = [{"emailAddress": {"address": a}} for a in cc]
+
+        payload = {"message": message, "saveToSentItems": "true"}
+
+        r = httpx.post(
+            f"{self._base_url()}/sendMail",
+            headers=self._headers(),
+            content=json.dumps(payload),
+        )
+        return r.status_code
+
+    # ------------------------------------------------------------------
+    # Reply to existing thread
+    # ------------------------------------------------------------------
+
+    def reply_email(
+        self,
+        to: str | list[str],
+        body: str,
+        original_subject: str = "",
+        message_id: str = "",
+        search_folder: str = "sentItems",
+        cc: str | list[str] | None = None,
+    ) -> int:
+        """Reply to an existing email thread. Returns HTTP status code (202 = success).
+
+        Finds the original message by subject (or uses message_id directly),
+        then uses the /messages/{id}/reply endpoint for proper threading.
+
+        Args:
+            to: Recipient(s) for the reply.
+            body: HTML body for the reply.
+            original_subject: Subject of the original email to find.
+            message_id: Graph message ID (skips search if provided).
+            search_folder: Where to search — 'sentItems' for emails you sent,
+                          'inbox' for emails you received.
+            cc: Optional CC recipient(s).
+        """
+        if not message_id:
+            if not original_subject:
+                raise ValueError("Either message_id or original_subject is required")
+            message_id = self._find_message_id(original_subject, search_folder)
+
+        if isinstance(to, str):
+            to = [to]
+
+        payload: dict = {
+            "message": {
+                "toRecipients": [{"emailAddress": {"address": a}} for a in to],
+            },
+            "comment": body,
+        }
+
+        if cc:
+            if isinstance(cc, str):
+                cc = [cc]
+            payload["message"]["ccRecipients"] = [{"emailAddress": {"address": a}} for a in cc]
+
+        r = httpx.post(
+            f"{self._base_url()}/messages/{message_id}/reply",
+            headers=self._headers(),
+            content=json.dumps(payload),
+        )
+        return r.status_code
+
+    # ------------------------------------------------------------------
+    # Read inbox
+    # ------------------------------------------------------------------
+
+    def read_inbox(self, top: int = 10, unread_only: bool = False) -> list[dict]:
+        """Read messages from inbox.
+
+        Returns list of message dicts with subject, from, receivedDateTime, bodyPreview.
+        """
+        url = (
+            f"{self._base_url()}/messages"
+            f"?$top={top}"
+            f"&$select=id,subject,from,receivedDateTime,bodyPreview,isRead"
+            f"&$orderby=receivedDateTime desc"
+        )
+        if unread_only:
+            url += "&$filter=isRead eq false"
+
+        r = httpx.get(url, headers=self._headers())
+        if r.status_code != 200:
+            return []
+        return r.json().get("value", [])
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _find_message_id(self, subject: str, folder: str = "sentItems") -> str:
+        """Find a message ID by subject in the specified folder."""
+        # Use $search instead of $filter — more reliable with special characters
+        # $search uses KQL syntax
+        safe_subject = subject.replace('"', '\\"')
+        url = (
+            f"{self._base_url()}/mailFolders/{folder}/messages"
+            f'?$search="subject:{safe_subject}"'
+            f"&$select=id,subject"
+            f"&$top=5"
+        )
+        r = httpx.get(url, headers=self._headers())
+
+        # Fallback: fetch recent messages and match locally
+        if r.status_code != 200:
+            url = (
+                f"{self._base_url()}/mailFolders/{folder}/messages"
+                f"?$select=id,subject"
+                f"&$top=25"
+                f"&$orderby=receivedDateTime desc"
+            )
+            r = httpx.get(url, headers=self._headers())
+            if r.status_code != 200:
+                raise RuntimeError(f"Failed to search {folder}: {r.status_code} {r.text[:200]}")
+            messages = [
+                m for m in r.json().get("value", [])
+                if subject.lower() in m.get("subject", "").lower()
+            ]
+        else:
+            messages = r.json().get("value", [])
+
+        if not messages:
+            raise ValueError(
+                f"No message found with subject '{subject}' in {folder}. "
+                f"Try search_folder='inbox' if replying to a received message."
+            )
+        return messages[0]["id"]

--- a/install-all.sh
+++ b/install-all.sh
@@ -1,30 +1,221 @@
 #!/bin/bash
-# Install both Claude and Codex shared configurations.
-# Usage: ./install-all.sh
+# Install agents configurations with machine profile support.
+#
+# Usage:
+#   ./install-all.sh              # auto-detects profile or prompts
+#   ./install-all.sh --profile work
+#   ./install-all.sh --profile personal
+#   ./install-all.sh --skip-profile   # base install only, no profile
+#
+# Profiles live in machines/<name>/ and contain:
+#   config.toml      — obsidian-agent configuration
+#   env.template     — required environment variables (no secrets)
+#   post-install.sh  — platform-specific automation (launchd/systemd/cron)
 
 set -e
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MACHINES_DIR="$ROOT_DIR/machines"
+PROFILE=""
+SKIP_PROFILE=false
+
+# ─── Parse arguments ────────────────────────────────────────────────────────
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --profile|-p)
+            PROFILE="$2"
+            shift 2
+            ;;
+        --skip-profile)
+            SKIP_PROFILE=true
+            shift
+            ;;
+        --help|-h)
+            echo "Usage: $0 [--profile <name>] [--skip-profile]"
+            echo ""
+            echo "Profiles: $(ls -1 "$MACHINES_DIR" 2>/dev/null | tr '\n' ' ')"
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1"
+            exit 1
+            ;;
+    esac
+done
+
+# ─── Profile detection ──────────────────────────────────────────────────────
+
+detect_profile() {
+    # Check for a saved profile marker
+    local marker="$HOME/.config/agents-profile"
+    if [ -f "$marker" ]; then
+        cat "$marker"
+        return
+    fi
+
+    # Auto-detect by hostname patterns
+    local hostname
+    hostname="$(hostname 2>/dev/null || echo unknown)"
+
+    # Add your hostname patterns here
+    case "$hostname" in
+        *JJ-DELLPRO14*|*dell*|*personal*)
+            echo "personal"
+            return
+            ;;
+        *work*|*mac*|*MBP*|*MacBook*)
+            echo "work"
+            return
+            ;;
+    esac
+
+    # Auto-detect by platform
+    if [[ "$(uname)" == "Darwin" ]]; then
+        echo "work"
+        return
+    fi
+
+    # Can't detect — return empty
+    echo ""
+}
+
+select_profile() {
+    local profiles
+    profiles=($(ls -1 "$MACHINES_DIR" 2>/dev/null))
+
+    if [ ${#profiles[@]} -eq 0 ]; then
+        echo "  No profiles found in $MACHINES_DIR"
+        return
+    fi
+
+    echo ""
+    echo "  Available profiles:"
+    local i=1
+    for p in "${profiles[@]}"; do
+        echo "    $i) $p"
+        i=$((i + 1))
+    done
+    echo "    s) Skip profile (base install only)"
+    echo ""
+    read -rp "  Select profile [1-${#profiles[@]}/s]: " choice
+
+    if [[ "$choice" == "s" || "$choice" == "S" ]]; then
+        SKIP_PROFILE=true
+        return
+    fi
+
+    if [[ "$choice" =~ ^[0-9]+$ ]] && [ "$choice" -ge 1 ] && [ "$choice" -le "${#profiles[@]}" ]; then
+        PROFILE="${profiles[$((choice - 1))]}"
+    else
+        echo "  Invalid choice. Skipping profile."
+        SKIP_PROFILE=true
+    fi
+}
 
 echo "=== Agents Unified Installer ==="
 echo "  Repo: $ROOT_DIR"
+
+# Resolve profile
+if [ "$SKIP_PROFILE" = false ] && [ -z "$PROFILE" ]; then
+    PROFILE=$(detect_profile)
+    if [ -z "$PROFILE" ]; then
+        echo ""
+        echo "  Could not auto-detect machine profile."
+        select_profile
+    else
+        echo "  Auto-detected profile: $PROFILE"
+        read -rp "  Use this profile? [Y/n]: " confirm
+        if [[ "$confirm" =~ ^[nN] ]]; then
+            select_profile
+        fi
+    fi
+fi
+
+if [ "$SKIP_PROFILE" = false ] && [ -n "$PROFILE" ]; then
+    PROFILE_DIR="$MACHINES_DIR/$PROFILE"
+    if [ ! -d "$PROFILE_DIR" ]; then
+        echo "  ERROR: Profile '$PROFILE' not found at $PROFILE_DIR"
+        exit 1
+    fi
+    echo "  Profile: $PROFILE ($PROFILE_DIR)"
+
+    # Save profile marker for future runs
+    mkdir -p "$HOME/.config"
+    echo "$PROFILE" > "$HOME/.config/agents-profile"
+else
+    echo "  Profile: none (base install only)"
+fi
+
 echo ""
+
+# ─── Step 1: Claude config ──────────────────────────────────────────────────
 
 if [ -x "$ROOT_DIR/claude-config/install.sh" ]; then
-    echo "[1/2] Installing Claude config"
+    echo "[1/3] Installing Claude config"
     "$ROOT_DIR/claude-config/install.sh"
 else
-    echo "[1/2] Skipped Claude config (install.sh missing or not executable)"
+    echo "[1/3] Skipped Claude config (install.sh missing or not executable)"
 fi
 
 echo ""
+
+# ─── Step 2: Codex config ───────────────────────────────────────────────────
 
 if [ -x "$ROOT_DIR/codex-config/install.sh" ]; then
-    echo "[2/2] Installing Codex config"
+    echo "[2/3] Installing Codex config"
     "$ROOT_DIR/codex-config/install.sh"
 else
-    echo "[2/2] Skipped Codex config (install.sh missing or not executable)"
+    echo "[2/3] Skipped Codex config (install.sh missing or not executable)"
 fi
 
 echo ""
-echo "Done."
+
+# ─── Step 3: Machine profile ────────────────────────────────────────────────
+
+if [ "$SKIP_PROFILE" = false ] && [ -n "$PROFILE" ]; then
+    echo "[3/3] Applying machine profile: $PROFILE"
+
+    # Apply obsidian-agent config
+    CONFIG_DIR="$HOME/.config/obsidian-agent"
+    CONFIG_FILE="$CONFIG_DIR/config.toml"
+    if [ -f "$PROFILE_DIR/config.toml" ]; then
+        mkdir -p "$CONFIG_DIR"
+        if [ -f "$CONFIG_FILE" ]; then
+            echo "  ✓ Config: $CONFIG_FILE (already exists — not overwriting)"
+            echo "    Profile template: $PROFILE_DIR/config.toml"
+        else
+            cp "$PROFILE_DIR/config.toml" "$CONFIG_FILE"
+            echo "  ✓ Config: $CONFIG_FILE (created from profile)"
+        fi
+    fi
+
+    # Show env template
+    if [ -f "$PROFILE_DIR/env.template" ]; then
+        ENV_FILE="$HOME/.claude/.env"
+        if [ -f "$ENV_FILE" ]; then
+            echo "  ✓ Env: $ENV_FILE (already exists)"
+        else
+            echo "  ⚠ Env: copy $PROFILE_DIR/env.template to $ENV_FILE and fill in values"
+        fi
+    fi
+
+    # Run post-install
+    if [ -x "$PROFILE_DIR/post-install.sh" ]; then
+        echo ""
+        echo "  Running post-install for $PROFILE..."
+        echo ""
+        "$PROFILE_DIR/post-install.sh"
+    fi
+else
+    echo "[3/3] Skipped machine profile"
+fi
+
+echo ""
+echo "=== Installation Complete ==="
+echo ""
+if [ -n "$PROFILE" ] && [ "$SKIP_PROFILE" = false ]; then
+    echo "  Profile '$PROFILE' applied."
+    echo "  Saved to ~/.config/agents-profile (auto-detected on next run)."
+fi
+echo ""

--- a/machines/personal/config.toml
+++ b/machines/personal/config.toml
@@ -1,0 +1,13 @@
+# Obsidian Agent config — Personal machine (WSL/Linux)
+# Applied by install-all.sh when profile=personal
+
+[vault]
+path = "~/obsidian/MyVault"
+projects_folder = "Projects"
+
+[claude]
+projects_path = "~/.claude/projects"
+
+[extraction]
+model = "haiku"
+max_conversation_chars = 50000

--- a/machines/personal/env.template
+++ b/machines/personal/env.template
@@ -1,0 +1,12 @@
+# Environment variables for Personal machine
+# Copy to ~/.claude/.env and fill in values
+# NEVER commit actual values to git
+
+# Optional: OpenAI API key (for Codex plugin)
+# OPENAI_API_KEY=
+
+# Email helper (Graph API) — only needed if using agent email
+# GRAPH_TENANT_ID=48d2c3de-8345-4a88-93c5-21ec0de71de4
+# GRAPH_CLIENT_ID=b8ca22c4-cc71-411a-97aa-6dfd20a21bc4
+# GRAPH_CLIENT_SECRET=
+# GRAPH_SENDER=jjob@vital-enterprises.com

--- a/machines/personal/post-install.sh
+++ b/machines/personal/post-install.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Post-install for Personal machine (WSL/Linux)
+# Sets up systemd timer + cron for obsidian-agent automation
+
+set -e
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PYTHON_BIN="$(command -v python3)"
+
+echo "=== Personal Machine Post-Install ==="
+echo "  Platform: Linux/WSL"
+echo ""
+
+# ─── Obsidian Agent: systemd timer (real-time updates) ────────────────────
+echo "Setting up systemd timer..."
+cd "$REPO_DIR/obsidian-agent"
+"$PYTHON_BIN" -m obsidian_agent --install-systemd
+echo ""
+
+# ─── Obsidian Agent: cron (scheduled rollups) ─────────────────────────────
+echo "Setting up cron entries..."
+"$PYTHON_BIN" -m obsidian_agent --install-cron
+echo ""
+
+# ─── Email helper dependencies ────────────────────────────────────────────
+echo "Checking email helper dependencies..."
+if "$PYTHON_BIN" -c "import azure.identity; import httpx" 2>/dev/null; then
+    echo "  ✓ azure-identity + httpx already installed"
+else
+    echo "  Installing azure-identity httpx..."
+    "$PYTHON_BIN" -m pip install --user azure-identity httpx 2>/dev/null || \
+    "$PYTHON_BIN" -m pip install --user --break-system-packages azure-identity httpx 2>/dev/null || \
+    echo "  ⚠ Failed to install email deps — install manually: pip3 install azure-identity httpx"
+fi
+echo ""
+
+echo "=== Personal machine setup complete ==="
+echo ""
+echo "  Systemd timer: active (60s polling)"
+echo "  Cron: nightly daily rollup, weekly, monthly"
+echo "  Email: deps installed (configure credentials in ~/.claude/.env)"
+echo ""

--- a/machines/work/config.toml
+++ b/machines/work/config.toml
@@ -1,0 +1,13 @@
+# Obsidian Agent config — Work machine (macOS)
+# Applied by install-all.sh when profile=work
+
+[vault]
+path = "~/Library/Mobile Documents/iCloud~md~obsidian/Documents/WorkVault"
+projects_folder = "Projects"
+
+[claude]
+projects_path = "~/.claude/projects"
+
+[extraction]
+model = "haiku"
+max_conversation_chars = 50000

--- a/machines/work/env.template
+++ b/machines/work/env.template
@@ -1,0 +1,12 @@
+# Environment variables for Work machine
+# Copy to ~/.claude/.env and fill in values
+# NEVER commit actual values to git
+
+# Optional: OpenAI API key (for Codex plugin)
+# OPENAI_API_KEY=
+
+# Email helper (Graph API) — agent email for VitalAILabs
+# GRAPH_TENANT_ID=48d2c3de-8345-4a88-93c5-21ec0de71de4
+# GRAPH_CLIENT_ID=b8ca22c4-cc71-411a-97aa-6dfd20a21bc4
+# GRAPH_CLIENT_SECRET=
+# GRAPH_SENDER=jjob@vital-enterprises.com

--- a/machines/work/post-install.sh
+++ b/machines/work/post-install.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Post-install for Work machine (macOS)
+# Sets up launchd agents for obsidian-agent automation
+
+set -e
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PYTHON_BIN="$(command -v python3)"
+
+echo "=== Work Machine Post-Install ==="
+echo "  Platform: macOS"
+echo ""
+
+# ─── Obsidian Agent: launchd (real-time updates + scheduled rollups) ──────
+echo "Setting up launchd agents..."
+cd "$REPO_DIR/obsidian-agent"
+"$PYTHON_BIN" -m obsidian_agent --install-launchd
+echo ""
+
+# ─── Email helper dependencies ────────────────────────────────────────────
+echo "Checking email helper dependencies..."
+if "$PYTHON_BIN" -c "import azure.identity; import httpx" 2>/dev/null; then
+    echo "  ✓ azure-identity + httpx already installed"
+else
+    echo "  Installing azure-identity httpx..."
+    "$PYTHON_BIN" -m pip install azure-identity httpx 2>/dev/null || \
+    echo "  ⚠ Failed to install email deps — install manually: pip3 install azure-identity httpx"
+fi
+echo ""
+
+echo "=== Work machine setup complete ==="
+echo ""
+echo "  launchd watcher: active (60s polling)"
+echo "  launchd rollups: daily 11 PM (includes weekly/monthly)"
+echo "  Email: deps installed (configure credentials in ~/.claude/.env)"
+echo ""
+echo "  Check status:  launchctl list | grep obsidian-agent"
+echo "  View logs:     ~/Library/Logs/obsidian-agent/"
+echo ""


### PR DESCRIPTION
## Summary
- **Machine profiles** (`machines/work/` and `machines/personal/`) with per-machine config, env template, and post-install automation (launchd on macOS, systemd+cron on Linux/WSL)
- **Email helper** (`email-helper/graph_email.py`) — Graph API client with proper threading via `/messages/{id}/reply` endpoint (not sendMail with RE: prefix)
- **Enhanced installer** — `install-all.sh` now auto-detects profile by hostname/platform, supports interactive selection, and persists choice to `~/.config/agents-profile`

## Work laptop setup (after merge)
```bash
git clone https://github.com/jwj2002/agents.git ~/agents
~/agents/install-all.sh --profile work
```

## Test plan
- [x] Profile auto-detection verified (hostname JJ-DELLPRO14 → personal)
- [x] Email helper: send, reply (threaded), and read inbox tested
- [x] Credentials moved to env vars (no secrets in repo)
- [ ] Verify install-all.sh on macOS work laptop

🤖 Generated with [Claude Code](https://claude.com/claude-code)