### PR TITLE
fix: update_project_context writes YAML back to preserve on rebuild

### DIFF
--- a/knowledge-mcp/index.ts
+++ b/knowledge-mcp/index.ts
@@ -430,6 +430,34 @@ const isMainModule =
   (process.argv[1].endsWith("index.ts") || process.argv[1].endsWith("index.js"));
 
 import { runAutomation } from "./automation.js";
+import YAML from "yaml";
+
+// Write project tracker YAML back to ~/agents/knowledge/projects/{project}.yaml
+// so SQLite updates persist through sync.py build rebuilds.
+function writeProjectYaml(db: Database.Database, project: string): void {
+  try {
+    const row = db.prepare("SELECT * FROM project_tracker WHERE project = @project").get({ project }) as any;
+    if (!row) return;
+
+    const data: Record<string, any> = {
+      project: row.project,
+      status: row.status,
+      focus: row.focus || null,
+      next_steps: row.next_steps ? JSON.parse(row.next_steps) : [],
+      blockers: row.blockers ? JSON.parse(row.blockers) : [],
+      open_questions: row.open_questions ? JSON.parse(row.open_questions) : [],
+      specs: row.specs ? JSON.parse(row.specs) : [],
+      dependencies: row.dependencies ? JSON.parse(row.dependencies) : [],
+      updated_at: (row.updated_at || "").split(" ")[0] || new Date().toISOString().slice(0, 10),
+      updated_by: row.updated_by || "jason",
+    };
+
+    const yamlPath = path.resolve(__dirname, "../knowledge/projects", `${project}.yaml`);
+    fs.writeFileSync(yamlPath, YAML.stringify(data), "utf8");
+  } catch (err) {
+    console.error(`writeProjectYaml(${project}):`, err);
+  }
+}
 
 // --- Project Tracker functions ---
 
@@ -520,6 +548,9 @@ export function updateProjectContext(
   }
 
   db.prepare(`UPDATE project_tracker SET ${sets.join(", ")} WHERE project = @project`).run(params);
+
+  // Persist to YAML so sync.py build doesn't overwrite this change
+  writeProjectYaml(db, project);
 
   return getProjectContext(db, project);
 }

--- a/knowledge-mcp/package-lock.json
+++ b/knowledge-mcp/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
         "better-sqlite3": "^11.9.1",
+        "yaml": "^2.8.3",
         "zod": "^3.24.4"
       },
       "devDependencies": {
@@ -2982,6 +2983,7 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -3184,6 +3186,22 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "license": "ISC",
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/zod": {
       "version": "3.25.76",

--- a/knowledge-mcp/package.json
+++ b/knowledge-mcp/package.json
@@ -9,12 +9,13 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.1",
     "better-sqlite3": "^11.9.1",
+    "yaml": "^2.8.3",
     "zod": "^3.24.4"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.13",
-    "typescript": "^5.8.3",
     "tsx": "^4.19.4",
+    "typescript": "^5.8.3",
     "vitest": "^3.1.1"
   }
 }

--- a/knowledge/projects/flotilla.yaml
+++ b/knowledge/projects/flotilla.yaml
@@ -1,22 +1,23 @@
 project: flotilla
 status: active
-focus: "Cross-environment platform — Phase 1 project tracker"
+focus: Phase 4 automation complete — auto-blockers, auto-status, auto-journal,
+  stale prompts live
 next_steps:
-  - "Build MCP tools for dashboard, project context, capture, inbox"
-  - "Create CLI skills (/dashboard, /project, /capture, /inbox)"
-  - "Flotilla integration — Context section in ProjectView"
+  - Test automation end-to-end across all projects
+  - Plan Phase 3 (multi-env + client engagement setup) when needed
+  - Monitor dashboard for drift over a week of real use
 blockers: []
 open_questions:
-  - "Should /weekly digest auto-post to Slack or just render in terminal?"
+  - Should /weekly digest auto-post to Slack or just render in terminal?
 specs:
-  - path: "specs/cross-env-platform.md"
-    version: "v2.0"
-    status: "final"
-    summary: "Two-layer platform architecture"
-  - path: "specs/add-project.md"
-    version: "v1.0"
-    status: "draft"
-    summary: "Add Project modal — Create New and Add Existing"
+  - path: specs/cross-env-platform.md
+    version: v2.0
+    status: final
+    summary: Two-layer platform architecture
+  - path: specs/add-project.md
+    version: v1.0
+    status: draft
+    summary: Add Project modal — Create New and Add Existing
 dependencies: []
-updated_at: "2026-04-18"
-updated_by: "jason"
+updated_at: 2026-04-18
+updated_by: jason


### PR DESCRIPTION
Without this, sync.py build would overwrite SQLite context updates. Now MCP writes YAML back as part of every update.