### PR TITLE
fix(orchestrate): derive agents_run from artifacts (#107)

### DIFF
--- a/claude-config/commands/orchestrate.md
+++ b/claude-config/commands/orchestrate.md
@@ -296,6 +296,13 @@ this step performs the deterministic write. PROVE does NOT write to
 `.claude/memory/` directly (see issue #104 — embedding the write in PROVE's
 prompt was unreliable).
 
+`agents_run` is **derived from `.agents/outputs/`** by scanning for
+`<phase>-<issue>-<mmddyy>.md` artifacts and sorting by mtime — the
+artifact directory IS the ground truth for what ran, not state tracked
+across phase dispatches (the orchestrator command is stateless between
+Task() calls; see issue #107). The `$AGENTS_RUN_JSON` env var is no
+longer used.
+
 After PROVE returns, parse its artifact frontmatter and call the
 `state_manager` helpers:
 
@@ -305,10 +312,10 @@ if [ -z "$PROVE_ART" ] || [ ! -f "$PROVE_ART" ]; then
   echo "WARNING: no PROVE artifact found for issue ${ISSUE}; skipping outcome recording"
 else
   python3 - <<PYEOF
-import sys, re, json
+import sys, re
 sys.path.insert(0, '$HOME/.claude/hooks')
 from pathlib import Path
-from state_manager import record_metrics, record_failure
+from state_manager import record_metrics, record_failure, derive_agents_run
 
 art = Path("$PROVE_ART").read_text(encoding="utf-8")
 fm_match = re.search(r"^---\n(.*?)\n---", art, re.DOTALL | re.MULTILINE)
@@ -321,7 +328,10 @@ def field(name, default=None):
 status     = field("status", "PASS")
 complexity = "$COMPLEXITY" or field("complexity", "SIMPLE")
 stack      = "$STACK"      or field("stack", "backend")
-agents_run = json.loads('$AGENTS_RUN_JSON' or '["MAP-PLAN","PATCH","PROVE"]')
+agents_run = derive_agents_run(Path("."), int("$ISSUE"))
+if not agents_run:
+    print(f"Warning: no artifacts found for issue $ISSUE; recording with empty agents_run")
+    agents_run = []
 root_cause = field("root_cause") if status == "BLOCKED" else None
 
 record_metrics(
@@ -350,8 +360,11 @@ fi
 
 If PROVE's frontmatter is malformed, `record_metrics` still writes a minimal
 record with sensible defaults (`status=PASS`, `complexity=SIMPLE`,
-`stack=backend`) — partial data > no data. The helpers fail open on IOError;
-losing one metric line never fails the orchestrate run.
+`stack=backend`) — partial data > no data. If no artifacts are found for
+the issue, `agents_run` is recorded as `[]` (clearly wrong, easy to filter
+out later) rather than a hardcoded but plausible default that would lie
+about what actually ran. The helpers fail open on IOError; losing one
+metric line never fails the orchestrate run.
 
 ### Step 5: Report Status
 

--- a/claude-config/hooks/state_manager.py
+++ b/claude-config/hooks/state_manager.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 from datetime import datetime
 from pathlib import Path
 
@@ -327,3 +328,76 @@ def record_failure(
         _append_jsonl(target, record)
     except OSError as e:
         logging.warning(f"record_failure: could not append to {target}: {e}")
+
+
+# ---------------------------------------------------------------------------
+# Derive agents_run from artifact directory (issue #107)
+# ---------------------------------------------------------------------------
+#
+# The orchestrator's Step 4 needs the ordered list of phase names that
+# actually ran for an issue. Tracking that across phase dispatches is
+# error-prone (the orchestrator command is stateless between agent calls),
+# so we derive it after the fact from `.agents/outputs/`. Every agent that
+# ran wrote a `<phase>-<issue>-<mmddyy>.md` artifact — the directory IS the
+# ground truth for what ran.
+
+# Compiled per-call (issue number is variable). Match `<phase>-<issue>-NNNNNN.md`
+# where phase is lowercase letters with optional hyphens (map, map-plan,
+# plan-check, test-plan, etc.) and the date is exactly 6 digits.
+_PHASE_RE_TEMPLATE = r"^([a-z\-]+)-{issue}-\d{{6}}\.md$"
+
+
+def derive_agents_run(project_dir: Path, issue: int) -> list[str]:
+    """Scan ``.agents/outputs/`` for this issue's artifact files; return phase
+    names in mtime order.
+
+    Each agent that ran wrote a ``<phase>-<issue>-<mmddyy>.md`` artifact.
+    Reading the directory is the ground truth for what actually ran — more
+    reliable than tracking state across phase dispatches in the orchestrator
+    command (which is stateless between Task() calls).
+
+    Phase name mapping: filename stem → uppercase canonical name.
+    Examples::
+
+        map-184-042926.md          → MAP
+        map-plan-184-042926.md     → MAP-PLAN
+        plan-check-184-042926.md   → PLAN-CHECK
+        test-plan-184-042926.md    → TEST-PLAN
+
+    Args:
+        project_dir: Project root. Artifacts live under
+            ``<project_dir>/.agents/outputs/``.
+        issue: GitHub issue number.
+
+    Returns:
+        Ordered list of uppercase phase names. Empty list if the
+        ``.agents/outputs/`` directory doesn't exist or no matching
+        artifacts are found.
+    """
+    out_dir = project_dir / ".agents" / "outputs"
+    if not out_dir.is_dir():
+        return []
+
+    pattern = re.compile(_PHASE_RE_TEMPLATE.format(issue=issue))
+
+    # Glob first (fast directory scan), then regex-validate each name.
+    # The glob is permissive — it catches anything matching the issue stem;
+    # the regex enforces the actual `<phase>-<issue>-NNNNNN.md` shape and
+    # rejects oddities like `random-1234-thing.md`.
+    matches: list[tuple[float, str]] = []
+    for p in out_dir.glob(f"*-{issue}-*.md"):
+        m = pattern.match(p.name)
+        if not m:
+            continue
+        try:
+            mtime = p.stat().st_mtime
+        except OSError:
+            # Fail open: if we can't stat the file, skip rather than raise.
+            continue
+        matches.append((mtime, m.group(1).upper()))
+
+    # Sort by mtime to preserve actual execution order. Alphabetical sort
+    # would put `map` after `map-plan`; mtime is more honest about what
+    # ran when.
+    matches.sort()
+    return [phase for _, phase in matches]


### PR DESCRIPTION
## What

Replaces #105's `\$AGENTS_RUN_JSON` env-var-with-hardcoded-fallback approach with a deterministic `derive_agents_run(project_dir, issue)` helper that scans `.agents/outputs/` for the issue's artifacts.

Closes #107

## Why

#105 introduced Step 4 in `commands/orchestrate.md` to record outcomes via `state_manager.record_metrics(...)`. The `agents_run` field was read from `\$AGENTS_RUN_JSON` env var with a hardcoded fallback `["MAP-PLAN","PATCH","PROVE"]`. The orchestrator never populated the env var. So every recorded metric would lie about which agents actually ran:

- COMPLEX run (MAP, PLAN, PLAN-CHECK, PATCH, PROVE) → recorded as MAP-PLAN, PATCH, PROVE
- `--with-tests` (adds TEST-PLAN) → not recorded
- `--discuss` (adds DISCUSS) → not recorded
- Fullstack (adds CONTRACT) → not recorded

Plausible-but-wrong is worse than empty-and-clearly-wrong: `/learn` queries filtering on `agents_run` would silently mislead.

## How

Each agent that runs writes a `<phase>-<issue>-<mmddyy>.md` artifact. The artifact directory IS the ground truth for what executed.

- `state_manager.py` adds `derive_agents_run` next to `record_metrics`/`record_failure`. Glob `.agents/outputs/*-<issue>-*.md` → regex-validate the filename shape → sort by mtime → return uppercase phase names. Stdlib only.
- `commands/orchestrate.md` Step 4 calls the helper instead of reading the env var. Empty list (with warning) if no artifacts — clearly wrong, easy to filter.

## Verified scenarios

- [x] COMPLEX → `["MAP","PLAN","PLAN-CHECK","PATCH","PROVE"]`
- [x] SIMPLE `--with-tests` → `["MAP-PLAN","TEST-PLAN","PATCH","PROVE"]`
- [x] Full COMPLEX `--with-tests --discuss` fullstack → 8-phase sequence including DISCUSS + CONTRACT
- [x] No artifacts → `[]`
- [x] Missing `.agents/outputs/` → `[]`
- [x] Cross-issue isolation (different issue numbers don't bleed)
- [x] Bad-shape filenames rejected by regex
- [x] No new dependencies (stdlib `re` + `pathlib`)
- [x] Real `.claude/memory/` baseline preserved (still 2 records, no failures.jsonl)
- [x] No credentials introduced (E15)

## Note on canonical names

The helper returns the artifact filename stem uppercased (e.g., `TEST-PLAN`, not `TEST-PLANNER`). The artifact name is what was actually written; if the registered subagent name differs internally, that's separate metadata not captured by this mechanism. If `/learn` ever needs subagent vs artifact distinction, it'll need a separate field.

## Risks / Rollback

Low. Pure helper addition + env-var path removal. Single-commit revert restores the previous behavior (which was producing wrong data anyway, so reverting is strictly worse).

🤖 Generated with [Claude Code](https://claude.com/claude-code)