### PR TITLE
chore: register MCP servers via claude mcp add in installer

### DIFF
--- a/claude-config/install.sh
+++ b/claude-config/install.sh
@@ -250,6 +250,82 @@ fi
 
 echo ""
 
+# ─── Phase 2.6: MCP Servers ────────────────────────────────────────────────
+#
+# Claude Code reads MCP servers from ~/.claude.json (NOT ~/.claude/settings.json).
+# The `claude mcp add --scope user` command registers them in the right place.
+# Each server is registered idempotently — existing entries are overwritten.
+
+echo "Phase 2.6: MCP Servers (user-level, ~/.claude.json)"
+
+MCP_SERVERS_REGISTERED=0
+MCP_SERVERS_TOTAL=0
+
+if command -v claude &>/dev/null; then
+    EXISTING_MCP=$(claude mcp list 2>/dev/null || true)
+
+    register_mcp() {
+        # register_mcp <name> <command> [args...]
+        local name="$1"
+        shift
+        MCP_SERVERS_TOTAL=$((MCP_SERVERS_TOTAL + 1))
+
+        if echo "$EXISTING_MCP" | grep -q "^${name}:.*Connected"; then
+            echo "  ✓ $name (already connected)"
+            MCP_SERVERS_REGISTERED=$((MCP_SERVERS_REGISTERED + 1))
+        else
+            if claude mcp add --scope user "$name" -- "$@" 2>/dev/null; then
+                echo "  ✓ $name registered"
+                MCP_SERVERS_REGISTERED=$((MCP_SERVERS_REGISTERED + 1))
+            else
+                echo "  ✗ Failed to register $name"
+            fi
+        fi
+    }
+
+    # --- knowledge-mcp (TypeScript, requires node_modules) ---
+    KNOWLEDGE_MCP_DIR="$REPO_DIR/knowledge-mcp"
+    if [ -f "$KNOWLEDGE_MCP_DIR/index.ts" ]; then
+        # Ensure dependencies are installed
+        if [ ! -d "$KNOWLEDGE_MCP_DIR/node_modules" ]; then
+            echo "  Installing knowledge-mcp dependencies..."
+            (cd "$KNOWLEDGE_MCP_DIR" && npm install --silent 2>/dev/null) || true
+        fi
+        TSX_BIN="$KNOWLEDGE_MCP_DIR/node_modules/.bin/tsx"
+        if [ -x "$TSX_BIN" ]; then
+            register_mcp knowledge "$TSX_BIN" "$KNOWLEDGE_MCP_DIR/index.ts"
+        else
+            echo "  ✗ knowledge: tsx not found (run: cd $KNOWLEDGE_MCP_DIR && npm install)"
+            MCP_SERVERS_TOTAL=$((MCP_SERVERS_TOTAL + 1))
+        fi
+    fi
+
+    # --- vault-metrics (Python, uses dedicated venv) ---
+    MCP_VENV_PYTHON="$REPO_DIR/mcp-server/.venv/bin/python"
+    MCP_SERVER_PY="$REPO_DIR/mcp-server/server.py"
+    if [ -x "$MCP_VENV_PYTHON" ] && [ -f "$MCP_SERVER_PY" ]; then
+        register_mcp vault-metrics "$MCP_VENV_PYTHON" "$MCP_SERVER_PY"
+    elif [ -f "$MCP_SERVER_PY" ]; then
+        echo "  ✗ vault-metrics: venv not found (created in Phase 2)"
+        MCP_SERVERS_TOTAL=$((MCP_SERVERS_TOTAL + 1))
+    fi
+
+    # --- context7 (npm package, no local install needed) ---
+    register_mcp context7 npx -y @upstash/context7-mcp@latest
+
+    # --- apple-mcp (macOS only — Apple Contacts, Notes, Calendar, etc.) ---
+    if [ "$PLATFORM" = "macos" ]; then
+        register_mcp apple-mcp npx -y apple-mcp@latest
+    else
+        echo "  - apple-mcp: skipped (macOS only, current platform: $PLATFORM_LABEL)"
+    fi
+else
+    echo "  ⚠ claude CLI not found — skipping MCP server registration"
+    echo "    Install Claude Code, then re-run this script."
+fi
+
+echo ""
+
 # ─── Phase 3: First-time Setup ──────────────────────────────────────────────
 
 echo "Phase 3: First-time setup"
@@ -415,10 +491,11 @@ echo ""
 # ─── Summary ─────────────────────────────────────────────────────────────────
 
 echo "=== Installation Summary ==="
-echo "  Platform:    $PLATFORM_LABEL"
-echo "  Symlinks:    ✓ $LINKS_TOTAL/$LINKS_TOTAL linked"
-echo "  MCP Server:  $MCP_STATUS"
-echo "  PyYAML:      $PYYAML_STATUS"
+echo "  Platform:     $PLATFORM_LABEL"
+echo "  Symlinks:     ✓ $LINKS_TOTAL/$LINKS_TOTAL linked"
+echo "  MCP Server:   $MCP_STATUS"
+echo "  MCP Servers:  $MCP_SERVERS_REGISTERED/$MCP_SERVERS_TOTAL registered in ~/.claude.json"
+echo "  PyYAML:       $PYYAML_STATUS"
 echo "  Codex Plugin: $CODEX_PLUGIN_STATUS"
 
 # Vault summary

--- a/claude-config/settings.json
+++ b/claude-config/settings.json
@@ -81,35 +81,5 @@
       }
     }
   },
