### PR TITLE
fix(install): warm npm cache so first session doesn't see Failed to connect (#77)

### DIFF
--- a/claude-config/install.sh
+++ b/claude-config/install.sh
@@ -340,6 +340,42 @@ if command -v claude &>/dev/null; then
     else
         echo "  - apple-mcp: skipped (macOS only, current platform: $PLATFORM_LABEL)"
     fi
+
+    # --- npm cache warm-up for npx-based MCP servers ---
+    #
+    # Cold `npx -y <pkg>@latest` resolves the dist-tag, downloads the tarball,
+    # then runs lifecycle scripts. On a cold npm cache this can take 5–30s and
+    # exceed Claude Code's MCP handshake timeout, so the first `claude mcp list`
+    # after install (or after `npm cache clean`) shows context7 / apple-mcp as
+    # "Failed to connect" even though they're correctly registered. Once the
+    # cache is warm the same servers start in ~1s. See issue #77.
+    #
+    # We pre-warm by running each server once with stdin closed; servers exit
+    # immediately on EOF without doing any real work. This is best-effort:
+    # network failures here do not break install (the registration already
+    # succeeded; the user can warm the cache later by re-running `claude mcp list`).
+    if command -v npx &>/dev/null; then
+        echo "  Warming npm cache for npx-based MCP servers (one-time, ~10s)..."
+        (npx -y @upstash/context7-mcp@latest </dev/null >/dev/null 2>&1) &
+        WARM_PID1=$!
+        if [ "$PLATFORM" = "macos" ]; then
+            (npx -y apple-mcp@latest </dev/null >/dev/null 2>&1) &
+            WARM_PID2=$!
+        fi
+        # Bound the wait — if a download is genuinely stuck, don't block install.
+        WAIT_DEADLINE=$(( $(date +%s) + 30 ))
+        for pid in $WARM_PID1 ${WARM_PID2:-}; do
+            while kill -0 "$pid" 2>/dev/null; do
+                if [ "$(date +%s)" -ge "$WAIT_DEADLINE" ]; then
+                    kill "$pid" 2>/dev/null || true
+                    break
+                fi
+                sleep 1
+            done
+            wait "$pid" 2>/dev/null || true
+        done
+        echo "  ✓ npm cache warmed"
+    fi
 else
     echo "  ⚠ claude CLI not found — skipping MCP server registration"
     echo "    Install Claude Code, then re-run this script."

--- a/claude-config/install.sh
+++ b/claude-config/install.sh
@@ -354,27 +354,40 @@ if command -v claude &>/dev/null; then
     # immediately on EOF without doing any real work. This is best-effort:
     # network failures here do not break install (the registration already
     # succeeded; the user can warm the cache later by re-running `claude mcp list`).
+    # Note: playwright is registered via the Claude plugin system (Phase 2.5),
+    # not Phase 2.6, so warming it isn't this script's job — the plugin owns
+    # its own lifecycle. This warm-up only covers the Phase 2.6 npx servers.
     if command -v npx &>/dev/null; then
         echo "  Warming npm cache for npx-based MCP servers (one-time, ~10s)..."
-        (npx -y @upstash/context7-mcp@latest </dev/null >/dev/null 2>&1) &
+        # Background npx directly (no subshell) so $! captures the npx PID,
+        # which lets the timeout-kill below actually target the download.
+        npx -y @upstash/context7-mcp@latest </dev/null >/dev/null 2>&1 &
         WARM_PID1=$!
+        WARM_PIDS="$WARM_PID1"
         if [ "$PLATFORM" = "macos" ]; then
-            (npx -y apple-mcp@latest </dev/null >/dev/null 2>&1) &
+            npx -y apple-mcp@latest </dev/null >/dev/null 2>&1 &
             WARM_PID2=$!
+            WARM_PIDS="$WARM_PIDS $WARM_PID2"
         fi
         # Bound the wait — if a download is genuinely stuck, don't block install.
         WAIT_DEADLINE=$(( $(date +%s) + 30 ))
-        for pid in $WARM_PID1 ${WARM_PID2:-}; do
+        WARM_TIMED_OUT=0
+        for pid in $WARM_PIDS; do
             while kill -0 "$pid" 2>/dev/null; do
                 if [ "$(date +%s)" -ge "$WAIT_DEADLINE" ]; then
                     kill "$pid" 2>/dev/null || true
+                    WARM_TIMED_OUT=1
                     break
                 fi
                 sleep 1
             done
             wait "$pid" 2>/dev/null || true
         done
-        echo "  ✓ npm cache warmed"
+        if [ "$WARM_TIMED_OUT" -eq 1 ]; then
+            echo "  ~ npm cache warm-up timed out (best-effort; first session may still see Failed to connect)"
+        else
+            echo "  ✓ npm cache warmed"
+        fi
     fi
 else
     echo "  ⚠ claude CLI not found — skipping MCP server registration"

