### PR TITLE
docs(manual): refresh user manual + add mermaid architecture diagrams

### DIFF
--- a/docs/manual/agents/contract.md
+++ b/docs/manual/agents/contract.md
@@ -6,11 +6,14 @@ CONTRACT defines the API boundary between backend and frontend for fullstack wor
 
 ## When CONTRACT Runs
 
-CONTRACT is positioned between planning and implementation:
+CONTRACT is positioned between planning and implementation. The downstream chain depends on the pipeline tier:
 
 ```
-PLAN or MAP-PLAN  -->  CONTRACT  -->  PLAN-CHECK  -->  PATCH
+SIMPLE:   MAP-PLAN  -->  CONTRACT  -->  PATCH
+COMPLEX:  PLAN      -->  CONTRACT  -->  PLAN-CHECK  -->  PATCH
 ```
+
+PLAN-CHECK only runs in the COMPLEX pipeline; the SIMPLE pipeline drops PLAN-CHECK and goes straight from CONTRACT to PATCH.
 
 | Condition | CONTRACT Required? |
 |-----------|--------------------|

--- a/docs/manual/agents/map-plan.md
+++ b/docs/manual/agents/map-plan.md
@@ -5,13 +5,13 @@
 MAP-PLAN is the first agent to run on most issues. It reads the issue, investigates your codebase, and produces a detailed implementation plan. The plan includes which files to modify, what patterns to follow, and acceptance criteria for verification. It does not write any code -- that's PATCH's job.
 
 !!! info "Routing context"
-    MAP-PLAN runs when the routing model selects `/orchestrate` for MODERATE or higher tasks, and the orchestrate pipeline classifies the work as TRIVIAL or SIMPLE pipeline tier. Tasks routed to `/quick` or Plan Mode never reach MAP-PLAN.
+    MAP-PLAN runs when `/orchestrate` classifies the work as the SIMPLE pipeline tier. TRIVIAL classifications are rejected by `/orchestrate` and redirected to `/quick` (no pipeline). COMPLEX classifications use separate MAP and PLAN agents instead. Tasks routed to `/quick` or Plan Mode never reach MAP-PLAN.
 
 ## When to Use
 
 | Pipeline Tier | Use MAP-PLAN? | Alternative |
 |---------------|---------------|-------------|
-| TRIVIAL | Yes | -- |
+| TRIVIAL | No | `/orchestrate` rejects TRIVIAL; use `/quick` |
 | SIMPLE | Yes | -- |
 | COMPLEX | No | Use separate MAP + PLAN agents |
 
@@ -69,11 +69,11 @@ Every MAP-PLAN output must include a **Verification Steps** section documenting:
 
     ### 1. Classify Pipeline Tier
 
-    | Pipeline Tier | Criteria |
-    |---------------|----------|
-    | TRIVIAL | Docs, config, renames, deletions |
-    | SIMPLE | 1-3 files, localized change |
-    | COMPLEX | New endpoints, migrations, cross-module |
+    | Pipeline Tier | Criteria | Handling |
+    |---------------|----------|----------|
+    | TRIVIAL | Docs, config, renames, deletions | Rejected by `/orchestrate`; redirected to `/quick` |
+    | SIMPLE | 1-3 files, localized change | Run MAP-PLAN |
+    | COMPLEX | New endpoints, migrations, cross-module | Escalate to separate MAP + PLAN agents |
 
     ### 2. Identify Stack
 

--- a/docs/manual/agents/overview.md
+++ b/docs/manual/agents/overview.md
@@ -2,19 +2,33 @@
 
 When you run `/orchestrate`, a team of specialized agents handles your issue. Each agent has one job — investigate, plan, implement, or verify. Only one agent (PATCH) writes code. The rest are read-only, which means they can't break anything while they work.
 
-## Agent Roles
+## Agent Roster
+
+There are **12 agent definitions** in `claude-config/agents/`. Nine participate in the orchestrate pipeline; three are dispatched by other commands (`/spec-review`, `/pr`).
+
+### Pipeline Agents (9)
 
 | Agent | Phase | Role | Read-Only? | Target / Max Lines |
 |-------|-------|------|------------|-------------------|
+| DISCUSS | 0.5 | Decision Capturer (optional, `--discuss`) | Yes | 80 / 120 |
 | MAP | 1 | Investigator (COMPLEX pipeline only) | Yes | 150 / 200 |
-| MAP-PLAN | 1+2 | Investigator + Architect (TRIVIAL/SIMPLE pipeline) | Yes | 400 / 500 |
+| MAP-PLAN | 1+2 | Investigator + Architect (SIMPLE pipeline) | Yes | 400 / 500 |
 | PLAN | 2 | Architect (COMPLEX pipeline only) | Yes | 400 / 500 |
 | TEST-PLANNER | 2 | Test matrix designer | Yes | 250 / 350 |
 | CONTRACT | 2.5 | Interface designer (fullstack) | Yes | 200 / 300 |
-| PLAN-CHECK | 2.8 | Plan validator | Yes | 80 / 120 |
+| PLAN-CHECK | 2.8 | Plan validator (COMPLEX pipeline only) | Yes | 80 / 120 |
 | PATCH | 3 | Implementer | **No** | 300 / 400 |
 | PROVE | 4 | Verifier + outcome recorder | Metrics only | 250 / 350 |
-| DISCUSS | 0.5 | Decision Capturer (optional, `--discuss`) | Yes | 80 / 120 |
+
+### Dispatched Agents (3)
+
+| Agent | Dispatched By | Role | Read-Only? |
+|-------|---------------|------|------------|
+| spec-reviewer | `/spec-review` | Spec analysis and gap classification | Yes |
+| plan-checker | `/orchestrate` (COMPLEX) | Plan validator (alias for PLAN-CHECK) | Yes |
+| pr-fresh-reviewer | `/pr` | Pre-merge fresh-eyes diff review | Yes |
+
+Plus the shared `_base.md` definition (not an agent itself, but inherited by all).
 
 !!! warning "Separation of Concerns"
     Only PATCH writes code. Only PROVE records metrics. Investigation agents must never start implementing. Verification agents must never start fixing.
@@ -24,39 +38,41 @@ When you run `/orchestrate`, a team of specialized agents handles your issue. Ea
 !!! info "Pipeline tiers vs routing tiers"
     This page describes the **pipeline tiers** — which agents run inside `/orchestrate`. For the full **routing model** (how tasks are classified and directed to `/quick`, Plan Mode, or `/orchestrate`), see the [Orchestrate Pipeline](../workflow/orchestrate.md) page.
 
-When `/orchestrate` runs, it selects one of three pipeline tiers:
+When `/orchestrate` runs, it selects one of two pipeline tiers. TRIVIAL classifications are rejected — `/orchestrate` redirects them to `/quick` (no pipeline).
 
 ```
-TRIVIAL pipeline:  MAP-PLAN ─────────────────────────────────────────── PATCH ── PROVE-lite
-SIMPLE pipeline:   [DISCUSS] ── MAP-PLAN ── [TEST-PLANNER] ── CONTRACT* ── PLAN-CHECK ── PATCH ── PROVE
+SIMPLE pipeline:   [DISCUSS] ── MAP-PLAN ── [TEST-PLANNER] ── CONTRACT* ── PATCH ── PROVE
 COMPLEX pipeline:  [DISCUSS] ── MAP ── PLAN ── [TEST-PLANNER] ── CONTRACT* ── PLAN-CHECK ── PATCH ── PROVE
 
 * = mandatory for fullstack only
 [ ] = optional, enabled with --with-tests or --discuss
 ```
 
+PLAN-CHECK was removed from the SIMPLE pipeline in v5 — the cost of a separate validation phase did not justify the savings on small changes. PATCH catches plan defects fast enough on SIMPLE work, and Codex adversarial review (post-PROVE) picks up the rest. COMPLEX retains PLAN-CHECK because the cost of a botched multi-file PATCH is much higher.
+
 ```
                   +----------------+
                   | /orchestrate   |
                   +-------+--------+
                           |
-                +---------+---------+
-                | Select Pipeline   |
-                +---------+---------+
-           +----------+----------+----------+
-           v          v                     v
-     TRIVIAL       SIMPLE              COMPLEX
-     pipeline      pipeline            pipeline
-           |          |                     |
-           |     [DISCUSS]             [DISCUSS]
-           |          |                     |
-       MAP-PLAN   MAP-PLAN             MAP -> PLAN
-           |          |                     |
-           |     CONTRACT* / PLAN-CHECK  CONTRACT / PLAN-CHECK
-           |          |                     |
-        PATCH      PATCH                 PATCH
-           |          |                     |
-      PROVE-lite   PROVE                 PROVE
+                  +-------+--------+
+                  | Classify Tier  |
+                  +-------+--------+
+              +-----+-----+-----+
+              v           v     v
+          TRIVIAL       SIMPLE  COMPLEX
+              |           |       |
+         [reject;        |  [DISCUSS]
+          tell user      |       |
+          to use     [DISCUSS] MAP -> PLAN
+          /quick]        |       |
+                     MAP-PLAN  CONTRACT* / PLAN-CHECK
+                         |       |
+                     CONTRACT* PATCH
+                         |       |
+                       PATCH   PROVE
+                         |
+                       PROVE
 ```
 
 ## Artifact Chains and Validation
@@ -70,20 +86,36 @@ Each agent produces a named artifact following the pattern `{agent}-{issue}-{mmd
 | PLAN | MAP artifact | Yes |
 | TEST-PLANNER | MAP or MAP-PLAN | Yes |
 | CONTRACT | PLAN or MAP-PLAN | Yes |
-| PLAN-CHECK | PLAN or MAP-PLAN; CONTRACT if fullstack | Yes |
-| PATCH | PLAN or MAP-PLAN; CONTRACT if fullstack; PLAN-CHECK | Yes |
+| PLAN-CHECK | PLAN; CONTRACT if fullstack (COMPLEX only) | Yes |
+| PATCH | PLAN or MAP-PLAN; CONTRACT if fullstack; PLAN-CHECK if COMPLEX | Yes |
 | PROVE | PATCH artifact | Yes |
+
+SIMPLE artifact chain:
 
 ```
 map-plan-184-030826.md
     |
     +-- contract-184-030826.md (if fullstack)
-    |
-    +-- plan-check-184-030826.md
             |
             +-- patch-184-030826.md
                     |
                     +-- prove-184-030826.md
+```
+
+COMPLEX artifact chain:
+
+```
+map-184-030826.md
+    |
+    +-- plan-184-030826.md
+            |
+            +-- contract-184-030826.md (if fullstack)
+                    |
+                    +-- plan-check-184-030826.md
+                            |
+                            +-- patch-184-030826.md
+                                    |
+                                    +-- prove-184-030826.md
 ```
 
 !!! note "Blocking on Missing Artifacts"
@@ -93,15 +125,15 @@ map-plan-184-030826.md
 
     ## Shared Behaviors from _base.md
 
-    All agents inherit from `_base.md` (v3.0), which provides:
+    All agents inherit from `_base.md` (v4.1, 265 lines — trimmed from 399 in PR #97). It provides:
 
-    **Pre-flight checks** -- Before any work begins, agents load learned failure patterns (via MCP `failure_patterns()` or file fallback), search for similar past artifacts, and verify project constraints.
+    **Pre-flight checks** -- Before any work begins, agents load learned failure patterns (via MCP `failure_patterns_v1()` or file fallback), search for similar past artifacts, and verify project constraints.
 
     **Artifact naming** -- `{agent}-{issue}-{mmddyy}.md` in `.agents/outputs/`.
 
     **Size compliance** -- Each agent has target and max line counts. Artifacts over max must be compressed before submission using a priority checklist: replace code quotes with line references, remove restated acceptance criteria, consolidate duplicates, remove appendices.
 
-    **Verification commands** -- Standardized gates for backend (`ruff check . && pytest -q`) and frontend (`npm run lint && npm run build`).
+    **Verification commands** -- Standardized gates for backend (`ruff check . && pytest -q`) and frontend (`npm run lint && npm run build`). The full command catalog now lives in `claude-config/snippets/verify-commands.md`; `_base.md` references the snippet rather than enumerating commands inline.
 
     **AGENT_RETURN directive** -- Every agent must end output with `AGENT_RETURN: {filename}` to signal completion to the orchestrator.
 
@@ -121,7 +153,7 @@ All agents include `version: X.Y` in their YAML frontmatter.
 Versions are recorded in `metrics.jsonl` via the `agent_versions` field, enabling correlation between agent versions and success rates through the `/metrics` command.
 
 ```json
-"agent_versions": {"map-plan": "1.0", "patch": "1.2", "prove": "1.3"}
+"agent_versions": {"map-plan": "1.1", "patch": "1.5", "prove": "1.5"}
 ```
 
 ??? info "Root cause classification codes"

--- a/docs/manual/agents/patch.md
+++ b/docs/manual/agents/patch.md
@@ -1,6 +1,6 @@
 # PATCH Agent
 
-**Version**: 1.2 | **Phase**: 3 | **Role**: Implementer
+**Version**: 1.5 | **Phase**: 3 | **Role**: Implementer
 
 PATCH is the only agent that modifies code. It reads the plan from MAP-PLAN, follows the project's architecture patterns, and implements the changes. Before writing any code, it runs a pre-flight checklist. After implementation, it runs verification gates (linting, tests). If anything fails, it fixes in-place before submitting.
 

--- a/docs/manual/agents/prove.md
+++ b/docs/manual/agents/prove.md
@@ -1,6 +1,6 @@
 # PROVE Agent
 
-**Version**: 1.3 | **Phase**: 4 | **Role**: Verifier + Outcome Recorder
+**Version**: 1.5 | **Phase**: 4 | **Role**: Verifier + Outcome Recorder
 
 PROVE is the final agent in the pipeline. It verifies that PATCH's implementation actually works, checks every acceptance criterion, records the outcome to structured data files, and classifies any failures by root cause. PROVE never fixes code -- it only reports.
 
@@ -13,6 +13,32 @@ ls .agents/outputs/patch-${ISSUE}-*.md
 ```
 
 If the PATCH artifact is missing, PROVE stops with `BLOCKED: PATCH artifact not found`.
+
+## Step 0: Select Applicable Behavioral Evals
+
+Before running the verification levels, PROVE selects which behavioral evals apply to the change. The eval framework is defined in `rules/behavioral-evals.md` (E01-E15) and the file-pattern routing in `rules/eval-file-mapping.md`.
+
+```bash
+git diff --name-only origin/main
+# Match each changed file against the eval-file-mapping table
+# Collect the unique set of applicable eval IDs
+```
+
+| File Pattern | Applicable Evals |
+|-------------|------------------|
+| `*.tsx`, `*.ts` | E01 (ENUM_VALUE), E02 (COMPONENT_API), E03 (HOOK_DEPS), E15 (SECRETS) |
+| `models/*.py`, `app/models/*.py` | E04, E05, E06, E08, E13, E15 |
+| `schemas/*.py`, `app/schemas/*.py` | E01, E05, E06 |
+| `alembic/versions/*.py` | E07, E08 |
+| `services/*.py`, `app/services/*.py` | E09, E10, E12, E15 |
+| `routers/*.py`, `app/routers/*.py` | E11, E12, E15 |
+| `repositories/*.py`, `app/repositories/*.py` | E10, E13 |
+| `Dockerfile`, `docker-compose.yml` | E14 |
+| `*.py` (catch-all) | E15 |
+
+If no files match any pattern, PROVE runs E15 (SECRETS) as a catch-all. Fullstack changes always add E01 (ENUM_VALUE). The `--thorough` flag forces all evals regardless of file mapping.
+
+The selected evals run inline within the verification levels below: file-pattern checks (E01, E02, E03, E11, etc.) feed into Level 3 (WIRED); secret/migration checks (E15, E07) feed into Level 4 (FUNCTIONAL).
 
 ## Four Verification Levels
 
@@ -144,7 +170,7 @@ Append to `.claude/memory/metrics.jsonl`:
   "complexity": "SIMPLE",
   "stack": "backend",
   "agents_run": ["MAP-PLAN", "PATCH", "PROVE"],
-  "agent_versions": {"map-plan": "1.0", "patch": "1.2", "prove": "1.3"}
+  "agent_versions": {"map-plan": "1.1", "patch": "1.5", "prove": "1.5"}
 }
 ```
 
@@ -185,13 +211,9 @@ When recording a BLOCKED outcome, PROVE classifies the failure using one of 12 c
 !!! tip "See also"
     For the full ENUM_VALUE pattern with code examples, see [Core Patterns -- ENUM_VALUE](../rules/core-patterns.md#enum_value-in-detail). For the complete 12-code taxonomy, see [Failure Patterns](../learning/failure-patterns.md#full-root-cause-taxonomy).
 
-## PROVE-lite
+## PROVE-lite (Deprecated)
 
-For TRIVIAL issues, PROVE runs in a lightweight mode:
-
-- Runs Level 4 (FUNCTIONAL) gates only
-- Skips Level 2 (SUBSTANTIVE) and Level 3 (WIRED) checks
-- Still records the outcome to `metrics.jsonl`
+PROVE-lite was the lightweight variant for the TRIVIAL pipeline (Level 4 gates only). Since `/orchestrate` now rejects TRIVIAL classifications and redirects them to `/quick` (which has no PROVE phase), PROVE-lite no longer runs in the orchestrate pipeline. It remains in the agent definition for historical reference but is not invoked by any current workflow.
 
 ## When BLOCKED
 

--- a/docs/manual/getting-started/installation.md
+++ b/docs/manual/getting-started/installation.md
@@ -34,9 +34,11 @@ cd ~/agents/claude-config && ./install.sh
 ```
 
 !!! success "Expected output"