-  "skipDangerousModePermissionPrompt": true,
-  "mcpServers": {
-    "vault-metrics": {
-      "command": "python3",
-      "args": [
-        "~/agents/mcp-server/server.py",
-        "--mcp"
-      ]
-    },
-    "apple-mcp": {
-      "command": "bunx",
-      "args": [
-        "--no-cache",
-        "apple-mcp@latest"
-      ]
-    },
-    "context7": {
-      "command": "npx",
-      "args": [
-        "-y",
-        "@upstash/context7-mcp@latest"
-      ]
-    },
-    "knowledge": {
-      "command": "bash",
-      "args": [
-        "-c",
-        "npx tsx \"$HOME/agents/knowledge-mcp/index.ts\""
-      ]
-    }
-  }
+  "skipDangerousModePermissionPrompt": true
 }

--- a/docs/CONFIG-BOOTSTRAP.md
+++ b/docs/CONFIG-BOOTSTRAP.md
@@ -74,6 +74,36 @@ git pull
 ~/agents/install-all.sh
 ```
 
+## MCP Server Registration
+
+Claude Code reads MCP servers from `~/.claude.json` (NOT `~/.claude/settings.json`).
+The installer registers them automatically via `claude mcp add --scope user`.
+
+**What the installer registers:**
+
+| Server | Command | Platform |
+|--------|---------|----------|
+| `knowledge` | `<repo>/knowledge-mcp/node_modules/.bin/tsx <repo>/knowledge-mcp/index.ts` | All |
+| `vault-metrics` | `<repo>/mcp-server/.venv/bin/python <repo>/mcp-server/server.py` | All |
+| `context7` | `npx -y @upstash/context7-mcp@latest` | All |
+| `apple-mcp` | `npx -y apple-mcp@latest` | macOS only |
+
+**Paths are absolute and platform-specific.** On Linux/WSL `<repo>` is `/home/<user>/agents`, on macOS it's `/Users/<user>/agents`. The installer resolves paths at install time — no manual editing needed.
+
+**Manual registration** (if the installer can't run `claude mcp add`):
+
+```bash
+# Linux / WSL
+claude mcp add --scope user knowledge -- ~/agents/knowledge-mcp/node_modules/.bin/tsx ~/agents/knowledge-mcp/index.ts
+claude mcp add --scope user vault-metrics -- ~/agents/mcp-server/.venv/bin/python ~/agents/mcp-server/server.py
+claude mcp add --scope user context7 -- npx -y @upstash/context7-mcp@latest
+
+# macOS (same as above, plus apple-mcp)
+claude mcp add --scope user apple-mcp -- npx -y apple-mcp@latest
+```
+
+**Verify:** `claude mcp list` should show all servers as `✓ Connected`.
+
 ## What Is Shared vs Local
 
 Shared in git:
@@ -82,6 +112,7 @@ Shared in git:
 - `install-all.sh`
 
 Local only (not shared):
+- `~/.claude.json` (MCP servers, session stats — generated per-machine by installer)
 - `~/.claude/history.jsonl`, `~/.claude/projects/`, `~/.claude/debug/`
 - `~/.codex/auth.json`, `~/.codex/history.jsonl`, `~/.codex/sessions/`, `~/.codex/tmp/`
 - `~/.codex/rules/default.rules`

--- a/knowledge/README.md
+++ b/knowledge/README.md
@@ -210,10 +210,10 @@ Claude calls these automatically — you don't invoke them manually.
 # 1. Pull latest repo
 cd ~/agents && git pull
 
-# 2. Run installer (sets up hooks, plugins, symlinks)
+# 2. Run installer (sets up hooks, plugins, symlinks, AND registers MCP servers)
 cd ~/agents/claude-config && ./install.sh
 
-# 3. Install knowledge-mcp dependencies
+# 3. Install knowledge-mcp dependencies (installer does this, but just in case)
 cd ~/agents/knowledge-mcp && npm install
 
 # 4. Build database from YAML
@@ -222,9 +222,16 @@ cd ~/agents/knowledge && python3 sync.py build
 # 5. Verify counts
 sqlite3 knowledge/knowledge.db "SELECT COUNT(*) FROM patterns;"  # Should be 23+
 
-# 6. Launch Claude Code — MCP server starts automatically
+# 6. Verify MCP server is registered
+claude mcp list  # knowledge should show ✓ Connected
+
+# 7. Launch Claude Code — MCP server starts automatically
 claude
 ```
+
+**Note:** MCP servers are registered in `~/.claude.json` (not `~/.claude/settings.json`).
+The installer handles this via `claude mcp add --scope user`. If you need to register
+manually, see `docs/CONFIG-BOOTSTRAP.md` for platform-specific commands.
 
 ## Validation
 


### PR DESCRIPTION
## Summary
- Add Phase 2.6 to `install.sh` that registers MCP servers in `~/.claude.json` via `claude mcp add --scope user` (the correct config location)
- Remove stale `mcpServers` block from `settings.json` (was silently ignored by Claude Code)
- apple-mcp only registered on macOS; knowledge, vault-metrics, context7 on all platforms
- Update CONFIG-BOOTSTRAP.md with MCP registration docs and manual commands per platform
- Update knowledge README with correct setup steps

## Test plan
- [ ] Run `./install.sh` on WSL — verify knowledge, vault-metrics, context7 registered
- [ ] Run `claude mcp list` — all 3 show `✓ Connected`
- [ ] Run `./install.sh` again — idempotent, shows "already connected"
- [ ] On macOS: verify apple-mcp also registered

🤖 Generated with [Claude Code](https://claude.com/claude-code)