### PR TITLE
fix: swap machine profiles (work=WSL, personal=macOS)

### DIFF
--- a/install-all.sh
+++ b/install-all.sh
@@ -60,12 +60,12 @@ detect_profile() {
 
     # Add your hostname patterns here
     case "$hostname" in
-        *JJ-DELLPRO14*|*dell*|*personal*)
-            echo "personal"
+        *JJ-DELLPRO14*|*dell*)
+            echo "work"
             return
             ;;
-        *work*|*mac*|*MBP*|*MacBook*)
-            echo "work"
+        *mac*|*MBP*|*MacBook*|*personal*)
+            echo "personal"
             return
             ;;
     esac

--- a/machines/personal/config.toml
+++ b/machines/personal/config.toml
@@ -1,8 +1,8 @@
-# Obsidian Agent config — Personal machine (WSL/Linux)
+# Obsidian Agent config — Personal machine (macOS)
 # Applied by install-all.sh when profile=personal
 
 [vault]
-path = "~/obsidian/MyVault"
+path = "~/Library/Mobile Documents/iCloud~md~obsidian/Documents/MyVault"
 projects_folder = "Projects"
 
 [claude]

--- a/machines/personal/post-install.sh
+++ b/machines/personal/post-install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-# Post-install for Personal machine (WSL/Linux)
-# Sets up systemd timer + cron for obsidian-agent automation
+# Post-install for Personal machine (macOS)
+# Sets up launchd agents for obsidian-agent automation
 
 set -e
 
@@ -8,18 +8,13 @@ REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 PYTHON_BIN="$(command -v python3)"
 
 echo "=== Personal Machine Post-Install ==="
-echo "  Platform: Linux/WSL"
+echo "  Platform: macOS"
 echo ""
 
-# ─── Obsidian Agent: systemd timer (real-time updates) ────────────────────
-echo "Setting up systemd timer..."
+# ─── Obsidian Agent: launchd (real-time updates + scheduled rollups) ──────
+echo "Setting up launchd agents..."
 cd "$REPO_DIR/obsidian-agent"
-"$PYTHON_BIN" -m obsidian_agent --install-systemd
-echo ""
-
-# ─── Obsidian Agent: cron (scheduled rollups) ─────────────────────────────
-echo "Setting up cron entries..."
-"$PYTHON_BIN" -m obsidian_agent --install-cron
+"$PYTHON_BIN" -m obsidian_agent --install-launchd
 echo ""
 
 # ─── Email helper dependencies ────────────────────────────────────────────
@@ -28,15 +23,17 @@ if "$PYTHON_BIN" -c "import azure.identity; import httpx" 2>/dev/null; then
     echo "  ✓ azure-identity + httpx already installed"
 else
     echo "  Installing azure-identity httpx..."
-    "$PYTHON_BIN" -m pip install --user azure-identity httpx 2>/dev/null || \
-    "$PYTHON_BIN" -m pip install --user --break-system-packages azure-identity httpx 2>/dev/null || \
+    "$PYTHON_BIN" -m pip install azure-identity httpx 2>/dev/null || \
     echo "  ⚠ Failed to install email deps — install manually: pip3 install azure-identity httpx"
 fi
 echo ""
 
 echo "=== Personal machine setup complete ==="
 echo ""
-echo "  Systemd timer: active (60s polling)"
-echo "  Cron: nightly daily rollup, weekly, monthly"
+echo "  launchd watcher: active (60s polling)"
+echo "  launchd rollups: daily 11 PM (includes weekly/monthly)"
 echo "  Email: deps installed (configure credentials in ~/.claude/.env)"
+echo ""
+echo "  Check status:  launchctl list | grep obsidian-agent"
+echo "  View logs:     ~/Library/Logs/obsidian-agent/"
 echo ""

--- a/machines/work/config.toml
+++ b/machines/work/config.toml
@@ -1,8 +1,8 @@
-# Obsidian Agent config — Work machine (macOS)
+# Obsidian Agent config — Work machine (WSL/Linux)
 # Applied by install-all.sh when profile=work
 
 [vault]
-path = "~/Library/Mobile Documents/iCloud~md~obsidian/Documents/WorkVault"
+path = "~/obsidian/MyVault"
 projects_folder = "Projects"
 
 [claude]

--- a/machines/work/post-install.sh
+++ b/machines/work/post-install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-# Post-install for Work machine (macOS)
-# Sets up launchd agents for obsidian-agent automation
+# Post-install for Work machine (WSL/Linux)
+# Sets up systemd timer + cron for obsidian-agent automation
 
 set -e
 
@@ -8,13 +8,18 @@ REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 PYTHON_BIN="$(command -v python3)"
 
 echo "=== Work Machine Post-Install ==="
-echo "  Platform: macOS"
+echo "  Platform: Linux/WSL"
 echo ""
 
-# ─── Obsidian Agent: launchd (real-time updates + scheduled rollups) ──────
-echo "Setting up launchd agents..."
+# ─── Obsidian Agent: systemd timer (real-time updates) ────────────────────
+echo "Setting up systemd timer..."
 cd "$REPO_DIR/obsidian-agent"
-"$PYTHON_BIN" -m obsidian_agent --install-launchd
+"$PYTHON_BIN" -m obsidian_agent --install-systemd
+echo ""
+
+# ─── Obsidian Agent: cron (scheduled rollups) ─────────────────────────────
+echo "Setting up cron entries..."
+"$PYTHON_BIN" -m obsidian_agent --install-cron
 echo ""
 
 # ─── Email helper dependencies ────────────────────────────────────────────
@@ -23,17 +28,15 @@ if "$PYTHON_BIN" -c "import azure.identity; import httpx" 2>/dev/null; then
     echo "  ✓ azure-identity + httpx already installed"
 else
     echo "  Installing azure-identity httpx..."
-    "$PYTHON_BIN" -m pip install azure-identity httpx 2>/dev/null || \
+    "$PYTHON_BIN" -m pip install --user azure-identity httpx 2>/dev/null || \
+    "$PYTHON_BIN" -m pip install --user --break-system-packages azure-identity httpx 2>/dev/null || \
     echo "  ⚠ Failed to install email deps — install manually: pip3 install azure-identity httpx"
 fi
 echo ""
 
 echo "=== Work machine setup complete ==="
 echo ""
-echo "  launchd watcher: active (60s polling)"
-echo "  launchd rollups: daily 11 PM (includes weekly/monthly)"
+echo "  Systemd timer: active (60s polling)"
+echo "  Cron: nightly daily rollup, weekly, monthly"
 echo "  Email: deps installed (configure credentials in ~/.claude/.env)"
-echo ""
-echo "  Check status:  launchctl list | grep obsidian-agent"
-echo "  View logs:     ~/Library/Logs/obsidian-agent/"
 echo ""


### PR DESCRIPTION
## Summary
- JJ-DELLPRO14 is the work machine (WSL/Linux), not personal
- Swapped hostname detection, config paths, and post-install scripts
- Work profile: systemd timer + cron (Linux)
- Personal profile: launchd (macOS)

## Test plan
- [x] Profile auto-detects "work" on JJ-DELLPRO14
- [x] Email helper works with env vars from ~/.claude/.env
- [x] Profile marker set at ~/.config/agents-profile

🤖 Generated with [Claude Code](https://claude.com/claude-code)