-    The installer prints progress for each phase: `[1/4] Symlinks... [2/4] Dependencies... [2.5/4] Plugins... [3/4] First-time setup... [4/4] Verification...` with a final summary of all checks passed.
+    The installer prints progress for each phase:
+    `[1/4] Symlinks... [2/4] Dependencies... [2.5/4] Plugins... [2.6/4] MCP Servers (registration + npm cache warm-up)... [3/4] First-time setup... [3.5/4] Git hooks... [4/4] Verify symlinks + MCP server health... [4.5/4] Hook script path validation...`
+    with a final summary of all checks passed.
 
-The installer runs four phases automatically.
+The installer runs the following phases automatically: symlinks, dependencies, plugins, MCP server registration, first-time setup, git hooks, verification, and hook validation.
 
 ### Phase 1: Symlinks
 
@@ -106,6 +108,35 @@ claude plugin install frontend-design@claude-plugins-official
     - **LSP plugins** (typescript-lsp, pyright-lsp) require their respective language servers installed locally
     - All other plugins work out of the box
 
+### Phase 2.6: MCP Servers
+
+Registers the four standard MCP servers at user scope (writes to `~/.claude.json` -- per-machine, not symlinked). The installer runs `claude mcp add --scope user` for each server:
+
+```bash
+# Knowledge graph (TypeScript, runs under tsx)
+claude mcp add --scope user knowledge -- \
+  ~/agents/knowledge-mcp/node_modules/.bin/tsx \
+  ~/agents/knowledge-mcp/index.ts
+
+# Vault metrics (Python, dedicated venv from Phase 2)
+claude mcp add --scope user vault-metrics -- \
+  ~/agents/mcp-server/.venv/bin/python \
+  ~/agents/mcp-server/server.py
+
+# Library docs (npx)
+claude mcp add --scope user context7 -- \
+  npx -y @upstash/context7-mcp@latest
+
+# macOS-only platform integration
+claude mcp add --scope user apple-mcp -- \
+  npx -y apple-mcp@latest
+```
+
+After registration, the installer warms the npm cache by invoking each `npx`-based server once with stdin closed. This avoids the cold-cache failure mode where the first `npx -y <pkg>@latest` invocation exceeds Claude Code's MCP handshake timeout and shows `Failed to connect` on `claude mcp list`. The warm-up is bounded at 30 seconds and is best-effort -- registration succeeds either way.
+
+!!! note "Why per-machine"
+    `~/.claude.json` holds machine-specific paths (the `mcp-server/.venv` location, the `knowledge-mcp/node_modules/.bin/tsx` binary). It is not committed to the repo and not symlinked.
+
 ### Phase 3: First-time Setup
 
 Creates the Obsidian vault directory and agent configuration:
@@ -124,6 +155,18 @@ The installer verifies all components:
 - MCP server runs from its dedicated venv
 - PyYAML is importable by `python3`
 - `python3` command is available (hooks depend on it)
+
+### Phase 4.5: Hook Validation
+
+The installer runs `claude-config/scripts/validate-hooks.py`, which walks every hook command in `settings.json` and verifies the referenced script exists on disk. This catches the failure mode where `settings.json` references a hook script that did not ship -- which would brick every tool call in subsequent sessions.
+
+The validator:
+
+- Resolves each hook `command` field, including shebang-style invocations
+- Skips commands that resolve through `${CLAUDE_PLUGIN_ROOT}` (those are owned by the plugin lifecycle, not by `install.sh`)
+- Reports any missing script paths and increments the installer's error count
+
+If validation fails, the installer reports which hook scripts are missing and exits non-zero. Fix the paths in `settings.json` before restarting Claude Code.
 
 ## Platform Detection
 
@@ -165,6 +208,7 @@ claude
     - All three `ls -la` commands show symlinks pointing to `~/agents/claude-config/...`
     - PyYAML prints `OK`
     - `claude` launches and typing `/` lists all slash commands (orchestrate, quick, pr, learn, metrics, etc.)
+    - Phase 4.5 confirms `validate-hooks.py` resolved every hook script path; any missing script is reported before Claude Code starts
 
 You should see all slash commands available (type `/` to list them).
 

--- a/docs/manual/getting-started/multi-machine.md
+++ b/docs/manual/getting-started/multi-machine.md
@@ -47,6 +47,10 @@ Because `~/.claude/` is symlinked to the repo, a `git pull` in `~/agents/` insta
 !!! note "Project-level memory lives in the project repo"
     Files under `<project>/.claude/memory/` (metrics, failures, patterns) are committed to each project's own repository, not to the agents repo. They sync with the project, not with the configuration.
 
+### Pattern IDs Across Machines
+
+Patterns under `knowledge/patterns/*.yaml` use slug-format IDs derived from the filename: a pattern in `pat-fastapi-base-model.yaml` has `id: pat-fastapi-base-model`. Because the filename is the namespace, two machines authoring different patterns get different filenames automatically -- no coordination needed, no merge conflicts on numeric counters. Each pattern also retains a `legacy_id: PAT-NNN` field for cross-reference with the historical numeric IDs. The `sync.py` build enforces uniqueness across the corpus, so a stray duplicate slug is caught at validation time rather than at runtime.
+
 ## Updating Shared Config
 
 When you edit configuration on one machine:

--- a/docs/manual/getting-started/sample-walkthrough.md
+++ b/docs/manual/getting-started/sample-walkthrough.md
@@ -25,7 +25,7 @@ The orchestrator reads the issue, classifies it, and selects a pipeline:
 
 ```
 Issue #42 classified as: SIMPLE (backend)
-Using workflow: MAP-PLAN → PLAN-CHECK → PATCH → PROVE
+Using workflow: MAP-PLAN → PATCH → PROVE
 ```
 
 No CONTRACT agent is needed because this is backend-only work.
@@ -87,20 +87,7 @@ No CONTRACT agent is needed because this is backend-only work.
     AGENT_RETURN: map-plan-42-033126.md
     ```
 
-## 4. PLAN-CHECK Result
-
-The orchestrator validates the plan before handing off to PATCH:
-
-```
-PLAN-CHECK: map-plan-42-033126.md
-  ✓ Frontmatter complete
-  ✓ Acceptance criteria present (3 items)
-  ✓ File plan covers all identified files
-  ✓ No unresolved ambiguities
-Result: PASS — cleared for PATCH
-```
-
-## 5. PATCH Artifact
+## 4. PATCH Artifact
 
 ???+ example "Full PATCH artifact"
 
@@ -146,7 +133,7 @@ Result: PASS — cleared for PATCH
     AGENT_RETURN: patch-42-033126.md
     ```
 
-## 6. PROVE Artifact
+## 5. PROVE Artifact
 
 ???+ example "Full PROVE artifact"
 
@@ -178,7 +165,7 @@ Result: PASS — cleared for PATCH
     AGENT_RETURN: prove-42-033126.md
     ```
 
-## 7. The Result
+## 6. The Result
 
 The orchestrator reports the completed workflow:
 
@@ -192,7 +179,7 @@ Next: /pr 42
 === "SIMPLE (this example)"
 
     ```
-    MAP-PLAN → PLAN-CHECK → PATCH → PROVE
+    MAP-PLAN → PATCH → PROVE
     2 files, 3 artifacts, ~3 minutes
     ```
 
@@ -204,12 +191,12 @@ Next: /pr 42
     Separate investigation and planning phases
     ```
 
-## 8. What's in metrics.jsonl
+## 7. What's in metrics.jsonl
 
 PROVE appended this record to `.claude/memory/metrics.jsonl`:
 
 ```json
-{"issue":42,"date":"2026-03-31","status":"PASS","complexity":"SIMPLE","stack":"backend","agents_run":["MAP-PLAN","PLAN-CHECK","PATCH","PROVE"],"agent_versions":{"map-plan":"1.0","patch":"1.2","prove":"1.3"}}
+{"issue":42,"date":"2026-03-31","status":"PASS","complexity":"SIMPLE","stack":"backend","agents_run":["MAP-PLAN","PATCH","PROVE"],"agent_versions":{"map-plan":"1.0","patch":"1.2","prove":"1.3"}}
 ```
 
 Over time, these records power the `/metrics` dashboard and the `/learn` pattern extraction loop.

--- a/docs/manual/git/contributing.md
+++ b/docs/manual/git/contributing.md
@@ -150,6 +150,6 @@ When onboarding a new project:
 - [ ] Enable merge queue (squash merge, required checks)
 - [ ] Allow only squash merging (disable merge commit and rebase options)
 - [ ] Auto-delete head branches after merge
-- [ ] Add CI workflow (`.github/workflows/ci.yml`)
+- [ ] Add CI workflow (`.github/workflows/validate.yml`) covering: settings.json JSON validity, `install.sh` shell syntax, hook script paths via `claude-config/scripts/validate-hooks.py`, the `sync.py` knowledge build, and the pattern slug invariant (every YAML in `knowledge/patterns/` has a unique slug-format `id`). The workflow runs on every PR that touches `claude-config/`, `knowledge/`, `codex-config/`, or `install*.sh`.
 - [ ] Add `.gitignore` covering generated files, secrets, IDE configs
 - [ ] Create `CLAUDE.md` referencing this policy

--- a/docs/manual/hooks/lifecycle.md
+++ b/docs/manual/hooks/lifecycle.md
@@ -1,15 +1,28 @@
 # Hook Lifecycle
 
-Claude Code hooks fire at specific moments during a session. Five hooks turn stateless chat sessions into stateful development workflows by persisting context across compactions, monitoring context usage, verifying completion quality, and sending notifications.
+Claude Code hooks fire at specific moments during a session. The `hooks/` directory contains **11 Python files**: 7 hook entry points wired into `settings.json`, plus shared modules (`state_manager.py`, `worktree_manager.py`) and a guard script (`secret_guard.py`) that is not currently wired into the lifecycle. Together they turn stateless chat sessions into stateful development workflows by persisting context across compactions, monitoring context usage, verifying completion quality, and sending notifications.
+
+## Wired Hooks
+
+| Lifecycle Event | Wired Scripts (in order) |
+|-----------------|--------------------------|
+| SessionStart | `sessionstart_restore_state.py`, `load_learning_rules.py` |
+| PreCompact | `precompact_checkpoint.py` |
+| PostToolUse | `context_monitor.py` |
+| Stop | `verify_completion.py`, `notify_completion.py`, `session_end_context_update.py` |
+
+`secret_guard.py` exists in `hooks/` but is not registered in `settings.json` — it can be wired into a `PreToolUse` matcher when secret-scanning is desired.
 
 ## Hook Execution Order
 
 ```
-+-- SessionStart ------------------------------------------------+
-|  sessionstart_restore_state.py                                  |
-|  +-- state_manager.get_active_work() -> restore active context  |
-|  +-- Load patterns (project -> global -> core-patterns.md)      |
-|  +-- Output ~500 tokens of restored context                     |
++-- SessionStart (2 hooks, sequential) -------------------------+
+|  1. sessionstart_restore_state.py                              |
+|     +-- state_manager.get_active_work() -> restore context     |
+|     +-- Load patterns (project -> global -> core-patterns.md)  |
+|     +-- Output ~500 tokens of restored context                 |
+|  2. load_learning_rules.py                                     |
+|     +-- Inject any project-specific learning rules             |
 +-----------------------------------------------------------------+
                           |
                     [Session Work]
@@ -32,9 +45,11 @@ Claude Code hooks fire at specific moments during a session. Five hooks turn sta
                           |
                     [Session Stop]
                           |
-+-- Stop (2 hooks, sequential) ---------------------------------+
++-- Stop (3 hooks, sequential) ---------------------------------+
 |  1. verify_completion.py                                       |
 |     +-- Check for uncommitted changes                          |
+|     +-- Check for un-pushed commits vs upstream                |
+|     +-- Check for branch ahead of origin/main with no PR       |
 |     +-- Scan for TODO/FIXME/HACK in diff                       |
 |     +-- Exit 0 to allow, advisory warning printed              |
 |                                                                |
@@ -43,6 +58,9 @@ Claude Code hooks fire at specific moments during a session. Five hooks turn sta
 |     +-- state_manager.get_active_work() -> get context         |
 |     +-- osascript display notification -> Notification Center  |
 |     +-- Auto-forwards to iPhone via Handoff                    |
+|                                                                |
+|  3. session_end_context_update.py                              |
+|     +-- Persist end-of-session context updates                 |
 +-----------------------------------------------------------------+
 ```
 
@@ -109,8 +127,10 @@ The extracted state is written to `PERSISTENT_STATE.yaml` via `state_manager.upd
 
 This hook checks for signs of incomplete work:
 
-- **Uncommitted changes** in substantive files (ignoring lock files and config files like `.yaml`, `.yml`, `.toml`)
-- **TODO/FIXME/HACK markers** in added lines within the current diff
+- **Uncommitted changes** -- any tracked file with staged or unstaged modifications. Reports as `Uncommitted changes (N files): a, b, c[, +K more]`. (As of PR #84 the hook flags every uncommitted file, including `.yaml`, `.yml`, `.toml`, and lock files — earlier versions excluded those.)
+- **Un-pushed commits** -- commits on the current branch that have not been pushed to its upstream. Reports as `N commit(s) not pushed to upstream`. Skipped silently if no upstream is configured.
+- **Branch ahead of origin/main with no open PR** -- a feature branch with commits beyond `origin/main` and no matching open PR according to `gh pr list`. Reports as `branch '<name>' is N commit(s) ahead of origin/main with no open PR`. Skipped silently if `gh` is unavailable or the current branch is `main`/`master`.
+- **TODO/FIXME/HACK markers** in added lines within the current diff.
 
 The output is advisory -- it prints warnings visible to the user as context for whether to continue the conversation. The hook always exits 0 to avoid feedback loops.
 
@@ -119,6 +139,18 @@ The output is advisory -- it prints warnings visible to the user as context for 
 **File**: `notify_completion.py`
 
 Sends a macOS Notification Center alert when the session finishes. See [Notifications](notifications.md) for details.
+
+## Stop: Session End Context Update
+
+**File**: `session_end_context_update.py`
+
+Runs last in the Stop chain. Persists end-of-session context — session metadata, last touched files, and any rolling state — so the next SessionStart has fresh material to restore from. Always exits 0; failures are logged but never block.
+
+## SessionStart: Load Learning Rules
+
+**File**: `load_learning_rules.py`
+
+Runs after `sessionstart_restore_state.py`. Injects project-specific learning rules drawn from the local memory store so that learned patterns surface alongside the always-loaded rule files. Output is appended to the same restored-context block — no separate banner.
 
 ## PostToolUse: Context Monitor
 
@@ -162,6 +194,10 @@ Hooks are configured in `settings.json`:
           {
             "type": "command",
             "command": "python3 ~/.claude/hooks/sessionstart_restore_state.py"
+          },
+          {
+            "type": "command",
+            "command": "python3 ~/.claude/hooks/load_learning_rules.py"
           }
         ]
       }
@@ -188,6 +224,10 @@ Hooks are configured in `settings.json`:
           {
             "type": "command",
             "command": "python3 ~/.claude/hooks/notify_completion.py"
+          },
+          {
+            "type": "command",
+            "command": "python3 ~/.claude/hooks/session_end_context_update.py"
           }
         ]
       }

--- a/docs/manual/hooks/notifications.md
+++ b/docs/manual/hooks/notifications.md
@@ -4,7 +4,7 @@
 
 ## How It Works
 
-The hook runs on the `Stop` event, after `verify_completion.py`. It follows this sequence:
+The hook runs on the `Stop` event as the second of three Stop hooks: `verify_completion.py` runs first (so any advisory warnings appear before the notification fires), `notify_completion.py` runs second, and `session_end_context_update.py` runs last (after the user has been notified). It follows this sequence:
 
 1. **Platform guard** -- Check `sys.platform`. If not `darwin` (macOS), exit 0 immediately. The hook is a no-op on Linux, WSL, and Windows.
 2. **Read context** -- Call `state_manager.get_active_work()` to get the current issue number, phase, and last action.
@@ -95,7 +95,7 @@ The hook is designed to never interfere with the session:
 
 ## Configuration
 
-The hook is registered as the second Stop hook in `settings.json`:
+The hook is registered as the second of three Stop hooks in `settings.json`:
 
 ```json
 {
@@ -105,7 +105,8 @@ The hook is registered as the second Stop hook in `settings.json`:
         "matcher": "",
         "hooks": [
           {"type": "command", "command": "python3 ~/.claude/hooks/verify_completion.py"},
-          {"type": "command", "command": "python3 ~/.claude/hooks/notify_completion.py"}
+          {"type": "command", "command": "python3 ~/.claude/hooks/notify_completion.py"},
+          {"type": "command", "command": "python3 ~/.claude/hooks/session_end_context_update.py"}
         ]
       }
     ]
@@ -113,4 +114,4 @@ The hook is registered as the second Stop hook in `settings.json`:
 }
 ```
 
-Order matters: `verify_completion.py` runs first so its advisory warning appears before `notify_completion.py` sends the alert.
+Order matters: `verify_completion.py` runs first so its advisory warning appears before the notification, `notify_completion.py` sends the alert, and `session_end_context_update.py` persists rolling state for the next session.

--- a/docs/manual/index.md
+++ b/docs/manual/index.md
@@ -92,12 +92,12 @@ For a guided walkthrough, see [First 10 Minutes](getting-started/first-10-minute
     ```
     ~/agents/                              Source of truth (git repo)
     ├── claude-config/                     Claude Code configuration
