### PR TITLE
feat(hooks): detect un-pushed commits and branch ahead of main (#83)

### DIFF
--- a/claude-config/hooks/verify_completion.py
+++ b/claude-config/hooks/verify_completion.py
@@ -10,6 +10,7 @@ as context for whether to continue the conversation.
 """
 
 import os
+import shlex
 import subprocess
 import sys
 from datetime import datetime
@@ -52,6 +53,37 @@ def check_uncommitted_changes() -> str | None:
     return f"Uncommitted changes ({n} files): {preview}{suffix}"
 
 
+def check_unpushed_commits() -> str | None:
+    """Check for commits not pushed to upstream."""
+    code, output = run("git log @{u}..HEAD --oneline 2>/dev/null")
+    if code != 0:
+        return None  # no upstream set; not applicable
+    if not output.strip():
+        return None
+    n = len(output.strip().split("\n"))
+    return f"{n} commit(s) not pushed to upstream"
+
+
+def check_branch_ahead_no_pr() -> str | None:
+    """Check for feature branch ahead of origin/main with no open PR."""
+    code, branch = run("git branch --show-current 2>/dev/null")
+    if code != 0 or not branch or branch in ("main", "master"):
+        return None
+    code, ahead = run("git log origin/main..HEAD --oneline 2>/dev/null")
+    if code != 0 or not ahead.strip():
+        return None
+    n = len(ahead.strip().split("\n"))
+    code, pr_state = run(
+        f"gh pr list --head {shlex.quote(branch)} --state open --json number 2>/dev/null",
+        timeout=3,
+    )
+    if code != 0:
+        return None  # gh unavailable / unauthed / timeout — skip silently
+    if pr_state.strip() not in ("", "[]"):
+        return None  # PR is open; not incomplete
+    return f"branch '{branch}' is {n} commit(s) ahead of origin/main with no open PR"
+
+
 def check_todos_in_changes() -> str | None:
     """Check for TODO/FIXME in recently changed files."""
     code, output = run("git diff HEAD 2>/dev/null")
@@ -80,6 +112,14 @@ def main() -> None:
     uncommitted = check_uncommitted_changes()
     if uncommitted:
         issues.append(uncommitted)
+
+    unpushed = check_unpushed_commits()
+    if unpushed:
+        issues.append(unpushed)
+
+    branch_no_pr = check_branch_ahead_no_pr()
+    if branch_no_pr:
+        issues.append(branch_no_pr)
 
     todos = check_todos_in_changes()
     if todos:


### PR DESCRIPTION
## What

Extends `verify_completion.py` (Stop hook) with two new advisory checks:

1. **`check_unpushed_commits`** — detects commits that exist locally but haven't been pushed to upstream (`git log @{u}..HEAD`).
2. **`check_branch_ahead_no_pr`** — detects feature branches with commits ahead of `origin/main` but no open PR (`git log origin/main..HEAD` + `gh pr list --head <branch>`).

Both checks fail open on every error path: no upstream, on main/master, detached HEAD, no commits ahead, `gh` unavailable / unauthed / network down → skip silently.

## Why

The orchestrate workflow's terminal state is "PR open and merging." The current Stop hook only catches the first stage of incomplete work (uncommitted changes). The middle stages — committed-but-not-pushed, pushed-but-no-PR — are equally common end-of-session states in this repo and currently slip past with no reminder.

Closes #83

## How

`main()` ordering reflects the natural completion progression:
```
uncommitted → unpushed → branch-ahead-no-PR → TODOs
```

`gh pr list` is bounded by a 3-second timeout (vs the default 10s) so a slow network doesn't stall session end. False-negative ("we couldn't determine PR state in 3s, skip") is preferred over a stalled Stop hook.

Hook still exits 0 in all cases. Both new checks are advisory — they print warnings to stdout but never block.

## Stack
- [x] Backend (Python hook)

## Verification

- [x] `python3 -c "import ast; ast.parse(...)"` parses
- [x] 8 manufactured-state behavior tests pass (un-pushed with upstream, no upstream, branch ahead with no PR, branch ahead with PR open, gh unavailable, on main, detached HEAD, all-clean)
- [x] AC #7 (gh unavailable → skip silently) verified: `if code != 0: return None` guard precedes the PR-open check
- [x] Existing functions (`check_uncommitted_changes`, `check_todos_in_changes`, `run`, `log`) byte-identical to main
- [x] No credentials introduced (E15)

## Implementation note

PATCH initially flagged a deviation: the as-specified gh-state check (`if code == 0 and ...`) would treat `gh` failure as "no PR" and falsely warn. Caught and fixed before PROVE; the merged code splits the check into two guards (skip-on-failure first, then suppress-on-PR-open).

## Reviewer Notes

Pre-PR fresh-context review: ship-it. One nit on garbage `gh` output (would be treated as "PR is open" and suppress the warning) flagged as acceptable fail-open behavior consistent with the hook's advisory nature.

## Risks / Rollback

Low. Hook is advisory so any logic regression is at most a noisy false-positive, never a session blocker. Rollback is single-commit revert.

---
Artifacts: `.agents/outputs/{map-plan,patch,prove}-83-042826.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)