### PR TITLE
feat(pr): advisory Codex review gate for COMPLEX-tier diffs (#91)

### DIFF
--- a/claude-config/commands/pr.md
+++ b/claude-config/commands/pr.md
@@ -95,6 +95,60 @@ manually via `/codex:review` or `/codex:adversarial-review` for risky diffs.
 
 ---
 
+## Pre-merge Codex review for COMPLEX changes
+
+If the diff matches COMPLEX-tier signals (file count, migrations, auth code,
+data models, cross-cutting refactors), prompt the user to run
+`/codex:adversarial-review` BEFORE squash-merging. The review is advisory —
+user can override — but the prompt at PR-creation time is the moment they
+have full context to decide.
+
+```bash
+# Count files changed (linear diff: feature branch ahead of main)
+N_FILES=$(git diff --name-only origin/main..HEAD | wc -l | tr -d ' ')
+
+# Detect COMPLEX signals
+SIGNALS=()
+[ "$N_FILES" -gt 5 ] && SIGNALS+=("$N_FILES files changed")
+
+if git diff --name-only origin/main..HEAD | grep -qE "alembic|migration|migrate"; then
+  SIGNALS+=("migration files")
+fi
+
+if git diff --name-only origin/main..HEAD | grep -qE "auth|permissions|security|rbac"; then
+  SIGNALS+=("auth/permissions code")
+fi
+
+if git diff --name-only origin/main..HEAD | grep -qE "models/.*\.py$|schemas/.*\.py$"; then
+  SIGNALS+=("data model files")
+fi
+
+if git diff --name-only origin/main..HEAD | grep -qE "_base\.md|core-patterns\.md|behavioral-evals\.md"; then
+  SIGNALS+=("cross-cutting refactor")
+fi
+
+if [ ${#SIGNALS[@]} -gt 0 ]; then
+  echo ""
+  echo "⚠ This PR matches COMPLEX-tier signals:"
+  printf "  - %s\n" "${SIGNALS[@]}"
+  echo ""
+  echo "Per implementation-routing.md, a Codex adversarial review is recommended."
+  echo "Run before squash-merge:"
+  echo ""
+  echo "  /codex:adversarial-review --wait"
+  echo ""
+  echo "(or /codex:adversarial-review --background and check /codex:status)"
+  echo ""
+  echo "If you've already assessed the risk yourself, you can proceed."
+fi
+```
+
+**Why advisory not mandatory**: `/codex:*` plugin commands need user invocation
+from an interactive session; subagent context can't trigger them. The structural
+gate is the prompt; the user decides whether to honor it.
+
+---
+
 ## Create PR
 
 ### Step 1: Summarize Scope


### PR DESCRIPTION
## What

Adds Step "Pre-merge Codex review for COMPLEX changes" to `/pr` (between fresh-context review and Create PR). Detects COMPLEX-tier signals from the diff and prompts the user to run `/codex:adversarial-review --wait` before squash-merging.

Closes #91

## Why

`implementation-routing.md` says COMPLEX changes should get Codex adversarial review post-PROVE. Plugin commands need user invocation (subagent context can't trigger them), so we needed a reminder at PR-creation time when the user is interactive. PR #87 (50-file migration) shipped without Codex review for exactly this reason.

## Detection signals

- File count > 5
- Migration paths (`alembic|migration|migrate`)
- Auth/permissions/security/RBAC code
- Data model files (`models/*.py`, `schemas/*.py`)
- Cross-cutting refactor (`_base.md`, `core-patterns.md`, `behavioral-evals.md`)

## Verification

- [x] Section sits between fresh-context review and Create PR
- [x] Bash detection logic uses 2-dot diff (`origin/main..HEAD`) for linear ahead-of-main scope
- [x] Doesn't auto-invoke `/codex:adversarial-review` (advisory)
- [x] User can skip with explicit acknowledgment
- [x] No credentials introduced (E15)

## Risks / Rollback

Trivial. Single docs change. Single-commit revert.

---
Artifact: `.agents/outputs/patch-91-042826.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)