-    │   ├── agents/     → ~/.claude/agents/    9 agent definitions
-    │   ├── commands/   → ~/.claude/commands/  18 slash commands
-    │   ├── hooks/      → ~/.claude/hooks/     6 lifecycle hooks + modules
-    │   ├── rules/      → ~/.claude/rules/     4 conditional rules
-    │   ├── skills/     → ~/.claude/skills/    3 workflow skills
-    │   ├── templates/  agent prompt template  1 shared prompt template
+    │   ├── agents/     → ~/.claude/agents/    12 agent definitions
+    │   ├── commands/   → ~/.claude/commands/  16 slash commands
+    │   ├── hooks/      → ~/.claude/hooks/     11 lifecycle hooks + modules
+    │   ├── rules/      → ~/.claude/rules/     12 rules (mix of always-loaded and conditional)
+    │   ├── skills/     → ~/.claude/skills/    7 workflow skills
+    │   ├── templates/  agent prompt template  8 template entries
     │   └── settings.json → ~/.claude/settings.json
     ├── mcp-server/                        Custom MCP (metrics, vault access)
     ├── obsidian-agent/                    Session → Obsidian vault writer
@@ -132,13 +132,15 @@ For a guided walkthrough, see [First 10 Minutes](getting-started/first-10-minute
     | **FULLSTACK** | Any | `/orchestrate` + CONTRACT | Cross-stack feature with enum/API contracts |
     | **PRIOR FAIL** | Any | `/orchestrate` + failure context | Retry with root cause injection |
 
+    `/orchestrate` rejects TRIVIAL classifications and redirects to `/quick`; the TRIVIAL row above is the canonical destination.
+
     ```
     TRIVIAL ──────────────── /quick (direct fix, no agents)
     SIMPLE ─────────────────  Plan Mode (no agents, no pipeline)
     MODERATE ───┐
     FULLSTACK ──┤            /orchestrate pipelines:
     PRIOR FAIL ─┤
-    COMPLEX ────┘              SIMPLE:   MAP-PLAN → [CONTRACT*] → PLAN-CHECK → PATCH → PROVE
+    COMPLEX ────┘              SIMPLE:   MAP-PLAN → [CONTRACT*] → PATCH → PROVE
                                COMPLEX:  MAP → PLAN → [CONTRACT*] → PLAN-CHECK → PATCH → PROVE
     ```
 

--- a/docs/manual/integrations/codex-plugin.md
+++ b/docs/manual/integrations/codex-plugin.md
@@ -245,6 +245,10 @@ Both review and delegation are **automatically applied based on task complexity*
 | **FULLSTACK** | Automatic (enum/API focus) | Delegate frontend to Codex |
 | **PRIOR FAIL** | Automatic | Codex-first implementation |
 
+### `/pr` Advisory Review Gate
+
+Independent of the routing table above, the `/pr` command runs a lightweight diff inspection before squash-merge. When the diff matches **COMPLEX-tier signals** -- more than five files changed, database migrations, authentication or authorization code, data-model files, or cross-cutting refactors of foundational rules (`_base.md`, `core-patterns.md`, `behavioral-evals.md`) -- `/pr` prompts the user to run `/codex:adversarial-review` before merging. The prompt is **advisory, not blocking**: the user can decline and proceed with the merge. This catches changes that slipped through orchestrate without an automatic adversarial review (for example, hot-fixes that bypass `/orchestrate`, or changes made manually in plan mode).
+
 ### Orchestrate Integration
 
 ```
@@ -383,13 +387,21 @@ PROVE passes → /codex:adversarial-review --background
 
     ## Review Gate
 
-    When enabled via `/codex:setup`, the review gate runs an automatic Codex review before certain operations (e.g., commit, PR creation). If the review identifies critical issues, it blocks the operation until the issues are addressed.
+    Two distinct review mechanisms exist, and they operate independently:
+
+    ### 1. Plugin-Level Review Gate (toggled via `/codex:setup`)
+
+    When enabled via `/codex:setup`, the plugin's built-in review gate runs an automatic Codex review at certain plugin lifecycle moments (e.g., before commit). If the review identifies critical issues, it blocks the operation until the issues are addressed.
 
     Enable or disable the gate:
 
     ```bash
     /codex:setup    # Toggle review gate on/off
     ```
+
+    ### 2. `/pr` Advisory Pre-Merge Prompt (always on)
+
+    Separate from the plugin gate, the `/pr` command inspects the diff and -- when COMPLEX-tier signals are present (>5 files, migrations, auth, data models, cross-cutting refactors) -- prompts the user to run `/codex:adversarial-review` before squash-merge. This prompt is **advisory only** and cannot be turned off via `/codex:setup`; the user can always decline and proceed. See [Automatic Routing](#automatic-routing-review--delegation) above for the full signal list.
 
 ## Configuration
 

--- a/docs/manual/learning/self-learning-loop.md
+++ b/docs/manual/learning/self-learning-loop.md
@@ -152,6 +152,12 @@ Agents prefer MCP tools over file reads for pattern data during pre-flight. MCP 
 !!! tip "See also"
     For the full MCP pattern loading diagram and configuration details, see [MCP Servers -- MCP-First Pattern Loading](../integrations/mcp-servers.md#mcp-first-pattern-loading).
 
+## Pattern IDs (Slug Format)
+
+Patterns under `knowledge/patterns/*.yaml` use slug-format IDs derived from the filename: a pattern stored in `pat-fastapi-base-model.yaml` has `id: pat-fastapi-base-model`. Each YAML also retains a `legacy_id: PAT-NNN` field that preserves the historical numeric ID for cross-reference with older artifacts and metrics records.
+
+Slugs are multi-machine safe by construction: the filename is the namespace, so two machines authoring different patterns concurrently get different filenames automatically -- no shared counter, no merge conflicts. The `sync.py` build enforces slug uniqueness across the whole corpus, so any accidental duplicate is caught at validation time. When `/learn --apply` writes a new pattern it picks the slug from the chosen filename and copies the legacy numeric counter only if the pattern is migrating from the old scheme.
+
 ## Real-World Results
 
 From one production project (86 issues analyzed over 5 weeks):

--- a/docs/manual/reference/architecture-diagrams.md
+++ b/docs/manual/reference/architecture-diagrams.md
@@ -1,225 +1,694 @@
 # Architecture Diagrams
 
-All system diagrams collected in one reference. These diagrams show how the components connect, how data flows, and how lifecycle events are sequenced.
+All system diagrams in one reference. These show how the components connect, how data flows, and how lifecycle events sequence.
+
+---
 
 ## 1. Repository Structure
 
 The `~/agents/` monorepo contains all Claude Code configuration alongside standalone agent projects.
 
 ```
-~/agents/                              # Single git repo
-  claude-config/                       # Claude Code configuration
-    agents/          (11 .md files)    # Agent definitions
-    commands/        (15 .md files)    # Slash commands
-    hooks/           (6 .py files)     # Lifecycle hooks + shared modules
-    rules/           (7 .md files)     # Conditional + always-loaded rules
-    skills/          (3 directories)   # Multi-step workflows
-    templates/       (2 entries)       # Prompt templates
-    settings.json                      # Global settings
-    statusline.py                      # Custom status bar
-    install.sh                         # Symlink installer
-  mcp-server/                          # Custom MCP server (5 tools)
-  obsidian-agent/                      # Session -> vault writer
-  code-review/                         # Pre-commit review agent
-  daily-standup/                       # Standup report generator
-  pr-changelog/                        # Post-merge changelog
-  doc-reader/                          # Document TTS reader
-  youtube-summarizer/                  # Video summarizer
+~/agents/                                # single git repo
+  claude-config/                         # Claude Code configuration (symlinked into ~/.claude/)
+    agents/          (12 .md files)      # Agent definitions
+    commands/        (16 .md files)      # Slash commands
+    rules/           (12 .md files)      # Always-loaded + path-scoped rules
+    hooks/           (10 .py files)      # Lifecycle hooks + shared modules
+    skills/                              # Workflow skills (linked from ~/.claude/skills)
+    snippets/                            # Shared prompt snippets (verify-commands.md)
+    scripts/                             # Validators (validate-hooks.py, validate-paths-globs.py)
+    templates/       (8 entries)         # Prompt + scaffold templates
+    settings.json                        # Hook registrations, plugins, permissions
+    statusline.py                        # Custom status bar
+    install.sh                           # Symlink + dependency installer
+    CLAUDE.md                            # Top-level orientation file
+  knowledge/                             # Knowledge graph (YAML source of truth)
+    patterns/        (39 .yaml files)    # Patterns with slug IDs (pat-<stem>)
+    decisions/                           # Decision log
+    learning_rules/                      # Learning rules
+    projects/                            # Project state snapshots
+    specs/                               # Spec docs
+    sync.py                              # Builds knowledge.db from YAMLs
+  knowledge-mcp/                         # MCP server for knowledge graph
+  mcp-server/                            # MCP server for vault-metrics
+  obsidian-agent/                        # Session → Obsidian vault writer
+  code-review/                           # Pre-commit review agent
+  daily-standup/                         # Standup report generator
+  pr-changelog/                          # Post-merge changelog
+  doc-reader/                            # Document TTS reader
+  youtube-summarizer/                    # Video summarizer
+  email-helper/                          # Mail integration
+  frontend-design/                       # Frontend design helpers
+  scripts/                               # Repo-wide tooling
+  docs/                                  # This manual + supporting docs
+  .github/
+    workflows/validate.yml               # CI: validates config on PR
 ```
+
+---
 
 ## 2. Symlink Deployment
 
-How version-controlled config in the repo maps to the paths Claude Code reads at runtime.
+`install.sh` installs the Claude config by symlinking pieces of `claude-config/` into `~/.claude/`. The repo is the source of truth; `~/.claude/` is the runtime view.
 
-```
-~/agents/claude-config/                ~/.claude/
-  agents/          ---symlink--->        agents/
-  commands/        ---symlink--->        commands/
-  hooks/           ---symlink--->        hooks/
-  rules/           ---symlink--->        rules/
-  skills/          ---symlink--->        skills/
-  settings.json    ---symlink--->        settings.json
-  statusline.py    ---symlink--->        statusline.py
+```mermaid
+flowchart LR
+    subgraph repo["~/agents/claude-config/ (source of truth, version-controlled)"]
+        rc_settings[settings.json]
+        rc_claude[CLAUDE.md]
+        rc_agents[agents/]
+        rc_cmds[commands/]
+        rc_rules[rules/]
+        rc_hooks[hooks/]
+        rc_skills[skills/]
+        rc_snip[snippets/]
+        rc_status[statusline.py]
+    end
 
-  NOT symlinked (machine-local):
-                                         settings.local.json
-                                         memory/
-                                         projects/
-```
+    subgraph deployed["~/.claude/ (runtime, machine-specific)"]
+        d_settings[settings.json]
+        d_claude[CLAUDE.md]
+        d_agents[agents/]
+        d_cmds[commands/]
+        d_rules[rules/]
+        d_hooks[hooks/]
+        d_skills[skills/]
+        d_status[statusline.py]
+        d_mcp[".claude.json (MCP servers)"]
+    end
 
-Changes to the repo are live immediately --- symlinks mean no re-install is needed. Run `git pull` on another machine and updates propagate.
+    install["install.sh"]
+    mcpadd["claude mcp add --scope user"]
+    npmwarm["npm cache warm-up<br/>(context7, apple-mcp)"]
 
-## 3. Hook Lifecycle Flow
+    install -.symlinks.-> d_settings
+    install -.symlinks.-> d_claude
+    install -.symlinks.-> d_agents
+    install -.symlinks.-> d_cmds
+    install -.symlinks.-> d_rules
+    install -.symlinks.-> d_hooks
+    install -.symlinks.-> d_skills
+    install -.symlinks.-> d_status
 
-The sequence of hook events from session start through completion, showing how state is persisted and restored.
+    rc_settings -.-> d_settings
+    rc_claude -.-> d_claude
+    rc_agents -.-> d_agents
+    rc_cmds -.-> d_cmds
+    rc_rules -.-> d_rules
+    rc_hooks -.-> d_hooks
+    rc_skills -.-> d_skills
+    rc_status -.-> d_status
 
-```
-SESSION START
-  sessionstart_restore_state.py
-    +- Load PERSISTENT_STATE.yaml
-    +- Load patterns-critical.md
-    +- Output ~500 tokens restored context
-        |
-        v
-  [ SESSION WORK ]
-        |
-  Context limit? --YES--> PreCompact Hook
-        |                   +- Extract state from transcript
-        |                   +- Update PERSISTENT_STATE.yaml
-        |                   +- Auto-delete >7 day files
-        |<------------------+
-        |
-  Task complete? --YES--> Stop Hooks (sequential)
-        |                   1. verify_completion.py
-        |                      Exit 2 = block (uncommitted/TODOs)
-        |                   2. notify_completion.py
-        |                      macOS notification + iPhone
-        v
-  [continue working]
-```
-
-## 4. Task Routing Decision Tree
-
-How incoming tasks are classified by complexity tier and routed to the appropriate workflow.
-
-```
-Task / GitHub Issue
-        |
-  Classify Routing Tier
-        |
-  +-----+-------+----------+-----------+-----------+
-  |     |       |          |           |           |
-TRIVIAL SIMPLE MODERATE  COMPLEX   FULLSTACK  PRIOR FAIL
-(1 file)(1-3)  (4-5)     (6+)      (any)      (any)
-  |     |       |          |           |           |
-/quick  Plan    +--------- /orchestrate -----------+
-        Mode    |          |           |           |
-              SIMPLE     COMPLEX    SIMPLE or   SIMPLE or
-              pipeline   pipeline   COMPLEX +   COMPLEX +
-                |          |        CONTRACT    failure ctx
-                |          |           |           |
-              MAP-PLAN  MAP->PLAN  MAP-PLAN or MAP->PLAN
-                |          |           |           |
-           PLAN-CHECK  PLAN-CHECK  CONTRACT(*)    |
-                |          |           |           |
-              PATCH      PATCH      PATCH       PATCH
-                |          |           |           |
-              PROVE      PROVE      PROVE       PROVE
-                |          |           |           |
-                +--------- /pr --------+----------+
-
-(*) CONTRACT-lite if 0 new endpoints + <=2 frontend files
+    install --> mcpadd
+    mcpadd --> d_mcp
+    install --> npmwarm
 ```
 
-## 5. Parallel Worktree Sessions
+`settings.json` lives in the repo and is symlinked, so editing the runtime config means editing source. MCP servers are not symlinked — they're registered per machine via `claude mcp add --scope user` which writes to `~/.claude.json`.
 
-How two concurrent `/orchestrate --parallel` sessions each get isolated worktrees with independent file systems.
+---
 
+## 3. Configuration Loading at Session Start
+
+When you start `claude`, the harness loads configuration in a specific order and triggers SessionStart hooks before you can interact.
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant CLI as Claude Code CLI
+    participant Settings as ~/.claude/settings.json
+    participant Hooks as SessionStart hooks
+    participant State as PERSISTENT_STATE.yaml
+    participant MCP as MCP servers
+    participant Plugins as Plugin commands
+
+    User->>CLI: claude (start session)
+    CLI->>Settings: load permissions, plugins, hook table
+    CLI->>Plugins: load enabled plugin commands
+    CLI->>MCP: spawn each registered MCP server (~/.claude.json)
+    Note over MCP: knowledge, vault-metrics, context7, apple-mcp
+    CLI->>Hooks: fire SessionStart hooks in order
+    Hooks->>State: sessionstart_restore_state.py reads PERSISTENT_STATE
+    Hooks->>Hooks: load_learning_rules.py (LR-001, LR-002, ...)
+    Hooks-->>CLI: stdout becomes session context
+    CLI-->>User: ready prompt
 ```
-Tab 1: /orchestrate 42 --parallel    Tab 2: /orchestrate 57 --parallel
-  .worktrees/issue-42/ (isolated)      .worktrees/issue-57/ (isolated)
-      |                                    |
-      v                                    v
-  PR from worktree branch              PR from worktree branch
-      |                                    |
-      v                                    v
-  Merge -> worktree removed            Merge -> worktree removed
+
+---
+
+## 4. Issue → PR Pipeline (Orchestrate)
+
+The full flow from a GitHub issue to a merged PR. Tier classification routes the work; some phases are conditional.
+
+```mermaid
+flowchart TD
+    issue([GitHub issue #N])
+    classify{"Classify<br/>complexity"}
+
+    issue --> classify
+
+    classify -- "TRIVIAL" --> redirect["/orchestrate rejects<br/>→ redirect to /quick"]
+    classify -- "SIMPLE" --> simple_branch["create feature/issue-N-...<br/>off origin/main"]
+    classify -- "COMPLEX" --> complex_branch["create feature/issue-N-...<br/>off origin/main"]
+    classify -- "FULLSTACK" --> complex_branch
+
+    simple_branch --> simple_pipeline
+
+    subgraph simple_pipeline["SIMPLE pipeline"]
+        s_discuss["[DISCUSS]<br/>(if --discuss)"] --> s_mapplan[MAP-PLAN]
+        s_mapplan --> s_test["[TEST-PLANNER]<br/>(if --with-tests)"]
+        s_test --> s_contract["[CONTRACT]<br/>(if fullstack)"]
+        s_contract --> s_patch[PATCH]
+        s_patch --> s_prove[PROVE]
+    end
+
+    complex_branch --> complex_pipeline
+
+    subgraph complex_pipeline["COMPLEX pipeline"]
+        c_discuss["[DISCUSS]<br/>(if --discuss)"] --> c_map[MAP]
+        c_map --> c_plan[PLAN]
+        c_plan --> c_test["[TEST-PLANNER]<br/>(if --with-tests)"]
+        c_test --> c_contract["[CONTRACT]<br/>(if fullstack)"]
+        c_contract --> c_check[PLAN-CHECK]
+        c_check --> c_patch[PATCH]
+        c_patch --> c_prove[PROVE]
+    end
+
+    s_prove --> pr_workflow
+    c_prove --> pr_workflow
+
+    subgraph pr_workflow["/pr workflow"]
+        pr_fresh[Fresh-context review]
+        pr_codex{"COMPLEX-tier<br/>signals?"}
+        pr_codex_run["recommend<br/>/codex:adversarial-review"]
+        pr_create[gh pr create]
+        pr_ci[".github/workflows/<br/>validate.yml"]
+        pr_squash[squash merge]
+        pr_postmerge[post-merge hook<br/>rebuilds knowledge.db]
+
+        pr_fresh --> pr_codex
+        pr_codex -- yes --> pr_codex_run
+        pr_codex_run --> pr_create
+        pr_codex -- no --> pr_create
+        pr_create --> pr_ci
+        pr_ci --> pr_squash
+        pr_squash --> pr_postmerge
+    end
+
+    pr_postmerge --> learn[record outcome to<br/>metrics.jsonl + failures.jsonl]
 ```
 
-Each worktree has its own files, git index, and `.agents/outputs/`. `PERSISTENT_STATE.yaml` lives in the main repo so `--resume` can locate the worktree.
+---
 
-## 6. State Manager Functions
+## 5. Tier Routing Decision Tree
 
-The `state_manager.py` API surface and which components call each function.
+Every task is classified by complexity. The routing is mostly deterministic; gray areas use `--discuss` to capture design decisions before MAP/PLAN runs.
 
+```mermaid
+flowchart TD
+    task([Task arrives])
+    files{"How many<br/>files?"}
+
+    task --> files
+
+    files -- "1, obvious" --> trivial["TRIVIAL<br/>→ /quick<br/>(no pipeline)"]
+    files -- "1-3" --> simple_q
+    files -- "4-5" --> moderate_q
+    files -- "6+" --> complex_q
+    files -- "any (cross-stack)" --> fullstack_q
+
+    simple_q{"Risk profile?"}
+    simple_q -- low --> simple["SIMPLE<br/>→ /orchestrate"]
+    simple_q -- medium --> moderate["MODERATE<br/>→ /orchestrate SIMPLE tier<br/>+ Codex review recommended"]
+
+    moderate_q{"Cross-cutting?"}
+    moderate_q -- yes --> complex
+    moderate_q -- no --> moderate
+
+    complex_q{"Cross-cutting<br/>or migration?"}
+    complex_q -- yes --> complex["COMPLEX<br/>→ /orchestrate COMPLEX tier<br/>+ Codex review recommended"]
+    complex_q -- no --> moderate
+
+    fullstack_q{"Backend +<br/>frontend?"}
+    fullstack_q -- yes --> fullstack["FULLSTACK<br/>→ /orchestrate + CONTRACT<br/>+ Codex review (enum/API focus)"]
+
+    classDef trivialStyle fill:#e0f7e0,stroke:#2d8a2d
+    classDef simpleStyle fill:#e0f0ff,stroke:#3060c0
+    classDef complexStyle fill:#fff0d0,stroke:#c08030
+    classDef fullStackStyle fill:#ffe0e0,stroke:#c03030
+    class trivial trivialStyle
+    class simple,moderate simpleStyle
+    class complex complexStyle
+    class fullstack fullStackStyle
 ```
-state_manager.py
-  load_state()            <- read PERSISTENT_STATE.yaml
-  update_phase()          <- orchestrate: before each agent
-  clear_active()          <- orchestrate: after completion
-  get_completed_phases()  <- --resume: skip finished phases
-  get_active_work()       <- sessionstart + notify hooks
-  get_worktree_for_issue()<- --parallel: find worktree path
-  update_from_extracted() <- precompact: save transcript state
 
-Callers: orchestrate (commands/), precompact, sessionstart, notify (hooks/)
+---
+
+## 6. Hook Lifecycle
+
+Hooks attach to specific Claude Code lifecycle events. Each hook is a Python script registered in `settings.json`.
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant CLI as Claude Code
+    participant SS as SessionStart
+    participant PT as PreToolUse
+    participant Tool as Tool execution
+    participant PoT as PostToolUse
+    participant PC as PreCompact
+    participant Stop as Stop
+
+    User->>CLI: start session
+    CLI->>SS: fire SessionStart hooks
+    Note over SS: sessionstart_restore_state.py<br/>load_learning_rules.py
+    SS-->>CLI: hooks return stdout to context
+
+    loop tool calls
+        CLI->>PT: fire PreToolUse hooks (if any)
+        PT-->>CLI: exit 0 (allow) or exit 2 (block)
+        CLI->>Tool: execute tool
+        Tool-->>CLI: result
+        CLI->>PoT: fire PostToolUse hooks
+        Note over PoT: context_monitor.py
+    end
+
+    opt context approaching limit
+        CLI->>PC: fire PreCompact hooks
+        Note over PC: precompact_checkpoint.py<br/>(saves state to PERSISTENT_STATE.yaml)
+        PC-->>CLI: state saved
+    end
+
+    User->>CLI: stop / end session
+    CLI->>Stop: fire Stop hooks in order
+    Note over Stop: 1. verify_completion.py<br/>2. notify_completion.py<br/>3. session_end_context_update.py
+    Stop-->>CLI: warnings / notifications
+    CLI-->>User: end
 ```
+
+---
 
 ## 7. Self-Learning Loop
 
-How PROVE outcomes feed back into agent behavior through the `/learn` command and pattern files.
+Every orchestrate outcome is recorded. Failures get root-cause classified, aggregated into patterns, and surface back through the agent pre-flight.
 
-```
-/orchestrate --> PROVE --> metrics.jsonl + failures.jsonl
-                              |
-                              v
-                  /learn (weekly) --> patterns.md
-                     +--apply     --> agent .md files (prevention checklists)
-                     +--validate  --> before/after success rate comparison
-                     +--cross-project --> aggregate across all projects
-                              |
-                              v
-                  Next /orchestrate loads updated patterns via:
-                    1. MCP failure_patterns() (preferred)
-                    2. .claude/memory/patterns-critical.md (fallback)
-                              |
-                              v
-                        Cycle repeats
-```
+```mermaid
+flowchart LR
+    issue([Issue]) --> orchestrate[/orchestrate run]
+    orchestrate --> outcome{"PROVE result"}
 
-## 8. MCP Pattern Loading
+    outcome -- PASS --> metrics_pass["metrics.jsonl<br/>(success record)"]
+    outcome -- BLOCKED --> failure_record["failures.jsonl<br/>(root_cause, files, prevention)"]
+    outcome -- BLOCKED --> metrics_fail["metrics.jsonl<br/>(failure record)"]
 
-The fallback chain agents use to load failure patterns: MCP first, file-based second.
+    failure_record --> learn["/learn (weekly)"]
+    metrics_pass --> learn
+    metrics_fail --> learn
 
-```
-+---------------------+     +---------------------------+
-|  Agent Pre-Flight   |---->|  MCP: failure_patterns()  |
-|  (all agents via    |     |  MCP: agent_metrics(30d)  |
-|   _base.md section 1)|    +-------------+-------------+
-|                     |                   |
-|                     |                   | fails?
-|                     |                   v
-|                     |     +---------------------------+
-|                     |---->|  File: patterns-critical  |
-|                     |     |  File: patterns-full.md   |
-+---------------------+     +---------------------------+
+    learn --> patterns["knowledge/patterns/*.yaml<br/>(new + updated)"]
+    learn --> rules["knowledge/learning_rules/<br/>(prevention rules)"]
+
+    patterns --> sync[knowledge/sync.py build]
+    rules --> sync
+    sync --> db[(knowledge.db)]
+
+    db --> mcp[vault-metrics MCP]
+    mcp --> preflight[Agent pre-flight<br/>at next session start]
+
+    preflight --> orchestrate
+
+    classDef recordStyle fill:#fff0d0,stroke:#c08030
+    classDef knowledgeStyle fill:#e0f0ff,stroke:#3060c0
+    classDef agentStyle fill:#e0f7e0,stroke:#2d8a2d
+    class metrics_pass,metrics_fail,failure_record recordStyle
+    class patterns,rules,db,mcp knowledgeStyle
+    class orchestrate,preflight agentStyle
 ```
 
-Agents prefer MCP tools over file reads for pattern data. MCP provides structured JSON responses. File-based loading is the fallback when MCP is unavailable.
+---
 
-## 9. Obsidian Data Flow
+## 8. MCP Server Topology
 
-How Claude Code session data flows through the Obsidian agent into the vault, and which downstream tools consume it.
+Five MCP servers extend Claude Code with structured tool APIs. Two are local processes from this repo; three come from npm packages.
 
+```mermaid
+flowchart TB
+    cli[Claude Code session]
+
+    subgraph local["Local processes (this repo)"]
+        knowledge["knowledge<br/>(tsx + index.ts)"]
+        vault["vault-metrics<br/>(.venv/python + server.py)"]
+    end
+
+    subgraph npm["npm-launched (warmed by install.sh)"]
+        context7["context7<br/>(npx -y @upstash/context7-mcp@latest)"]
+        apple["apple-mcp<br/>(npx -y apple-mcp@latest)<br/>macOS only"]
+        playwright["playwright<br/>(via Claude plugin)"]
+    end
+
+    cli -- "stdio" --> knowledge
+    cli -- "stdio" --> vault
+    cli -- "stdio" --> context7
+    cli -- "stdio" --> apple
+    cli -- "stdio" --> playwright
+
+    knowledge --> kdb[(knowledge.db)]
+    vault --> vault_data["~/agents/.claude/memory/<br/>+ Obsidian vault"]
+    context7 --> registry["upstash docs registry<br/>(network)"]
+    apple --> apple_apps["macOS apps<br/>(Calendar, Mail, Notes...)"]
+    playwright --> browser["headless browser<br/>(navigate, click, screenshot)"]
+
+    classDef localStyle fill:#e0f7e0,stroke:#2d8a2d
+    classDef remoteStyle fill:#fff0d0,stroke:#c08030
+    class knowledge,vault localStyle
+    class context7,apple,playwright remoteStyle
 ```
-Claude Code Sessions (.claude/projects/*/session.jsonl)
-        |
-        v
-obsidian-agent (Haiku) --+--> Obsidian Vault (STATUS.md, Daily, DASHBOARD)
-                         |       |
-                         |       +--> mcp-server (vault_status/search/dashboard)
-                         |       +--> daily-standup (reads vault)
-                         |       +--> pr-changelog (writes to vault)
-                         |
-                         +--> .claude/memory/ (metrics.jsonl, failures.jsonl)
-                                 +--> /learn, /metrics, mcp-server
+
+---
+
+## 9. Knowledge Graph Data Flow
+
+The knowledge graph is YAML files in git, built into a local SQLite database, surfaced to agents via the MCP server.
+
+```mermaid
+flowchart LR
+    subgraph yaml["YAML source (git)"]
+        patterns["knowledge/patterns/*.yaml<br/>(39 files, slug IDs)"]
+        decisions["knowledge/decisions/*.yaml"]
+        rules["knowledge/learning_rules/*.yaml"]
+        projects["knowledge/projects/*.yaml"]
+    end
+
+    subgraph build["Build (local)"]
+        guard["sync.py:<br/>uniqueness guard<br/>(refuses duplicate IDs)"]
+        sync["knowledge/sync.py build"]
+    end
+
+    db[(knowledge.db<br/>SQLite)]
+
+    subgraph access["Access"]
+        mcp["knowledge MCP server<br/>(query interface)"]
+        agents["Agents<br/>(pre-flight pattern lookup)"]
+        cli["Manual queries<br/>(agents/_base.md)"]
+    end
+
+    posthook["post-merge hook<br/>(install.sh-installed)"]
+    pull["git pull"]
+
+    pull --> posthook
+    posthook --> sync
+
+    patterns --> guard
+    guard --> sync
+    decisions --> sync
+    rules --> sync
+    projects --> sync
+    sync --> db
+
+    db --> mcp
+    mcp --> agents
+    mcp --> cli
+
+    classDef sourceStyle fill:#e0f0ff,stroke:#3060c0
+    classDef buildStyle fill:#fff0d0,stroke:#c08030
+    classDef accessStyle fill:#e0f7e0,stroke:#2d8a2d
+    class patterns,decisions,rules,projects sourceStyle
+    class guard,sync,posthook buildStyle
+    class mcp,agents,cli accessStyle
 ```
 
