### PR TITLE
fix(hooks): include all uncommitted files in verify_completion (#80)

### DIFF
--- a/claude-config/hooks/verify_completion.py
+++ b/claude-config/hooks/verify_completion.py
@@ -46,17 +46,10 @@ def check_uncommitted_changes() -> str | None:
     if not changed_files:
         return None
 
-    substantive = [
-        f for f in changed_files
-        if not f.endswith((".lock", ".yaml", ".yml", ".toml"))
-        or f.endswith("package.json")
-    ]
-
-    if substantive:
-        file_list = ", ".join(substantive[:5])
-        return f"Uncommitted changes: {file_list}"
-
-    return None
+    n = len(changed_files)
+    preview = ", ".join(changed_files[:5])
+    suffix = f", +{n - 5} more" if n > 5 else ""
+    return f"Uncommitted changes ({n} files): {preview}{suffix}"
 
 
 def check_todos_in_changes() -> str | None:


### PR DESCRIPTION
## What

Removes the substantive-file filter from `verify_completion.py` so every uncommitted file (including `*.yaml`, `*.yml`, `*.toml`, `*.lock`) counts toward the end-of-session warning. Drops the dead `or f.endswith("package.json")` clause and improves the display to show `count + first-5 + "+N more"`.

## Why

In this repo YAML is first-class state (`knowledge/patterns/`, `knowledge/projects/`, `knowledge/decisions/`). YAML-only sessions silently passed the Stop hook with no reminder. Mixed sessions still fired the warning but filtered YAML out of the displayed file list, masking the actual scope of dirty work.

The hook is advisory (`sys.exit(0)` always); over-warning is free, missed warnings on YAML work were the real cost.

Closes #80

## How

Single-function rewrite in `claude-config/hooks/verify_completion.py`. Net: -7 lines (-11/+4). Other functions (`check_todos_in_changes`, `main`, `log`, `run`) byte-identical.

## Stack
- [x] Backend (Python hook)

## Verification

- [x] `python3 -c "import ast; ast.parse(...)"` parses
- [x] Behavior smoke: editing a `.yaml` file now triggers warning (was silent before)
- [x] Display format: `Uncommitted changes (N files): a, b, c[, +K more]` confirmed for 1, 2, 7-file cases
- [x] Hook still exits 0 (advisory contract preserved)
- [x] No credentials introduced (E15)

## Reviewer Notes

Pre-PR fresh-context review: clean. One optional polish flagged (`"(1 files)"` pluralization) — matches the issue's accepted code spec verbatim, so shipping as-is. Trivial follow-up if it bothers anyone.

## Risks / Rollback

Trivial. Hook is advisory so even a logic regression doesn't block sessions. Rollback is single-commit revert.

---
Artifacts: `.agents/outputs/{map-plan,patch,prove}-80-042826.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)