### PR TITLE
feat(commands): add /discover-patterns for bottom-up pattern extraction (#102)

### DIFF
--- a/claude-config/README.md
+++ b/claude-config/README.md
@@ -93,8 +93,9 @@ Canonical paths:
 
 | Command | Usage | Description |
 |---------|-------|-------------|
-| `/learn` | `/learn --cross-project` | Analyze failures, extract patterns across projects |
+| `/learn` | `/learn --cross-project` | Analyze failures, extract patterns across projects (top-down) |
 | `/learn --validate` | `/learn --validate` | A/B test pattern effectiveness (before/after rates) |
+| `/discover-patterns` | `/discover-patterns api` | Bottom-up extraction: read existing code, surface non-obvious conventions as `knowledge/patterns/pat-<slug>.yaml` files. Complements `/learn`. |
 | `/metrics` | `/metrics --week` | Agent performance dashboard with version correlation |
 
 ### FastAPI Scaffolding

--- a/claude-config/commands/discover-patterns.md
+++ b/claude-config/commands/discover-patterns.md
@@ -1,0 +1,176 @@
+---
+description: Extract patterns from existing code into knowledge/patterns/
+argument-hint: [focus-area]
+---
+
+# Discover Patterns
+
+**Role**: Bottom-up pattern extraction. Read working code, surface non-obvious conventions, write them as `knowledge/patterns/pat-<slug>.yaml`.
+
+Complements `/learn` (top-down from failures). Use this when onboarding a new project, inheriting a repo, or auditing established code.
+
+---
+
+## Usage
+
+```bash
+/discover-patterns                # interactive — pick focus area
+/discover-patterns api            # pre-seed focus area
+```
+
+Run from inside the target repo. Writes to `knowledge/patterns/` in the cwd repo root.
+
+---
+
+## Output Prelude (print verbatim on start)
+
+```
+Discovering patterns in <repo-name>.
+Each pattern captures a non-obvious convention from the codebase
+(things a newcomer wouldn't infer from generic best practices).
+
+I'll ask you to pick a focus area, then walk through 3-5 candidates.
+For each one you keep, I'll ask why the team does it that way before
+drafting. Capped at 3 patterns per run — re-run for more.
+
+Output: knowledge/patterns/pat-<slug>.yaml (status: pilot).
+```
+
+`<repo-name>` = `basename "$(git rev-parse --show-toplevel)"` (or cwd basename if not a git repo).
+
+---
+
+## Process
+
+### Step 1 — Determine focus area
+
+Scan top-level dirs. Identify 3-5 major areas (e.g. `api/`, `database/`, `auth/`, `tests/`, `frontend/src/`, `services/`, `config/`). Skip `node_modules/`, `.git/`, `__pycache__/`, `dist/`, `build/`.
+
+Use `AskUserQuestion` to present the candidates. Single-select, single area per run. If `$ARGUMENTS` matches a real directory, use it directly and skip the question.
+
+### Step 2 — Analyze and present findings
+
+Read 5-10 representative files in the chosen area. Prefer files that are central (touched often, imported widely) over leaves.
+
+Identify candidate patterns. A candidate qualifies if it is **unusual, opinionated, or non-obvious** — something a newcomer wouldn't infer from generic best practices. Disqualify generic advice ("use type hints", "write docstrings"). Qualify project-specific conventions (RBAC at the dependency layer, enum VALUE strings, services raising domain exceptions never HTTPException, etc.).
+
+Present 3-5 candidates via `AskUserQuestion`. Multi-select OK; cap drafted patterns at 3 per run.
+
+### Step 3 — Ask why, then draft
+
+For each chosen pattern, ask 1-2 clarifying questions about WHY the team does it that way. Use `AskUserQuestion` with concrete options when enumerable; free-form only when the answer truly isn't.
+
+**Don't skip the why.** Patterns without context don't survive contact with a different project. Wait for the answer before drafting.
+
+### Step 4 — Create pattern file
+
+Write to `knowledge/patterns/pat-<slug>.yaml`. Slug rules:
+
+- All lowercase, hyphens, no underscores
+- 3-6 words describing the rule (`pat-permission-dependency`, not `pat-auth`)
+- Filename and `id` field MUST match (slug invariant — see `sync.py` duplicate-id guard)
+
+Required fields (per `sync.py` PATTERN_REQUIRED — build rejects anything missing):
+
+```yaml
+id: pat-<slug>
+category: <auth | database | api | frontend | infrastructure | workflow | testing | observability>
+name: <short human label, ≤10 words>
+status: pilot
+tier: secondary  # only "primary" or "secondary" are valid per sync.py — use "primary" for foundational
+description: <lead with the rule, then the why, ≤2 sentences>
+```
+
+Strongly recommended:
+
+```yaml
+when_to_use: <1-2 sentences>
+when_not_to_use: <1-2 sentences>
+implementation:
+  language: <python | typescript | bash | ...>
+  framework: <FastAPI | React | null>
+  key_decisions:
+    - <bullet>
+  reference_code: |
+    <minimal snippet>
+  gotchas:
+    - <pitfall>
+reference_project: <repo-name from cwd>
+reference_path: <relative-path>:<start-line>-<end-line>
+lifecycle:
+  created_at: "<today YYYY-MM-DD>"
+  extracted_from: <repo-name>
+  extracted_by: discover-patterns
+created_at: "<today YYYY-MM-DD>"
+updated_at: "<today YYYY-MM-DD>"
+```
+
+**Body length**: ≤200 words excluding `reference_code`. Lead `description` with the rule, then the why. Terse.
+
+**Confirm before write**: Show drafted YAML, ask via `AskUserQuestion` (Yes / Revise / Skip). All writes go to `knowledge/patterns/` only.
+
+### Step 5 — Validate
+
+After ≥1 pattern written, run:
+
+```bash
+cd knowledge && python3 sync.py build
+```
+
+Confirm exit 0. If guard fails (likely: duplicate id, missing required field, invalid status/tier):
+
+1. Capture stderr
+2. Revert just-written file (`rm` if brand new, `git checkout --` if previously tracked)
+3. Report error to user — don't retry blindly
+
+**Don't run `sync.py build` until ≥1 pattern is written.**
+
+### Step 6 — Offer to continue
+
+After validation passes, `AskUserQuestion`:
+
+- "Yes, same area" → return to Step 2
+- "Yes, different area" → return to Step 1
+- "Stop" → exit and print summary
+
+Hard cap: 3 patterns per run. After 3, force-stop regardless of choice.
+
+---
+
+## Constraints
+
+- **`AskUserQuestion`** for every choice (focus area, pattern selection, why-options, write confirmation, continue prompt). Never free-form prompt for selections.
+- **Lead with the rule** in each `description`, then the why.
+- **Terse** — ≤200 words per pattern body.
+- **Status `pilot`** for all newly extracted patterns.
+- **`reference_project` from cwd** + **`reference_path: <file>:<start>-<end>`** so each pattern points back to its source.
+- **Cap at 3 patterns per run.**
+- **Confirm before each write.**
+- **All writes to `knowledge/patterns/` only.**
+- **Don't run `sync.py build`** until ≥1 pattern is written.
+- **No bulk extraction** — interactive only.
+- **No updates** — `/discover-patterns` only creates. Updating existing patterns stays manual or via `/learn`.
+
+---
+
+## Final Report
+
+```
+Discovered N patterns in <focus-area>:
+  knowledge/patterns/pat-<slug-1>.yaml  — <name>
+  knowledge/patterns/pat-<slug-2>.yaml  — <name>
+
+sync.py build: PASS (exit 0)
+
+Patterns are status: pilot. They surface through vault-metrics MCP at
+next session start. Promote to validated manually after the convention
+holds across at least one new use.
+```
+
+---
+
+## Related
+
+- `/learn` — top-down extraction from `failures.jsonl`
+- `knowledge/sync.py` — slug-uniqueness guard
+- `knowledge/patterns/` — destination; existing files are the schema reference

--- a/docs/manual/cookbook.md
+++ b/docs/manual/cookbook.md
@@ -111,6 +111,25 @@ You've finished implementation. Diff includes auth, migrations, or a 50-file cro
 
 Codex reads the diff fresh (different model, different blind spots) and reports BLOCKING / NON-BLOCKING / CLEAN findings. `/pr` will prompt you to run this for COMPLEX-tier diffs automatically.
 
+### Document an existing project's conventions as patterns
+
+You've inherited a repo or are auditing established code. Surface the team's tribal knowledge as queryable patterns.
+
+```bash
+cd ~/projects/<repo>
+/discover-patterns
+```
+
+What happens:
+
+1. Claude scans the directory and offers 3-5 major focus areas (`api/`, `database/`, `auth/`, etc.)
+2. You pick one. Claude reads representative files and surfaces 3-5 candidate patterns.
+3. For each pattern you keep, Claude asks why the team does it that way (1-2 clarifying questions).
+4. Claude writes `knowledge/patterns/pat-<slug>.yaml` with `status: pilot` and a reference back to the source file.
+5. `sync.py` validates the slug-uniqueness invariant. New patterns surface through `vault-metrics` MCP at next session start.
+
+Capped at 3 patterns per run. Complements `/learn` (top-down from failures) — use `/discover-patterns` when you want bottom-up from working code.
+
 ### Capture a thought without losing focus
 
 Mid-implementation, an idea hits you. You don't want to context-switch.


### PR DESCRIPTION
## What

Adds a new slash command `/discover-patterns` that extracts non-obvious conventions from existing code and writes them as YAML patterns in `knowledge/patterns/`. Complements `/learn` (top-down from failures) with a bottom-up code-reading flow.

Closes #102

## Why

Pattern authoring had two routes today: top-down via `/learn` (failures → preventive patterns) and hand-written. Neither covers *"point at an existing repo, surface its tribal knowledge as queryable patterns."* That's specifically valuable when onboarding a new project, inheriting a repo, or auditing established code.

Inspired by (not copied from) Builder Methods' Agent OS `/discover-standards`. Output goes to existing `knowledge/patterns/` with slug IDs — no new infrastructure, no parallel `agent-os/standards/` directory.

## How

Six-step interactive flow per #102:

1. Focus area selection (`AskUserQuestion`)
2. Analyze 5-10 representative files, present 3-5 candidate patterns
3. Ask 1-2 "why" questions per pattern before drafting
4. Write to `knowledge/patterns/pat-<slug>.yaml` with `status: pilot`
5. Run `sync.py build` to confirm slug-uniqueness guard accepts the new file
6. Offer to continue (capped at 3 patterns/run)

Caught during PATCH: `sync.py` enforces `VALID_TIERS = {"primary", "secondary"}`, not the `medium/low` originally in the issue. Spec corrected inline; new patterns default to `tier: secondary`.

## Stack
- [x] Backend (slash command + docs)

## Verification

- [x] Frontmatter parses as valid YAML
- [x] 6-step process matches issue spec
- [x] Pattern schema in command body cross-checked against existing patterns (e.g. `fastapi-base-model.yaml`)
- [x] `cd knowledge && python3 sync.py build` succeeds (39 patterns baseline preserved — no pattern files touched)
- [x] No credentials introduced (E15)
- [ ] Manual test on a real codebase (deferred — interactive command, can't run unattended; will validate post-merge by running on `mymoney-dev` or `buddy`)

## Risks / Rollback

Trivial. Pure additive — new command file + minor doc updates. No existing structure changed. Single-commit revert.

## Reviewer Notes

The new command is registered automatically via the `claude-config/commands/` symlink — visible at next session start as a callable slash command. Manual testing post-merge: `cd ~/projects/<repo> && /discover-patterns` should walk through area selection → finding presentation → why-questions → file write.

---
Artifact: `.agents/outputs/patch-102-042926.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)