### PR TITLE
feat(install): validate hook script paths in settings.json (#82)

### DIFF
--- a/claude-config/install.sh
+++ b/claude-config/install.sh
@@ -545,6 +545,23 @@ if [ $ERRORS -eq 0 ]; then
     echo "  ✓ All symlinks resolve"
 fi
 
+# ─── Phase 4.5: Hook script path validation ─────────────────────────────────
+# Walks settings.json and verifies every interpreted hook command points at
+# an existing script. Catches the PR #75→#76 class of bug (hook references
+# a script that didn't ship). Standalone validator; install.sh just delegates.
+
+HOOK_VALIDATOR="$SCRIPT_DIR/scripts/validate-hooks.py"
+if [ -f "$HOOK_VALIDATOR" ]; then
+    if SETTINGS_PATH="$SCRIPT_DIR/settings.json" python3 "$HOOK_VALIDATOR"; then
+        : # OK
+    else
+        echo "  ✗ Hook validation failed — fix the missing script paths above"
+        ERRORS=$((ERRORS + 1))
+    fi
+else
+    echo "  ⚠ Hook validator not found at $HOOK_VALIDATOR — skipping"
+fi
+
 # Verify MCP server (runs as script, not importable as package)
 MCP_PYTHON="$REPO_DIR/mcp-server/.venv/bin/python"
 if [ -f "$MCP_PYTHON" ] && \

--- a/claude-config/scripts/validate-hooks.py
+++ b/claude-config/scripts/validate-hooks.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""
+Validate that hook command paths in settings.json reference existing scripts.
+
+For each hook entry under `hooks.<Stage>[*].hooks[*].command`, parse the
+command string, identify the interpreted script (if any), and verify the
+file exists on disk. Heuristic is intentionally narrow:
+
+  - Skip commands containing `${CLAUDE_PLUGIN_ROOT}` (resolved at runtime by
+    the Claude Code plugin loader, not by this checker).
+  - Only inspect commands whose first token is a known interpreter
+    (`python3`, `python`, `bash`, `sh`, `node`, `npx`).
+  - Take the first argument after the interpreter ending in a known script
+    extension (`.py`, `.sh`, `.js`); ignore other tokens (data args, flags).
+
+Anything else (raw scripts on PATH, complex pipelines via `bash -c`, etc.)
+is intentionally not validated — false-positive risk outweighs the benefit.
+
+Usage:
+  validate-hooks.py                       # uses ../settings.json relative to script
+  SETTINGS_PATH=/path/to/settings.json validate-hooks.py
+  validate-hooks.py /path/to/settings.json   # positional arg also accepted
+
+Exit codes:
+  0  all checked hook script paths resolve (or no checkable hooks)
+  1  one or more script paths missing, or settings.json unreadable
+
+Run: python3 scripts/validate-hooks.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import sys
+from pathlib import Path
+
+KNOWN_INTERPRETERS = {"python3", "python", "bash", "sh", "node", "npx"}
+SCRIPT_EXTS = (".py", ".sh", ".js")
+HOOK_STAGES = (
+    "PreCompact",
+    "SessionStart",
+    "Stop",
+    "PostToolUse",
+    "PreToolUse",
+    "UserPromptSubmit",
+    "Notification",
+    "SubagentStop",
+)
+
+
+def _resolve_settings_path() -> Path:
+    """Resolve settings.json path: argv[1] > $SETTINGS_PATH > ../settings.json."""
+    if len(sys.argv) > 1 and sys.argv[1]:
+        return Path(sys.argv[1]).expanduser()
+    env = os.environ.get("SETTINGS_PATH")
+    if env:
+        return Path(env).expanduser()
+    return Path(__file__).resolve().parent.parent / "settings.json"
+
+
+def _extract_script(cmd: str) -> str | None:
+    """Return the first script-extension token after a known interpreter, or None."""
+    if not cmd or "${CLAUDE_PLUGIN_ROOT}" in cmd:
+        return None
+    try:
+        tokens = shlex.split(cmd)
+    except ValueError:
+        # Malformed quoting — fail open (don't flag, don't crash).
+        return None
+    if not tokens:
+        return None
+    interpreter = os.path.basename(tokens[0])
+    if interpreter not in KNOWN_INTERPRETERS:
+        return None
+    for tok in tokens[1:]:
+        if tok.endswith(SCRIPT_EXTS):
+            return tok
+    return None
+
+
+def main() -> int:
+    settings_path = _resolve_settings_path()
+    try:
+        data = json.loads(settings_path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        print(f"  ✗ settings.json not found at {settings_path}", file=sys.stderr)
+        return 1
+    except (OSError, json.JSONDecodeError) as e:
+        # Fail open with a clear error rather than raising.
+        print(f"  ✗ Could not parse {settings_path}: {e}", file=sys.stderr)
+        return 1
+
+    hooks_root = data.get("hooks") if isinstance(data, dict) else None
+    if not isinstance(hooks_root, dict):
+        print(f"  ✓ No hooks section in {settings_path.name} — nothing to check")
+        return 0
+
+    missing: list[dict] = []
+    checked = 0
+
+    for stage in HOOK_STAGES:
+        entries = hooks_root.get(stage, [])
+        if not isinstance(entries, list):
+            continue
+        for entry_idx, entry in enumerate(entries):
+            if not isinstance(entry, dict):
+                continue
+            for hook_idx, hook in enumerate(entry.get("hooks", []) or []):
+                if not isinstance(hook, dict):
+                    continue
+                cmd = hook.get("command", "")
+                if not isinstance(cmd, str):
+                    continue
+                script = _extract_script(cmd)
+                if script is None:
+                    continue
+                checked += 1
+                resolved = Path(os.path.expanduser(script))
+                if not resolved.is_file():
+                    missing.append(
+                        {
+                            "stage": stage,
+                            "location": (
+                                f"hooks.{stage}[{entry_idx}]"
+                                f".hooks[{hook_idx}].command"
+                            ),
+                            "command": cmd,
+                            "script": script,
+                            "resolved": str(resolved),
+                        }
+                    )
+
+    if missing:
+        print("  ✗ Hook script paths missing:", file=sys.stderr)
+        for m in missing:
+            print(f"    {m['location']}", file=sys.stderr)
+            print(f"      command:  {m['command']}", file=sys.stderr)
+            print(
+                f"      script:   {m['script']}  →  {m['resolved']} (not found)",
+                file=sys.stderr,
+            )
+        return 1
+
+    print(f"  ✓ All hook script paths resolve ({checked} checked)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

Adds a structural safeguard against the failure mode that bricked the session in PR #75: a `PreToolUse` hook entry pointed at `~/.claude/hooks/secret_guard.py` while the script didn't exist, causing every tool call to fail at session start with `[Errno 2] No such file or directory`.

This change adds `Phase 4.5` to `install.sh` that walks every hook stage (`PreCompact`, `SessionStart`, `Stop`, `PostToolUse`, `PreToolUse`) in `settings.json`, identifies the script path token after a recognized interpreter (`python3`/`python`/`bash`/`sh`/`node`/`npx`), expands `~`, and verifies the file exists. Missing scripts cause a clear actionable error naming the JSON location, the command, and the resolved absolute path. `${CLAUDE_PLUGIN_ROOT}` references are skipped — those resolve at plugin load time, not install time.

Closes #82

## How

Implemented as a standalone validator script (`claude-config/scripts/validate-hooks.py`) following the existing `validate-paths-globs.py` convention. `install.sh` delegates to it via `SETTINGS_PATH` env var. The validator is independently runnable for pre-commit hooks or CI usage.

Stdlib-only (`json`, `os`, `shlex`, `sys`, `pathlib`). Fail-open on malformed `settings.json` — never raises. Bumps the existing `ERRORS` accumulator in install.sh Phase 4 rather than introducing a separate exit path.

## Stack
- [x] Backend (install/tooling)

## Verification

- [x] `bash -n claude-config/install.sh` — clean
- [x] `python3 -c "import ast; ast.parse(...)"` — clean
- [x] Stdlib-only imports verified
- [x] Validator script is `+x` with `#!/usr/bin/env python3` shebang
- [x] Behavior — positive: real `settings.json` → exit 0, "7 hooks checked"
- [x] Behavior — negative: bogus hook entry → exit 1 with location + resolved path
- [x] Behavior — plugin-skip: `${CLAUDE_PLUGIN_ROOT}` reference correctly skipped
- [x] Behavior — standalone callable from any cwd via SETTINGS_PATH default
- [x] install.sh end-to-end: Phase 4.5 line appears, exit 0 on clean, exit 1 on synthesized broken state
- [x] settings.json untouched after all tests (verified with git diff empty)
- [x] No regressions in Phases 1-4
- [x] No credentials introduced (E15)

## Reviewer Notes

Pre-PR fresh-context review: clean. Two minor non-blocking observations:
- Token extraction grabs the first `.py`/`.sh`/`.js`-ending token after the interpreter; would false-positive on commands with a script-named arg (e.g., `python3 -c "..." log.py`). Not present in current settings.json.
- `npx <package>` doesn't pass a script path; validator is a no-op for those entries. Harmless.

## Side observation (out of scope, worth flagging)

While investigating I confirmed `claude-config/hooks/secret_guard.py` actually exists (committed in PR #75) but is no longer wired into `settings.json` (the reference was removed in #76). This is an orphaned script that does nothing currently. Decision worth making separately: re-wire it to add Bash-side secret-exfil coverage (which was its original purpose), or delete it. Not part of #82.

## Risks / Rollback

Low. Validator only fails install on broken state; can't break a working install. Single-commit revert restores prior behavior.

---
Artifacts: `.agents/outputs/{map-plan,patch,prove}-82-042826.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)