### PR TITLE
feat(ci): add lightweight validation workflow (#89)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,58 @@
+name: Validate config
+on:
+  pull_request:
+    paths:
+      - 'claude-config/**'
+      - 'knowledge/**'
+      - 'codex-config/**'
+      - 'install*.sh'
+  workflow_dispatch: {}
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: pip install pyyaml
+
+      - name: Validate settings.json is valid JSON
+        run: python3 -c "import json; json.load(open('claude-config/settings.json'))"
+
+      - name: Validate install.sh shell syntax
+        run: bash -n claude-config/install.sh
+
+      - name: Validate hook script paths in settings.json
+        env:
+          SETTINGS_PATH: ${{ github.workspace }}/claude-config/settings.json
+        run: python3 claude-config/scripts/validate-hooks.py
+
+      - name: Build knowledge.db (catches duplicate pattern IDs + schema drift)
+        run: |
+          cd knowledge
+          python3 sync.py build
+
+      - name: Verify pattern ID slug format
+        run: |
+          set -e
+          fail=0
+          for f in knowledge/patterns/*.yaml; do
+            stem=$(basename "$f" .yaml)
+            id=$(grep "^id:" "$f" | head -1 | awk '{print $2}')
+            if [ "$id" != "pat-$stem" ]; then
+              echo "MISMATCH: $f has id=$id (expected pat-$stem)"
+              fail=1
+            fi
+          done
+          if [ "$fail" = "1" ]; then
+            exit 1
+          fi
+          echo "All $(ls knowledge/patterns/*.yaml | wc -l | tr -d ' ') patterns have correct slug IDs"


### PR DESCRIPTION
## What

Adds `.github/workflows/validate.yml` running 5 validation checks on every PR that touches `claude-config/`, `knowledge/`, `codex-config/`, or `install*.sh`.

Closes #89

## Why

The repo had no CI. Local-only validation meant a bad commit could land on main and break the next session for any puller. Direct evidence: PR #75's broken hook reference bricked session start until #76 removed it.

This wires up the safeguards we already have:
- `validate-hooks.py` (from #82) now runs at PR time, not just install time
- `sync.py`'s duplicate-ID guard (from #78) now runs pre-merge, not post-merge
- Pattern ID slug invariant (from #78) is enforced

## Checks

1. `settings.json` is valid JSON
2. `bash -n install.sh` passes
3. `validate-hooks.py` confirms every hook script path resolves
4. `sync.py build` succeeds (catches duplicate pattern IDs, missing required fields, schema drift)
5. Every pattern has `id: pat-<filename-stem>` (slug invariant)

## Verification

All checks ran locally before commit:
- [x] YAML parses
- [x] settings.json validates
- [x] install.sh shell syntax clean
- [x] validate-hooks.py: 7 hook script paths resolve
- [x] sync.py build: 39 patterns, 9 decisions, 6 rules
- [x] Slug invariant: all 39 patterns match
- [x] No credentials introduced (E15)

## Risks / Rollback

Trivial. New file, no existing behavior changed. Single-commit revert removes the workflow.

## First-run note

The first PR after this merges will be the first one to trigger the workflow. If anything fails on a real PR that should pass, the path filter or specific check command may need tuning. Easy to iterate on.

---
Artifact: `.agents/outputs/patch-89-042826.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)