### PR TITLE
feat: MCP pattern server with 18 reusable code patterns (#35)

### DIFF
--- a/mcp-server/patterns/alembic-migration.yaml
+++ b/mcp-server/patterns/alembic-migration.yaml
@@ -1,0 +1,143 @@
+name: alembic-migration
+category: backend
+description: "Alembic async migration conventions: naming, FK indexes, additive-only, exclusion constraints"
+tags: ["alembic", "migration", "database", "postgresql", "async"]
+created: "2026-04-01"
+content: |
+  ## Alembic Migration Conventions
+
+  Sources: `alembic/env.py`, `alembic/versions/`
+
+  ### Async Migration Environment
+
+  ```python
+  """Alembic async migration environment."""
+  import asyncio
+  from sqlalchemy import pool
+  from sqlalchemy.ext.asyncio import create_async_engine
+  from alembic import context
+  from app.core.config import get_settings
+  from app.models import Base  # triggers all model imports
+
+  target_metadata = Base.metadata
+
+  async def run_async_migrations() -> None:
+      settings = get_settings()
+      connectable = create_async_engine(
+          settings.async_database_url,
+          poolclass=pool.NullPool,
+      )
+      async with connectable.connect() as connection:
+          await connection.run_sync(do_run_migrations)
+      await connectable.dispose()
+
+  def run_migrations_online() -> None:
+      asyncio.run(run_async_migrations())
+  ```
+
+  Key: `from app.models import Base` triggers all model imports so autogenerate sees every table.
+
+  ### Migration File Naming
+
+  Format: `YYYY_MM_DD_HHMM-<revision_id>_<description>.py`
+
+  Example: `2026_03_31_1012-ce01774087ce_initial_schema.py`
+
+  Generate with:
+  ```bash
+  alembic revision --autogenerate -m "add_personnel_schedule_table"
+  ```
+
+  ### Column Conventions
+
+  | Convention              | Example                                                    |
+  |-------------------------|------------------------------------------------------------|
+  | Primary key             | `sa.Column('id', sa.UUID(), nullable=False)`               |
+  | Foreign key with index  | `ForeignKeyConstraint(...)` + `create_index()` on FK col   |
+  | Timestamps              | `server_default=sa.text('now()')` on created_at/updated_at |
+  | Enums                   | `native_enum=False` (stored as varchar, not PG enum)       |
+  | Version column          | `sa.Column('version', sa.Integer(), nullable=False)`       |
+  | Unique constraints      | Named: `sa.UniqueConstraint(..., name='uq_table_cols')`    |
+  | Check constraints       | Named: `sa.CheckConstraint(..., name='ck_table_rule')`     |
+
+  ### Foreign Key Rules
+
+  ```python
+  # Always index FK columns
+  sa.ForeignKeyConstraint(['customer_id'], ['customer.id'], ondelete='RESTRICT'),
+  op.create_index(op.f('ix_job_customer_id'), 'job', ['customer_id'], unique=False)
+
+  # ondelete strategies:
+  # CASCADE  -- child deleted when parent deleted (addresses when customer deleted)
+  # RESTRICT -- prevent parent deletion if children exist (jobs reference customers)
+  # SET NULL -- set FK to null when parent deleted (optional references)
+  ```
+
+  ### Index Naming Conventions
+
+  | Type               | Pattern                          | Example                          |
+  |--------------------|----------------------------------|----------------------------------|
+  | Single column      | `ix_{table}_{col}`               | `ix_job_customer_id`             |
+  | Composite          | `ix_{table}_{col1}_{col2}`       | `ix_job_status_created`          |
+  | Unique             | `ix_{table}_{col}` with unique   | `ix_user_email`                  |
+  | Partial            | `ix_{table}_{col}` + where       | `ix_job_display_id` (WHERE NOT NULL) |
+  | Composite function | `ix_{table}_{purpose}`           | `ix_audit_log_entity`            |
+
+  ### Partial Index Example
+
+  ```python
+  op.create_index(
+      'ix_job_display_id', 'job', ['display_id'],
+      unique=False,
+      postgresql_where=sa.text('display_id IS NOT NULL')
+  )
+  ```
+
+  ### Exclusion Constraints (PostgreSQL)
+
+  ```python
+  # Enable btree_gist extension first
+  op.execute("CREATE EXTENSION IF NOT EXISTS btree_gist")
+
+  # Prevent overlapping date ranges for the same resource
+  op.execute("""
+      ALTER TABLE restriction ADD CONSTRAINT excl_restriction_no_overlap
+      EXCLUDE USING gist (
+          resource_id WITH =,
+          daterange(start, COALESCE("end", '9999-12-31'::date), '[]') WITH &&
+      )
+  """)
+  ```
+
+  ### Downgrade: Always Reversible
+
+  ```python
+  def downgrade() -> None:
+      # Drop constraints first
+      op.execute("ALTER TABLE restriction DROP CONSTRAINT IF EXISTS excl_restriction_no_overlap")
+      # Drop tables in reverse dependency order
+      op.drop_index(op.f('ix_job_customer_id'), table_name='job')
+      op.drop_table('job')
+      # Drop extensions last
+      op.execute("DROP EXTENSION IF EXISTS btree_gist")
+  ```
+
+  ### Enum Storage
+
+  Enums use `native_enum=False` so they are stored as varchar, not PostgreSQL native enums.
+  This avoids the need for `ALTER TYPE` migrations when adding enum values.
+
+  ```python
+  sa.Column('status', sa.Enum('ACTIVE', 'INACTIVE', 'ON_LEAVE',
+            name='personnel_status', native_enum=False), nullable=False)
+  ```
+
+usage_notes: |
+  - Always use async engine in env.py (asyncio.run wraps the migration)
+  - Import Base in env.py to trigger all model registration for autogenerate
+  - Every FK column MUST have a corresponding index
+  - Use `native_enum=False` for all enums (avoids ALTER TYPE hassle)
+  - Name all constraints explicitly (unique, check, exclusion)
+  - Prefer additive-only migrations; avoid dropping columns in production
+  - Downgrade functions must be the exact inverse of upgrade
+  - Use `server_default=sa.text('now()')` for timestamps, not Python defaults

--- a/mcp-server/patterns/annotated-deps.yaml
+++ b/mcp-server/patterns/annotated-deps.yaml
@@ -1,0 +1,139 @@
+name: annotated-deps
+category: backend
+description: "FastAPI Annotated type aliases for dependency injection: DBSession, CurrentUser, require_role"
+tags: ["fastapi", "dependencies", "annotated", "auth", "di"]
+created: "2026-04-01"
+content: |
+  ## Annotated Dependencies Pattern
+
+  Source: `app/core/dependencies.py`
+
+  Uses Python's `Annotated` type to create reusable dependency aliases, eliminating repeated `Depends()` boilerplate.
+
+  ### Database Session
+
+  ```python
+  from typing import Annotated
+  from collections.abc import AsyncGenerator
+  from fastapi import Depends, Request
+  from sqlalchemy.ext.asyncio import AsyncSession
+
+  async def get_db(request: Request) -> AsyncGenerator[AsyncSession, None]:
+      """Yield an async database session from app state."""
+      async_session = request.app.state.async_session
+      async with async_session() as session:
+          yield session
+
+  DBSession = Annotated[AsyncSession, Depends(get_db)]
+  ```
+
+  ### Bearer Token
+
+  ```python
+  from fastapi.security import OAuth2PasswordBearer
+
+  oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/v1/auth/login")
+  BearerToken = Annotated[str, Depends(oauth2_scheme)]
+  ```
+
+  ### Current User (authenticated)
+
+  ```python
+  async def get_current_user(
+      token: BearerToken,
+      db: DBSession,
+  ) -> User:
+      """Decode Bearer token and return the authenticated User."""
+      credentials_exception = HTTPException(
+          status_code=status.HTTP_401_UNAUTHORIZED,
+          detail="Could not validate credentials",
+          headers={"WWW-Authenticate": "Bearer"},
+      )
+
+      try:
+          payload = decode_token(token)
+      except JWTError:
+          raise credentials_exception from None
+
+      if payload.get("type") != "access":
+          raise credentials_exception
+
+      user_id_str = payload.get("sub")
+      if user_id_str is None:
+          raise credentials_exception
+
+      try:
+          user_id = uuid.UUID(user_id_str)
+      except ValueError:
+          raise credentials_exception from None
+
+      user_repo = UserRepository(db)
+      user = await user_repo.get_by_id(user_id)
+
+      if user is None or not user.is_active:
+          raise credentials_exception
+
+      return user
+
+  CurrentUser = Annotated[User, Depends(get_current_user)]
+  ```
+
+  ### Role-Based Access Control
+
+  ```python
+  from app.models.base import UserRole
+
+  def require_role(*roles: UserRole) -> Callable:
+      """Return a dependency that enforces the user has one of the given roles."""
+
+      async def _role_checker(current_user: CurrentUser) -> User:
+          if current_user.role not in roles:
+              raise HTTPException(
+                  status_code=status.HTTP_403_FORBIDDEN,
+                  detail="Insufficient permissions",
+              )
+          return current_user
+
+      return _role_checker
+  ```
+
+  ### Usage in Routers
+
+  ```python
+  @router.get("/jobs")
+  async def list_jobs(
+      db: DBSession,                          # async session
+      user: CurrentUser,                      # authenticated user
+  ):
+      service = JobService(db)
+      return await service.list_jobs()
+
+  @router.post("/admin/seed")
+  async def seed_data(
+      user: User = Depends(require_role(UserRole.ADMIN)),  # admin only
+  ):
+      ...
+
+  @router.patch("/jobs/{job_id}")
+  async def update_job(
+      user: User = Depends(require_role(UserRole.ADMIN, UserRole.SCHEDULER)),
+  ):
+      ...
+  ```
+
+  ### Dependency Chain
+
+  ```
+  get_db() -> DBSession
+  oauth2_scheme -> BearerToken
+  get_current_user(BearerToken, DBSession) -> CurrentUser
+  require_role(*roles)(CurrentUser) -> User (with role check)
+  ```
+
+usage_notes: |
+  - Use `DBSession` as a type hint instead of `db: AsyncSession = Depends(get_db)`
+  - Use `CurrentUser` for any endpoint that needs an authenticated user
+  - Use `require_role(UserRole.ADMIN)` for role-restricted endpoints
+  - `get_current_user` validates token type is "access" (prevents refresh token abuse)
+  - Inactive users are rejected even with a valid token
+  - Service factories take DBSession as parameter: `service = JobService(db)`

--- a/mcp-server/patterns/auth-context.yaml
+++ b/mcp-server/patterns/auth-context.yaml
@@ -1,0 +1,106 @@
+name: auth-context
+category: frontend
+description: "AuthContext pattern — silent refresh, login/logout with WS lifecycle, sessionStorage caching"
+tags: ["auth", "react-context", "jwt", "websocket", "session"]
+created: "2026-04-01"
+content: |
+  ## Auth Context Pattern
+
+  Central authentication provider that manages user state, JWT tokens, and WebSocket
+  connection lifecycle. Located at `frontend/src/contexts/AuthContext.tsx`.
+
+  ### Provider Structure
+
+  ```typescript
+  import { wsManager } from "@/lib/websocket";
+  import { AuthContext } from "./auth-context";  // context object in separate file
+
+  export function AuthProvider({ children }: { children: ReactNode }) {
+    const [user, setUser] = useState<User | null>(null);
+    const [isLoading, setIsLoading] = useState(true);  // true until refresh attempt completes
+
+    // 1. Silent refresh on mount
+    useEffect(() => {
+      let cancelled = false;
+      async function restoreSession() {
+        try {
+          await apiRefresh();
+          if (!cancelled) {
+            const cached = sessionStorage.getItem("diq_user");
+            if (cached) {
+              setUser(JSON.parse(cached) as User);
+              const token = getAccessToken();
+              if (token) wsManager.connect(token);
+            }
+          }
+        } catch {
+          if (!cancelled) { clearAccessToken(); setUser(null); }
+        } finally {
+          if (!cancelled) setIsLoading(false);
+        }
+      }
+      void restoreSession();
+      return () => { cancelled = true; };
+    }, []);
+
+    // 2. Login — set user, cache to sessionStorage, connect WS
+    const login = useCallback(async (credentials: LoginRequest) => {
+      const data = await apiLogin(credentials);
+      setUser(data.user);
+      sessionStorage.setItem("diq_user", JSON.stringify(data.user));
+      const token = getAccessToken();
+      if (token) wsManager.connect(token);
+    }, []);
+
+    // 3. Logout — best-effort server call, disconnect WS, clear state
+    const logout = useCallback(async () => {
+      try { await apiLogout(); } catch { /* ignore — logging out regardless */ }
+      wsManager.disconnect();
+      setUser(null);
+      sessionStorage.removeItem("diq_user");
+    }, []);
+
+    const value = useMemo(() => ({
+      user, isAuthenticated: user !== null, isLoading, login, logout,
+    }), [user, isLoading, login, logout]);
+
+    return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+  }
+  ```
+
+  ### Key Behaviors
+
+  | Behavior | Implementation |
+  |----------|---------------|
+  | Silent refresh | On mount, call `apiRefresh()` to get new access token via httpOnly cookie |
+  | User caching | `sessionStorage.setItem("diq_user", ...)` — survives page refresh within tab |
+  | Loading state | `isLoading=true` until refresh completes — prevents flash of login screen |
+  | WS connect | After login or successful refresh, `wsManager.connect(token)` |
+  | WS disconnect | On logout, `wsManager.disconnect()` — stops reconnect attempts |
+  | Cleanup guard | `cancelled` flag prevents state updates after unmount (StrictMode safe) |
+  | Best-effort logout | Server logout errors are swallowed — client clears state regardless |
+
+  ### Context Value Shape
+
+  ```typescript
+  interface AuthContextValue {
+    user: User | null;
+    isAuthenticated: boolean;
+    isLoading: boolean;
+    login: (credentials: LoginRequest) => Promise<void>;
+    logout: () => Promise<void>;
+  }
+  ```
+
+  ### Token Storage
+
+  - Access token: stored via `@/lib/auth` (memory or localStorage)
+  - Refresh token: httpOnly cookie (managed by backend)
+  - User object: sessionStorage under key `diq_user`
+
+usage_notes: |
+  - WebSocket lifecycle is ONLY controlled here — never from components
+  - isLoading must start as true to prevent auth flash on mount
+  - Always use the cancelled flag pattern for async effects
+  - Context object and Provider are in separate files (auth-context.ts + AuthContext.tsx)
+  - Logout swallows server errors — client state is always cleared

--- a/mcp-server/patterns/base-repository.yaml
+++ b/mcp-server/patterns/base-repository.yaml
@@ -1,0 +1,162 @@
+name: base-repository
+category: backend
+description: "Async generic BaseRepository[ModelT] with CRUD, pagination, filtering, and existence checks"
+tags: ["repository", "sqlalchemy", "async", "crud", "generic"]
+created: "2026-04-01"
+content: |
+  ## Base Repository Pattern
+
+  Source: `app/repositories/base.py`
+
+  Generic async repository using Python 3.12 type parameter syntax with SQLAlchemy 2.0.
+
+  ### Full BaseRepository Implementation
+
+  ```python
+  import uuid
+  from typing import Any
+
+  from sqlalchemy import func, select
+  from sqlalchemy.ext.asyncio import AsyncSession
+  from sqlalchemy.orm import exc as orm_exc
+
+  from app.core.exceptions import ConflictError, NotFoundError
+  from app.models.base import Base
+
+
+  class BaseRepository[ModelT: Base]:
+      """Base repository with common CRUD operations."""
+
+      def __init__(self, session: AsyncSession, model: type[ModelT]) -> None:
+          self.session = session
+          self.model = model
+
+      # --- Single-entity retrieval ---
+
+      async def get(self, id_: uuid.UUID) -> ModelT | None:
+          result = await self.session.execute(
+              select(self.model).where(self.model.id == id_)
+          )
+          return result.scalar_one_or_none()
+
+      async def get_or_raise(self, id_: uuid.UUID) -> ModelT:
+          obj = await self.get(id_)
+          if obj is None:
+              raise NotFoundError(f"{self.model.__name__} not found")
+          return obj
+
+      # --- List with pagination ---
+
+      async def get_multi(
+          self,
+          *,
+          offset: int = 0,
+          limit: int = 50,
+          order_by: str | None = None,
+          descending: bool = False,
+          filters: dict[str, Any] | None = None,
+          options: list | None = None,
+      ) -> tuple[list[ModelT], int]:
+          """Return (items, total_count) with pagination and optional filters."""
+          stmt = select(self.model)
+          count_stmt = select(func.count()).select_from(self.model)
+
+          if options:
+              for opt in options:
+                  stmt = stmt.options(opt)
+
+          if filters:
+              for key, value in filters.items():
+                  if value is not None:
+                      col = getattr(self.model, key)
+                      stmt = stmt.where(col == value)
+                      count_stmt = count_stmt.where(col == value)
+
+          total = (await self.session.execute(count_stmt)).scalar_one()
+
+          if order_by and hasattr(self.model, order_by):
+              col = getattr(self.model, order_by)
+              stmt = stmt.order_by(col.desc() if descending else col)
+          elif hasattr(self.model, "created_at"):
+              stmt = stmt.order_by(self.model.created_at.desc())
+
+          stmt = stmt.offset(offset).limit(limit)
+          result = await self.session.execute(stmt)
+          if options:
+              return list(result.unique().scalars().all()), total
+          return list(result.scalars().all()), total
+
+      # --- Mutations (flush only, never commit) ---
+
+      async def create(self, data: dict[str, Any]) -> ModelT:
+          obj = self.model(**data)
+          self.session.add(obj)
+          await self.session.flush()
+          await self.session.refresh(obj)
+          return obj
+
+      async def update(self, obj: ModelT, data: dict[str, Any]) -> ModelT:
+          for key, value in data.items():
+              setattr(obj, key, value)
+          try:
+              await self.session.flush()
+          except orm_exc.StaleDataError as exc:
+              raise ConflictError(
+                  "Conflict: entity was modified by another user",
+              ) from exc
+          await self.session.refresh(obj)
+          return obj
+
+      async def delete(self, obj: ModelT) -> None:
+          await self.session.delete(obj)
+          await self.session.flush()
+
+      # --- Helpers ---
+
+      async def exists(self, **filters: Any) -> bool:
+          stmt = select(func.count()).select_from(self.model)
+          for key, value in filters.items():
+              stmt = stmt.where(getattr(self.model, key) == value)
+          result = (await self.session.execute(stmt)).scalar_one()
+          return result > 0
+
+      async def count(self, **filters: Any) -> int:
+          stmt = select(func.count()).select_from(self.model)
+          for key, value in filters.items():
+              if value is not None:
+                  stmt = stmt.where(getattr(self.model, key) == value)
+          return (await self.session.execute(stmt)).scalar_one()
+  ```
+
+  ### Concrete Repository Example (JobRepository)
+
+  ```python
+  class JobRepository(BaseRepository[Job]):
+      def __init__(self, session: AsyncSession) -> None:
+          super().__init__(session, Job)
+
+      async def get_with_relations(self, id_: uuid.UUID) -> Job | None:
+          result = await self.session.execute(
+              select(Job)
+              .where(Job.id == id_)
+              .options(
+                  joinedload(Job.customer),
+                  joinedload(Job.service_address),
+                  joinedload(Job.creator),
+              )
+          )
+          return result.unique().scalar_one_or_none()
+
+      async def get_multi_filtered(self, *, offset, limit, status, ...) -> tuple[list[Job], int]:
+          # Domain-specific complex filtering beyond what get_multi provides
+          ...
+  ```
+
+usage_notes: |
+  - Always extend BaseRepository[ModelT] with `super().__init__(session, Model)`
+  - Repositories flush only, NEVER commit -- service layer owns the transaction
+  - Return `ModelT | None` for single, `tuple[list[ModelT], int]` for paginated
+  - Use `get_or_raise()` when the caller expects the entity to exist
+  - Add domain-specific queries as methods on the concrete repository
+  - Use `joinedload()` for 1:1, `selectinload()` for 1:many eager loading
+  - StaleDataError from SQLAlchemy is caught and converted to ConflictError in `update()`

--- a/mcp-server/patterns/behavioral-evals.yaml
+++ b/mcp-server/patterns/behavioral-evals.yaml
@@ -1,0 +1,95 @@
+name: behavioral-evals
+category: workflow
+description: "Production-derived verification checks (E01-E15) with file-to-eval mapping for PROVE phase"
+tags: ["evals", "verification", "prove", "quality", "testing"]
+created: "2026-04-01"
+content: |
+  ## Behavioral Evals Catalog (E01-E15)
+
+  Each eval traces back to a real production failure. PROVE selects applicable evals
+  based on changed files using the mapping table below.
+
+  ### Eval Catalog
+
+  | ID | Name | Trigger Files | What to Check |
+  |----|------|--------------|---------------|
+  | E01 | ENUM_VALUE_MISMATCH | *.tsx, *.ts, schemas/*.py | Frontend uses enum VALUE not NAME |
+  | E02 | COMPONENT_API_MISMATCH | *.tsx, *.ts | All required props passed with correct types |
+  | E03 | HOOK_DEPENDENCY_ARRAY | *.tsx, *.ts | Every ref'd variable in useEffect/useMemo/useCallback deps |
+  | E04 | MODEL_WITHOUT_MIGRATION | models/*.py | Model column changed -> Alembic migration exists |
+  | E05 | NULLABLE_MISMATCH | models/*.py, schemas/*.py | nullable=True <-> Optional[T]; nullable=False <-> required |
+  | E06 | SCHEMA_MODEL_DRIFT | schemas/*.py, models/*.py | Pydantic fields match SQLAlchemy model fields |
+  | E07 | MIGRATION_NOT_ADDITIVE | alembic/versions/*.py | No drop_column/drop_table; downgrade() is inverse |
+  | E08 | MIGRATION_MISSING_INDEX | alembic/versions/*.py | FK columns have create_index |
+  | E09 | SERVICE_BYPASSES_REPO | services/*.py | No self.db.execute — use self.repo.* instead |
+  | E10 | STALE_DATA_UNHANDLED | services/*.py, repositories/*.py | Flush wrapped in try/except StaleDataError |
+  | E11 | AUTH_DEPENDENCY_MISSING | routers/*.py | Every endpoint has CurrentUser/AdminUser dependency |
+  | E12 | AUDIT_LOG_MISSING | routers/*.py, services/*.py | CUD operations call AuditService |
+  | E13 | MISSING_FK_INDEX | models/*.py | ForeignKey columns have index=True |
+  | E14 | DOCKER_ROOT_USER | Dockerfile | USER directive set to non-root |
+  | E15 | SECRETS_IN_CODE | *.py, *.ts, *.tsx, *.env* | No hardcoded keys/passwords/tokens |
+
+  ### File-to-Eval Mapping
+
+  PROVE uses `git diff --name-only origin/main` and matches against these patterns:
+
+  | File Pattern | Applicable Evals |
+  |-------------|-----------------|
+  | *.tsx, *.ts | E01, E02, E03, E15 |
+  | models/*.py | E04, E05, E06, E08, E13, E15 |
+  | schemas/*.py | E01, E05, E06 |
+  | alembic/versions/*.py | E07, E08 |
+  | services/*.py | E09, E10, E12, E15 |
+  | routers/*.py | E11, E12, E15 |
+  | repositories/*.py | E10, E13 |
+  | Dockerfile, docker-compose.yml | E14 |
+  | *.py (catch-all) | E15 |
+  | *.env* | E15 |
+
+  ### Override Rules
+
+  - No files match any pattern: run only E15 (SECRETS)
+  - FULLSTACK change (backend + frontend): always add E01 (ENUM_VALUE)
+  - `--thorough` flag: run ALL evals regardless of file mapping
+
+  ### PROVE Integration
+
+  ```
+  Step 0: Determine applicable evals
+    1. Run: git diff --name-only origin/main
+    2. Match each changed file against patterns
+    3. Collect unique eval IDs
+    4. Load those evals
+    5. Run each eval's verification checks
+
+  Step 1-4: Continue with standard verification levels
+  ```
+
+  ### Detailed Verification Steps
+
+  **E01 — ENUM_VALUE_MISMATCH:**
+  Grep frontend for string literals matching status/role/type. Cross-reference with
+  backend StrEnum in models/base.py. Verify VALUE ("CO-OWNER") not NAME ("CO_OWNER").
+
+  **E04 — MODEL_WITHOUT_MIGRATION:**
+  Check if model column added/removed/type-changed. Verify corresponding Alembic
+  migration exists in same commit/PR. If model changed and no migration: FAIL.
+
+  **E05 — NULLABLE_MISMATCH:**
+  For each changed model field, check nullable=True/False. Find corresponding Pydantic
+  schema field. Verify: nullable=True <-> Optional[T]; nullable=False <-> required.
+
+  **E09 — SERVICE_BYPASSES_REPO:**
+  Grep for self.db.execute, self.db.add, self.db.flush in service files. Should use
+  self.repo.* methods. Exception: complex aggregation with no natural repo home.
+
+  **E11 — AUTH_DEPENDENCY_MISSING:**
+  Every new/modified endpoint needs auth dependency (current_user: CurrentUser).
+  Exception: explicitly public endpoints (health, login) with comment.
+
+usage_notes: |
+  - PROVE runs applicable evals automatically based on changed files
+  - E15 (SECRETS) is the catch-all — always runs
+  - E01 (ENUM_VALUE) is forced on all FULLSTACK changes
+  - Each eval traces to a real production failure — none are theoretical
+  - For COMPLEX tasks, consider running --thorough to check all evals

--- a/mcp-server/patterns/codex-delegation.yaml
+++ b/mcp-server/patterns/codex-delegation.yaml
@@ -1,0 +1,124 @@
+name: codex-delegation
+category: workflow
+description: "5 Codex delegation patterns and model selection guide for parallel agent work"
+tags: ["codex", "delegation", "parallel", "gpt", "multi-model"]
+created: "2026-04-01"
+content: |
+  ## Codex Delegation Patterns
+
+  Codex (GPT) runs in background while Claude continues primary work. Delegate when
+  the task is independent and doesn't require orchestrate pipeline state or MCP access.
+
+  ### When to Delegate vs Keep
+
+  **Delegate to Codex:**
+  - Task is independent (doesn't block Claude)
+  - Prior Claude attempt was BLOCKED (try different model)
+  - Fullstack: frontend parallel to Claude's backend
+  - Debugging: test failures, regression investigation
+  - Refactoring: mechanical changes (rename, extract, move)
+  - Review: any MODERATE+ task after implementation
+
+  **Keep in Claude:**
+  - Requires orchestrate pipeline state (MAP->PATCH)
+  - Needs MCP server access
+  - Project-specific rules/patterns
+  - Primary implementation thread
+  - Architectural decisions needing deep context
+
+  ### Pattern 1: Parallel Fullstack Split
+
+  Claude handles backend. Codex handles frontend in background.
+
+  ```
+  Claude: PATCH backend (services, models, routes)
+    └── /codex:rescue --background --write
+          "Implement frontend component per CONTRACT..."
+    ├── Claude continues with backend tests
+    └── /codex:status -> check when done
+  ```
+
+  ### Pattern 2: Debug Delegation
+
+  Claude works on issue A. Tests for issue B fail. Delegate debugging.
+
+  ```
+  Claude: working on issue A...
+    └── /codex:rescue --background
+          "Investigate why tests in backend/auth/tests/ are failing..."
+    ├── Claude continues issue A
+    └── /codex:result -> review fix when done
+  ```
+
+  ### Pattern 3: Prior Failure Escalation
+
+  Claude's PATCH was BLOCKED. Try Codex first (different model = different approach).
+
+  ```
+  PROVE: BLOCKED (root cause: MULTI_MODEL)
+    └── /codex:rescue --write --effort high
+          "Fix issue #N. Prior attempt failed with MULTI_MODEL error.
+           See .agents/outputs/patch-N-*.md for what was tried."
+  ```
+
+  ### Pattern 4: Mechanical Refactoring
+
+  Large rename/extract/move operations without architectural judgment.
+
+  ```
+  Claude: planning the refactor...
+    └── /codex:rescue --background --write
+          "Rename all 'UserAccount' to 'Account' across backend/.
+           Update imports, type hints, test references."
+    ├── Claude works on architectural changes
+    └── /codex:status -> merge when done
+  ```
+
+  ### Pattern 5: Test Writing
+
+  Claude implements feature. Codex writes tests.
+
+  ```
+  Claude: PATCH completes feature
+    └── /codex:rescue --background --write
+          "Write tests for new module. Use pytest + pytest-asyncio.
+           Cover: success, validation errors, edge cases."
+    ├── Claude continues to PROVE phase
+    └── /codex:result -> incorporate tests
+  ```
+
+  ### Prompt Construction (MANDATORY)
+
+  Never delegate with plain language alone. Use XML prompt blocks:
+
+  **Minimum blocks for every prompt:**
+  1. `<task>` — concrete job with expected end state
+  2. `<completeness_contract>` — don't stop at first plausible answer
+  3. `<verification_loop>` — verify result before finalizing
+
+  **Additional by task type:**
+
+  | Task Type | Extra Blocks |
+  |-----------|-------------|
+  | Bug fix / implementation | `<action_safety>`, `<default_follow_through_policy>` |
+  | Review / analysis | `<grounding_rules>`, `<dig_deeper_nudge>` |
+  | Research | `<research_mode>`, `<citation_rules>` |
+  | Write-capable | `<action_safety>` |
+
+  ### Model Selection Guide
+
+  | Task Type | Model | Effort | Why |
+  |-----------|-------|--------|-----|
+  | Quick review | gpt-5.4-mini | medium | Fast, sufficient for review |
+  | Adversarial review | gpt-5.4 | high | Needs reasoning depth |
+  | Bug investigation | gpt-5.4-mini | medium | Read-only, speed matters |
+  | Feature implementation | gpt-5.4 | high | Write-capable, needs quality |
+  | Mechanical refactoring | gpt-5.4-mini | low | Repetitive, pattern-following |
+  | Test writing | gpt-5.4 | medium | Needs code understanding |
+  | Prior failure rescue | gpt-5.4 | xhigh | Maximum reasoning for stuck problems |
+
+usage_notes: |
+  - Always use structured XML prompt blocks — never plain language delegation
+  - Read prompt-blocks.md and codex-prompt-recipes.md on first delegation per session
+  - Codex runs in background — Claude continues primary work in parallel
+  - For prior failures, always try Codex before re-running Claude (different model bias)

--- a/mcp-server/patterns/core-failure-patterns.yaml
+++ b/mcp-server/patterns/core-failure-patterns.yaml
@@ -1,0 +1,74 @@
+name: core-failure-patterns
+category: workflow
+description: "3 core failure patterns causing >50% of agent failures — ENUM_VALUE, COMPONENT_API, VERIFICATION_GAP"
+tags: ["failure-patterns", "enum", "component-api", "verification", "quality"]
+created: "2026-04-01"
+content: |
+  ## Core Failure Patterns
+
+  These 3 patterns cause >50% of agent failures. Apply proactively on every task.
+
+  ### ENUM_VALUE (26% of failures)
+
+  **Trigger:** Fullstack issue involving role/status/type fields.
+
+  **Problem:** Frontend uses Python enum NAME (`"CO_OWNER"`) instead of VALUE (`"CO-OWNER"`).
+  Server silently rejects or mismatches — no error, just wrong behavior.
+
+  **Prevention:**
+  1. Read the backend StrEnum definition in `models/base.py`
+  2. Use the VALUE string, not the Python name
+  3. Example: `"CO-OWNER"` not `"CO_OWNER"`, `"in-progress"` not `"IN_PROGRESS"`
+
+  **Verification:**
+  - Grep changed frontend files for string literals matching status/role/type patterns
+  - Cross-reference each with backend StrEnum definitions
+  - Confirm frontend uses VALUE not NAME
+
+  ### COMPONENT_API (17% of failures)
+
+  **Trigger:** Reusing an existing frontend component or hook.
+
+  **Problem:** Component renders but silently ignores unknown props, producing broken UI.
+  Missing required props cause runtime errors or empty renders.
+
+  **Prevention:**
+  1. Read the actual component source file before using it
+  2. Extract its prop interface/types
+  3. Pass all required props with correct types
+
+  **Verification:**
+  - For each imported component in changed files, read the component source
+  - Extract prop interface
+  - Verify all required props are passed with correct types
+
+  ### VERIFICATION_GAP
+
+  **Trigger:** Any assumption about code structure.
+
+  **Problem:** Agent assumes how code works without reading it. Leads to wrong
+  function signatures, missing parameters, incorrect data shapes.
+
+  **Prevention:**
+  1. Verify by reading actual code — never assume
+  2. Check function signatures, return types, required fields
+  3. Read imports to understand dependencies
+
+  **Verification:**
+  - Before using any function/component/hook, read its source
+  - Before modifying any file, read it first
+  - Before assuming a pattern, verify it exists in the codebase
+
+  ### Quick Reference
+
+  | Pattern | Frequency | Trigger | One-Line Prevention |
+  |---------|-----------|---------|-------------------|
+  | ENUM_VALUE | 26% | Fullstack role/status/type | Read backend enum, use VALUE not NAME |
+  | COMPONENT_API | 17% | Reusing frontend component | Read source, extract PropTypes first |
+  | VERIFICATION_GAP | — | Any assumption | Read actual code — never assume |
+
+usage_notes: |
+  - These patterns are ALWAYS loaded — apply proactively on every task
+  - For COMPLEX issues, also load full patterns from .claude/memory/patterns-full.md
+  - ENUM_VALUE is automatically added to evals for any FULLSTACK change
+  - COMPONENT_API applies whenever importing an existing component — always read source first

--- a/mcp-server/patterns/domain-exceptions.yaml
+++ b/mcp-server/patterns/domain-exceptions.yaml
@@ -1,0 +1,120 @@
+name: domain-exceptions
+category: backend
+description: "DocketIQ exception hierarchy with structured data for frontend error handling"
+tags: ["exceptions", "error-handling", "validation", "conflict"]
+created: "2026-04-01"
+content: |
+  ## Domain Exception Hierarchy
+
+  Source: `app/core/exceptions.py`
+
+  All domain exceptions inherit from `DocketIQException`. Services raise these; global error handlers convert them to HTTP responses.
+
+  ### Exception Classes
+
+  ```python
+  class DocketIQException(Exception):
+      """Base exception for all DocketIQ errors."""
+
+
+  class NotFoundError(DocketIQException):
+      """Raised when a requested resource does not exist. -> 404"""
+
+
+  class ConflictError(DocketIQException):
+      """Raised on optimistic concurrency or uniqueness conflicts. -> 409
+
+      When current_version and current_entity are provided the global
+      exception handler returns the canonical 409 body that the frontend
+      ConflictDialog relies on.
+      """
+      def __init__(
+          self,
+          message: str = "Conflict: entity was modified by another user",
+          *,
+          current_version: int | None = None,
+          current_entity: dict | None = None,
+      ) -> None:
+          super().__init__(message)
+          self.current_version = current_version
+          self.current_entity = current_entity
+
+
+  class AuthenticationError(DocketIQException):
+      """Raised on invalid credentials or tokens. -> 401"""
+
+
+  class ForbiddenError(DocketIQException):
+      """Raised when the user lacks permission for the action. -> 403"""
+
+
+  class BusinessValidationError(DocketIQException):
+      """Raised when a business rule is violated. -> 422"""
+
+
+  class WarningValidationError(DocketIQException):
+      """Raised when write-path validation produces warnings that need overrides. -> 422
+
+      The global exception handler returns a 422 with the structured warnings list
+      so the frontend can display the WarningDialog.
+      """
+      def __init__(
+          self,
+          warnings: list[dict],
+          message: str = "Validation warnings require override",
+      ) -> None:
+          super().__init__(message)
+          self.warnings = warnings
+  ```
+
+  ### Exception -> HTTP Status Mapping
+
+  | Exception                | HTTP Status | Frontend Handling       |
+  |--------------------------|-------------|------------------------|
+  | NotFoundError            | 404         | Toast / redirect       |
+  | ConflictError            | 409         | ConflictDialog         |
+  | AuthenticationError      | 401         | Redirect to login      |
+  | ForbiddenError           | 403         | Permission denied page |
+  | BusinessValidationError  | 422         | Form error display     |
+  | WarningValidationError   | 422         | WarningDialog          |
+
+  ### ConflictError Structured Data
+
+  The ConflictError carries `current_version` and `current_entity` so the frontend
+  can show the user what changed and allow them to retry with the new version:
+
+  ```python
+  raise ConflictError(
+      "Conflict: entity was modified by another user",
+      current_version=job.version,
+      current_entity=JobRead.model_validate(job).model_dump(mode="json"),
+  )
+  ```
+
+  ### WarningValidationError Structured Warnings
+
+  Carries a list of warning dicts for the frontend WarningDialog:
+
+  ```python
+  raise WarningValidationError(
+      warnings=[
+          {"type": "DUPLICATE_DISPLAY_ID", "overridable": True, "severity": "warning",
+           "message": "Display ID 42 is already used by another job", "details": {...}},
+      ]
+  )
+  ```
+
+  ### Who Raises What
+
+  | Layer      | Raises                              | Never Raises    |
+  |------------|-------------------------------------|-----------------|
+  | Repository | Nothing (returns None or empty list) | Any exception   |
+  | Service    | NotFoundError, ConflictError, etc.  | HTTPException   |
+  | Router     | HTTPException(404) for simple cases | Domain errors   |
+
+usage_notes: |
+  - Always raise domain exceptions from service layer, never HTTPException
+  - ConflictError should include current_version and current_entity for optimistic concurrency
+  - WarningValidationError carries structured warnings list for the frontend WarningDialog
+  - Global error handlers in the app convert these to HTTP responses automatically
+  - BaseRepository.update() catches SQLAlchemy StaleDataError and raises ConflictError

--- a/mcp-server/patterns/fastapi-module.yaml
+++ b/mcp-server/patterns/fastapi-module.yaml
@@ -1,0 +1,150 @@
+name: fastapi-module
+category: backend
+description: "Layered FastAPI module scaffold: Model -> Schema -> Repository -> Service -> Router -> Deps"
+tags: ["fastapi", "architecture", "scaffold", "module"]
+created: "2026-04-01"
+content: |
+  ## FastAPI Layered Module Pattern
+
+  Every domain module follows this structure:
+
+  ```
+  module_name/
+  ├── models.py          # SQLAlchemy ORM models
+  ├── schemas.py         # Pydantic request/response schemas
+  ├── enums.py           # Module-specific enums (if needed)
+  ├── repository.py      # Data access layer (extends BaseRepository)
+  ├── services.py        # Business logic layer
+  ├── deps.py            # FastAPI dependencies (repo/service factories + access control)
+  └── router.py          # HTTP endpoints (thin layer)
+  ```
+
+  ### Architecture Flow
+
+  ```
+  Request -> Router (HTTP) -> Service (Business Logic) -> Repository (Data Access) -> Database
+              ^                    ^                         ^
+            deps.py             schemas.py               models.py
+         (access control)    (validation)             (ORM definitions)
+  ```
+
+  **Transaction boundary**: Service layer commits. Repositories never commit.
+  **Error boundary**: Services raise domain exceptions. Routers never catch -- global error handlers convert to HTTP responses.
+
+  ### Layer 1: Model
+
+  ```python
+  from sqlalchemy import String, Text, ForeignKey
+  from sqlalchemy.orm import Mapped, mapped_column, relationship
+  from app.models.base import Base, TimestampMixin
+  import uuid
+
+  class Item(TimestampMixin, Base):
+      __tablename__ = "items"
+
+      id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+      name: Mapped[str] = mapped_column(String(255), nullable=False)
+      account_id: Mapped[uuid.UUID] = mapped_column(
+          ForeignKey("accounts.id", ondelete="CASCADE"), nullable=False, index=True,
+      )
+      description: Mapped[str | None] = mapped_column(Text, nullable=True)
+      version: Mapped[int] = mapped_column(default=1, nullable=False)
+
+      account: Mapped["Account"] = relationship("Account", back_populates="items")
+  ```
+
+  ### Layer 2: Schema (Create / Update / Read trio)
+
+  ```python
+  class ItemCreate(BaseModel):
+      name: str
+      description: str | None = None
+
+  class ItemUpdate(BaseModel):
+      name: str | None = None
+      description: str | None = None
+      version: int  # Required for optimistic concurrency
+
+  class ItemRead(BaseModel):
+      model_config = {"from_attributes": True}
+      id: uuid.UUID
+      name: str
+      description: str | None = None
+      version: int
+      created_at: datetime
+      updated_at: datetime
+  ```
+
+  ### Layer 3: Repository (extends BaseRepository)
+
+  ```python
+  class ItemRepository(BaseRepository[Item]):
+      def __init__(self, session: AsyncSession) -> None:
+          super().__init__(session, Item)
+
+      async def get_with_relations(self, id_: uuid.UUID) -> Item | None:
+          result = await self.session.execute(
+              select(Item).where(Item.id == id_).options(joinedload(Item.account))
+          )
+          return result.unique().scalar_one_or_none()
+  ```
+
+  ### Layer 4: Service (business logic + transaction owner)
+
+  ```python
+  class ItemService:
+      def __init__(self, db: AsyncSession) -> None:
+          self.db = db
+          self.repo = ItemRepository(db)
+
+      async def create_item(self, data: ItemCreate, user_id: uuid.UUID) -> Item:
+          return await self.repo.create({**data.model_dump(), "created_by": user_id})
+
+      async def update_item(self, item_id: uuid.UUID, data: ItemUpdate) -> Item:
+          item = await self.repo.get_or_raise(item_id)
+          await self.check_version(item, data.version)
+          return await self.repo.update(item, data.model_dump(exclude_unset=True, exclude={"version"}))
+  ```
+
+  ### Layer 5: Dependencies (Annotated type aliases)
+
+  ```python
+  DBSession = Annotated[AsyncSession, Depends(get_db)]
+  CurrentUser = Annotated[User, Depends(get_current_user)]
+
+  async def get_item_service(db: DBSession) -> ItemService:
+      return ItemService(db)
+  ```
+
+  ### Layer 6: Router (thin HTTP layer)
+
+  ```python
+  router = APIRouter(prefix="/items", tags=["items"])
+
+  @router.post("", response_model=ItemRead, status_code=status.HTTP_201_CREATED)
+  async def create_item(
+      payload: ItemCreate,
+      user: CurrentUser,
+      service: ItemService = Depends(get_item_service),
+  ):
+      return await service.create_item(payload, user.id)
+  ```
+
+  ### Layer Responsibilities
+
+  | Layer      | Does                              | Never Does              |
+  |------------|-----------------------------------|-------------------------|
+  | Model      | Define columns, relationships     | Business logic, queries |
+  | Schema     | Validate input, shape output      | Side effects            |
+  | Repository | Query DB, return ORM objects      | Commit, raise HTTP exc  |
+  | Service    | Business logic, orchestrate       | HTTP concerns           |
+  | Deps       | Wire repo/service, access control | Business logic          |
+  | Router     | Parse HTTP, call service, respond | Business logic, DB      |
+
+usage_notes: |
+  - Use this pattern for every new domain module
+  - Transaction boundary is always in the service layer
+  - Repositories flush only, never commit
+  - Services raise domain exceptions (NotFoundError, ConflictError), never HTTPException
+  - Routers are thin -- no if/else on business rules
+  - Registration checklist: import model in models/__init__.py, include router in main_router.py, create Alembic migration

--- a/mcp-server/patterns/git-workflow.yaml
+++ b/mcp-server/patterns/git-workflow.yaml
@@ -1,0 +1,94 @@
+name: git-workflow
+category: workflow
+description: "Git branch naming, commit conventions, PR checklist, and pre-PR verification commands"
+tags: ["git", "branching", "commits", "pr", "ci"]
+created: "2026-04-01"
+content: |
+  ## Git Workflow Rules
+
+  Main stays green at all times. All agents follow these rules for every git operation.
+
+  ### Branch Rules
+
+  - Always branch from latest origin/main: `git fetch origin && git checkout -b {branch} origin/main`
+  - Naming: `{type}/issue-{N}-{slug}` where type is `feature/`, `fix/`, `chore/`, `docs/`, `test/`, `perf/`
+  - One branch = one PR = one logical change
+  - Branch lifetime: <24h preferred, 48h max
+  - Never commit directly to main
+
+  ### Commit Conventions
+
+  - Format: `type(scope): description` (imperative, lowercase, no period, max 72 chars)
+  - One issue per commit — never bundle `(#123, #124, #125)`
+  - No `debug:` commits — remove all debug logging before PR
+  - No flip-flops — validate architecture decisions BEFORE implementing
+
+  ### Pre-PR Checklist (MANDATORY)
+
+  Run these steps in order before creating any PR:
+
+  ```bash
+  # 1. Rebase on latest main
+  git fetch origin && git rebase origin/main
+
+  # 2. Run checks (Python projects)
+  ruff check . && ruff format --check .
+  pytest tests/ -x --timeout=60
+
+  # 3. Verify only relevant files changed
+  git diff --name-only origin/main
+  ```
+
+  If any check fails, fix before creating PR. Never skip checks.
+
+  ### PR Creation
+
+  - Title: Conventional Commits format
+  - Body: Summary + Test Plan + issue reference (`Closes #N`)
+  - Merge strategy: Squash merge only
+  - After merge: Delete remote branch (enable auto-delete in repo settings)
+
+  ### Branch Cleanup (After Every PR Merge)
+
+  ```bash
+  git fetch --prune origin
+  git branch -d feature/issue-N-slug
+  ```
+
+  Before starting new work:
+  ```bash
+  git branch -r --merged origin/main | grep -v 'main\|HEAD'
+  git branch -vv | grep ': gone]' | awk '{print $1}' | xargs -r git branch -D
+  ```
+
+  ### Large Features (500+ lines)
+
+  Split into phased PRs, each leaving main working:
+  1. Schema/model -> merge
+  2. Service/logic -> merge (branch from updated main)
+  3. API/integration -> merge
+  4. Tests -> merge
+
+  ### Parallel Agent Work
+
+  1. Check for file conflicts: `gh pr list --state open --json headRefName,files`
+  2. No two agents edit the same file — serialize if overlap
+  3. Use worktree isolation per agent
+  4. Rebase before PR after other agents merge
+  5. Wave scheduling: independent issues parallel, dependent issues sequential
+
+  ### Never Do These
+
+  - Reuse one branch for multiple PRs
+  - Bundle multiple issues in one commit
+  - Ship debug commits to main
+  - Implement then immediately revert
+  - Force push to shared branches
+  - Skip CI with --no-verify
+  - Merge without rebasing on latest main
+
+usage_notes: |
+  - Pre-PR checklist is mandatory — no exceptions
+  - Branch naming must include issue number for traceability
+  - Squash merge only — keeps main history clean
+  - For emergency hotfixes: branch from last green commit as fix/hotfix-{description}

--- a/mcp-server/patterns/implementation-routing.yaml
+++ b/mcp-server/patterns/implementation-routing.yaml
@@ -1,0 +1,71 @@
+name: implementation-routing
+category: workflow
+description: "Task complexity assessment and routing to Quick, Plan Mode, or Orchestrate workflows"
+tags: ["routing", "workflow", "orchestrate", "complexity", "codex"]
+created: "2026-04-01"
+content: |
+  ## Implementation Routing
+
+  Assess task complexity BEFORE starting work. Route to the right workflow automatically
+  — do not ask the user which mode to use.
+
+  ### Routing Table
+
+  | Complexity | Files | Criteria | Route To | Codex Role |
+  |------------|-------|----------|----------|-----------|
+  | TRIVIAL | 1 | Typo, config, rename, obvious fix | `/quick` | None |
+  | SIMPLE | 1-3 | Clear requirements, single subsystem | Plan Mode | Offer review after |
+  | MODERATE | 4-5 | Clear pattern, single subsystem | `/orchestrate` (SIMPLE tier) | Review (recommended) |
+  | COMPLEX | 6+ | Cross-cutting, architectural decisions | `/orchestrate` (COMPLEX tier) | Review (automatic) + delegate subtasks |
+  | FULLSTACK | Any | Backend + frontend changes | `/orchestrate` + CONTRACT | Review (enum/API focus) + parallel impl |
+  | PRIOR FAIL | Any | Re-attempt of a BLOCKED issue | `/codex:rescue` first | Primary implementer (different model) |
+
+  ### Modifiers
+
+  - Multiple independent issues: add `--parallel` (worktree isolation)
+  - Interrupted workflow: add `--resume` (skip completed phases)
+  - Independent subtasks: delegate to Codex via `/codex:rescue --background`
+
+  ### Workflow Pipelines
+
+  ```
+  Quick:     change → verify → done
+  Plan:      plan → implement → [offer review]
+  TRIVIAL:   MAP-PLAN → PATCH → PROVE-lite
+  SIMPLE:    MAP-PLAN → [CONTRACT*] → PLAN-CHECK → PATCH → PROVE
+  COMPLEX:   MAP → PLAN → [CONTRACT*] → PLAN-CHECK → PATCH → PROVE
+  ```
+
+  ### Codex Review by Risk Level
+
+  | Risk | Action | Command |
+  |------|--------|---------|
+  | TRIVIAL | Skip | — |
+  | SIMPLE | Offer | "Want a cross-model review?" |
+  | MODERATE | Auto after impl | `/codex:review --background` |
+  | COMPLEX | Adversarial after PROVE | `/codex:adversarial-review --background` |
+  | FULLSTACK | Enum/API focus | `/codex:adversarial-review "Focus on: enum mismatches, API contract"` |
+  | PRIOR FAIL | Before commit | `/codex:adversarial-review --wait "Focus on: {root cause}"` |
+
+  ### Review Integration Flow
+
+  ```
+  PATCH → PROVE passes → /codex:adversarial-review --background
+                                │
+                           findings?
+                           ├── No  → /pr
+                           └── Yes → fix → re-run PROVE → /pr
+  ```
+
+  ### Announce Format
+
+  State routing decision concisely:
+  - "Quick — typo in README, 1 file. No Codex."
+  - "Plan mode — 2 files, clear requirements. Will offer Codex review after."
+  - "Orchestrate (COMPLEX, fullstack) — new module + frontend. Claude backend, Codex frontend."
+
+usage_notes: |
+  - Always assess BEFORE entering any mode — read the issue, check files involved
+  - Make the routing call yourself — do not ask the user
+  - User can override any routing decision
+  - For FULLSTACK: always add E01 (ENUM_VALUE) eval regardless of file mapping

--- a/mcp-server/patterns/jwt-auth.yaml
+++ b/mcp-server/patterns/jwt-auth.yaml
@@ -1,0 +1,127 @@
+name: jwt-auth
+category: backend
+description: "JWT token creation/validation, bcrypt password hashing, and role-based access control"
+tags: ["jwt", "auth", "security", "bcrypt", "rbac"]
+created: "2026-04-01"
+content: |
+  ## JWT Authentication Pattern
+
+  Source: `app/core/security.py`
+
+  Uses `python-jose` for JWT and `passlib[bcrypt]` for password hashing.
+
+  ### Password Hashing (bcrypt, cost 12)
+
+  ```python
+  from passlib.context import CryptContext
+
+  pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto", bcrypt__rounds=12)
+
+  def hash_password(plain: str) -> str:
+      return pwd_context.hash(plain)
+
+  def verify_password(plain: str, hashed: str) -> bool:
+      return pwd_context.verify(plain, hashed)
+  ```
+
+  ### Password Policy
+
+  ```python
+  def validate_password_strength(password: str) -> None:
+      """8-128 chars, at least 1 upper, 1 lower, 1 digit."""
+      if len(password) < 8:
+          raise ValueError("Password must be at least 8 characters")
+      if len(password) > 128:
+          raise ValueError("Password must be at most 128 characters")
+      if not re.search(r"[A-Z]", password):
+          raise ValueError("Must contain at least one uppercase letter")
+      if not re.search(r"[a-z]", password):
+          raise ValueError("Must contain at least one lowercase letter")
+      if not re.search(r"\d", password):
+          raise ValueError("Must contain at least one digit")
+  ```
+
+  ### JWT Access Token
+
+  ```python
+  def create_access_token(user_id: uuid.UUID, role: str) -> tuple[str, int]:
+      """Returns (token, expires_in_seconds)."""
+      settings = get_settings()
+      expires_delta = timedelta(minutes=settings.access_token_expire_minutes)
+      now = datetime.now(UTC)
+      payload = {
+          "sub": str(user_id),
+          "role": role,
+          "exp": now + expires_delta,
+          "iat": now,
+          "type": "access",
+      }
+      token = jwt.encode(payload, settings.jwt_secret_key, algorithm=settings.jwt_algorithm)
+      return token, int(expires_delta.total_seconds())
+  ```
+
+  ### JWT Refresh Token (with JTI for revocation)
+
+  ```python
+  def create_refresh_token(user_id: uuid.UUID) -> tuple[str, str, datetime]:
+      """Returns (token, jti, expires_at)."""
+      settings = get_settings()
+      jti = str(uuid.uuid4())
+      expires_at = datetime.now(UTC) + timedelta(days=settings.refresh_token_expire_days)
+      payload = {
+          "sub": str(user_id),
+          "jti": jti,
+          "exp": expires_at,
+          "iat": datetime.now(UTC),
+          "type": "refresh",
+      }
+      token = jwt.encode(payload, settings.jwt_secret_key, algorithm=settings.jwt_algorithm)
+      return token, jti, expires_at
+  ```
+
+  ### Password Reset Token (10 minute TTL)
+
+  ```python
+  def create_password_reset_token(user_id: uuid.UUID) -> str:
+      payload = {
+          "sub": str(user_id),
+          "purpose": "password_reset",
+          "exp": datetime.now(UTC) + timedelta(minutes=10),
+          "iat": datetime.now(UTC),
+          "type": "password_reset",
+      }
+      return jwt.encode(payload, settings.jwt_secret_key, algorithm=settings.jwt_algorithm)
+  ```
+
+  ### Token Decode
+
+  ```python
+  def decode_token(token: str) -> dict:
+      """Decode and verify a JWT. Raises JWTError on failure."""
+      settings = get_settings()
+      return jwt.decode(token, settings.jwt_secret_key, algorithms=[settings.jwt_algorithm])
+  ```
+
+  ### Token Type Discrimination
+
+  All tokens include a `"type"` field to prevent cross-use:
+  - `"access"` -- short-lived, carries role
+  - `"refresh"` -- long-lived, has JTI for revocation via refresh_session table
+  - `"password_reset"` -- 10 min TTL, has `"purpose": "password_reset"`
+
+  ### Role Enum
+
+  ```python
+  class UserRole(enum.StrEnum):
+      ADMIN = "ADMIN"
+      SCHEDULER = "SCHEDULER"
+      VIEWER = "VIEWER"
+  ```
+
+usage_notes: |
+  - Access tokens carry the user's role in the payload for fast RBAC checks
+  - Refresh tokens use JTI stored in refresh_session table for revocation
+  - Always check `payload["type"]` to prevent using a refresh token as an access token
+  - Password reset tokens are short-lived (10 min) with a dedicated purpose field
+  - Settings come from get_settings() (Pydantic BaseSettings), not hardcoded values
+  - bcrypt cost factor is 12 (higher than default 10)

--- a/mcp-server/patterns/nested-read-schemas.yaml
+++ b/mcp-server/patterns/nested-read-schemas.yaml
@@ -1,0 +1,114 @@
+name: nested-read-schemas
+category: backend
+description: "Slim Summary schemas (CustomerSummary, UserSummary, AddressSummary) for nested reads without N+1 queries"
+tags: ["pydantic", "schema", "nested", "summary", "performance"]
+created: "2026-04-01"
+content: |
+  ## Nested Read Schemas (Summary Pattern)
+
+  Source: `app/schemas/job.py`
+
+  Instead of nesting the full Read schema for related entities, use slim Summary schemas
+  that include only the fields needed for display.
+
+  ### Summary Schemas
+
+  ```python
+  class UserSummary(BaseModel):
+      """Slim user representation for nested reads."""
+      model_config = {"from_attributes": True}
+
+      id: uuid.UUID
+      first_name: str
+      last_name: str
+
+
+  class CustomerSummary(BaseModel):
+      """Slim customer representation for nested reads."""
+      model_config = {"from_attributes": True}
+
+      id: uuid.UUID
+      display_name: str
+
+
+  class AddressSummary(BaseModel):
+      """Slim address representation for nested reads."""
+      model_config = {"from_attributes": True}
+
+      id: uuid.UUID
+      address_line1: str
+      city: str
+      state: str
+  ```
+
+  ### Usage in Parent Read Schema
+
+  ```python
+  class JobRead(BaseModel):
+      model_config = {"from_attributes": True}
+
+      id: uuid.UUID
+      customer_id: uuid.UUID
+      status: str
+      version: int
+      # ... other fields ...
+
+      # Nested summaries (optional because joinedload may not always be used)
+      customer: CustomerSummary | None = None
+      service_address: AddressSummary | None = None
+      creator: UserSummary | None = None
+
+      created_at: datetime
+      updated_at: datetime
+  ```
+
+  ### Repository: Eager Loading
+
+  Summary schemas work because the repository eager-loads relationships:
+
+  ```python
+  class JobRepository(BaseRepository[Job]):
+      async def get_with_relations(self, id_: uuid.UUID) -> Job | None:
+          result = await self.session.execute(
+              select(Job)
+              .where(Job.id == id_)
+              .options(
+                  joinedload(Job.customer),
+                  joinedload(Job.service_address),
+                  joinedload(Job.creator),
+              )
+          )
+          return result.unique().scalar_one_or_none()
+
+      async def get_multi_filtered(self, ...) -> tuple[list[Job], int]:
+          stmt = (
+              select(Job)
+              .options(
+                  joinedload(Job.customer),
+                  joinedload(Job.service_address),
+                  joinedload(Job.creator),
+              )
+              .order_by(Job.created_at.desc())
+          )
+          # ... filtering and pagination ...
+  ```
+
+  ### Design Principles
+
+  | Principle             | Detail                                                  |
+  |-----------------------|---------------------------------------------------------|
+  | Minimal fields        | Only id + display fields needed by the frontend         |
+  | Always from_attributes| `model_config = {"from_attributes": True}` on all       |
+  | Optional on parent    | `customer: CustomerSummary | None = None`               |
+  | No circular imports   | Summary schemas live in the parent's schema file        |
+  | joinedload for 1:1    | Use `joinedload()` for belongs-to relationships         |
+  | selectinload for 1:N  | Use `selectinload()` for has-many relationships         |
+  | unique() after join   | Always call `result.unique()` after joinedload          |
+
+usage_notes: |
+  - Create a Summary schema for any entity that appears as a nested read
+  - Include only id + fields needed for display (name, email, etc.)
+  - Mark nested fields as Optional on the parent (not always eager-loaded)
+  - Place Summary schemas in the consuming schema's file to avoid circular imports
+  - Always call `.unique()` on results when using joinedload (SQLAlchemy deduplication)
+  - Use joinedload for single-object relations, selectinload for collections

--- a/mcp-server/patterns/optimistic-concurrency.yaml
+++ b/mcp-server/patterns/optimistic-concurrency.yaml
@@ -1,0 +1,116 @@
+name: optimistic-concurrency
+category: backend
+description: "Version-based optimistic concurrency with ConflictError carrying current entity state"
+tags: ["concurrency", "version", "conflict", "stale-data"]
+created: "2026-04-01"
+content: |
+  ## Optimistic Concurrency Pattern
+
+  Sources: `app/services/job.py`, `app/repositories/base.py`, `app/schemas/job.py`, `app/core/exceptions.py`
+
+  Prevents lost updates when multiple users edit the same entity concurrently.
+
+  ### How It Works
+
+  1. Client reads entity, receives `version: N` in the response
+  2. Client sends update with `version: N` (required field on Update schema)
+  3. Service checks if the DB version matches the submitted version
+  4. If mismatch: raises ConflictError with current entity state
+  5. If match: proceeds with update, version auto-increments
+
+  ### Schema: version is required on Update
+
+  ```python
+  class JobUpdate(BaseModel):
+      """PATCH semantics -- all fields optional except version."""
+      display_id: int | None = None
+      amount: float | None = None
+      notes: str | None = None
+      version: int  # Required -- forces optimistic concurrency
+  ```
+
+  ### Service: explicit version check
+
+  ```python
+  class JobService:
+      def __init__(self, db: AsyncSession) -> None:
+          self.db = db
+          self.repo = JobRepository(db)
+
+      async def check_version(self, job: Job, version: int) -> None:
+          """Check optimistic concurrency version."""
+          if job.version != version:
+              raise ConflictError(
+                  "Conflict: entity was modified by another user",
+                  current_version=job.version,
+                  current_entity=JobRead.model_validate(job).model_dump(mode="json"),
+              )
+  ```
+
+  ### ConflictError: carries current state for frontend
+
+  ```python
+  class ConflictError(DocketIQException):
+      """409 -- carries current_version and current_entity for the ConflictDialog."""
+      def __init__(
+          self,
+          message: str = "Conflict: entity was modified by another user",
+          *,
+          current_version: int | None = None,
+          current_entity: dict | None = None,
+      ) -> None:
+          super().__init__(message)
+          self.current_version = current_version
+          self.current_entity = current_entity
+  ```
+
+  ### Repository: catches SQLAlchemy StaleDataError
+
+  ```python
+  async def update(self, obj: ModelT, data: dict[str, Any]) -> ModelT:
+      for key, value in data.items():
+          setattr(obj, key, value)
+      try:
+          await self.session.flush()
+      except orm_exc.StaleDataError as exc:
+          raise ConflictError(
+              "Conflict: entity was modified by another user",
+          ) from exc
+      await self.session.refresh(obj)
+      return obj
+  ```
+
+  ### Model: version column with server-side increment
+
+  ```python
+  class Job(TimestampMixin, Base):
+      __tablename__ = "job"
+      # ...
+      version: Mapped[int] = mapped_column(default=1, nullable=False)
+  ```
+
+  ### Full Flow
+
+  ```
+  Client: GET /jobs/123 -> { version: 3, ... }
+  Client: PATCH /jobs/123 { notes: "updated", version: 3 }
+
+  Service:
+    job = await repo.get_or_raise(job_id)       # version is 3
+    await self.check_version(job, data.version)  # 3 == 3, OK
+    await repo.update(job, data_dict)            # version -> 4
+
+  If another user updated first (version is now 4):
+    await self.check_version(job, data.version)  # 4 != 3, CONFLICT
+    -> ConflictError(current_version=4, current_entity={...})
+    -> 409 response with current entity state
+    -> Frontend shows ConflictDialog
+  ```
+
+usage_notes: |
+  - Every mutable entity MUST have a `version: int` column
+  - Update schemas MUST require `version: int` (not optional)
+  - Service calls `check_version()` BEFORE applying the update
+  - ConflictError carries current_version + current_entity for the frontend ConflictDialog
+  - BaseRepository.update() also catches SQLAlchemy StaleDataError as a safety net
+  - Frontend must store and send back the version from the last read

--- a/mcp-server/patterns/pagination-response.yaml
+++ b/mcp-server/patterns/pagination-response.yaml
@@ -1,0 +1,89 @@
+name: pagination-response
+category: backend
+description: "PaginatedResponse[T] generic schema with total, page, page_size, and pages fields"
+tags: ["pagination", "schema", "pydantic", "generic", "api"]
+created: "2026-04-01"
+content: |
+  ## Pagination Response Pattern
+
+  Source: `app/schemas/common.py`
+
+  Uses Python 3.12 generic syntax for a reusable paginated response wrapper.
+
+  ### PaginatedResponse Schema
+
+  ```python
+  from pydantic import BaseModel
+
+  class PaginatedResponse[T](BaseModel):
+      """Paginated list response."""
+      items: list[T]
+      total: int
+      page: int
+      page_size: int
+      pages: int
+  ```
+
+  ### Companion Schemas
+
+  ```python
+  class ErrorResponse(BaseModel):
+      """Standard error response."""
+      detail: str
+      code: str | None = None
+
+  class MessageResponse(BaseModel):
+      """Simple message response."""
+      message: str
+  ```
+
+  ### Repository Pattern (returns tuple)
+
+  The BaseRepository `get_multi()` returns `tuple[list[ModelT], int]` (items + total_count).
+  The router constructs the PaginatedResponse:
+
+  ```python
+  @router.get("", response_model=PaginatedResponse[JobRead])
+  async def list_jobs(
+      page: int = Query(1, ge=1),
+      page_size: int = Query(50, ge=1, le=100),
+      db: DBSession,
+      user: CurrentUser,
+  ):
+      service = JobService(db)
+      offset = (page - 1) * page_size
+      items, total = await service.repo.get_multi(offset=offset, limit=page_size)
+      return PaginatedResponse(
+          items=[JobRead.model_validate(j) for j in items],
+          total=total,
+          page=page,
+          page_size=page_size,
+          pages=(total + page_size - 1) // page_size,
+      )
+  ```
+
+  ### BaseRepository.get_multi() Signature
+
+  ```python
+  async def get_multi(
+      self,
+      *,
+      offset: int = 0,
+      limit: int = 50,
+      order_by: str | None = None,
+      descending: bool = False,
+      filters: dict[str, Any] | None = None,
+      options: list | None = None,
+  ) -> tuple[list[ModelT], int]:
+      """Return (items, total_count) with pagination and optional filters."""
+  ```
+
+  Default ordering is `created_at DESC` if no `order_by` is specified and the model has a `created_at` column.
+
+usage_notes: |
+  - Always use `PaginatedResponse[SpecificReadSchema]` as the response_model
+  - Calculate `pages` as `ceil(total / page_size)`
+  - Default page_size is 50, max is 100
+  - Repository returns raw (items, total) tuple; router wraps in PaginatedResponse
+  - The `pages` field is computed in the router, not in the schema
+  - Use Query params for `page` (1-indexed) and `page_size` with validation bounds

--- a/mcp-server/patterns/react-query-hook.yaml
+++ b/mcp-server/patterns/react-query-hook.yaml
@@ -1,0 +1,93 @@
+name: react-query-hook
+category: frontend
+description: "TanStack React Query hook pattern — useQuery for reads, useMutation for writes, cache invalidation"
+tags: ["react-query", "tanstack", "hooks", "data-fetching", "cache"]
+created: "2026-04-01"
+content: |
+  ## React Query Hook Pattern
+
+  All data fetching hooks follow this standard pattern using TanStack React Query.
+  Each entity gets its own hook file in `frontend/src/hooks/`.
+
+  ### Single Entity Query
+
+  ```typescript
+  import { useQuery } from "@tanstack/react-query";
+  import { fetchJob, type JobRead } from "@/api/jobs";
+  import { QUERY_STALE_TIMES } from "@/lib/constants";
+
+  export function useJob(jobId: string | null) {
+    return useQuery<JobRead>({
+      queryKey: ["job", jobId],
+      queryFn: () => fetchJob(jobId!),
+      enabled: !!jobId,                      // conditional — only fetch when ID exists
+      staleTime: QUERY_STALE_TIMES.SHORT,    // use constants, not magic numbers
+    });
+  }
+  ```
+
+  ### Create Mutation
+
+  ```typescript
+  import { useMutation, useQueryClient } from "@tanstack/react-query";
+  import { createJob, type JobCreate } from "@/api/jobs";
+
+  export function useCreateJob() {
+    const queryClient = useQueryClient();
+    return useMutation({
+      mutationFn: (data: JobCreate) => createJob(data),
+      onSuccess: () => {
+        queryClient.invalidateQueries({ queryKey: ["jobs"] });  // invalidate list
+      },
+    });
+  }
+  ```
+
+  ### Update Mutation
+
+  ```typescript
+  export function useUpdateJob() {
+    const queryClient = useQueryClient();
+    return useMutation({
+      mutationFn: ({ jobId, data }: { jobId: string; data: JobUpdate }) =>
+        updateJob(jobId, data),
+      onSuccess: (updated) => {
+        queryClient.invalidateQueries({ queryKey: ["jobs"] });          // list
+        queryClient.invalidateQueries({ queryKey: ["job", updated.id] }); // detail
+      },
+    });
+  }
+  ```
+
+  ### Key Conventions
+
+  | Convention | Rule |
+  |-----------|------|
+  | Query keys | `["entity"]` for lists, `["entity", id]` for detail |
+  | Conditional queries | `enabled: !!param` — prevents fetching with null/undefined |
+  | Stale times | Use `QUERY_STALE_TIMES` constants (SHORT, MEDIUM, LONG) |
+  | Cache invalidation | Invalidate both list and detail keys on mutation success |
+  | API layer | Import types and functions from `@/api/*` — hooks don't call fetch directly |
+  | Mutation input | Single object param with destructured fields for multi-arg mutations |
+
+  ### File Organization
+
+  ```
+  frontend/src/
+    hooks/
+      useJob.ts          # single job + create/update mutations
+      useJobs.ts         # job list queries (with filters)
+      useCustomers.ts    # customer queries + mutations
+      useSchedule.ts     # schedule queries + mutations
+      ...
+    api/
+      jobs.ts            # fetchJob, fetchJobs, createJob, updateJob
+      customers.ts       # API layer with typed request/response
+  ```
+
+usage_notes: |
+  - Always read the existing hook file before reusing — check prop types (COMPONENT_API pattern)
+  - Use `enabled` for conditional queries — never fetch with null IDs
+  - Invalidate all affected query keys on mutation success
+  - Keep API calls in @/api/* layer — hooks compose them with React Query
+  - Types (JobRead, JobCreate, JobUpdate) come from the API layer, not defined in hooks

--- a/mcp-server/patterns/schema-trio.yaml
+++ b/mcp-server/patterns/schema-trio.yaml
@@ -1,0 +1,105 @@
+name: schema-trio
+category: backend
+description: "Create/Update/Read Pydantic schema convention with version field for optimistic concurrency"
+tags: ["pydantic", "schema", "crud", "optimistic-concurrency"]
+created: "2026-04-01"
+content: |
+  ## Schema Trio Pattern (Create / Update / Read)
+
+  Source: `app/schemas/job.py`
+
+  Every entity gets three Pydantic schemas following strict conventions.
+
+  ### JobCreate -- what the client sends to create
+
+  ```python
+  class JobCreate(BaseModel):
+      """Schema for creating a job."""
+      customer_id: uuid.UUID
+      service_address_id: uuid.UUID | None = None
+      status: str = "NEW"
+      amount: float | None = None
+      notes: str | None = None
+      priority: int = 0
+      display_id: int | None = None
+      warning_overrides: list[WarningOverride] | None = None
+  ```
+
+  Rules:
+  - No `id` field (server generates it)
+  - No `created_at` / `updated_at` (server manages timestamps)
+  - No `version` field (starts at 1 on creation)
+  - Sensible defaults for optional fields (`status = "NEW"`, `priority = 0`)
+  - May include `warning_overrides` for the warning system
+
+  ### JobUpdate -- PATCH semantics with required version
+
+  ```python
+  class JobUpdate(BaseModel):
+      """Schema for updating a job (PATCH semantics)."""
+      display_id: int | None = None
+      service_address_id: uuid.UUID | None = None
+      amount: float | None = None
+      notes: str | None = None
+      priority: int | None = None
+      is_finalized: bool | None = None
+      version: int  # Required for optimistic concurrency
+      warning_overrides: list[WarningOverride] | None = None
+  ```
+
+  Rules:
+  - All mutable fields are `Optional` (PATCH semantics -- only send what changes)
+  - `version: int` is **required** (not optional) -- forces optimistic concurrency
+  - Immutable fields excluded (`customer_id`, `created_by`)
+  - Use `model_dump(exclude_unset=True)` to get only the fields the client sent
+  - `warning_overrides` allows the client to override validation warnings
+
+  ### JobRead -- full representation for API responses
+
+  ```python
+  class JobRead(BaseModel):
+      """Schema for reading a job."""
+      model_config = {"from_attributes": True}
+
+      id: uuid.UUID
+      display_id: int | None = None
+      customer_id: uuid.UUID
+      service_address_id: uuid.UUID | None = None
+      status: str
+      amount: float | None = None
+      notes: str | None = None
+      priority: int
+      is_finalized: bool
+      version: int
+      created_by: uuid.UUID
+      customer: CustomerSummary | None = None
+      service_address: AddressSummary | None = None
+      creator: UserSummary | None = None
+      created_at: datetime
+      updated_at: datetime
+  ```
+
+  Rules:
+  - `model_config = {"from_attributes": True}` enables ORM model -> Pydantic conversion
+  - Includes all DB fields plus `version` for the client to track
+  - Nested relationships use slim Summary schemas (not full Read schemas)
+  - `created_at` and `updated_at` included for display
+
+  ### WarningOverride Schema
+
+  ```python
+  class WarningOverride(BaseModel):
+      """Override for a single warning type, provided by the client."""
+      warning_type: str
+      reason: str = Field(..., min_length=5)
+  ```
+
+  Used in both Create and Update schemas when the write path has validation warnings.
+
+usage_notes: |
+  - Every entity needs all three: Create, Update, Read
+  - Update schema MUST include `version: int` (not optional) for optimistic concurrency
+  - Use `model_dump(exclude_unset=True)` on Update to get only changed fields
+  - Read schema MUST have `model_config = {"from_attributes": True}`
+  - Nested reads use slim Summary schemas to avoid circular imports and N+1 queries
+  - Immutable fields (customer_id, created_by) appear in Create and Read, NOT in Update

--- a/mcp-server/patterns/websocket-singleton.yaml
+++ b/mcp-server/patterns/websocket-singleton.yaml
@@ -1,0 +1,124 @@
+name: websocket-singleton
+category: frontend
+description: "Plain TS singleton for WebSocket connections — never use React hooks for WS lifecycle"
+tags: ["websocket", "react", "singleton", "useSyncExternalStore"]
+created: "2026-04-01"
+content: |
+  ## WebSocket Singleton Pattern
+
+  WebSocket connections MUST be managed as a plain TypeScript singleton class, NOT inside
+  React useEffect hooks. React hooks are tied to component lifecycle — re-renders, StrictMode
+  double-mounting, and dependency changes tear down and recreate the connection.
+
+  ### Architecture
+
+  ```
+  WebSocketManager (plain TS singleton — lives outside React)
+    ├── connect(token) / disconnect()
+    ├── send(type, payload, requestId?)
+    ├── onMessage callbacks
+    ├── reconnect with exponential backoff
+    ├── ping/pong keepalive (30s interval)
+    ├── offline queue (replayed on reconnect)
+    └── state replay (presence view, subscriptions)
+
+  useWebSocket (thin React hook)
+    └── useSyncExternalStore(manager.subscribe, manager.getSnapshot)
+  ```
+
+  ### Singleton Class (lib/websocket.ts)
+
+  ```typescript
+  interface WsSnapshot {
+    isConnected: boolean;
+    lastMessage: WsMessage | null;
+  }
+
+  class WebSocketManager {
+    private ws: WebSocket | null = null;
+    private token: string | null = null;
+    private intentionalClose = false;
+    private listeners = new Set<() => void>();
+    private _snapshot: WsSnapshot = { isConnected: false, lastMessage: null };
+    private offlineQueue: QueuedMessage[] = [];
+
+    connect(token: string): void {
+      if (this.ws && this.token === token) return;
+      this.token = token;
+      this.intentionalClose = false;
+      this.doConnect();
+    }
+
+    disconnect(): void {
+      this.intentionalClose = true;
+      this.token = null;
+      if (this.ws) { this.ws.onclose = null; this.ws.close(); this.ws = null; }
+      this._snapshot = { isConnected: false, lastMessage: null };
+      this.notify();
+    }
+
+    send(type: string, payload: Record<string, unknown>, requestId?: string): void {
+      if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+        this.offlineQueue.push({ type, payload, requestId });
+        return;
+      }
+      this.ws.send(JSON.stringify({ type, payload, ...(requestId && { request_id: requestId }) }));
+    }
+
+    // useSyncExternalStore interface
+    subscribe = (listener: () => void) => {
+      this.listeners.add(listener);
+      return () => this.listeners.delete(listener);
+    };
+    getSnapshot = (): WsSnapshot => this._snapshot;
+  }
+
+  export const wsManager = new WebSocketManager();
+  ```
+
+  ### React Hook (hooks/useWebSocket.ts)
+
+  ```typescript
+  import { useCallback, useSyncExternalStore } from "react";
+  import { wsManager } from "@/lib/websocket";
+
+  export function useWebSocket() {
+    const snapshot = useSyncExternalStore(wsManager.subscribe, wsManager.getSnapshot);
+    const sendMessage = useCallback(
+      (type: string, payload: Record<string, unknown>, requestId?: string) => {
+        wsManager.send(type, payload, requestId);
+      }, [],
+    );
+    return { sendMessage, lastMessage: snapshot.lastMessage, isConnected: snapshot.isConnected };
+  }
+  ```
+
+  ### Connection Lifecycle (AuthContext)
+
+  Connection is controlled ONLY by AuthContext — never by individual components:
+
+  ```typescript
+  // On login
+  const token = getAccessToken();
+  if (token) wsManager.connect(token);
+
+  // On logout
+  wsManager.disconnect();
+
+  // On silent refresh (mount)
+  const token = getAccessToken();
+  if (token) wsManager.connect(token);
+  ```
+
+  ### Reconnect Strategy
+
+  - Exponential backoff: 1s, 2s, 4s, 8s, 16s, 30s (max 6 attempts)
+  - On reconnect: replay last presence view + subscription, drain offline queue
+  - Intentional close (logout) skips reconnect entirely
+
+usage_notes: |
+  - NEVER create WebSocket inside useEffect — use singleton class
+  - NEVER close/reopen WS from component lifecycle
+  - Connection is tied to auth state, not component mount/unmount
+  - Discovered during DocketIQ Phase 4 — initial useEffect approach caused StrictMode double-mount issues
+  - setTimeout workarounds are hacks — refactor to singleton instead

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -35,6 +35,7 @@ from tools.vault_search import vault_search
 from tools.vault_dashboard import vault_dashboard
 from tools.agent_metrics import agent_metrics
 from tools.failure_patterns import failure_patterns
+from tools.patterns import get_pattern, list_patterns, create_pattern
 
 
 TOOLS = {
@@ -88,6 +89,43 @@ TOOLS = {
             "properties": {
                 "project": {"type": "string", "description": "Optional project path"},
             },
+        },
+    },
+    "get_pattern": {
+        "fn": get_pattern,
+        "description": "Get a reusable code pattern by name. Returns code templates, conventions, and usage notes. Use list_patterns() first to discover available patterns.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string", "description": "Pattern name (e.g., 'fastapi-module', 'websocket-singleton')"},
+            },
+            "required": ["name"],
+        },
+    },
+    "list_patterns": {
+        "fn": list_patterns,
+        "description": "List available code patterns with names and descriptions. Optionally filter by category (backend, frontend, workflow, convention).",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "category": {"type": "string", "description": "Filter by category: 'backend', 'frontend', 'workflow', 'convention'"},
+            },
+        },
+    },
+    "create_pattern": {
+        "fn": create_pattern,
+        "description": "Create a new reusable code pattern. Stores as YAML in the patterns directory for future use by any agent.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string", "description": "Pattern name in kebab-case (e.g., 'my-custom-pattern')"},
+                "category": {"type": "string", "description": "Category: 'backend', 'frontend', 'workflow', 'convention'"},
+                "description": {"type": "string", "description": "One-line description of the pattern"},
+                "content": {"type": "string", "description": "The pattern content (code templates, conventions, rules)"},
+                "tags": {"type": "string", "description": "Comma-separated tags (e.g., 'fastapi,crud,async')"},
+                "usage_notes": {"type": "string", "description": "When and how to use this pattern"},
+            },
+            "required": ["name", "category", "description", "content"],
         },
     },
 }

--- a/mcp-server/tools/patterns.py
+++ b/mcp-server/tools/patterns.py
@@ -1,0 +1,214 @@
+"""MCP tools for managing reusable code patterns.
+
+Patterns are stored as YAML files in mcp-server/patterns/.
+Agents query patterns on-demand instead of loading large files into context.
+"""
+from __future__ import annotations
+
+import re
+from datetime import datetime
+from pathlib import Path
+
+try:
+    import yaml
+    HAS_YAML = True
+except ImportError:
+    HAS_YAML = False
+
+PATTERNS_DIR = Path(__file__).parent.parent / "patterns"
+
+
+def _load_pattern(path: Path) -> dict:
+    """Load a single pattern YAML file."""
+    if HAS_YAML:
+        with open(path) as f:
+            return yaml.safe_load(f)
+    else:
+        # Fallback: simple YAML parsing for flat structures
+        return _parse_yaml_simple(path.read_text())
+
+
+def _parse_yaml_simple(text: str) -> dict:
+    """Minimal YAML parser for pattern files (no external deps)."""
+    result = {}
+    current_key = None
+    current_value_lines = []
+    in_multiline = False
+
+    for line in text.split("\n"):
+        # Skip comments and empty lines at top level
+        if line.startswith("#") or (not line.strip() and not in_multiline):
+            continue
+
+        # Key: value on one line
+        if not in_multiline and re.match(r"^[a-z_]+:", line):
+            # Save previous multiline value
+            if current_key and current_value_lines:
+                result[current_key] = "\n".join(current_value_lines).strip()
+                current_value_lines = []
+
+            key, _, value = line.partition(":")
+            key = key.strip()
+            value = value.strip()
+
+            if value == "|":
+                current_key = key
+                in_multiline = True
+                current_value_lines = []
+            elif value.startswith("[") and value.endswith("]"):
+                # Inline list
+                items = [i.strip().strip("'\"") for i in value[1:-1].split(",") if i.strip()]
+                result[key] = items
+                current_key = None
+            elif value:
+                result[key] = value.strip("'\"")
+                current_key = None
+            else:
+                result[key] = ""
+                current_key = None
+        elif in_multiline:
+            if line and not line[0].isspace() and re.match(r"^[a-z_]+:", line):
+                # New key — end multiline
+                result[current_key] = "\n".join(current_value_lines).strip()
+                current_value_lines = []
+                in_multiline = False
+                # Re-process this line
+                key, _, value = line.partition(":")
+                result[key.strip()] = value.strip().strip("'\"")
+                current_key = None
+            else:
+                current_value_lines.append(line)
+
+    # Final multiline value
+    if current_key and current_value_lines:
+        result[current_key] = "\n".join(current_value_lines).strip()
+
+    return result
+
+
+def get_pattern(name: str) -> dict:
+    """Get a single pattern by name.
+
+    Args:
+        name: Pattern name (e.g., 'fastapi-module', 'websocket-singleton')
+
+    Returns:
+        Dict with pattern data: name, category, description, tags, content, usage_notes
+    """
+    pattern_file = PATTERNS_DIR / f"{name}.yaml"
+    if not pattern_file.exists():
+        # Try partial match
+        matches = list(PATTERNS_DIR.glob(f"*{name}*.yaml"))
+        if len(matches) == 1:
+            pattern_file = matches[0]
+        elif len(matches) > 1:
+            return {
+                "error": f"Ambiguous pattern name '{name}'. Matches: {[m.stem for m in matches]}",
+                "suggestion": "Use list_patterns() to see all available patterns",
+            }
+        else:
+            return {
+                "error": f"Pattern '{name}' not found",
+                "available": [p.stem for p in sorted(PATTERNS_DIR.glob("*.yaml"))],
+            }
+
+    data = _load_pattern(pattern_file)
+    data["_source"] = str(pattern_file)
+    return data
+
+
+def list_patterns(category: str = "") -> dict:
+    """List available patterns with names and descriptions.
+
+    Args:
+        category: Optional filter (e.g., 'backend', 'frontend', 'workflow')
+
+    Returns:
+        Dict with patterns list and categories summary
+    """
+    patterns = []
+    categories = set()
+
+    for path in sorted(PATTERNS_DIR.glob("*.yaml")):
+        data = _load_pattern(path)
+        cat = data.get("category", "uncategorized")
+        categories.add(cat)
+
+        if category and cat != category:
+            continue
+
+        patterns.append({
+            "name": data.get("name", path.stem),
+            "category": cat,
+            "description": data.get("description", ""),
+            "tags": data.get("tags", []),
+        })
+
+    return {
+        "total": len(patterns),
+        "filter": category or "all",
+        "categories": sorted(categories),
+        "patterns": patterns,
+    }
+
+
+def create_pattern(
+    name: str,
+    category: str,
+    description: str,
+    content: str,
+    tags: str = "",
+    usage_notes: str = "",
+) -> dict:
+    """Create a new pattern YAML file.
+
+    Args:
+        name: Pattern name (kebab-case, e.g., 'my-custom-pattern')
+        category: Category ('backend', 'frontend', 'workflow', 'convention')
+        description: One-line description
+        content: The pattern content (code templates, conventions, rules)
+        tags: Comma-separated tags (e.g., 'fastapi,crud,async')
+        usage_notes: When and how to use this pattern
+
+    Returns:
+        Dict with created file path and pattern summary
+    """
+    # Sanitize name
+    safe_name = re.sub(r"[^a-z0-9-]", "-", name.lower()).strip("-")
+    if not safe_name:
+        return {"error": "Invalid pattern name"}
+
+    pattern_file = PATTERNS_DIR / f"{safe_name}.yaml"
+    if pattern_file.exists():
+        return {"error": f"Pattern '{safe_name}' already exists. Use a different name."}
+
+    tag_list = [t.strip() for t in tags.split(",") if t.strip()] if tags else []
+
+    PATTERNS_DIR.mkdir(parents=True, exist_ok=True)
+
+    # Build YAML content manually (no yaml dependency needed for writing)
+    yaml_content = f"""name: {safe_name}
+category: {category}
+description: "{description}"
+tags: [{', '.join(f'"{t}"' for t in tag_list)}]
+created: "{datetime.now().strftime('%Y-%m-%d')}"
+content: |
+"""
+    # Indent content for YAML block scalar
+    for line in content.split("\n"):
+        yaml_content += f"  {line}\n"
+
+    if usage_notes:
+        yaml_content += "usage_notes: |\n"
+        for line in usage_notes.split("\n"):
+            yaml_content += f"  {line}\n"
+
+    pattern_file.write_text(yaml_content)
+
+    return {
+        "created": str(pattern_file),
+        "name": safe_name,
+        "category": category,
+        "description": description,
+        "tags": tag_list,
+    }


### PR DESCRIPTION
## Summary

Adds pattern management tools to the existing MCP server. Patterns are stored as YAML files and served on-demand — only the requested pattern enters the context window, saving hundreds of lines of context vs loading full markdown files.

### New MCP Tools

| Tool | Description |
|------|-------------|
| `get_pattern(name)` | Returns a single pattern with code templates, conventions, usage notes |
| `list_patterns(category?)` | Lists all patterns with descriptions, filterable by category |
| `create_pattern(name, category, description, content)` | Creates a new pattern YAML file for future use |

### 18 Patterns (extracted from actual DocketIQ source + agent configs)

**Backend (10):** fastapi-module, base-repository, domain-exceptions, jwt-auth, annotated-deps, pagination-response, schema-trio, optimistic-concurrency, nested-read-schemas, alembic-migration

**Frontend (3):** websocket-singleton, react-query-hook, auth-context

**Workflow (5):** implementation-routing, codex-delegation, core-failure-patterns, git-workflow, behavioral-evals

## Test plan
- [x] `list_patterns()` returns all 18 patterns with correct categories
- [x] `list_patterns(category="frontend")` filters correctly (3 results)
- [x] `get_pattern("fastapi-module")` returns full content with code templates
- [x] `create_pattern(...)` writes valid YAML and returns confirmation
- [x] Partial name matching works (e.g., "fastapi" matches "fastapi-module")
- [x] Error messages for unknown patterns include available names

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)