-## 10. Cross-Model Review
+---
 
-How three AI models (Opus, Haiku, Codex) divide responsibilities across implementation, review, and validation.
+## 10. Codex × Claude Collaboration
 
+Two AI models, complementary roles. Claude is the conductor; Codex is the second-opinion reviewer for risky work.
+
+```mermaid
+flowchart TD
+    task([Task])
+
+    claude["Claude<br/>(implementation, orchestration)"]
+    task --> claude
+    claude --> impl[implements via /orchestrate or /quick]
+
+    impl --> prove[PROVE pass]
+
+    prove --> tier_check{"Tier signals<br/>(MODERATE+,<br/>auth/data/migration)?"}
+
+    tier_check -- "TRIVIAL/SIMPLE,<br/>low risk" --> commit_simple["commit + /pr<br/>(no Codex)"]
+
+    tier_check -- "MODERATE/COMPLEX/<br/>FULLSTACK" --> pr_gate["/pr advisory gate"]
+
+    pr_gate --> codex_review["/codex:adversarial-review<br/>(separate model, fresh context)"]
+
+    codex_review --> findings{"Findings?"}
+    findings -- "BLOCKING" --> fix[fix issues<br/>re-run PROVE]
+    findings -- "NON-BLOCKING" --> commit_pr["commit + /pr<br/>(notes in PR body)"]
+    findings -- "CLEAN" --> commit_pr
+
+    fix --> prove
+
+    commit_simple --> ci[".github/workflows/<br/>validate.yml"]
+    commit_pr --> ci
+    ci --> merge[squash merge]
+
+    classDef claudeStyle fill:#fff0d0,stroke:#c08030
+    classDef codexStyle fill:#e0f0ff,stroke:#3060c0
+    classDef gateStyle fill:#e0f7e0,stroke:#2d8a2d
+    class claude,impl,prove,fix claudeStyle
+    class codex_review codexStyle
+    class pr_gate,ci,tier_check gateStyle
 ```
-Claude Opus (Primary)          Claude Haiku (Review)
-  /orchestrate, /spec-draft      code-reviewer, obsidian-agent
-  Implementation, reasoning      Lightweight proactive review
-        |                              |
-        +----------+-------------------+
-                   v
-          Codebase (main branch)
-                   |
-                   v
-          Codex (OpenAI) -- Spec validation, secondary check
+
+---
+
+## 11. Multi-Machine Pattern Coordination
+
+Pattern IDs use slugs derived from filenames. This makes multi-machine pattern authoring collision-free by construction — git's filename-uniqueness handles the coordination.
+
+```mermaid
+sequenceDiagram
+    participant LapA as Laptop A
+    participant Git as origin/main
+    participant LapB as Laptop B
+
+    Note over LapA,LapB: Both clone the repo and run install.sh
+
+    par Same starting state
+        LapA->>Git: git pull
+        LapB->>Git: git pull
+    end
+
+    Note over LapA,LapB: Different patterns scenario (no conflict)
+    LapA->>LapA: author pat-fastapi-foo.yaml
+    LapB->>LapB: author pat-react-bar.yaml
+    LapA->>Git: PR #X (merges)
+    LapB->>Git: PR #Y (merges)
+    Note over Git: Both land cleanly — different filenames, different IDs
+
+    Note over LapA,LapB: Same pattern scenario (conflict surfaces)
+    LapA->>LapA: author pat-auth-jwt.yaml (content A)
+    LapB->>LapB: author pat-auth-jwt.yaml (content B)
+    LapA->>Git: PR #X (merges first)
+    LapB->>Git: PR #Y push
+    Git-->>LapB: real merge conflict<br/>(same filename, different content)
+    Note over LapB: Human resolves consciously — are they actually the same pattern?
+
+    Note over Git: sync.py duplicate-ID guard fires post-merge<br/>if anything slips past
 ```
 