--- a/docs/manual/integrations/mcp-servers.md
+++ b/docs/manual/integrations/mcp-servers.md
@@ -136,3 +136,4 @@ To add a new MCP server:
 | Server crashes at startup | Run the command manually to see error output |
 | `failure_patterns()` returns empty | Verify `.claude/memory/failures.jsonl` exists and has data |
 | context7 slow on first call | Normal -- `npx` downloads the package on first run |
+| `claude mcp list` shows context7 / apple-mcp / playwright "Failed to connect" right after install or `npm cache clean` | Cold-cache artifact: the first `npx -y <pkg>@latest` invocation downloads the package, which can exceed Claude Code's MCP handshake timeout. Re-run `claude mcp list` once the cache is warm, or run the install script (Phase 2.6 includes a warm-up step). To verify a server can start at all, run the registered command manually: `npx -y @upstash/context7-mcp@latest </dev/null` should print `... running on stdio` within ~1s once warm. See issue [#77](https://github.com/jwj2002/agents/issues/77). |


### PR DESCRIPTION
## What

Appends a best-effort `npm cache` warm-up to `install.sh` Phase 2.6 so that `npx`-based MCP servers (`context7`, `apple-mcp`) are pre-downloaded before the first Claude Code session connects. Adds a Troubleshooting row in the MCP docs so future debuggers can recognize the cold-cache pattern (e.g. after `npm cache clean`).

## Why

`claude mcp list` was reporting `context7`, `apple-mcp`, and `playwright` as **Failed to connect** while `knowledge` and `vault-metrics` worked fine. Diagnostics ruled out package failures, toolchain breakage, registry issues, and PATH stripping. Root cause: the first cold `npx -y <pkg>@latest` invocation downloads and extracts the tarball before the MCP server can emit handshake output, exceeding Claude Code's MCP timeout. On a warm cache the same servers start in ~1s.

Closes #77

## How

`install.sh` Phase 2.6 — after the four `claude mcp add` calls, run `npx -y <pkg>@latest </dev/null` for each `npx`-based server in parallel. Stdin-EOF makes the server exit immediately without doing real work, so we get the side-effect (npm cache warm) without paying for handshake. A 30s wall-clock deadline kills any stuck process — registration already happened, so killing the warm-up doesn't break anything; the worst case is the first session shows the same Failed-to-connect on a slow network.

`mcp-servers.md` Troubleshooting — adds a row pointing at the cold-cache pattern, with a manual verification command (`npx -y <pkg>@latest </dev/null` should print "running on stdio" within ~1s warm) so the bug is recognizable even after a cache eviction by external tools (CleanMyMac, etc).

## Stack

- [x] Backend (install/tooling)
- [ ] Frontend
- [ ] Database/migrations

## Contract Changes

N/A — no API or schema changes.

## Verification

- [x] `bash -n claude-config/install.sh` passes
- [x] Manual `npx -y @upstash/context7-mcp@latest </dev/null` and `apple-mcp@latest` and `@playwright/mcp@latest` each start in <1s on a warm cache
- [x] `claude mcp list` shows all 5 servers `✓ Connected`
- [x] `python3 -c "import json; json.load(open('claude-config/settings.json'))"` still parses (settings.json untouched)
- [x] No hardcoded credentials introduced (E15 catch-all)

## How to test

```bash
# Simulate cold cache and confirm warm-up makes session start clean
npm cache clean --force
~/agents/claude-config/install.sh   # should print "Warming npm cache for npx-based MCP servers..."
                                    # then "✓ npm cache warmed" or the timed-out advisory
claude mcp list                     # all 5 servers ✓ Connected
```

## Risks / Rollback

Low risk — config + docs only, no schema or runtime behavior change. The warm-up is best-effort: every fail-prone op is guarded with `|| true` / `&>/dev/null` / wall-clock kill, so install never fails because of warm-up. Rollback is a one-commit revert.

## Reviewer Notes

Pre-PR fresh-context review surfaced one WARNING that's been addressed in the second commit on this branch:
- `(npx ...) &` was capturing the subshell PID rather than npx's, so the timeout-kill could miss a still-running download after the subshell reaped. Fixed by backgrounding `npx` directly.

Two SUGGESTIONS also addressed: timeout-aware success echo (no more spurious "✓ npm cache warmed" when the deadline fired), and an explicit comment noting playwright is out of scope (registered by Phase 2.5 plugin system, lifecycle owned there).

E15 (SECRETS) check: clean. No tokens, keys, or credentials introduced.

---

Artifacts:
- `.agents/outputs/map-plan-77-042826.md`
- `.agents/outputs/patch-77-042826.md`
- `.agents/outputs/prove-77-042826.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)