### PR TITLE
fix(orchestrate): record outcomes via deterministic helper, not PROVE shell-echo (#104)

### DIFF
--- a/claude-config/agents/_base.md
+++ b/claude-config/agents/_base.md
@@ -187,14 +187,25 @@ Optional: `severity`, `recovery_minutes`.
 
 ---
 
-## 13. Outcome Recording (PROVE Agent Only)
+## 13. Outcome Recording (Orchestrator-Driven)
 
-After verification, append a JSON record matching the schemas in §11 and §12.
+PROVE no longer writes outcome records directly. Recording is the
+orchestrator's job — see `commands/orchestrate.md` Step 4 (the canonical
+recording site, calling `state_manager.record_metrics` /
+`state_manager.record_failure`).
 
-- **PASS**: append metrics record (status:`PASS`, root_cause:`null`) to `.claude/memory/metrics.jsonl`
-- **BLOCKED**: append failure record to `.claude/memory/failures.jsonl` AND metrics record (status:`BLOCKED`, root_cause:`<code>`, blocking_agent:`PROVE`) to `.claude/memory/metrics.jsonl`
+PROVE's responsibility is to **specify the data via artifact frontmatter**:
 
-Use shell `echo '<json>' >> <file>` with substituted variables. See PROVE agent for full append commands.
+- `status: PASS | BLOCKED`
+- `complexity: TRIVIAL | SIMPLE | COMPLEX`
+- `stack: backend | frontend | fullstack`
+- `root_cause: <code from §10>` (mandatory if BLOCKED)
+- `blocking_agent: PROVE` (mandatory if BLOCKED)
+
+The schemas in §11 and §12 remain authoritative — they define what the
+orchestrator's helpers write. Why this changed: embedding `echo >> file`
+in PROVE's prompt at the end of a long verification flow proved unreliable
+(see issue #104). The deterministic Python call closes the gap.
 
 ---
 

--- a/claude-config/agents/prove.md
+++ b/claude-config/agents/prove.md
@@ -186,30 +186,46 @@ Reference PLAN/MAP-PLAN acceptance criteria:
 
 ---
 
-## Outcome Recording (MANDATORY)
+## Outcome Data (MANDATORY in artifact frontmatter)
 
-### If PASS
+**You do NOT write to `.claude/memory/` yourself.** The orchestrator records
+the outcome deterministically (see `commands/orchestrate.md` Step 4 — the
+canonical recording site). Your job is to populate the data the orchestrator
+will record, by setting these fields in your artifact's YAML frontmatter:
 
-```bash
-# Append to metrics
-echo '{"issue":'$ISSUE',"date":"'$(date +%Y-%m-%d)'","status":"PASS","complexity":"'$COMPLEXITY'","stack":"'$STACK'","agents_run":["MAP-PLAN","PATCH","PROVE"]}' >> .claude/memory/metrics.jsonl
+```yaml
+---
+issue: {issue_number}
+agent: PROVE
+date: {YYYY-MM-DD}
+status: PASS            # or BLOCKED
+complexity: SIMPLE      # TRIVIAL | SIMPLE | COMPLEX
+stack: backend          # backend | frontend | fullstack
+root_cause: null        # MANDATORY if status=BLOCKED — use a code from _base.md §10
+blocking_agent: null    # MANDATORY if status=BLOCKED — usually "PROVE"
+---
 ```
 
-### If BLOCKED
+If `status: BLOCKED`, also include a `## Failure Details` block in the
+artifact body so the orchestrator can populate `failures.jsonl`. Use simple
+`key: value` lines (one per line) — the orchestrator parses them with a
+basic regex:
 
-**Step 1**: Classify root cause using canonical enum from `_base.md` section 10.
-
-Common codes: `ENUM_VALUE`, `COMPONENT_API`, `MULTI_MODEL`, `API_MISMATCH`, `ACCESS_CONTROL`, `MISSING_TEST`, `SQLITE_COMPAT`, `STRUCTURE_VIOLATION`, `SCOPE_CREEP`, `VERIFICATION_GAP`, `OTHER`
-
-**Step 2**: Record failure using canonical schemas from `_base.md` sections 11-12.
-
-```bash
-# Append to failures (canonical schema)
-echo '{"issue":'$ISSUE',"date":"'$(date +%Y-%m-%d)'","agent":"PATCH","root_cause":"'$CAUSE'","details":"'$DETAILS'","fix":"'$FIX'","prevention":"'$PREVENTION'","files":['$FILES']}' >> .claude/memory/failures.jsonl
-
-# Append to metrics (canonical schema)
-echo '{"issue":'$ISSUE',"date":"'$(date +%Y-%m-%d)'","status":"BLOCKED","complexity":"'$COMPLEXITY'","stack":"'$STACK'","agents_run":['$AGENTS'],"agent_versions":{'$VERSIONS'},"root_cause":"'$CAUSE'","blocking_agent":"PROVE"}' >> .claude/memory/metrics.jsonl
+```markdown
+## Failure Details
+details: Frontend used CO_OWNER instead of CO-OWNER
+fix: Changed string literal to match backend enum VALUE
+prevention: MAP should document enum VALUES explicitly
 ```
+
+(Files involved are extracted from `git diff --name-only origin/main` by
+PROVE during verification — surface them in your "Issues Found" section
+prose; they are not required in the failure record.)
+
+**Why this changed (issue #104)**: Embedding the JSONL append in PROVE's
+prompt as an `echo >> file` step at the end of a long verification flow
+proved unreliable — recording was elided in production. Moving the write
+into the orchestrator (a deterministic Python call) closes the gap.
 
 ---
 
@@ -220,7 +236,11 @@ echo '{"issue":'$ISSUE',"date":"'$(date +%Y-%m-%d)'","status":"BLOCKED","complex
 issue: {issue_number}
 agent: PROVE
 date: {YYYY-MM-DD}
-status: PASS | BLOCKED
+status: PASS              # or BLOCKED
+complexity: SIMPLE        # required — orchestrator records this
+stack: backend            # required — orchestrator records this
+root_cause: null          # required if status=BLOCKED (use _base.md §10 codes)
+blocking_agent: null      # required if status=BLOCKED (usually "PROVE")
 ---
 
 # PROVE - Issue #{issue_number}
@@ -251,9 +271,11 @@ $ cd backend && ruff check .
 ## Issues Found
 [None | List with root cause classification]
 
-## Outcome Recorded
-- metrics.jsonl: ✅ Appended
-- failures.jsonl: ✅ Appended (if BLOCKED)
+## Failure Details
+(Include only if status=BLOCKED. Orchestrator parses these key:value lines.)
+details: <what went wrong>
+fix: <what unblocks>
+prevention: <how to avoid next time>
 
 ---
 AGENT_RETURN: prove-{issue_number}-{mmddyy}.md
@@ -289,7 +311,9 @@ Levels:
 - [ ] Level 3: Enum VALUES correct (if fullstack)
 - [ ] Level 3: Component APIs correct (if reusing)
 
-Recording:
-- [ ] Appended to metrics.jsonl
-- [ ] Appended to failures.jsonl (if BLOCKED)
+Outcome data (orchestrator records these — you populate the frontmatter):
+- [ ] Frontmatter has `status: PASS|BLOCKED`
+- [ ] Frontmatter has `complexity` and `stack`
+- [ ] If BLOCKED: frontmatter has `root_cause` (from _base.md §10) and `blocking_agent`
+- [ ] If BLOCKED: artifact body has a `## Failure Details` section with `details`/`fix`/`prevention`
 ```

--- a/claude-config/commands/orchestrate.md
+++ b/claude-config/commands/orchestrate.md
@@ -287,7 +287,73 @@ For per-agent dispatch tables, validation gates, and failure-context injection,
 For parallel patterns (MAP fan-out, speculative PATCH, parallel fullstack PATCH,
 worktree setup, resume mode), **read `templates/orchestrate-parallel.md`**.
 
-### Step 4: Report Status
+### Step 4: Record Outcome (MANDATORY)
+
+**This is the canonical outcome-recording site.** PROVE specifies the data
+via its artifact frontmatter (`status`, `complexity`, `stack`, `agents_run`,
+and — if BLOCKED — `root_cause`, `blocking_agent`, `files`, `prevention`);
+this step performs the deterministic write. PROVE does NOT write to
+`.claude/memory/` directly (see issue #104 — embedding the write in PROVE's
+prompt was unreliable).
+
+After PROVE returns, parse its artifact frontmatter and call the
+`state_manager` helpers:
+
+```bash
+PROVE_ART=$(ls .agents/outputs/prove-${ISSUE}-*.md 2>/dev/null | tail -1)
+if [ -z "$PROVE_ART" ] || [ ! -f "$PROVE_ART" ]; then
+  echo "WARNING: no PROVE artifact found for issue ${ISSUE}; skipping outcome recording"
+else
+  python3 - <<PYEOF
+import sys, re, json
+sys.path.insert(0, '$HOME/.claude/hooks')
+from pathlib import Path
+from state_manager import record_metrics, record_failure
+
+art = Path("$PROVE_ART").read_text(encoding="utf-8")
+fm_match = re.search(r"^---\n(.*?)\n---", art, re.DOTALL | re.MULTILINE)
+fm = fm_match.group(1) if fm_match else ""
+
+def field(name, default=None):
+    m = re.search(rf"^{name}:\s*(.+)$", fm, re.MULTILINE)
+    return m.group(1).strip() if m else default
+
+status     = field("status", "PASS")
+complexity = "$COMPLEXITY" or field("complexity", "SIMPLE")
+stack      = "$STACK"      or field("stack", "backend")
+agents_run = json.loads('$AGENTS_RUN_JSON' or '["MAP-PLAN","PATCH","PROVE"]')
+root_cause = field("root_cause") if status == "BLOCKED" else None
+
+record_metrics(
+    Path("."), int("$ISSUE"), status, complexity, stack, agents_run,
+    root_cause=root_cause,
+    blocking_agent=("PROVE" if status == "BLOCKED" else None),
+)
+
+if status == "BLOCKED" and root_cause:
+    # PROVE artifact may include a "## Failure Details" section with files /
+    # prevention / details / fix. Best-effort extraction; missing fields are OK.
+    def section(name):
+        m = re.search(rf"^{name}:\s*(.+)$", art, re.MULTILINE)
+        return m.group(1).strip() if m else None
+    record_failure(
+        Path("."), int("$ISSUE"), root_cause,
+        files=None, agent="PATCH",
+        prevention=section("prevention"),
+        details=section("details"),
+        fix=section("fix"),
+    )
+print(f"Recorded outcome for issue {sys.argv[0] or '$ISSUE'}: {status}")
+PYEOF
+fi
+```
+
+If PROVE's frontmatter is malformed, `record_metrics` still writes a minimal
+record with sensible defaults (`status=PASS`, `complexity=SIMPLE`,
+`stack=backend`) — partial data > no data. The helpers fail open on IOError;
+losing one metric line never fails the orchestrate run.
+
+### Step 5: Report Status
 
 ```
 ✓ Workflow complete for issue #184
@@ -298,6 +364,7 @@ Artifacts:
 - prove-184-010325.md
 
 PROVE status: PASS ✅
+Outcome recorded: ✅ metrics.jsonl (+1 line)
 Codex review: skipped | recommended | complete
 
 Next: /pr 184 to create pull request
@@ -314,7 +381,10 @@ If any agent fails:
 3. Show expected artifact path
 4. Do NOT proceed
 
-If PROVE returns BLOCKED, the failure is recorded to `.claude/memory/failures.jsonl`. Subsequent runs of `/orchestrate $ISSUE` automatically inject failure context into the PATCH prompt.
+If PROVE returns BLOCKED, **Step 4 records** the failure to
+`.claude/memory/failures.jsonl` (orchestrator-driven write — not PROVE).
+Subsequent runs of `/orchestrate $ISSUE` automatically inject failure
+context into the PATCH prompt by reading from that file.
 
 ---
 

--- a/claude-config/commands/quick.md
+++ b/claude-config/commands/quick.md
@@ -77,9 +77,26 @@ Quick task complete:
 
 ## Optional: Metrics Recording
 
+`/quick` doesn't go through `/orchestrate`, so it records its own outcome
+via the same `state_manager` helper the orchestrator uses (see issue #104
+for why we no longer rely on free-form `echo >> file` placeholders).
+
 ```bash
-echo '{"date":"'$(date +%Y-%m-%d)'","source":"quick","task":"DESCRIPTION","status":"PASS","files_changed":N}' >> .claude/memory/metrics.jsonl
+# After verification passes, optionally append a /quick outcome record.
+# /quick changes don't have GitHub issues, so use issue=0 as a sentinel.
+python3 -c "
+import sys
+sys.path.insert(0, '$HOME/.claude/hooks')
+from state_manager import record_metrics
+from pathlib import Path
+record_metrics(
+    Path('.'), 0, 'PASS', 'TRIVIAL', '$STACK',
+    ['quick'],
+)
+"
 ```
+
+`$STACK` is `backend`, `frontend`, or `config` based on Step 2's classification.
 
 ---
 

--- a/claude-config/hooks/state_manager.py
+++ b/claude-config/hooks/state_manager.py
@@ -1,14 +1,21 @@
 #!/usr/bin/env python3
 """
-Centralized state manager for PERSISTENT_STATE.yaml.
+Centralized state manager for PERSISTENT_STATE.yaml + outcome recording.
 
 Used by: orchestrate command (inline), precompact hook, sessionstart hook.
-Single source of truth for reading/writing orchestrate workflow state.
+
+Two responsibilities:
+1. PERSISTENT_STATE.yaml read/write (active_work tracking)
+2. Outcome recording — append to .claude/memory/{metrics,failures}.jsonl
+   after PROVE returns. Recording is the orchestrator's job, NOT PROVE's,
+   so the write is deterministic across runs (see issue #104).
 """
 
 from __future__ import annotations
 
+import json
 import logging
+import os
 from datetime import datetime
 from pathlib import Path
 
@@ -154,3 +161,169 @@ def update_from_extracted(project_dir: Path, extracted: dict) -> None:
     data["meta"]["updated"] = datetime.now().strftime("%Y-%m-%d")
 
     _write_state(project_dir, data)
+
+
+# ---------------------------------------------------------------------------
+# Outcome recording (issue #104)
+# ---------------------------------------------------------------------------
+#
+# Recording is the orchestrator's job, not PROVE's. PROVE produces the data
+# (status / complexity / stack / agents_run / root_cause via its artifact
+# frontmatter); the orchestrator calls these helpers to perform the write.
+# This makes recording deterministic — a long PROVE prompt can no longer
+# elide the tail-end echo command (the failure pattern documented in #104).
+#
+# Idempotency: callers should invoke each function exactly once per outcome.
+# These helpers do NOT dedupe internally — appending two records for the
+# same issue (e.g., a re-run that produces a second BLOCKED record) is
+# meaningful history, not a duplicate.
+#
+# Failure mode: fail-open. If the JSONL file can't be written (permissions,
+# read-only filesystem, etc.) we log a warning to ~/.claude/hooks.log and
+# return None. Losing one metric line is acceptable; failing a successful
+# orchestrate run because we couldn't write a metric is not.
+
+def _memory_dir(project_dir: Path) -> Path:
+    return project_dir / ".claude" / "memory"
+
+
+def _append_jsonl(target: Path, record: dict) -> None:
+    """Append one JSON line to ``target``, creating parent dirs if needed.
+
+    Uses append mode so concurrent ``--parallel`` orchestrate runs don't
+    clobber each other. ``fsync`` after write so a crash doesn't lose the
+    line. Single-line JSON writes ≤ PIPE_BUF are atomic on POSIX.
+    """
+    target.parent.mkdir(parents=True, exist_ok=True)
+    line = json.dumps(record, separators=(",", ":")) + "\n"
+    with open(target, "a", encoding="utf-8") as f:
+        f.write(line)
+        f.flush()
+        try:
+            os.fsync(f.fileno())
+        except OSError:
+            # fsync can fail on some filesystems (e.g. /tmp on macOS,
+            # NFS mounts). The write itself succeeded; safe to ignore.
+            pass
+
+
+def record_metrics(
+    project_dir: Path,
+    issue: int,
+    status: str,
+    complexity: str,
+    stack: str,
+    agents_run: list[str],
+    duration_seconds: int | None = None,
+    root_cause: str | None = None,
+    blocking_agent: str | None = None,
+    agent_versions: dict[str, str] | None = None,
+) -> None:
+    """Append a single record to ``.claude/memory/metrics.jsonl``.
+
+    Schema matches the existing 2 records (subset of _base.md §11):
+        {"issue":N,"date":"YYYY-MM-DD","status":"PASS|BLOCKED",
+         "complexity":"...","stack":"...","agents_run":[...]}
+
+    Optional fields (root_cause, blocking_agent, duration_seconds,
+    agent_versions) are included only when supplied — keeps a PASS
+    record compact and parseable by /learn's existing jq filters.
+
+    Args:
+        project_dir: Project root. The file lives at
+            ``<project_dir>/.claude/memory/metrics.jsonl``.
+        issue: GitHub issue number.
+        status: "PASS" or "BLOCKED".
+        complexity: "TRIVIAL", "SIMPLE", or "COMPLEX".
+        stack: "backend", "frontend", or "fullstack".
+        agents_run: Ordered list of phase names (e.g.
+            ["MAP-PLAN", "PATCH", "PROVE"]).
+        duration_seconds: Optional total wall-clock duration.
+        root_cause: Required if ``status == "BLOCKED"``. One of the
+            codes from ``_base.md`` §10.
+        blocking_agent: Which agent surfaced the BLOCKED outcome
+            (usually "PROVE"). Recorded only when status is BLOCKED.
+        agent_versions: Optional version map, e.g. {"prove": "1.5"}.
+
+    Returns: None. Errors are logged to ``~/.claude/hooks.log``; the
+    function never raises into the orchestrator.
+    """
+    record: dict = {
+        "issue": int(issue),
+        "date": datetime.now().strftime("%Y-%m-%d"),
+        "status": status,
+        "complexity": complexity,
+        "stack": stack,
+        "agents_run": list(agents_run),
+    }
+    if duration_seconds is not None:
+        record["duration_seconds"] = int(duration_seconds)
+    if root_cause:
+        record["root_cause"] = root_cause
+    if blocking_agent:
+        record["blocking_agent"] = blocking_agent
+    if agent_versions:
+        record["agent_versions"] = dict(agent_versions)
+
+    target = _memory_dir(project_dir) / "metrics.jsonl"
+    try:
+        _append_jsonl(target, record)
+    except OSError as e:
+        logging.warning(f"record_metrics: could not append to {target}: {e}")
+
+
+def record_failure(
+    project_dir: Path,
+    issue: int,
+    root_cause: str,
+    files: list[str] | None = None,
+    agent: str | None = None,
+    prevention: str | None = None,
+    details: str | None = None,
+    fix: str | None = None,
+) -> None:
+    """Append a single record to ``.claude/memory/failures.jsonl``.
+
+    Schema follows ``_base.md`` §12:
+        {"issue":N,"date":"YYYY-MM-DD","root_cause":"...",
+         "files":[...],"agent":"...","prevention":"...",
+         "details":"...","fix":"..."}
+
+    Only ``issue``, ``date``, and ``root_cause`` are mandatory; everything
+    else is included only if supplied. /learn's clustering reads
+    ``root_cause`` and (optionally) ``files``.
+
+    Args:
+        project_dir: Project root.
+        issue: GitHub issue number.
+        root_cause: One of the codes from ``_base.md`` §10
+            (ENUM_VALUE, COMPONENT_API, MULTI_MODEL, ...).
+        files: Files involved in the failure.
+        agent: Which agent's work failed (usually "PATCH").
+        prevention: Brief prevention recommendation for next time.
+        details: Free-form description of what went wrong.
+        fix: What was done (or needs to be done) to unblock.
+
+    Returns: None. Fails open with a logged warning on IOError.
+    """
+    record: dict = {
+        "issue": int(issue),
+        "date": datetime.now().strftime("%Y-%m-%d"),
+        "root_cause": root_cause,
+    }
+    if files:
+        record["files"] = list(files)
+    if agent:
+        record["agent"] = agent
+    if prevention:
+        record["prevention"] = prevention
+    if details:
+        record["details"] = details
+    if fix:
+        record["fix"] = fix
+
+    target = _memory_dir(project_dir) / "failures.jsonl"
+    try:
+        _append_jsonl(target, record)
+    except OSError as e:
+        logging.warning(f"record_failure: could not append to {target}: {e}")

--- a/claude-config/templates/agent-prompt.md
+++ b/claude-config/templates/agent-prompt.md
@@ -92,10 +92,18 @@ When `{SCOPE}` is set, add this line to "Inherited Context":
 Use `subagent_type='orchestrate-patch'` for both backend and frontend halves;
 the SCOPE line tells the agent which side to implement.
 
-## PROVE-lite Variant (TRIVIAL issues)
+## PROVE-lite Variant (TRIVIAL issues — currently unused)
 
-For TRIVIAL issues, use the same `subagent_type='orchestrate-prove'` but a
-minimal prompt — gates only, no Level 2-3 checks:
+> **Note (issue #94)**: `/orchestrate` rejects TRIVIAL issues at Step 1.0.1
+> and redirects to `/quick`. PROVE-lite is therefore dead code in the active
+> pipeline; the variant is kept here only so the template stays consistent
+> if TRIVIAL handling is ever reintroduced.
+
+If reactivated, use the same `subagent_type='orchestrate-prove'` but a
+minimal prompt — gates only, no Level 2-3 checks. As with full PROVE, the
+agent does NOT write to `.claude/memory/`; the orchestrator records via
+`state_manager` from the artifact's frontmatter (see
+`commands/orchestrate.md` Step 4).
 
 ```markdown
 ## Inherited Context
@@ -108,7 +116,8 @@ Run verification gates only (skip Level 2 SUBSTANTIVE and Level 3 WIRED):
 - If backend touched: `cd backend && ruff check . && pytest -q`
 - If frontend touched: `cd frontend && npm run lint && npm run build`
 
-Record outcome to `.claude/memory/metrics.jsonl`.
+Populate artifact frontmatter (status / complexity / stack) — orchestrator
+records the outcome from there. Do NOT write to `.claude/memory/` yourself.
 Write artifact to `.agents/outputs/{ARTIFACT_NAME}`.
 End with `AGENT_RETURN: {ARTIFACT_NAME}`.
 ```

--- a/claude-config/templates/orchestrate-pipeline.md
+++ b/claude-config/templates/orchestrate-pipeline.md
@@ -202,7 +202,11 @@ After both complete, validate no file conflicts and merge into a single `patch-{
 | subagent_type | `orchestrate-prove` |
 | ARTIFACT_NAME | `prove-{ISSUE}-{MMDDYY}.md` |
 | ARTIFACT_LIST | `- PATCH: ...` and `- MAP-PLAN: ...` |
-| AGENT_INSTRUCTIONS | Run verification commands (ruff, pytest, npm lint, npm build). Record outcome to `metrics.jsonl`. If BLOCKED, record to `failures.jsonl`. |
+| AGENT_INSTRUCTIONS | Run verification commands (ruff, pytest, npm lint, npm build). Populate frontmatter `status`, `complexity`, `stack`, `agents_run`, `root_cause` (if BLOCKED), `blocking_agent` (if BLOCKED). Do NOT write to `.claude/memory/` — the orchestrator records via `state_manager` after PROVE returns (see `commands/orchestrate.md` Step 4). |
+
+**Post-condition**: PROVE artifact frontmatter contains the outcome fields.
+Orchestrator's Step 4 reads them and calls `state_manager.record_metrics`
+(and `record_failure` if BLOCKED) — that step is the authoritative writer.
 
 ### PROVE-lite — TRIVIAL only
 


### PR DESCRIPTION
## What

Fixes the structurally inert self-learning loop. Moves outcome recording from "PROVE shell-echo at end of agent prompt" (which agents reliably elided) to "orchestrator calls deterministic Python helper after PROVE completes."

Closes #104

## Why

`/learn` is supposed to read accumulated outcomes from `.claude/memory/{metrics,failures}.jsonl` and extract prevention patterns. But:

- `metrics.jsonl` had only 2 stale records from March 2026
- `failures.jsonl` did not exist
- 13 successful `/orchestrate` runs in April produced **zero** new metrics records
- The whole self-learning cycle was structurally broken

## Root cause

PROVE agent prompts (`prove.md`, `_base.md`, `templates/*`) instructed PROVE to write records via inline `echo >> .claude/memory/metrics.jsonl` shell commands at the very end of a 295-line instruction file. With 19 sections and a 40-item checklist preceding that step, agents consistently skipped it. Empirical evidence: zero of the 5 surviving April PROVE artifacts contain the recording section.

This is **Classification A/B hybrid**: recording was specified in documentation but never implemented as executable code. There was no helper function, no orchestrator step, no hook — only natural-language instructions inside long prompts.

## How

Recording is now deterministic code, not a natural-language hope at the end of a prompt:

| Layer | Before | After |
|---|---|---|
| Where the WRITE happens | PROVE agent shell-echoes (skipped) | Orchestrator calls Python helper (deterministic) |
| Helper code | None | `state_manager.record_metrics()` + `record_failure()` |
| Caller | (no caller) | `orchestrate.md` Step 4 (MANDATORY) |
| PROVE's role | Write the file | Provide data via artifact frontmatter |
| `_base.md` §13 | "PROVE writes" | "Orchestrator writes; PROVE provides data" |

Concrete edits across 7 files. `state_manager.py` API additions only — existing 7 exports untouched.

## Stack
- [x] Backend (orchestrate workflow tooling)

## Verification

- [x] `python3 -m py_compile claude-config/hooks/state_manager.py` — clean
- [x] All 7 existing state_manager exports byte-identical
- [x] Helper happy path: 3 PASS + 1 BLOCKED records produced; valid JSONL; schema matches existing March records and `/learn`'s jq queries
- [x] Helper fail-open: `chmod 555 .` then `record_metrics(...)` returns cleanly without raising
- [x] End-to-end Step 4 simulation: fake BLOCKED PROVE artifact produces correct records in both files
- [x] `prove.md` no longer contains `metrics.jsonl >>` or `failures.jsonl >>` shell-echoes
- [x] Real `.claude/memory/` baseline (2 records) preserved throughout testing
- [x] No credentials introduced (E15)

## Reviewer Notes

Pre-PR fresh-context review: 2 non-blocking WARNINGs and 1 SUGGESTION:

**WARNING 1**: `agents_run` propagation depends on `$AGENTS_RUN_JSON` env var, which orchestrator doesn't yet populate. Falls back to a hardcoded 3-phase default. A `--with-tests` run that included TEST-PLANNER would silently record the wrong agents_run list. Documented limitation, follow-up issue worthwhile.

**WARNING 2**: Idempotency intentionally absent at call site; helpers don't dedupe. If `--resume` re-runs Step 4 on the same issue, a second PASS line gets written. Decide later whether this is intentional ("meaningful history") or needs a guard.

**SUGGESTION**: This PR modifies `_base.md` §13 (the agent base contract), which is exactly the cross-cutting signal the new `/pr` Codex gate was designed for. Recommend running before merge:

```
/codex:adversarial-review --background "Focus on: outcome-recording contract drift between _base.md §13, prove.md, orchestrate.md Step 4, and quick.md; verify schema compatibility with learn.md jq queries"
```

I'm not invoking the plugin commands from subagent context (architectural limitation). Run manually if you want the second-model pass before merge.

## Risks / Rollback

Low. Helpers fail open; orchestrator's Step 4 is wrapped in graceful fallbacks; no schema redesign. Rollback is single-commit revert. The 2 stale March records remain untouched; this PR only enables future writes.

## How to verify it works post-merge

Run any `/orchestrate <issue>` and let it complete. Then:

```bash
wc -l .claude/memory/metrics.jsonl   # should grow by 1
tail -1 .claude/memory/metrics.jsonl # should be a valid record for the just-finished issue
```

If BLOCKED:
```bash
cat .claude/memory/failures.jsonl    # should have a corresponding failure record with root_cause
```

After accumulating ≥3 outcomes per root_cause, `/learn` will start producing meaningful pattern extractions.

---
Artifacts: `.agents/outputs/{map-plan,patch,prove}-104-042926.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)