-Claude Opus handles primary development. Claude Haiku runs lightweight proactive code reviews and extracts session data to the Obsidian vault. Codex provides an independent review perspective from a different model family.
+---
+
+## 12. Pre-Merge Gate Stack
+
+A PR passes through several gates before reaching `main`. Each gate catches a different class of regression.
+
+```mermaid
+flowchart TD
+    branch[Feature branch<br/>committed + pushed]
+
+    gate1[/pr command]
+    branch --> gate1
+
+    subgraph local_gates["Local-machine gates (in /pr)"]
+        fresh["Pre-PR fresh-context review<br/>(pr-fresh-reviewer subagent)"]
+        codex_check{"COMPLEX<br/>signals?"}
+        codex_run["/codex:adversarial-review<br/>(advisory; user invokes)"]
+    end
+
+    gate1 --> fresh
+    fresh --> codex_check
+    codex_check -- yes --> codex_run
+    codex_check -- no --> create_pr
+    codex_run --> create_pr
+
+    create_pr[gh pr create]
+
+    subgraph ci_gates["GitHub Actions gates (.github/workflows/validate.yml)"]
+        v_json["settings.json valid JSON"]
+        v_bash["install.sh syntax (bash -n)"]
+        v_hooks["validate-hooks.py<br/>(every hook script path resolves)"]
+        v_sync["sync.py build<br/>(catches duplicate pattern IDs,<br/>schema drift)"]
+        v_slug["pattern slug invariant<br/>(every id matches filename)"]
+    end
+
+    create_pr --> v_json
+    v_json --> v_bash
+    v_bash --> v_hooks
+    v_hooks --> v_sync
+    v_sync --> v_slug
+    v_slug --> ready{"All<br/>green?"}
+
+    ready -- no --> fail[block merge]
+    ready -- yes --> merge[squash merge]
+
+    merge --> postmerge["post-merge hook<br/>(rebuilds knowledge.db,<br/>re-runs install.sh if config changed)"]
+
+    classDef localStyle fill:#fff0d0,stroke:#c08030
+    classDef ciStyle fill:#e0f0ff,stroke:#3060c0
+    classDef finalStyle fill:#e0f7e0,stroke:#2d8a2d
+    class fresh,codex_check,codex_run localStyle
+    class v_json,v_bash,v_hooks,v_sync,v_slug ciStyle
+    class merge,postmerge finalStyle
+```
+
+---
+
+## 13. Failure → Pattern Feedback Cycle
+
+Detail of how a single failure becomes a prevention rule that future agents apply automatically.
+
+```mermaid
+flowchart LR
+    failure([Agent fails PROVE])
+
+    classify["Classify root cause<br/>(11 codes: ENUM_VALUE,<br/>COMPONENT_API, etc.)"]
+    failure --> classify
+
+    record["Append to failures.jsonl<br/>{root_cause, files, agent,<br/>prevention}"]
+    classify --> record
+
+    weekly["/learn (weekly)<br/>aggregate by root_cause"]
+    record --> weekly
+
+    threshold{"Frequency<br/>≥ threshold?"}
+    weekly --> threshold
+
+    threshold -- no --> hold[remain in failures.jsonl<br/>for next aggregation]
+    threshold -- yes --> author["Author or update<br/>knowledge/patterns/<br/>pat-rootcause.yaml"]
+
+    author --> review["Human review<br/>+ commit"]
+    review --> sync[sync.py rebuild]
+    sync --> mcp[vault-metrics MCP<br/>now exposes the pattern]
+
+    mcp --> preflight[next agent pre-flight<br/>loads pattern automatically]
+    preflight --> avoidance[future agents<br/>avoid the failure mode]
+
+    classDef failStyle fill:#ffe0e0,stroke:#c03030
+    classDef analysisStyle fill:#fff0d0,stroke:#c08030
+    classDef knowledgeStyle fill:#e0f0ff,stroke:#3060c0
+    classDef preventionStyle fill:#e0f7e0,stroke:#2d8a2d
+    class failure,record failStyle
+    class classify,weekly,threshold,author analysisStyle
+    class sync,mcp knowledgeStyle
+    class preflight,avoidance preventionStyle
+```
+
+---
+
+## 14. State Continuity Across Sessions
+
+Orchestrate workflows can span multiple sessions. State persists via the PreCompact and SessionStart hooks.
+
+```mermaid
+sequenceDiagram
+    participant S1 as Session 1
+    participant State as PERSISTENT_STATE.yaml
+    participant Disk as disk
+    participant S2 as Session 2
+
+    S1->>S1: /orchestrate 184<br/>completes MAP-PLAN
+    S1->>State: state_manager.update_phase(PATCH, "starting")
+    State->>Disk: write yaml
+
+    Note over S1: context approaching limit
+    S1->>State: PreCompact hook checkpoints transcript
+    State->>Disk: write checkpoint
+    Note over S1: session ends
+
+    S2->>S2: claude (start new session)
+    S2->>Disk: SessionStart reads PERSISTENT_STATE
+    Disk-->>S2: active_work {issue 184, phase PATCH}
+    S2->>S2: SessionStart hook injects state into context
+    Note over S2: User can /orchestrate 184 --resume<br/>and skip MAP-PLAN
+    S2->>S2: continue PATCH where Session 1 left off
+    S2->>State: update_phase(PROVE, "passed")
+    S2->>State: clear_active(184) when done
+```
+
+---
+
+## 15. Slash Command Surface
+
+The 16 user-facing slash commands grouped by purpose.
+
+```mermaid
+flowchart TB
+    subgraph implementation["Implementation"]
+        quick[/quick<br/>TRIVIAL/]
+        orchestrate[/orchestrate<br/>SIMPLE+/]
+    end
+
+    subgraph issue_creation["Issue creation"]
+        bug[/bug/]
+        feature[/feature/]
+        spec_draft[/spec-draft/]
+        spec_review[/spec-review/]
+        feature_from_spec["/feature-from-spec<br/>(internal helper)"]
+    end
+
+    subgraph quality["Quality + review"]
+        review[/review/]
+        test_plan[/test-plan/]
+        pr[/pr/]
+    end
+
+    subgraph scaffolding["Scaffolding"]
+        scaffold_proj[/scaffold-project/]
+        scaffold_mod[/scaffold-module/]
+    end
+
+    subgraph learning["Learning + insight"]
+        learn[/learn/]
+        metrics[/metrics/]
+        seed[/seed/]
+    end
+
+    subgraph design["Design"]
+        frontend[/frontend-design/]
+    end
+
+    classDef impStyle fill:#fff0d0,stroke:#c08030
+    classDef issueStyle fill:#e0f0ff,stroke:#3060c0
+    classDef qualStyle fill:#e0f7e0,stroke:#2d8a2d
+    classDef scafStyle fill:#ffe0ff,stroke:#a030a0
+    classDef learnStyle fill:#ffe0e0,stroke:#c03030
+
+    class quick,orchestrate impStyle
+    class bug,feature,spec_draft,spec_review,feature_from_spec issueStyle
+    class review,test_plan,pr qualStyle
+    class scaffold_proj,scaffold_mod scafStyle
+    class learn,metrics,seed learnStyle
+```
+
+---
+
+## Where to look next
+
+- Pipeline phases in detail: [The Pipeline](../workflow/orchestrate.md)
+- Agent definitions: [Agent Roles](../agents/overview.md)
+- Hook contracts: [Hook Lifecycle](../hooks/lifecycle.md)
+- Codex integration: [Codex Plugin](../integrations/codex-plugin.md)
+- Self-learning system: [Self-Learning Loop](../learning/self-learning-loop.md)
+- File-by-file inventory: [File Inventory](file-inventory.md)

--- a/docs/manual/reference/file-inventory.md
+++ b/docs/manual/reference/file-inventory.md
@@ -1,148 +1,260 @@
 # File Inventory
 
-Complete listing of all files in the `~/agents/claude-config/` repository, organized by category. All paths are relative to `~/agents/claude-config/` and symlinked to `~/.claude/` via `install.sh`.
+Complete listing of all files in `~/agents/claude-config/` and related directories. All paths are relative to repo root unless noted.
+
+`claude-config/` is symlinked into `~/.claude/` by `install.sh`. The repo is the source of truth; runtime references via `~/.claude/...` resolve through symlinks.
+
+---
 
 ## Agents (12 files)
 
-Symlinked to `~/.claude/agents/`. Agent definitions are markdown files that define role, constraints, input requirements, output format, and verification gates.
+Located in `claude-config/agents/`. Each agent is a markdown file with frontmatter (`name:`, `description:`, `tools:`, `model:`) followed by the agent's prompt body.
 
 | File | Size | Purpose |
-|------|------|---------|
-| `_base.md` | 10.3 KB | Base agent inherited by all others: pre-flight, artifact naming, validation, AGENT_RETURN directive |
-| `map.md` | 3.6 KB | Investigator for COMPLEX issues (read-only, phase 1) |
-| `map-plan.md` | 6.5 KB | Combined investigator + architect for TRIVIAL/SIMPLE pipeline tiers (read-only, phase 1+2) |
-| `plan.md` | 4.1 KB | Architect for COMPLEX issues (read-only, phase 2) |
-| `contract.md` | 3.3 KB | Interface designer for fullstack issues (read-only, phase 2.5) |
-| `plan-checker.md` | 3.1 KB | Plan validator (read-only, phase 2.8) |
-| `patch.md` | 5.8 KB | Implementer --- the only agent that modifies code (phase 3) |
-| `prove.md` | 7.3 KB | Reviewer and outcome recorder (phase 4) |
-| `test-planner.md` | 7.9 KB | Test architect for `--with-tests` flag (optional, phase 1.5) |
-| `spec-reviewer.md` | 6.1 KB | Spec analyst and GitHub issue creator (pre-pipeline) |
-| `code-reviewer.md` | 1.3 KB | Proactive lightweight review (runs on Haiku model) |
-| `discuss.md` | 4.5 KB | Decision capturer --- identifies gray areas before planning (optional, `--discuss` flag) |
+|------|-----:|---------|
+| `_base.md` | 9.6 KB | Base prompt inherited by every agent (pre-flight pattern loading, AGENT_RETURN spec, failure prevention, artifact validation). Trimmed in PR #97 — verification commands now live in `snippets/verify-commands.md`. |
+| `contract.md` | 3.6 KB | Defines backend ↔ frontend API contract. **Mandatory for fullstack changes.** |
+| `discuss.md` | 4.6 KB | Captures design decisions and trade-offs before MAP/PLAN. Runs only when `--discuss` flag is set. |
+| `map-plan.md` | 6.8 KB | Combined MAP + PLAN for SIMPLE-tier work — investigates the codebase and produces an implementation plan. |
+| `map.md` | 3.9 KB | Investigates current state. Runs in COMPLEX tier as a separate phase before PLAN. |
+| `patch.md` | 8.4 KB | Implementation phase. Edits files, writes tests, runs verification commands. |
+| `plan-checker.md` | 3.3 KB | Validates a PLAN artifact's completeness before PATCH burns context implementing it. **COMPLEX-only** since v5 dropped PLAN-CHECK from SIMPLE. |
+| `plan.md` | 4.4 KB | Authors implementation plan in COMPLEX tier (after MAP). |
+| `pr-fresh-reviewer.md` | 1.7 KB | Fresh-context PR reviewer. Spawned by `/pr` to look at the diff with no inheritance from the implementation discussion. |
+| `prove.md` | 8.6 KB | Verification phase. Runs lint/tests, validates acceptance criteria, applies behavioral evals (E01–E15) per `eval-file-mapping.md`. |
+| `spec-reviewer.md` | 6.4 KB | Reviews a specification document against the codebase, optionally generates GitHub issues. |
+| `test-planner.md` | 8.2 KB | Generates pre-implementation test plan with edge cases. Runs when `--with-tests` flag is set. |
 
-## Commands (16 files)
+---
 
