### PR TITLE
docs: add issue-creation command map to README (#92)

### DIFF
--- a/claude-config/README.md
+++ b/claude-config/README.md
@@ -68,6 +68,21 @@ After installation, all commands and rules are immediately available in every Cl
 | `/spec-draft` | `/spec-draft "User auth"` | Interactive spec creation with codebase discovery |
 | `/feature-from-spec` | `/feature-from-spec` | Create feature issue from spec analysis (used by /spec-review) |
 
+#### Issue creation commands — when to use which
+
+| Command | When to use | Internal/External |
+|---|---|---|
+| `/bug` | Standalone bug report; no spec involved | External |
+| `/feature` | Standalone feature request; no spec involved | External |
+| `/spec-draft` | Author a new spec via guided Q&A | External |
+| `/spec-review` | Validate a spec against the codebase, optionally generate issues | External |
+| `/feature-from-spec` | Generate one issue from a spec entry — invoked by `/spec-review` | Internal helper |
+
+Canonical paths:
+- Bug found → `/bug`
+- Small feature → `/feature`
+- Larger feature → `/spec-draft` → `/spec-review` (issues auto-generated via `/feature-from-spec`)
+
 ### Review & Testing
 
 | Command | Usage | Description |


### PR DESCRIPTION
## What

Adds an "Issue creation commands" subsection to `claude-config/README.md` clarifying when to use `/bug`, `/feature`, `/spec-draft`, `/spec-review`, and `/feature-from-spec` (internal helper).

Closes #92

## Why

Five overlapping commands with no documented relationships. A reader scanning the README couldn't tell which to use without reading each command's body. This adds a 5-row table and 3 canonical-path bullets.

## Verification

- [x] README has clear "Issue creation commands" section
- [x] `feature-from-spec.md` already has `disable-model-invocation: true` (verified, no change needed)
- [x] No code changes — documentation-only

## Risks / Rollback

Trivial. Single docs change. Single-commit revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)