### PR TITLE
chore: add prd-generator to project tracker

### DIFF
--- a/knowledge/projects/prd-generator.yaml
+++ b/knowledge/projects/prd-generator.yaml
@@ -1,0 +1,10 @@
+project: prd-generator
+status: paused
+focus: "PRD generator for product requirements"
+next_steps: []
+blockers: []
+open_questions: []
+specs: []
+dependencies: []
+updated_at: "2026-04-11"
+updated_by: "jason"


### PR DESCRIPTION
Adds prd-generator to knowledge/projects/ so it appears in /dashboard.