### PR TITLE
chore(orchestrate): reject TRIVIAL classification, redirect to /quick (#88)

### DIFF
--- a/claude-config/commands/orchestrate.md
+++ b/claude-config/commands/orchestrate.md
@@ -33,12 +33,11 @@ If no issue provided, instruct user to create one with `/feature` or `/bug`.
 ## Workflow
 
 ```
-TRIVIAL:        MAP-PLAN → PATCH → PROVE-lite
 SIMPLE:         [DISCUSS] → MAP-PLAN → [TEST-PLANNER] → CONTRACT* → PATCH → PROVE
 COMPLEX:        [DISCUSS] → MAP → PLAN → [TEST-PLANNER] → CONTRACT* → PLAN-CHECK → PATCH → PROVE
 ```
 
-- `TRIVIAL` skips PLAN-CHECK and uses PROVE-lite
+- TRIVIAL work is **rejected** by Step 1 with a redirect to `/quick` (see `rules/implementation-routing.md`)
 - `[TEST-PLANNER]` runs if `--with-tests` is provided
 - `CONTRACT*` is **MANDATORY** if fullstack — PATCH will STOP without it
 - Codex is not a mandatory phase. Use `/codex:review` or `/codex:adversarial-review`
@@ -145,9 +144,11 @@ If seeds match, report before proceeding. If no `.planning/seeds/`, skip silentl
 
 | Level | Criteria | Workflow |
 |-------|----------|----------|
-| TRIVIAL | Docs, config | MAP-PLAN |
 | SIMPLE | 1-3 files | MAP-PLAN |
 | COMPLEX | Endpoints, migrations | MAP + PLAN |
+
+TRIVIAL work (typo, single-config-line fix, obvious one-file change) is **not**
+handled by `/orchestrate` — see the routing gate below.
 
 Report:
 
@@ -155,6 +156,30 @@ Report:
 Issue #184 classified as: SIMPLE (backend)
 Using workflow: MAP-PLAN → PATCH → PROVE
 ```
+
+### Step 1.0.1: Reject TRIVIAL — Redirect to /quick
+
+After classification, if `TIER=TRIVIAL`, exit immediately with a clear pointer
+to `/quick`. The full MAP-PLAN → PATCH → PROVE pipeline is over-ceremonious
+for a typo-class change.
+
+```bash
+if [ "$TIER" = "TRIVIAL" ]; then
+  echo "Issue #${ISSUE} classified as TRIVIAL — full orchestrate pipeline is over-ceremonious."
+  echo ""
+  echo "Use /quick instead:"
+  echo "  /quick \"${ISSUE_TITLE}\""
+  echo ""
+  echo "TRIVIAL work (typo, single-config-line fix, obvious one-file change) doesn't"
+  echo "need MAP-PLAN/PATCH/PROVE artifacts. /quick handles it directly without"
+  echo "branching, agent dispatches, or PR ceremony for changes that don't warrant them."
+  exit 0
+fi
+```
+
+If you genuinely want the full pipeline for a TRIVIAL issue (tracking,
+artifacts, parallel-wave bookkeeping), manually upgrade the classification to
+SIMPLE before re-running.
 
 ### Step 1.1: Decide Codex Escalation
 


### PR DESCRIPTION
## What

Adds Step 1.0.1 routing gate to `orchestrate.md`: if classification returns TRIVIAL, exit immediately with an actionable redirect to `/quick`. Drops TRIVIAL from the complexity table and workflow diagram.

Closes #88

## Why

`implementation-routing.md` says TRIVIAL → `/quick`. orchestrate also accepted TRIVIAL and ran the full pipeline. Two rules disagreed; the looser one won. Routing rule and orchestrate command now agree.

## Verification

- [x] `/orchestrate <trivial-issue>` exits early with `/quick` redirect message
- [x] Complexity table no longer includes TRIVIAL
- [x] Workflow diagram no longer shows TRIVIAL pipeline
- [x] Override path documented (manually upgrade classification to SIMPLE)

## Risks / Rollback

Trivial. Single-file docs/routing change. Single-commit revert.

---
Artifact: `.agents/outputs/patch-88-042826.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)