-Symlinked to `~/.claude/commands/`. Slash commands invokable by the user during a session.
+## Slash Commands (16 files)
+
+Located in `claude-config/commands/`. Each is a markdown file with frontmatter (`description:`, `argument-hint:`, sometimes `disable-model-invocation:`) and a process spec.
+
+### Implementation
+| File | Size | Purpose |
+|------|-----:|---------|
+| `quick.md` | 2.0 KB | Direct executor for TRIVIAL tasks. No pipeline, no artifacts. |
+| `orchestrate.md` | 10.8 KB | MAP-PLAN → PATCH → PROVE pipeline for SIMPLE+ tasks. **Rejects TRIVIAL classification** (PR #94) — redirects to `/quick`. |
+
+### Issue creation
+| File | Size | Purpose |
+|------|-----:|---------|
+| `bug.md` | 2.3 KB | Create a bug-report GitHub issue. |
+| `feature.md` | 2.8 KB | Create a feature-request GitHub issue. |
+| `spec-draft.md` | 7.5 KB | Draft a feature specification via guided Q&A. |
+| `spec-review.md` | 3.4 KB | Validate a spec against the codebase, optionally generate issues. |
+| `feature-from-spec.md` | 2.7 KB | Internal helper invoked by `/spec-review` to create one issue per spec entry. |
+
+### Quality + review
+| File | Size | Purpose |
+|------|-----:|---------|
+| `review.md` | 0.4 KB | Pre-commit code review. |
+| `test-plan.md` | 2.5 KB | Generate edge-case test plan before implementation. |
+| `pr.md` | 7.6 KB | Pre-PR fresh-context review, advisory Codex review gate for COMPLEX changes (PR #95), then `gh pr create`. |
+
+### Scaffolding
+| File | Size | Purpose |
+|------|-----:|---------|
+| `scaffold-project.md` | 6.0 KB | Scaffold a complete FastAPI project with layered architecture. |
+| `scaffold-module.md` | 7.5 KB | Scaffold a new FastAPI module (model, schema, repo, service, router, deps). |
+
+### Learning + insight
+| File | Size | Purpose |
+|------|-----:|---------|
+| `learn.md` | 11.0 KB | Analyze failure patterns, update learned knowledge base. |
+| `metrics.md` | 15.8 KB | Display agent performance metrics and trends. |
+| `seed.md` | 5.0 KB | Capture a deferred idea with a trigger condition for when it should surface. |
+
+### Design
+| File | Size | Purpose |
+|------|-----:|---------|
+| `frontend-design.md` | 3.7 KB | Frontend design helpers (per the `frontend-design` plugin). |
+
+---
+
+## Rules (12 files)
+
+Located in `claude-config/rules/`. Rules use `paths: [...]` frontmatter to declare when they auto-load. `paths: ["**"]` means "always load." Only `git-workflow.md` declares `alwaysApply: true`.
+
+| File | Size | Path scope | Purpose |
+|------|-----:|-----------|---------|
+| `core-patterns.md` | 0.7 KB | `["**"]` | Top 3 failure patterns (VERIFICATION_GAP, ENUM_VALUE, COMPONENT_API). Always loaded. |
+| `implementation-routing.md` | 3.5 KB | `["**"]` | Tier classification + Codex routing rules. Always loaded. |
+| `git-workflow.md` | 3.8 KB | `["**"]` (`alwaysApply: true`) | Branch naming, conventional commits, squash-merge contract. |
+| `github-accounts.md` | 1.6 KB | `["**"]` | Multi-account routing (jwj2002 vs jjob-spec). |
+| `dev-environment.md` | 5.0 KB | `["**"]` | Three development modes (laptop / jbox06 / hybrid). |
+| `behavioral-evals.md` | 7.2 KB | `["**/backend/**", "**/frontend/**", "**/.agents/**", "**/Dockerfile", "**/*.env*"]` | E01–E15 behavioral evals. |
+| `eval-file-mapping.md` | 1.8 KB | `["**/.agents/**", "**/backend/**", "**/frontend/**", "**/PROVE*.md"]` | Maps changed-file globs to applicable E-codes. |
+| `gitlab-access.md` | 2.9 KB | `["**/app-repos/**", "**/vitalailabs/**", "**/.gitlab/**"]` | Internal GitLab access for VitalAILabs apps. |
+| `post-merge-verification.md` | 1.2 KB | `["**/.github/**", "**/CHANGELOG*", "**/.agents/**"]` | Post-merge health checks. |
+| `rbac-pattern.md` | 3.8 KB | `["**/auth/**", ...]` | Permission-check dependency pattern for FastAPI. |
+| `orchestrate-workflow.md` | 16.7 KB | `.agents/**/*.md` | Internal workflow rules for orchestrate agents. |
+| `spec-review-workflow.md` | 12.0 KB | `["**/specs/**", "**/.agents/**"]` | Spec finalization workflow. |
+
+---
+
+## Hooks (10 files)
+
+Located in `claude-config/hooks/`. Python scripts attached to Claude Code lifecycle events via `settings.json`. Two of these are shared modules (`state_manager.py`, `worktree_manager.py`) imported by other hooks.
+
+| File | Size | Lifecycle event | Purpose |
+|------|-----:|----------------|---------|
+| `sessionstart_restore_state.py` | 5.5 KB | SessionStart | Restore PERSISTENT_STATE.yaml and critical patterns into context. |
+| `load_learning_rules.py` | 1.1 KB | SessionStart | Load learning rules into context at session start. |
+| `precompact_checkpoint.py` | 8.1 KB | PreCompact | Checkpoint orchestrate state to YAML before context compaction. |
+| `verify_completion.py` | 4.1 KB | Stop | Anti-rationalization gate. Warns on uncommitted files (all types post #84), un-pushed commits, branches ahead of main with no PR (post #85), TODO/FIXME/HACK markers. Always exits 0 (advisory). |
+| `notify_completion.py` | 3.1 KB | Stop | macOS Notification Center alert with iPhone Handoff relay. |
+| `session_end_context_update.py` | 5.7 KB | Stop | Updates project state YAML with session-end context. |
+| `context_monitor.py` | 4.3 KB | PostToolUse | Tracks context usage, flags approaching limits. |
+| `secret_guard.py` | 3.2 KB | (not currently wired) | Bash-side secret-exfil guard. Bundled but not registered in `settings.json` — covered by `permissions.deny` rules instead. |
+| `state_manager.py` | 4.9 KB | (shared module) | Centralized PERSISTENT_STATE.yaml read/write. |
+| `worktree_manager.py` | 6.7 KB | (shared module) | Git worktree lifecycle for `--parallel` flag. |
+
+### Hook registrations in `settings.json`
+
+| Event | Hooks (in order) |
+|-------|-----------------|
+| `SessionStart` | `sessionstart_restore_state.py`, `load_learning_rules.py` |
+| `PreCompact` | `precompact_checkpoint.py` |
+| `PostToolUse` | `context_monitor.py` |
+| `Stop` | `verify_completion.py`, `notify_completion.py`, `session_end_context_update.py` |
+| `PreToolUse` | (none) |
+
+---
+
+## Skills (7 directories)
+
+Located in `claude-config/skills/`. Each is a directory containing a `SKILL.md` (and optionally supporting files). Skills are listed at session start when Claude Code's harness asks "what can I help with?"
+
+| Directory | Purpose |
+|-----------|---------|
+| `capture/` | Quick non-interrupting capture to inbox. |
+| `dashboard/` | Cross-project status overview. |
+| `deep-review/` | Comprehensive critical code review. |
+| `inbox/` | View and triage inbox captures. |
+| `pdf/` | Convert markdown to PDF. |
+| `project/` | View or update project context. |
+| `review-session/` | Review session commits and propose focus updates. |
+
+---
+
+## Snippets (1 file, growing)
+
+Located in `claude-config/snippets/`. Shared prompt fragments referenced from multiple agents to avoid duplication. Introduced in PR #97.
 
 | File | Size | Purpose |
-|------|------|---------|
-| `orchestrate.md` | 18.4 KB | Full agent pipeline for GitHub issues (`/orchestrate`) |
-| `learn.md` | 8.5 KB | Pattern extraction from failures (`/learn`) |
-| `metrics.md` | 15.8 KB | Performance dashboard (`/metrics`) |
-| `pr.md` | 3.1 KB | PR creation with checklist (`/pr`) |
-| `spec-review.md` | 3.4 KB | Spec analysis and issue creation (`/spec-review`) |
-| `spec-draft.md` | 7.5 KB | Interactive specification creation (`/spec-draft`) |
-| `feature.md` | 2.8 KB | Feature request issue creation (`/feature`) |
-| `feature-from-spec.md` | 2.7 KB | Create issues from spec gaps (`/feature-from-spec`) |
-| `bug.md` | 2.3 KB | Bug report with investigation (`/bug`) |
-| `test-plan.md` | 2.5 KB | Pre-implementation test planning (`/test-plan`) |
-| `scaffold-project.md` | 22.4 KB | Full FastAPI project scaffolding (`/scaffold-project`) |
-| `scaffold-module.md` | 7.5 KB | Domain module addition (`/scaffold-module`) |
-| `quick.md` | 2.0 KB | Ad-hoc fix without orchestrate (`/quick`) |
-| `review.md` | 0.4 KB | Code review of staged changes (`/review`) |
-| `frontend-design.md` | --- | Frontend design plugin integration (`/frontend-design`) |
-| `seed.md` | 5.5 KB | Capture deferred ideas with trigger conditions for future surfacing |
+|------|-----:|---------|
+| `verify-commands.md` | 1.6 KB | Canonical backend/frontend verification command catalog. Referenced from `_base.md`, `patch.md`, and `prove.md`. |
 
-## Rules (10 files)
+---
 
-Symlinked to `~/.claude/rules/`. Conditional and always-loaded instruction files.
+## Scripts (2 files)
 
-| File | Size | Trigger | Purpose |
-|------|------|---------|---------|
-| `core-patterns.md` | 0.7 KB | Always | Top 3 failure patterns (89% coverage) |
-| `git-workflow.md` | 3.2 KB | Always | Branch, commit, and PR conventions |
-| `implementation-routing.md` | 2.1 KB | Always | Plan mode vs orchestrate decision matrix |
-| `github-accounts.md` | 1.0 KB | Always | Multi-account GitHub configuration |
-| `fastapi-layered-pattern.md` | 23.6 KB | `**/backend/**`, `**/api/**`, `**/services/**` | Full layered architecture reference |
-| `orchestrate-workflow.md` | 16.7 KB | `.agents/**/*.md` | Agent efficiency, artifact naming, CONTRACT rules |
-| `spec-review-workflow.md` | 12.0 KB | `**/specs/**`, `**/.agents/**` | Spec finalization gate and issue creation |
-| `behavioral-evals.md` | 4.2 KB | PROVE phase | Behavioral test suite for PROVE agent verification |
-| `eval-file-mapping.md` | 1.2 KB | PROVE phase | Maps changed file patterns to relevant behavioral evals |
-| `post-merge-verification.md` | 1.2 KB | `/pr --merge` | Post-merge ops checklist for /pr command |
-
-## Hooks (7 files)
-
-Symlinked to `~/.claude/hooks/`. Python scripts attached to Claude Code lifecycle events.
-
-| File | Size | Event | Purpose |
-|------|------|-------|---------|
-| `sessionstart_restore_state.py` | 4.8 KB | SessionStart | Restore PERSISTENT_STATE and critical patterns (~500 tokens) |
-| `precompact_checkpoint.py` | 7.5 KB | PreCompact | Extract state from transcript, update YAML, auto-clean old files |
-| `verify_completion.py` | 3.3 KB | Stop | Anti-rationalization: warn if uncommitted changes or TODOs exist |
-| `notify_completion.py` | 3.5 KB | Stop | macOS Notification Center alert with iPhone relay via Handoff |
-| `state_manager.py` | 4.5 KB | (shared module) | Centralized PERSISTENT_STATE.yaml read/write operations |
-| `worktree_manager.py` | 6.5 KB | (shared module) | Git worktree lifecycle for `--parallel` flag |
-| `context_monitor.py` | 4.5 KB | PostToolUse | Warns when context window is running low (35% WARNING, 25% CRITICAL) |
-
-## Skills (3 directories)
-
-Symlinked to `~/.claude/skills/`. Multi-step workflow definitions with reference documentation.
-
-| Directory | Files | Purpose |
-|-----------|-------|---------|
-| `orchestrate/` | SKILL.md (2.4 KB), ORCHESTRATE_REFERENCE.md (7.5 KB) | Multi-agent pipeline execution |
-| `test-plan/` | SKILL.md (2.1 KB) | Test matrix generation with edge cases |
-| `spec-review/` | SKILL.md (1.2 KB) | Spec analysis and gap identification |
-
-## Templates (2 entries)
-
-Not symlinked --- referenced by orchestrate and other commands directly.
+Located in `claude-config/scripts/`. Standalone validators callable independently or from `install.sh`.
 
 | File | Size | Purpose |
-|------|------|---------|
-| `agent-prompt.md` | 2.5 KB | Shared prompt template with variable substitution for all agents |
-| `github-actions/` | --- | GitHub Actions workflow templates (Copilot review setup) |
+|------|-----:|---------|
+| `validate-hooks.py` | 5.2 KB | Walks every hook command in `settings.json`, verifies each script path resolves. Skips `${CLAUDE_PLUGIN_ROOT}` references. **PR #82.** |
+| `validate-paths-globs.py` | 2.6 KB | Validates rule-file path globs are well-formed. |
 
-## Plugins (7 installed)
+---
 
-Installed via `install.sh` Phase 2.5. Stored in `~/.claude/plugins/cache/` (not symlinked — installed per machine).
+## Templates (8 entries)
 
-| Plugin | Source | Category | Purpose |
-|--------|--------|----------|---------|
-| `codex` | `openai-codex` | Cross-model AI | GPT-powered review, adversarial challenge, task delegation, rescue |
-| `security-guidance` | `claude-plugins-official` | Security | Vulnerability detection, compliance checks, secure coding guidance |
-| `typescript-lsp` | `claude-plugins-official` | Language | TypeScript/React type errors, auto-imports, go-to-definition |
-| `pyright-lsp` | `claude-plugins-official` | Language | Python type checking for FastAPI backend code |
-| `pr-review-toolkit` | `claude-plugins-official` | Git | Enhanced PR review with deeper analysis capabilities |
-| `playwright` | `claude-plugins-official` | Testing | End-to-end browser testing for frontend verification |
-| `frontend-design` | `claude-plugins-official` | Frontend | Production-grade UI generation with distinctive design |
+Located in `claude-config/templates/`. Used by scaffolding commands and the orchestrate pipeline.
 
-## Config Files
+| Entry | Type | Size | Purpose |
+|-------|------|-----:|---------|
+| `agent-prompt.md` | file | 4.8 KB | Base agent prompt template (variable substitution). |
+| `orchestrate-pipeline.md` | file | 8.2 KB | Per-agent prompt templates, validation gates, failure-context injection. |
+| `orchestrate-parallel.md` | file | 7.8 KB | MAP fan-out, speculative PATCH, worktree mode, resume mode. |
+| `orchestrate-mymoney-context.md` | file | 7.8 KB | Project-specific context for orchestrate runs in mymoney. |
+| `fastapi-layered-pattern.md` | file | 23.6 KB | Layered FastAPI architecture reference (read by `/scaffold-project` and `/scaffold-module`). |
+| `scaffold-fastapi-core.md` | file | 15.3 KB | FastAPI core scaffolding spec. |
+| `scaffold-fastapi-auth.md` | file | 1.8 KB | FastAPI auth scaffolding spec. |
+| `PLAN.md.template` | file | 2.4 KB | Template for per-project `PLAN.md`. |
+| `github-actions/` | dir | — | GitHub Actions workflow templates. |
+
+---
+
+## Top-level claude-config files
 
 | File | Size | Purpose |
-|------|------|---------|
-| `settings.json` | 2.1 KB | Global settings: hooks, MCP servers, permissions, plugins (symlinked) |
-| `statusline.py` | 1.2 KB | Custom ANSI status bar: hostname, user, date, context usage (symlinked) |
-| `install.sh` | 11.5 KB | Idempotent symlink installer (macOS/WSL/Linux aware) |
-| `project-template/` | --- | Starter `CLAUDE.md` and `.claude/rules/` for new projects |
+|------|-----:|---------|
+| `CLAUDE.md` | 6.6 KB | Top-level orientation file. Loaded into context at every session start. Symlinked to `~/.claude/CLAUDE.md`. |
+| `README.md` | 10.7 KB | Repo README — install instructions, structure overview, command map. |
+| `settings.json` | 3.7 KB | Hook registrations, plugin enablement, permissions, statusLine, skipDangerousModePermissionPrompt. Symlinked to `~/.claude/settings.json`. |
+| `statusline.py` | 2.0 KB | Custom status bar (hostname, user, date, context %). |
+| `install.sh` | 22.4 KB | Symlink installer + dependency setup + MCP registration + warm-up + hook validation. |
+| `new-project-claude.sh` | 1.4 KB | Bootstrap a per-project `CLAUDE.md` skeleton. |
 
-## Per-Project Files (Not in Repo)
+---
 
-These files live in each project repository, not in `~/agents/claude-config/`:
+## Repo-level files (outside claude-config/)
 
-```
-~/projects/<project>/
-  CLAUDE.md                              # Project-specific agent instructions
-  .claude/
-    settings.json                        # Project permissions
-    memory/
-      patterns.md                        # Project-specific learned patterns
-      patterns-full.md                   # Extended patterns (~660 lines)
-      metrics.jsonl                      # Issue outcome tracking
-      failures.jsonl                     # Failure details
-      pattern-events.jsonl               # /learn --apply tracking
-  .agents/
-    outputs/
-      map-plan-{issue}-{mmddyy}.md      # Agent artifacts
-      patch-{issue}-{mmddyy}.md
-      prove-{issue}-{mmddyy}.md
-      archive/                           # Post-merge artifact archive
-      claude_checkpoints/
-        PERSISTENT_STATE.yaml            # Workflow state
-  .worktrees/                            # Worktree isolation (gitignored)
-    issue-{N}/                           # Full repo copy on own branch
-```
+### Knowledge graph (`knowledge/`)
 
-!!! note "Machine-Local Files"
-    `~/.claude/settings.local.json` and `~/.claude/memory/` are machine-specific and not symlinked from the repo. Each machine configures its own MCP server paths and maintains its own global pattern files.
+| Path | Count | Purpose |
+|------|------:|---------|
+| `knowledge/patterns/*.yaml` | 39 | Patterns with slug IDs (`pat-<filename-stem>`). Each has a `legacy_id: PAT-NNN` field for backwards-compat (PR #87). |
+| `knowledge/decisions/*.yaml` | 9 | Decision log with `linked_patterns` cross-references. |
+| `knowledge/learning_rules/` | varies | Auto-extracted learning rules. |
+| `knowledge/projects/*.yaml` | 6 | Project state snapshots. |
+| `knowledge/specs/*.md` | several | Spec docs (knowledge-base-spec, pattern-lifecycle, etc.). |
+| `knowledge/sync.py` | — | Builds `knowledge.db` from YAMLs. Includes uniqueness guard (PR #87). |
+| `knowledge/knowledge.db` | — | SQLite, gitignored, rebuilt by post-merge hook. |
+
+### MCP servers (`knowledge-mcp/`, `mcp-server/`)
+
+| Server | Path | Language | Tools |
+|--------|------|----------|-------|
+| `knowledge` | `knowledge-mcp/index.ts` | TypeScript (tsx) | Pattern/decision query interface. |
+| `vault-metrics` | `mcp-server/server.py` | Python (.venv) | `vault_status`, `vault_search`, `vault_dashboard`, `agent_metrics`, `failure_patterns`. |
+
+### Migration scripts (`scripts/`)
+
+| File | Purpose |
+|------|---------|
+| `scripts/migrate-pattern-ids-to-slugs.py` | One-shot migration from `PAT-NNN` to slug IDs (PR #87). Idempotent — re-running is a no-op. |
+
+### CI (`.github/workflows/`)
+
+| File | Size | Purpose |
+|------|-----:|---------|
+| `.github/workflows/validate.yml` | 1.7 KB | Pre-merge config validation. Runs on PRs touching `claude-config/`, `knowledge/`, `codex-config/`, `install*.sh`. **PR #98.** |
+
+---
+
+## Per-project files (in any project's `.agents/outputs/`)
+
+When `/orchestrate` runs in a project, it produces artifacts in that project's `.agents/outputs/`:
+
+| Filename pattern | Producer | When |
+|------------------|----------|------|
+| `map-{issue}-{mmddyy}.md` | MAP agent | COMPLEX tier |
+| `plan-{issue}-{mmddyy}.md` | PLAN agent | COMPLEX tier |
+| `map-plan-{issue}-{mmddyy}.md` | MAP-PLAN agent | SIMPLE tier |
+| `discuss-{issue}-{mmddyy}.md` | DISCUSS agent | When `--discuss` is set |
+| `test-plan-{issue}-{mmddyy}.md` | TEST-PLANNER agent | When `--with-tests` is set |
+| `contract-{issue}-{mmddyy}.md` | CONTRACT agent | Fullstack tasks |
+| `plan-check-{issue}-{mmddyy}.md` | PLAN-CHECK agent | COMPLEX tier only |
+| `patch-{issue}-{mmddyy}.md` | PATCH agent | Always |
+| `prove-{issue}-{mmddyy}.md` | PROVE agent | Always (PROVE-lite for TRIVIAL no longer runs through orchestrate) |
+| `archive/*.md` | (post-merge) | Archived after PR merges |
+| `claude_checkpoints/PERSISTENT_STATE.yaml` | state_manager | Across sessions |
+
+Memory + metrics:
+
+| File | Purpose |
+|------|---------|
+| `~/agents/.claude/memory/metrics.jsonl` | One JSON-line per orchestrate outcome. |
+| `~/agents/.claude/memory/failures.jsonl` | One JSON-line per BLOCKED outcome with root_cause classification. |
+
+---
+
+## Where to look next
+
+- High-level orientation: [`claude-config/CLAUDE.md`](https://github.com/jwj2002/agents/blob/main/claude-config/CLAUDE.md)
+- All system diagrams: [Architecture Diagrams](architecture-diagrams.md)
+- Term definitions: [Glossary](glossary.md)

--- a/docs/manual/reference/glossary.md
+++ b/docs/manual/reference/glossary.md
@@ -45,7 +45,7 @@ Two related tier systems are used to categorize and route tasks:
 ## D
 
 **DISCUSS**
-An optional agent (phase 0.5) that identifies 2-5 gray areas in issue requirements and captures implementation decisions before MAP-PLAN runs. Triggered by `--discuss` flag.
+An optional agent (phase 0.5) that identifies 2-5 gray areas in issue requirements and captures implementation decisions before MAP/MAP-PLAN runs. Triggered by the `--discuss` flag on `/orchestrate`. Read-only -- produces a `discuss-{issue}-{mmddyy}.md` artifact that downstream agents reference. Recommended for COMPLEX and FULLSTACK tasks where requirements have ambiguities that would otherwise be resolved arbitrarily during PATCH.
 
 ## F
 
@@ -85,12 +85,18 @@ Structured outcome data recorded as JSON lines in `metrics.jsonl`. Each complete
 ## O
 
 **Orchestrate**
-The primary workflow command (`/orchestrate`) that takes a GitHub issue number and executes a multi-agent pipeline: MAP, PLAN, CONTRACT, PATCH, PROVE. Supports flags for test planning (`--with-tests`), session resumption (`--resume`), and parallel execution (`--parallel`).
+The primary workflow command (`/orchestrate`) that takes a GitHub issue number and executes a multi-agent pipeline. The canonical agent set is DISCUSS, MAP, PLAN, CONTRACT, TEST-PLANNER, PLAN-CHECK, PATCH, PROVE; any single run invokes a subset chosen by the routing tier, complexity classification, and flags. Supports flags for test planning (`--with-tests`), discussion (`--discuss`), session resumption (`--resume`), and parallel execution (`--parallel`).
 
 ## P
 
 **Pipeline Tier**
 One of three agent sequences used inside `/orchestrate`: TRIVIAL (MAP-PLAN, PATCH, PROVE-lite), SIMPLE (full agent chain with MAP-PLAN), or COMPLEX (full agent chain with separate MAP and PLAN). Distinct from routing tiers, which determine whether a task reaches `/orchestrate` at all.
+
+**plan-checker**
+A read-only agent that validates a PLAN or MAP-PLAN artifact for completeness before PATCH burns context implementing it. Confirms every acceptance criterion maps to a planned task, the file count matches the complexity classification, fullstack plans declare explicit enum VALUES, and multi-layer plans include integration steps. Runs in the COMPLEX pipeline only -- the v5 SIMPLE pipeline drops PLAN-CHECK because PATCH catches plan defects fast enough on small changes. Produces a `plan-check-{issue}-{mmddyy}.md` artifact (~80-120 lines).
+
+**pr-fresh-reviewer**
+A subagent invoked by `/pr` to review the proposed PR with a fresh context window -- no orchestrate-pipeline state, no prior conversation. The fresh perspective catches issues the implementing agent rationalized away during PATCH. Runs against the diff and produces concise findings; the user decides whether to address them before merge.
 
 **PRIOR FAIL (routing tier)**
 A routing tier applied to any task that previously failed. PRIOR FAIL tasks are routed to `/orchestrate` with the prior failure's root cause and prevention recommendation injected into agent context.
@@ -137,6 +143,9 @@ A multi-step workflow defined in `~/.claude/skills/`. Skills are more complex th
 
 **Slash Command**
 A user-invokable command defined as a markdown file in `~/.claude/commands/`. Examples: `/orchestrate`, `/pr`, `/learn`, `/metrics`, `/scaffold-project`. Commands encode workflow logic and can spawn agents, create PRs, or analyze data.
+
+**spec-reviewer**
+An agent that validates a specification document against the current codebase, identifies gaps and inconsistencies, and (after the spec is finalized) generates a set of GitHub issues that map spec requirements onto implementation work. Used by `/spec-review` and `/feature-from-spec`. Read-only against the codebase but write-capable against the issue tracker.
 
 **State Manager**
 The centralized Python module (`hooks/state_manager.py`) that handles all reads and writes to `PERSISTENT_STATE.yaml`. Used by orchestrate (update phase), precompact hook (save transcript state), sessionstart hook (restore context), and the `--resume`/`--parallel` flags.

--- a/docs/manual/rules/conditional-rules.md
+++ b/docs/manual/rules/conditional-rules.md
@@ -5,85 +5,108 @@ Rules in this system follow a tiered loading strategy: load the minimum context 
 ## How Conditional Loading Works
 
 !!! info "Auto-loading behavior"
-    Rules load automatically based on which files the agent is reading or editing. You do not need to manually activate rules -- Claude Code matches the file path against the glob patterns in each rule's frontmatter and loads matching rules transparently.
+    Rules load automatically based on which files the agent is reading or editing. You do not need to manually activate rules -- Claude Code matches the file path against the path patterns in each rule's frontmatter and loads matching rules transparently.
 
-Claude Code evaluates rule files based on **path-based triggers** defined in each file's YAML frontmatter. When the agent is working in a directory that matches a trigger glob, the corresponding rule is loaded. When no match occurs, the rule stays unloaded and costs zero tokens.
+Claude Code evaluates rule files based on **path-based triggers** defined in each file's YAML frontmatter under the `paths:` key. When the agent is working in a directory that matches a trigger pattern, the corresponding rule is loaded. When no match occurs, the rule stays unloaded and costs zero tokens.
 
 ```yaml
 ---
-description: "FastAPI layered architecture rules"
-globs: ["**/backend/**", "**/api/**", "**/services/**"]
+paths: ["**/backend/**", "**/api/**", "**/services/**"]
 ---
 ```
 
-Rules with `alwaysApply: true` bypass the path matching and load into every session. Only `core-patterns.md`, `git-workflow.md`, `implementation-routing.md`, and `github-accounts.md` use this setting.
+Only `git-workflow.md` declares `alwaysApply: true` in its frontmatter. Other always-loaded rules (`core-patterns.md`, `implementation-routing.md`, `github-accounts.md`, `dev-environment.md`) achieve the same effect by setting `paths: ["**"]`, which matches every file in the workspace.
 
 ## Complete Rule Inventory
 
-| Rule File | Size | Loaded When | Purpose |
-|-----------|------|-------------|---------|
-| `core-patterns.md` | 0.7 KB (12 lines) | **Always** (`alwaysApply: true`) | Top 3 failure patterns covering 89% of failures |
-| `git-workflow.md` | 3.2 KB | **Always** (`alwaysApply: true`) | Branch naming, commit conventions, PR process |
-| `implementation-routing.md` | 2.1 KB | **Always** (`alwaysApply: true`) | Plan mode vs orchestrate decision matrix |
-| `github-accounts.md` | 1.0 KB | **Always** (`alwaysApply: true`) | Multi-account git configuration |
-| `fastapi-layered-pattern.md` | 23.6 KB (767 lines) | `**/backend/**`, `**/api/**`, `**/services/**` | Full layered architecture reference: router, service, repository, models, schemas, deps |
-| `orchestrate-workflow.md` | 16.7 KB (588 lines) | `.agents/**/*.md` | Agent efficiency rules, artifact naming, size compliance, CONTRACT requirements |
-| `spec-review-workflow.md` | 12.0 KB (361 lines) | `**/specs/**`, `**/.agents/**` | Spec finalization gate, review process, issue creation rules |
-| `behavioral-evals.md` | 4.2 KB (~140 lines) | PROVE phase | Behavioral verification test suite |
-| `eval-file-mapping.md` | 1.2 KB (~38 lines) | PROVE phase | Maps file patterns to relevant evals |
-| `post-merge-verification.md` | 1.2 KB (~38 lines) | `/pr --merge` | Post-merge ops verification checklist |
+There are **12 rule files** in `claude-config/rules/`:
+
+| Rule File | Lines | Loaded When | Purpose |
+|-----------|-------|-------------|---------|
+| `core-patterns.md` | 15 | `paths: ["**"]` (always) | Top 3 failure patterns covering 89% of failures |
+| `git-workflow.md` | 113 | `alwaysApply: true` (always) | Branch naming, commit conventions, PR process |
+| `implementation-routing.md` | 90 | `paths: ["**"]` (always) | Codex delegation, plan mode vs orchestrate routing |
+| `github-accounts.md` | 43 | `paths: ["**"]` (always) | Multi-account git configuration |
+| `dev-environment.md` | 141 | `paths: ["**"]` (always) | Local vs jbox06 vs hybrid mode routing |
+| `behavioral-evals.md` | 144 | `**/backend/**`, `**/frontend/**`, `**/.agents/**`, `Dockerfile`, `*.env*` | E01-E15 verification check catalog |
+| `eval-file-mapping.md` | 42 | `**/.agents/**`, `**/backend/**`, `**/frontend/**`, `**/PROVE*.md` | Maps file patterns to relevant evals |
+| `orchestrate-workflow.md` | 587 | `.agents/**/*.md` | Agent efficiency rules, artifact naming, CONTRACT requirements |
+| `spec-review-workflow.md` | 360 | `**/specs/**`, `**/.agents/**` | Spec finalization gate, review process, issue creation rules |
+| `rbac-pattern.md` | 110 | `**/backend/**/auth/**`, `**/backend/**/permissions*`, `**/backend/**/security/**`, `**/auth/**`, `**/router*` | Permission-based access control pattern |
+| `gitlab-access.md` | 74 | `**/app-repos/**`, `**/vitalailabs/**`, `**/.gitlab/**` | Internal GitLab auth and credential handling |
+| `post-merge-verification.md` | 42 | `**/.github/**`, `**/CHANGELOG*`, `**/.agents/**` | Post-merge ops verification checklist |
 
 ## Token Budget Analysis
 
-Loading all rules simultaneously would consume approximately 43 KB of context. With conditional loading, a typical session loads only what it needs:
+Loading all rules simultaneously would consume roughly 50 KB of context. With conditional loading, a typical session loads only what it needs:
 
-| Scenario | Rules Loaded | Approximate Size |
-|----------|-------------|-----------------|
-| Backend bugfix | core-patterns + git-workflow + implementation-routing + fastapi-layered | ~28 KB |
-| Frontend-only change | core-patterns + git-workflow + implementation-routing | ~6 KB |
-| Orchestrate pipeline | core-patterns + git-workflow + orchestrate-workflow | ~21 KB |
-| Spec review | core-patterns + git-workflow + spec-review-workflow | ~16 KB |
-| Documentation update | core-patterns + git-workflow + implementation-routing | ~6 KB |
+| Scenario | Rules Loaded | Approximate Lines |
+|----------|-------------|-------------------|
+| Bare laptop session | core-patterns + git-workflow + implementation-routing + github-accounts + dev-environment | ~400 |
+| Backend module work | always-loaded + rbac-pattern (if auth path) | ~510 |
+| Orchestrate pipeline | always-loaded + orchestrate-workflow + behavioral-evals + eval-file-mapping | ~1,200 |
+| Spec review | always-loaded + spec-review-workflow | ~760 |
+| GitLab/jbox06 work | always-loaded + gitlab-access | ~470 |
 
 !!! note "Savings Compound"
-    A frontend-only session saves ~37 KB of context by not loading `fastapi-layered-pattern.md` or `orchestrate-workflow.md`. That recovered space is equivalent to reading two additional source files --- which directly improves implementation accuracy.
+    A frontend-only session can skip `orchestrate-workflow.md` (587 lines) and `rbac-pattern.md` (110 lines). The recovered space is equivalent to reading two additional source files -- which directly improves implementation accuracy.
 
 ## When Each Rule Loads
 
 ### Always-Loaded Rules
 
-These four rules load into every session regardless of working directory:
+These five rules load into every session:
 
-- **core-patterns.md** --- Three failure patterns that apply to all codebases
-- **git-workflow.md** --- Branch, commit, and PR conventions used on every project
-- **implementation-routing.md** --- Decision matrix for choosing plan mode vs orchestrate
-- **github-accounts.md** --- Maps projects to the correct GitHub account
+- **core-patterns.md** -- Three failure patterns that apply to all codebases (`paths: ["**"]`)
+- **git-workflow.md** -- Branch, commit, and PR conventions (`alwaysApply: true`)
+- **implementation-routing.md** -- Decision matrix for `/quick`, plan mode, `/orchestrate`, and Codex delegation (`paths: ["**"]`)
+- **github-accounts.md** -- Maps projects to the correct GitHub account (`paths: ["**"]`)
+- **dev-environment.md** -- Routes work between laptop, jbox06, and hybrid modes (`paths: ["**"]`)
 
-### Backend Context
+### Backend Authorization Context
 
-When the agent reads or writes files matching `**/backend/**`, `**/api/**`, or `**/services/**`:
+When the agent reads or writes auth-related backend files (`**/backend/**/auth/**`, `**/backend/**/permissions*`, `**/backend/**/security/**`, `**/auth/**`, `**/router*`):
 
-- **fastapi-layered-pattern.md** loads with the full architecture reference: layer responsibilities, module structure, enum conventions, access control patterns, and SQLAlchemy/Pydantic usage rules
+- **rbac-pattern.md** loads with the role-to-permission mapping pattern, the `require_permission()` dependency factory, and per-endpoint enforcement rules.
 
 ### Orchestrate Context
 
 When the agent operates on files matching `.agents/**/*.md` (typically during `/orchestrate` workflows):
 
-- **orchestrate-workflow.md** loads with artifact naming conventions, agent size compliance targets, and CONTRACT enforcement rules
+- **orchestrate-workflow.md** loads with artifact naming conventions, agent size compliance targets, and CONTRACT enforcement rules.
+
+### Verification Context
+
+When the agent is running PROVE or otherwise touching files in `**/backend/**`, `**/frontend/**`, `**/.agents/**`, `Dockerfile`, or `*.env*`:
+
+- **behavioral-evals.md** loads with the E01-E15 verification catalog.
+- **eval-file-mapping.md** loads with the file-pattern routing table.
 
 ### Spec Context
 
 When the agent operates on files matching `**/specs/**` or `**/.agents/**`:
 
-- **spec-review-workflow.md** loads with the spec finalization gate, draft-to-final workflow, and issue creation rules
+- **spec-review-workflow.md** loads with the spec finalization gate, draft-to-final workflow, and issue creation rules.
+
+### GitLab Context
+
+When working in `**/app-repos/**`, `**/vitalailabs/**`, or `**/.gitlab/**`:
+
+- **gitlab-access.md** loads with VitalAILabs GitLab auth, credential helpers, and dev-box mapping.
+
+### Post-Merge Context
+
+When working in `**/.github/**`, `**/CHANGELOG*`, or `**/.agents/**`:
+
+- **post-merge-verification.md** loads with the post-squash-merge health checklist used by `/pr`.
 
 ## Design Principles
 
-1. **Minimum context for current task** --- Only load rules relevant to the files being touched
-2. **Always-loaded stays tiny** --- The always-loaded rules total ~7 KB combined; any growth here costs every session
-3. **Conditional rules can be large** --- `fastapi-layered-pattern.md` at 767 lines is acceptable because it only loads for backend work
-4. **Path globs must be specific** --- Broad globs like `**/*.py` would defeat the purpose; use directory-based patterns that match project structure
-5. **No duplication across rules** --- Each rule owns its domain; cross-references use "see `core-patterns.md`" rather than repeating content
+1. **Minimum context for current task** -- Only load rules relevant to the files being touched.
+2. **Always-loaded stays small** -- Even the always-loaded set is now ~400 lines combined; growth here costs every session.
+3. **Conditional rules can be large** -- `orchestrate-workflow.md` at 587 lines is acceptable because it only loads inside `.agents/`.
+4. **Path patterns must be specific** -- Broad patterns like `**/*.py` would defeat the purpose; use directory-based patterns that match project structure.
+5. **No duplication across rules** -- Each rule owns its domain; cross-references use "see `core-patterns.md`" rather than repeating content.
 
 ## Rule File Anatomy
 
@@ -91,9 +114,9 @@ Every rule file follows the same structure:
 
 ```markdown
 ---
-description: "Human-readable description for tooling"
-alwaysApply: true                # or omit for conditional
-globs: ["**/backend/**"]         # path triggers (conditional only)
+description: "Optional human-readable description for tooling"
+alwaysApply: true                # only set on git-workflow.md
+paths: ["**/backend/**"]         # path triggers (use ["**"] for always-loaded)
 ---
 
 # Rule Title
@@ -101,25 +124,13 @@ globs: ["**/backend/**"]         # path triggers (conditional only)
 Content that agents read and follow.
 ```
 
-The frontmatter is parsed by Claude Code to determine loading behavior. The body is injected into the agent's context when the rule is active. Keep the body focused --- avoid tutorial-style explanations and focus on actionable instructions.
+The frontmatter is parsed by Claude Code to determine loading behavior. The body is injected into the agent's context when the rule is active. Keep the body focused -- avoid tutorial-style explanations and focus on actionable instructions.
 
 ## What Each Conditional Rule Contains
 
-### fastapi-layered-pattern.md (23.6 KB)
+### orchestrate-workflow.md (587 lines)
 
-The largest rule file. Contains the complete FastAPI layered architecture reference:
-
-- Layer responsibilities (router, service, repository, models, schemas, deps)
-- Module file structure with per-file conventions
-- Enum rules (member names = UPPER_SNAKE, values = stored in DB)
-- Access control patterns (always via dependencies, never inline)
-- SQLAlchemy 2.0 conventions (Mapped types, select() syntax)
-- Pydantic v2 conventions (ConfigDict, from_attributes)
-- Error handling (AppError subclasses, not HTTPException in services)
-
-### orchestrate-workflow.md (16.7 KB)
-
-Loaded during agent pipeline execution:
+The largest rule file. Loaded during agent pipeline execution:
 
 - Artifact naming convention (`{agent}-{issue}-{mmddyy}.md`)
 - Agent output size targets with compression checklists
@@ -127,7 +138,7 @@ Loaded during agent pipeline execution:
 - Parallel execution rules (which phases can overlap)
 - State management integration points
 
-### spec-review-workflow.md (12.0 KB)
+### spec-review-workflow.md (360 lines)
 
 Loaded during spec analysis and issue creation:
 
@@ -136,5 +147,17 @@ Loaded during spec analysis and issue creation:
 - Gap classification (Implemented, Partial, Missing, Differs)
 - Issue creation format and dependency ordering
 
+### behavioral-evals.md (144 lines)
+
+The E01-E15 catalog: each eval traces back to a real production failure with what to check, why, and how to verify. Used by PROVE.
+
+### dev-environment.md (141 lines)
+
+Routes work between local development, remote jbox06 development (VitalAILabs apps via SSH), and hybrid mode. Includes SSH alias conventions and bundle-based laptop-to-jbox06 sync flows.
+
+### rbac-pattern.md (110 lines)
+
+The single-org permission pattern: `User.role` -> `ROLE_PERMISSIONS` dict -> `require_permission("resource:action")` dependency. Includes the dependency factory implementation and router usage examples.
+
 !!! tip "Adding New Rules"
-    When creating a new rule file, choose the narrowest glob that covers the relevant files. Measure the file size and consider whether the content could be added to an existing rule instead. Rules under 1 KB can often be merged with an existing always-loaded rule; rules over 5 KB should always be conditional.
+    When creating a new rule file, choose the narrowest `paths:` pattern that covers the relevant files. Measure the file size and consider whether the content could be added to an existing rule instead. Rules under 1 KB can often be merged with an existing always-loaded rule; rules over 5 KB should always be conditional. Use `paths: ["**"]` (not `alwaysApply: true`) for new always-loaded rules unless you specifically need the legacy frontmatter key.

--- a/docs/manual/rules/core-patterns.md
+++ b/docs/manual/rules/core-patterns.md
@@ -81,7 +81,7 @@ These additional failure modes appear frequently enough to warrant awareness, ev
 
 ## How Agents Load It
 
-The rule file uses `alwaysApply: true` in its frontmatter, which means Claude Code loads it into every session automatically. No conditional trigger is needed. The file lives at:
+The rule file declares `paths: ["**"]` in its frontmatter, which matches every file in the workspace and causes Claude Code to load it into every session automatically. (Only `git-workflow.md` uses the legacy `alwaysApply: true` key; other always-loaded rules — including this one — use `paths: ["**"]` instead.) The file lives at:
 
 ```
 ~/.claude/rules/core-patterns.md  (symlink)

--- a/docs/manual/workflow/commands.md
+++ b/docs/manual/workflow/commands.md
@@ -13,7 +13,7 @@ All slash commands are defined in `claude-config/commands/` and available global
 
 ### /orchestrate
 
-Runs the multi-agent pipeline for a GitHub issue. Used for MODERATE, COMPLEX, FULLSTACK, and PRIOR FAIL routing tiers. Internally selects a pipeline tier (TRIVIAL, SIMPLE, or COMPLEX) to determine which agents run.
+Runs the multi-agent pipeline for a GitHub issue. Used for MODERATE, COMPLEX, FULLSTACK, and PRIOR FAIL routing tiers. Internally selects a pipeline tier (SIMPLE or COMPLEX) to determine which agents run. TRIVIAL classifications are rejected and redirected to `/quick` (per PR #94).
 
 ```bash
 /orchestrate 184                      # Standard
@@ -28,7 +28,7 @@ Runs the multi-agent pipeline for a GitHub issue. Used for MODERATE, COMPLEX, FU
     ```
     You: /orchestrate 42
     Claude: Issue #42 classified as: SIMPLE (backend)
-            Using workflow: MAP-PLAN → PLAN-CHECK → PATCH → PROVE
+            Using workflow: MAP-PLAN → PATCH → PROVE
             ... [agents run] ...
             Workflow complete. Next: /pr 42
     ```
@@ -230,19 +230,34 @@ Adds a domain module to an existing project with all layers.
 
 Generates: `models.py`, `schemas.py`, `repository.py`, `services.py`, `deps.py`, `router.py`.
 
-## External Agent Commands
+### /frontend-design
+
+Generates production-grade frontend interfaces with high design quality, avoiding generic AI aesthetics.
+
+```bash
+/frontend-design "Settings page with tabs for profile, billing, notifications"
+```
+
+## Codex Plugin Commands
+
+These commands are provided by the installed Codex plugin (not by `claude-config/commands/`). They enable cross-model review and delegation to OpenAI's GPT-5.4 family.
 
 | Command | Usage | Purpose |
 |---------|-------|---------|
-| `/obsidian` | `/obsidian [--dry-run]` | Capture session to Obsidian vault |
-| `/standup` | `/standup` | Generate daily standup from vault |
-| `/changelog` | `/changelog` | Update changelog from merged PRs |
-| `/codex-review` | `/codex-review` | Second opinion from OpenAI Codex |
+| `/codex:setup` | `/codex:setup` | Verify the local Codex CLI is ready; toggle review gate |
+| `/codex:review` | `/codex:review [--background]` | Standard cross-model review of staged or recent changes |
+| `/codex:adversarial-review` | `/codex:adversarial-review [--background]` | Adversarial review focused on contract / access-control / data drift |
+| `/codex:rescue` | `/codex:rescue [--background] [--write]` | Delegate investigation, a fix, or a follow-up task to Codex |
+| `/codex:status` | `/codex:status` | Check the status of background Codex jobs |
+| `/codex:result` | `/codex:result <id>` | Retrieve the output of a completed Codex job |
+| `/codex:cancel` | `/codex:cancel <id>` | Cancel an in-flight Codex job |
 
-!!! note "External commands require additional setup"
-    `/obsidian` requires the obsidian-agent module. `/codex-review` requires an OpenAI API key and the Codex plugin.
+!!! note "Codex commands require the plugin"
+    The `/codex:*` commands are provided by the Codex plugin and require an OpenAI API key plus the local Codex CLI. See [Codex Plugin](../integrations/codex-plugin.md) for setup and the full delegation playbook.
 
 ## All Commands at a Glance
+
+The 16 slash commands shipped from `claude-config/commands/`:
 
 | Command | Category | Requires Issue | Creates Files |
 |---------|----------|---------------|---------------|
@@ -261,7 +276,6 @@ Generates: `models.py`, `schemas.py`, `repository.py`, `services.py`, `deps.py`,
 | `/metrics` | Learning | No | None (read-only) |
 | `/scaffold-project` | Scaffolding | No | 30+ project files |
 | `/scaffold-module` | Scaffolding | No | 6 module files |
-| `/obsidian` | External | No | Vault entries |
-| `/standup` | External | No | Report output |
-| `/changelog` | External | No | CHANGELOG.md |
-| `/codex-review` | External | No | None |
+| `/frontend-design` | Design | No | Frontend source files |
+
+The `/codex:*` family lives in the Codex plugin, not in this repo — see the table above.

--- a/docs/manual/workflow/orchestrate.md
+++ b/docs/manual/workflow/orchestrate.md
@@ -33,15 +33,18 @@ If no issue number is provided, you will be prompted to create one with `/featur
 ```
 GitHub Issue
      |
-     +-- TRIVIAL --> MAP-PLAN --> PATCH --> PROVE-lite
+     +-- TRIVIAL --> rejected; /orchestrate redirects to /quick
      |
-     +-- SIMPLE ---> [DISCUSS] --> MAP-PLAN --> [TEST-PLANNER] --> CONTRACT* --> PLAN-CHECK --> PATCH --> PROVE
+     +-- SIMPLE ---> [DISCUSS] --> MAP-PLAN --> [TEST-PLANNER] --> CONTRACT* --> PATCH --> PROVE
      |
      +-- COMPLEX --> [DISCUSS] --> MAP --> PLAN --> [TEST-PLANNER] --> CONTRACT* --> PLAN-CHECK --> PATCH --> PROVE
 
      * CONTRACT is MANDATORY for fullstack (PATCH will STOP without it)
        CONTRACT-lite (inline) for simple fullstack (0 new endpoints, <=2 frontend files)
      [ ] = Optional (requires --with-tests or --discuss flag)
+
+     PLAN-CHECK runs only on the COMPLEX pipeline (per PR #93). SIMPLE relies on PATCH
+     to catch plan defects and Codex adversarial review (post-PROVE) for the rest.
 ```
 
 ## Complexity Classification
@@ -65,27 +68,26 @@ GitHub Issue
           +----+----+     +----+-----+     +----+-----+
                |               |                |
                v               v                v
-          MAP-PLAN       [DISCUSS]          [DISCUSS]
-               |               |                |
-               |          MAP-PLAN        MAP --> PLAN
-               |               |                |
-               |          +----+----+      +----+----+
-               |          |fullstack|      |fullstack|
-               |          +----+----+      +----+----+
-               |          yes  | no        yes  | no
-               |               v                v
-               |          CONTRACT(*)       CONTRACT
-               |               |                |
-               |          PLAN-CHECK       PLAN-CHECK
-               |               |                |
-               v               v                v
-            PATCH            PATCH            PATCH
-               |               |                |
-               v               v                v
-          PROVE-lite         PROVE            PROVE
-          (gates only)         |                |
-               |               v                v
-               +------------- /pr --------------+
+          rejected;       [DISCUSS]          [DISCUSS]
+          go to /quick         |                |
+          (PR #94)        MAP-PLAN        MAP --> PLAN
+                               |                |
+                          +----+----+      +----+----+
+                          |fullstack|      |fullstack|
+                          +----+----+      +----+----+
+                          yes  | no        yes  | no
+                               v                v
+                          CONTRACT(*)       CONTRACT
+                               |                |
+                               |           PLAN-CHECK
+                               |                |
+                               v                v
+                             PATCH            PATCH
+                               |                |
+                               v                v
+                             PROVE            PROVE
+                               |                |
+                               +----- /pr ------+
 
          (*) CONTRACT-lite if 0 new endpoints + <=2 frontend files
              CONTRACT-full otherwise
@@ -95,9 +97,9 @@ GitHub Issue
 
 | Level | Files | Criteria | Workflow |
 |-------|-------|----------|----------|
-| **TRIVIAL** | 1-2 | Docs, config, obvious fixes | MAP-PLAN, skips PLAN-CHECK, PROVE-lite |
-| **SIMPLE** | 3-5 | Clear pattern, single subsystem | MAP-PLAN with full verification |
-| **COMPLEX** | 6+ | Endpoints, migrations, architectural | Separate MAP and PLAN phases |
+| **TRIVIAL** | 1-2 | Docs, config, obvious fixes | Rejected by `/orchestrate`; redirected to `/quick` (per PR #94) |
+| **SIMPLE** | 3-5 | Clear pattern, single subsystem | MAP-PLAN → [CONTRACT*] → PATCH → PROVE (no PLAN-CHECK) |
+| **COMPLEX** | 6+ | Endpoints, migrations, architectural | MAP → PLAN → [CONTRACT*] → PLAN-CHECK → PATCH → PROVE |
 
 ??? info "Detailed step-by-step process"
 
@@ -215,10 +217,24 @@ When `--resume` is provided:
 3. Verifies artifacts exist for all completed phases
 4. Resumes from the next incomplete phase
 
+SIMPLE pipeline (no PLAN-CHECK):
+
 | Last Completed | Next Phase |
 |----------------|------------|
-| (none) | MAP-PLAN or MAP |
-| MAP-PLAN | PLAN-CHECK (or CONTRACT if fullstack) |
+| (none) | MAP-PLAN |
+| MAP-PLAN | CONTRACT (if fullstack) or PATCH |
+| CONTRACT | PATCH |
+| PATCH | PROVE |
+| PROVE | Done |
+
+COMPLEX pipeline (PLAN-CHECK still in chain):
+
+| Last Completed | Next Phase |
+|----------------|------------|
+| (none) | MAP |
+| MAP | PLAN |
+| PLAN | CONTRACT (if fullstack) or PLAN-CHECK |
+| CONTRACT | PLAN-CHECK |
 | PLAN-CHECK | PATCH |
 | PATCH | PROVE |
 | PROVE | Done |
@@ -308,6 +324,10 @@ Each agent validates the chain: PROVE checks for PATCH, PATCH checks for MAP-PLA
                               ├── No  → /pr
                               └── Yes → fix → re-run PROVE → /pr
     ```
+
+    ### Advisory Review Gate in /pr
+
+    Independent of the post-PROVE review above, the `/pr` command (per PR #95) detects COMPLEX-tier signals — file count > 5, migration paths, auth code, data models, cross-cutting refactors — and prompts you to run `/codex:adversarial-review` before squash-merge. This gate is **advisory, not blocking**: you can decline and proceed, but for COMPLEX or fullstack changes the second opinion typically catches enum, contract, and access-control drift that PROVE does not gate on.
 
     ### Parallel Delegation During PATCH
 

--- a/docs/manual/workflow/parallel.md
+++ b/docs/manual/workflow/parallel.md
@@ -42,8 +42,8 @@ Within a single orchestrate session, certain agents can run concurrently when th
 |---------|--------|-----------|
 | MAP fan-out | Explore backend + frontend + tests | COMPLEX pipeline tier |
 | MAP + TEST-PLANNER | MAP + TEST-PLANNER | COMPLEX pipeline with `--with-tests` |
-| PLAN-CHECK + TEST-PLANNER | PLAN-CHECK + TEST-PLANNER | `--with-tests` flag |
-| Speculative PATCH | PLAN-CHECK + PATCH | SIMPLE pipeline, backend-only |
+| PLAN-CHECK + TEST-PLANNER | PLAN-CHECK + TEST-PLANNER | COMPLEX only (PLAN-CHECK was dropped from SIMPLE in v5) + `--with-tests` |
+| Speculative PATCH | PLAN-CHECK + PATCH | COMPLEX only, backend-only |
 | Fullstack PATCH | Backend PATCH + Frontend PATCH | Fullstack with CONTRACT |
 
 ### MAP Fan-Out
@@ -65,7 +65,7 @@ Skip fan-out for TRIVIAL/SIMPLE pipeline tiers (MAP-PLAN handles exploration inl
 
 ### Speculative PATCH
 
-PLAN-CHECK passes approximately 90% of the time. Instead of waiting for validation, PATCH can start speculatively in parallel:
+This pattern only applies to the **COMPLEX pipeline**, since PLAN-CHECK was dropped from SIMPLE in v5. PLAN-CHECK passes approximately 90% of the time, so on COMPLEX backend-only issues PATCH can start speculatively in parallel:
 
 ```
 Spawn in parallel:
@@ -77,7 +77,7 @@ Spawn in parallel:
 ```
 
 !!! warning "When NOT to speculate"
-    Disable speculative PATCH for COMPLEX issues, fullstack changes, or issues that were previously BLOCKED. The plan rejection rate is higher in these cases.
+    Speculative PATCH never applies on the SIMPLE pipeline (no PLAN-CHECK to gate against). On COMPLEX, also disable speculation for fullstack changes or issues that were previously BLOCKED — the plan rejection rate is higher in those cases.
 
 ### Fullstack PATCH Split
 

--- a/docs/manual/workflow/quick-mode.md
+++ b/docs/manual/workflow/quick-mode.md
@@ -2,6 +2,9 @@
 
 The `/quick` command handles small, well-scoped tasks without the overhead of the full orchestrate pipeline. No sub-agents, no artifacts, no GitHub issue required. In the routing model, `/quick` is the destination for **TRIVIAL** routing tier tasks (1 file, obvious fix).
 
+!!! note "/orchestrate redirects TRIVIAL here"
+    Per PR #94, `/orchestrate` actively rejects TRIVIAL classifications and redirects you to `/quick` with an explicit message. There is no longer a TRIVIAL pipeline running through `/orchestrate` — this page describes where that work actually lives.
+
 ## Usage
 
 ```bash


### PR DESCRIPTION
## What

End-to-end refresh of `docs/manual/` to bring it current with the April PRs (#75–#98), plus a substantial visual layer added — 14 mermaid diagrams covering the full system architecture.

## Why

The manual was substantially stale relative to the recent shipped work:

- **Counts everywhere wrong**: 9 agents → actually 12, 18 commands → 16, 6 hooks → 11, etc.
- **Pipeline diagrams showed the deprecated TRIVIAL pipeline** and PLAN-CHECK in the SIMPLE pipeline (both removed in v5).
- **Several features had no documentation at all** (slug-format pattern IDs, validate-hooks.py, CI workflow, /pr Codex gate, verify_completion changes, _base.md trim).
- **No mermaid diagrams** despite mkdocs already supporting them. The reference page used ASCII tree art only.

## How

Three parallel update agents handled the routine updates by file group; the centerpiece (architecture-diagrams.md and file-inventory.md) was rewritten from scratch.

### Refresh coverage

**All counts** updated to current ground truth (12 / 16 / 12 / 11 / 7 / 8 / 39).

**Pipeline diagrams** updated:
- SIMPLE: `MAP-PLAN → [CONTRACT*] → PATCH → PROVE` (no PLAN-CHECK)
- COMPLEX: `MAP → PLAN → [CONTRACT*] → PLAN-CHECK → PATCH → PROVE`
- TRIVIAL: rejected by `/orchestrate`, redirects to `/quick`

**Newly documented features**:
- Slug-format pattern IDs and multi-machine safety (PR #87)
- `validate-hooks.py` install-time validator (PR #82)
- npm cache warm-up in install.sh Phase 2.6 (PR #81)
- `.github/workflows/validate.yml` CI gate (PR #98)
- `/pr` advisory Codex review gate for COMPLEX changes (PR #95)
- verify_completion now flags all uncommitted files (PR #84)
- verify_completion detects un-pushed + branch-ahead-no-PR (PR #85)
- `_base.md` trim + verify-commands.md snippet (PR #97)
- TRIVIAL → /quick redirect in /orchestrate (PR #94)

**Mermaid diagrams added** (in `reference/architecture-diagrams.md`, 14 total):

1. Symlink Deployment (`claude-config/` ↔ `~/.claude/`)
2. Configuration Loading at Session Start
3. Issue → PR Pipeline (full flow with conditional phases)
4. Tier Routing Decision Tree
5. Hook Lifecycle (sequence)
6. Self-Learning Loop (feedback cycle)
7. MCP Server Topology
8. Knowledge Graph Data Flow
9. Codex × Claude Collaboration
10. Multi-Machine Pattern Coordination (sequence)
11. Pre-Merge Gate Stack
12. Failure → Pattern Feedback Cycle
13. State Continuity Across Sessions (sequence)
14. Slash Command Surface (grouped)

**Other fixes**:
- Rule frontmatter terminology fixed (`paths:` not `globs:`, only `git-workflow.md` uses `alwaysApply: true`).
- Glossary entries added for `plan-checker`, `pr-fresh-reviewer`, `spec-reviewer`; `discuss` expanded.
- `git/contributing.md` corrected `ci.yml` → `validate.yml`.

## Stack
- [x] Documentation only (no code changes)

## Verification

- [x] All 23 files parse as well-formed markdown
- [x] Mermaid blocks use standard fenced syntax (`pymdownx.superfences` already configured in mkdocs.yml)
- [x] No credentials introduced (E15)
- [ ] Local mkdocs build verification (mkdocs not installed in this session — please run `mkdocs serve` after merge to verify diagrams render correctly)

## Risks / Rollback

None functional — pure docs change. If a mermaid block has a typo and fails to render, the surrounding text still reads fine and a quick fix-up commit resolves it. No effect on runtime behavior, hooks, agents, or tooling.

## Reviewer Notes

This PR is large (23 files, +1306/-503) but each file is a focused, scoped update against the audit findings in `.agents/outputs/manual-audit-042926.md`. The audit documents the specific staleness per file; the changes hew closely to that punch list.

The substantive rewrites are limited to two files:
- `reference/architecture-diagrams.md` (full mermaid rewrite)
- `reference/file-inventory.md` (fresh file inventory walkthrough)

Other files received targeted fixes against specific stale items.

---
Audit artifact: `.agents/outputs/manual-audit-042926.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)