### PR TITLE
feat(cap): add deterministic action capture CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ __pycache__/
 *.egg-info/
 dist/
 build/
+.pytest_cache/
 
 # Virtual environments
 .venv/

--- a/bin/README.md
+++ b/bin/README.md
@@ -1,0 +1,120 @@
+# `cap` — quick action capture for project `ACTIONS.md` files
+
+A small Python CLI that appends action items to a project's `ACTIONS.md`.
+Deterministic, instant, offline. No AI, no database, no daemon.
+
+This is **layer 1** of a layered capture system. See "Out of scope" below
+for what comes next.
+
+## Install
+
+```bash
+echo 'export PATH="$HOME/agents/bin:$PATH"' >> ~/.bashrc
+source ~/.bashrc
+```
+
+Verify: `which cap` should print `~/agents/bin/cap`.
+
+## Usage
+
+```bash
+cap "Re-check the training video link"           # one action, current project
+cap "Fix bug X" "Add test Y" "Update docs"       # N actions
+echo -e "thing 1\nthing 2" | cap                 # stdin, one per line
+cap --owner Laura "Search SharePoint videos"     # explicit owner
+cap --src M1 "..."                               # explicit source ref
+cap --project sweetprocess "..."                 # target a specific project
+cap -p sweetprocess "..."                        # short form
+```
+
+On success: prints assigned IDs (`A-011`, etc.), one per line. Nothing else.
+On error: writes to stderr, exits non-zero.
+
+## Project detection
+
+In order:
+
+1. `--project NAME` (or `-p NAME`) — resolves to `~/projects/<name>/`.
+   Special case: `--project agents` → `~/agents/`.
+2. Otherwise, from cwd:
+   - First, `git rev-parse --show-toplevel`. If cwd is in a git repo,
+     that's the project root.
+   - Else, walk up looking for `ACTIONS.md` or `CLAUDE.md`.
+3. If neither resolves a project, `cap` errors out. There is no inbox
+   fallback in v1.
+
+If the resolved project has no `ACTIONS.md` yet, `cap` creates one from a
+template matching the canonical schema (mirroring
+`~/projects/sweetprocess/ACTIONS.md`).
+
+## Schema
+
+8-column, mirrored from `~/projects/sweetprocess/ACTIONS.md`:
+
+```
+| ID    | Issue | Action | Owner | Status | Opened       | Src   | Notes |
+|-------|-------|--------|-------|--------|--------------|-------|-------|
+| A-NNN |       | <text> | Jason | open   | <YYYY-MM-DD> | <src> |       |
+```
+
+Defaults: owner=`Jason`, opened=today, status=`open`, Issue/Src/Notes blank
+unless flags are passed.
+
+The **Issue** column is left blank by `cap`. It's reserved for the
+`gh issue create` workflow you may run separately (see sweetprocess) — a
+v2 task may handle that integration. `cap` itself stays offline.
+
+The `Next ID: **A-NNN**` line at the bottom is incremented after each
+capture. If your file augments the line with ` · Next issue: **#N**` (as
+sweetprocess does), `cap` preserves that trailing token unchanged.
+
+Pipes (`|`) in action text are escaped as `\|`. Newlines are flattened to
+spaces (markdown rows must be one line).
+
+## Atomicity
+
+Writes go through a temp file in the same directory, then `os.replace`
+swaps atomically. A `kill -9` mid-run leaves `ACTIONS.md` intact (a stray
+`ACTIONS.md.*.tmp` may remain — safe to delete).
+
+## Tests
+
+```bash
+cd ~/agents/bin && python3 -m pytest tests/
+```
+
+## Out of scope (future layers)
+
+This is v1. Built later, in roughly this order:
+
+- **MCP bridge to `/dashboard`** — a new tool like
+  `mcp__knowledge__get_actions(project)` that reads `ACTIONS.md` files at
+  query time so cross-project action rollup shows up in the dashboard.
+  `ACTIONS.md` stays canonical; the DB caches nothing.
+- **Other capture surfaces** — iOS Shortcut, Apple Notes, voice, email →
+  all eventually write into `ACTIONS.md` (or a shared inbox).
+- **`-e` editor mode** — open `$EDITOR` with a template and parse rows.
+- **TODO comment scanner** — pull `TODO:` markers out of code into the
+  appropriate `ACTIONS.md`.
+
+## Relationship to `/capture` and `/inbox`
+
+The `/capture` slash command and `/inbox` skill in this repo
+(`claude-config/skills/capture/`, `claude-config/skills/inbox/`) write
+to the **Knowledge MCP** database — a separate, cross-project free-form
+inbox. They are **intentionally independent** from `cap` in v1:
+
+| | `/capture` (slash) | `cap` (shell) |
+|---|---|---|
+| Surface | Claude Code session | Any terminal |
+| Storage | Knowledge MCP DB | Per-project `ACTIONS.md` (git-tracked) |
+| Tagging | `@project` `#type` | `--owner --src --project`, `A-NNN` IDs |
+| Triage | `/inbox` | Edit the markdown file |
+
+`/capture` is for free-form mid-session captures. `cap` is for trackable,
+referenceable, project-scoped action items.
+
+## v2 / v3 plan summary
+
+- v2: MCP exposure of `ACTIONS.md` to `/dashboard`.
+- v3: alternate surfaces (iOS Shortcut, voice, email) and a TODO scanner.

--- a/bin/cap
+++ b/bin/cap
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""cap — append action items to a project's ACTIONS.md.
+
+Layer 1 of a layered capture system: deterministic, instant, offline.
+No AI, no database. Writes to per-project ACTIONS.md files only.
+
+See bin/README.md for full usage.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+DEFAULT_OWNER = "Jason"
+PROJECTS_ROOT = Path.home() / "projects"
+AGENTS_DIR = Path.home() / "agents"
+
+NEXT_ID_RE = re.compile(r"^(Next ID:\s*\*\*)A-(\d+)(\*\*.*?)$", re.MULTILINE)
+OPEN_HEADER_RE = re.compile(r"^## Open\s*$", re.MULTILINE)
+TABLE_HEADER_RE = re.compile(r"^\| ID \|.*\n\|[-| :]+\|\s*\n", re.MULTILINE)
+
+
+class CapError(Exception):
+    """User-facing capture error."""
+
+
+def today_iso() -> str:
+    return _dt.date.today().isoformat()
+
+
+def find_project_root(start: Path) -> Path | None:
+    """Resolve project root from cwd. git toplevel first, then ACTIONS.md/CLAUDE.md walk-up."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            cwd=str(start),
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return Path(result.stdout.strip())
+    except (FileNotFoundError, subprocess.SubprocessError):
+        pass
+
+    cur = start.resolve()
+    while True:
+        if (cur / "ACTIONS.md").exists() or (cur / "CLAUDE.md").exists():
+            return cur
+        if cur.parent == cur:
+            return None
+        cur = cur.parent
+
+
+def resolve_project_arg(name: str) -> Path:
+    candidate = AGENTS_DIR if name == "agents" else PROJECTS_ROOT / name
+    if not candidate.is_dir():
+        raise CapError(f"--project '{name}' does not exist at {candidate}")
+    return candidate
+
+
+def actions_template(project_name: str) -> str:
+    return (
+        f"# Actions — {project_name}\n"
+        "\n"
+        "Open and recently closed actions for this project.\n"
+        "\n"
+        "**How to use**\n"
+        "- Add: append a row, next ID, status=open, fill owner/opened/source\n"
+        "- Update: edit in place (status, notes, closed date)\n"
+        "- Closed >30 days: move to Archive\n"
+        "- Refer as `A-NNN` in commits, PRs, chat, other docs\n"
+        "\n"
+        "**Status:** `open` · `wip` · `blocked` · `done` · `cancelled`\n"
+        "\n"
+        "## Sources\n"
+        "\n"
+        "_(none yet)_\n"
+        "\n"
+        "## Open\n"
+        "\n"
+        "| ID | Issue | Action | Owner | Status | Opened | Src | Notes |\n"
+        "|----|-------|--------|-------|--------|--------|-----|-------|\n"
+        "\n"
+        "## Recently Closed\n"
+        "\n"
+        "| ID | Issue | Action | Owner | Closed | Notes |\n"
+        "|----|-------|--------|-------|--------|-------|\n"
+        "\n"
+        "## Archive\n"
+        "\n"
+        "_(none yet)_\n"
+        "\n"
+        "---\n"
+        "Next ID: **A-001**\n"
+    )
+
+
+def parse_next_id(content: str) -> int:
+    m = NEXT_ID_RE.search(content)
+    if not m:
+        raise CapError("ACTIONS.md is missing 'Next ID: **A-NNN**' line")
+    return int(m.group(2))
+
+
+def _escape_cell(s: str) -> str:
+    return s.replace("|", "\\|").replace("\n", " ").strip()
+
+
+def format_row(action_id: int, action: str, owner: str, opened: str, src: str) -> str:
+    return (
+        f"| A-{action_id:03d} "
+        f"|  "
+        f"| {_escape_cell(action)} "
+        f"| {_escape_cell(owner)} "
+        f"| open "
+        f"| {opened} "
+        f"| {_escape_cell(src)} "
+        f"|  |"
+    )
+
+
+def insert_rows(content: str, new_rows: list[str], next_id_after: int) -> str:
+    open_match = OPEN_HEADER_RE.search(content)
+    if not open_match:
+        raise CapError("ACTIONS.md is missing '## Open' section")
+
+    after_open = open_match.end()
+    h = TABLE_HEADER_RE.search(content[after_open:])
+    if not h:
+        raise CapError("ACTIONS.md '## Open' section is missing the table header")
+
+    pos = after_open + h.end()
+    while pos < len(content):
+        line_end = content.find("\n", pos)
+        if line_end == -1:
+            line_end = len(content)
+        line = content[pos:line_end]
+        if line.startswith("|"):
+            pos = line_end + 1
+            continue
+        break
+
+    block = "".join(row + "\n" for row in new_rows)
+    new_content = content[:pos] + block + content[pos:]
+    return NEXT_ID_RE.sub(
+        lambda m: f"{m.group(1)}A-{next_id_after:03d}{m.group(3)}",
+        new_content,
+    )
+
+
+def atomic_write(path: Path, content: str) -> None:
+    fd, tmp_str = tempfile.mkstemp(prefix=path.name + ".", suffix=".tmp", dir=str(path.parent))
+    tmp = Path(tmp_str)
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.write(content)
+        os.replace(tmp, path)
+    except Exception:
+        if tmp.exists():
+            tmp.unlink()
+        raise
+
+
+def collect_actions(args: argparse.Namespace) -> list[str]:
+    if args.actions:
+        return [a for a in args.actions if a.strip()]
+    if not sys.stdin.isatty():
+        return [line.rstrip() for line in sys.stdin if line.strip()]
+    return []
+
+
+def capture(
+    actions: list[str],
+    project_dir: Path,
+    owner: str,
+    src: str,
+    today: str | None = None,
+) -> list[str]:
+    if not actions:
+        raise CapError("no actions to capture")
+    today = today or today_iso()
+    actions_path = project_dir / "ACTIONS.md"
+    content = actions_path.read_text() if actions_path.exists() else actions_template(project_dir.name)
+
+    next_id = parse_next_id(content)
+    rows: list[str] = []
+    ids: list[str] = []
+    for i, action in enumerate(actions):
+        aid = next_id + i
+        rows.append(format_row(aid, action, owner, today, src))
+        ids.append(f"A-{aid:03d}")
+
+    new_content = insert_rows(content, rows, next_id + len(actions))
+    atomic_write(actions_path, new_content)
+    return ids
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="cap",
+        description="Capture action items to a project's ACTIONS.md file.",
+    )
+    parser.add_argument("actions", nargs="*", help="action description(s)")
+    parser.add_argument("-p", "--project", help="project name (~/projects/<name>/, or 'agents')")
+    parser.add_argument("--owner", default=DEFAULT_OWNER, help=f"owner (default: {DEFAULT_OWNER})")
+    parser.add_argument("--src", default="", help="source reference (e.g., M1)")
+    args = parser.parse_args(argv)
+
+    try:
+        if args.project:
+            project_dir = resolve_project_arg(args.project)
+        else:
+            project_dir = find_project_root(Path.cwd())
+            if project_dir is None:
+                raise CapError(
+                    "no project repo detected from cwd. "
+                    "Run from inside a project, or use --project NAME."
+                )
+
+        actions = collect_actions(args)
+        if not actions:
+            raise CapError("no actions provided. Pass as args or via stdin.")
+
+        for aid in capture(actions, project_dir, args.owner, args.src):
+            print(aid)
+        return 0
+    except CapError as e:
+        print(f"cap: error: {e}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bin/tests/test_cap.py
+++ b/bin/tests/test_cap.py
@@ -1,0 +1,309 @@
+"""Tests for cap. Loaded via importlib because cap has no .py extension."""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+import pytest
+
+CAP_PATH = Path(__file__).resolve().parent.parent / "cap"
+
+
+def _load_cap():
+    loader = SourceFileLoader("cap", str(CAP_PATH))
+    spec = importlib.util.spec_from_loader("cap", loader)
+    module = importlib.util.module_from_spec(spec)
+    loader.exec_module(module)
+    return module
+
+
+cap = _load_cap()
+
+
+# ---------- helpers ----------
+
+def _seed_actions_md(
+    path: Path,
+    next_id: int = 1,
+    rows: list[str] | None = None,
+    next_id_suffix: str = "",
+) -> None:
+    rows_block = "\n".join(rows or []) + ("\n" if rows else "")
+    path.write_text(
+        "# Actions — test\n\n"
+        "## Sources\n\n_(none yet)_\n\n"
+        "## Open\n\n"
+        "| ID | Issue | Action | Owner | Status | Opened | Src | Notes |\n"
+        "|----|-------|--------|-------|--------|--------|-----|-------|\n"
+        f"{rows_block}"
+        "\n## Recently Closed\n\n"
+        "| ID | Issue | Action | Owner | Closed | Notes |\n"
+        "|----|-------|--------|-------|--------|-------|\n"
+        "\n## Archive\n\n_(none yet)_\n\n"
+        "---\n"
+        f"Next ID: **A-{next_id:03d}**{next_id_suffix}\n"
+    )
+
+
+# ---------- format_row ----------
+
+def test_format_row_basic():
+    row = cap.format_row(11, "Do the thing", "Jason", "2026-05-04", "M1")
+    assert row == "| A-011 |  | Do the thing | Jason | open | 2026-05-04 | M1 |  |"
+
+
+def test_format_row_has_eight_columns():
+    row = cap.format_row(11, "x", "Jason", "2026-05-04", "")
+    # 8 cells means 9 pipe characters (including leading and trailing)
+    assert row.count("|") == 9
+
+
+def test_format_row_pads_id_to_three_digits():
+    assert cap.format_row(1, "x", "Jason", "2026-05-04", "").startswith("| A-001 ")
+    assert cap.format_row(999, "x", "Jason", "2026-05-04", "").startswith("| A-999 ")
+
+
+def test_format_row_escapes_pipes():
+    row = cap.format_row(5, "fix a|b parsing", "Jason", "2026-05-04", "")
+    assert "fix a\\|b parsing" in row
+
+
+def test_format_row_flattens_newlines():
+    row = cap.format_row(5, "line1\nline2", "Jason", "2026-05-04", "")
+    assert "line1 line2" in row
+    assert "\n" not in row.replace(" ", "")
+
+
+# ---------- parse_next_id ----------
+
+def test_parse_next_id():
+    assert cap.parse_next_id("...\nNext ID: **A-011**\n") == 11
+
+
+def test_parse_next_id_missing_raises():
+    with pytest.raises(cap.CapError):
+        cap.parse_next_id("no marker here")
+
+
+# ---------- insert_rows + capture ----------
+
+def test_capture_appends_to_existing_file(tmp_path: Path):
+    actions_path = tmp_path / "ACTIONS.md"
+    _seed_actions_md(
+        actions_path,
+        next_id=11,
+        rows=["| A-010 |  | old | Jason | done | 2026-05-01 |  |  |"],
+    )
+
+    ids = cap.capture(["First", "Second"], tmp_path, "Jason", "M1", today="2026-05-04")
+
+    assert ids == ["A-011", "A-012"]
+    content = actions_path.read_text()
+    assert "| A-011 |  | First | Jason | open | 2026-05-04 | M1 |  |" in content
+    assert "| A-012 |  | Second | Jason | open | 2026-05-04 | M1 |  |" in content
+    assert "| A-010 |  | old |" in content
+    assert "Next ID: **A-013**" in content
+
+
+def test_capture_preserves_next_issue_suffix(tmp_path: Path):
+    """Sweetprocess augments the footer with ` · Next issue: **#N**`. cap must keep it intact."""
+    actions_path = tmp_path / "ACTIONS.md"
+    _seed_actions_md(
+        actions_path,
+        next_id=11,
+        next_id_suffix=" · Next issue: **#11**",
+    )
+
+    cap.capture(["First"], tmp_path, "Jason", "", today="2026-05-04")
+    content = actions_path.read_text()
+    assert "Next ID: **A-012** · Next issue: **#11**" in content
+
+
+def test_capture_creates_file_when_missing(tmp_path: Path):
+    project_dir = tmp_path / "myproj"
+    project_dir.mkdir()
+    actions_path = project_dir / "ACTIONS.md"
+    assert not actions_path.exists()
+
+    ids = cap.capture(["Hello"], project_dir, "Jason", "", today="2026-05-04")
+
+    assert ids == ["A-001"]
+    content = actions_path.read_text()
+    assert "# Actions — myproj" in content
+    assert "| A-001 |  | Hello | Jason | open | 2026-05-04 |" in content
+    assert "| ID | Issue | Action | Owner | Status | Opened | Src | Notes |" in content
+    assert "Next ID: **A-002**" in content
+
+
+def test_capture_preserves_sections(tmp_path: Path):
+    actions_path = tmp_path / "ACTIONS.md"
+    _seed_actions_md(actions_path, next_id=1)
+
+    cap.capture(["First"], tmp_path, "Jason", "", today="2026-05-04")
+
+    content = actions_path.read_text()
+    assert "## Sources" in content
+    assert "## Recently Closed" in content
+    assert "## Archive" in content
+
+
+def test_capture_owner_override(tmp_path: Path):
+    actions_path = tmp_path / "ACTIONS.md"
+    _seed_actions_md(actions_path, next_id=1)
+    cap.capture(["Search"], tmp_path, "Laura", "M1", today="2026-05-04")
+    content = actions_path.read_text()
+    assert "| Search | Laura | open | 2026-05-04 | M1 |" in content
+
+
+def test_capture_empty_list_raises(tmp_path: Path):
+    actions_path = tmp_path / "ACTIONS.md"
+    _seed_actions_md(actions_path, next_id=1)
+    with pytest.raises(cap.CapError):
+        cap.capture([], tmp_path, "Jason", "", today="2026-05-04")
+
+
+# ---------- atomic_write ----------
+
+def test_atomic_write_no_temp_left_behind(tmp_path: Path):
+    target = tmp_path / "out.md"
+    cap.atomic_write(target, "hello")
+    assert target.read_text() == "hello"
+    assert not list(tmp_path.glob("*.tmp"))
+
+
+def test_atomic_write_unchanged_on_failure(tmp_path: Path, monkeypatch):
+    target = tmp_path / "out.md"
+    target.write_text("original")
+
+    def boom(*a, **kw):
+        raise OSError("disk on fire")
+
+    monkeypatch.setattr(cap.os, "replace", boom)
+    with pytest.raises(OSError):
+        cap.atomic_write(target, "new content")
+    assert target.read_text() == "original"
+    assert not list(tmp_path.glob("*.tmp"))
+
+
+# ---------- find_project_root ----------
+
+def test_find_project_root_git(tmp_path: Path):
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    found = cap.find_project_root(sub)
+    assert found is not None and found.resolve() == tmp_path.resolve()
+
+
+def test_find_project_root_actions_marker(tmp_path: Path):
+    (tmp_path / "ACTIONS.md").write_text("placeholder")
+    sub = tmp_path / "deep" / "sub"
+    sub.mkdir(parents=True)
+    found = cap.find_project_root(sub)
+    assert found is not None and found.resolve() == tmp_path.resolve()
+
+
+def test_find_project_root_claude_marker(tmp_path: Path):
+    (tmp_path / "CLAUDE.md").write_text("placeholder")
+    found = cap.find_project_root(tmp_path)
+    assert found is not None and found.resolve() == tmp_path.resolve()
+
+
+def test_find_project_root_none_when_no_repo(tmp_path: Path, monkeypatch):
+    # /tmp/pytest-... has no git repo and no markers up the chain
+    # (until we hit something on the way to /). To make this deterministic,
+    # mock subprocess.run so the git step always reports "not a repo", and
+    # confirm None is returned for a fresh tmp_path with no markers.
+    real_run = cap.subprocess.run
+
+    def fake_run(cmd, *args, **kwargs):
+        if cmd[:2] == ["git", "rev-parse"]:
+            class R:
+                returncode = 128
+                stdout = ""
+                stderr = "fatal"
+            return R()
+        return real_run(cmd, *args, **kwargs)
+
+    monkeypatch.setattr(cap.subprocess, "run", fake_run)
+    # walk-up will eventually hit / with no markers — should return None
+    # but in real test environments the user's home may have CLAUDE.md, so
+    # use an isolated fake home
+    monkeypatch.setattr(cap.Path, "home", classmethod(lambda c: tmp_path))
+    isolated = tmp_path / "isolated_dir"
+    isolated.mkdir()
+    assert cap.find_project_root(isolated) is None
+
+
+# ---------- collect_actions ----------
+
+def test_collect_actions_filters_empty():
+    class Args:
+        actions = ["one", "  ", "two"]
+    assert cap.collect_actions(Args()) == ["one", "two"]
+
+
+# ---------- end-to-end via main() ----------
+
+def test_main_writes_ids_to_stdout(tmp_path: Path, capsys, monkeypatch):
+    project_dir = tmp_path / "myproj"
+    project_dir.mkdir()
+    monkeypatch.chdir(project_dir)
+    # Make detection deterministic: mock git to fail, mock home to tmp_path,
+    # add CLAUDE.md so walk-up finds the project
+    (project_dir / "CLAUDE.md").write_text("x")
+    monkeypatch.setattr(cap.Path, "home", classmethod(lambda c: tmp_path))
+
+    real_run = cap.subprocess.run
+
+    def fake_run(cmd, *args, **kwargs):
+        if cmd[:2] == ["git", "rev-parse"]:
+            class R:
+                returncode = 128
+                stdout = ""
+                stderr = "fatal"
+            return R()
+        return real_run(cmd, *args, **kwargs)
+
+    monkeypatch.setattr(cap.subprocess, "run", fake_run)
+
+    rc = cap.main(["First", "Second"])
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert captured.out == "A-001\nA-002\n"
+    assert captured.err == ""
+
+
+def test_main_errors_when_no_project(tmp_path: Path, capsys, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(cap.Path, "home", classmethod(lambda c: tmp_path))
+
+    def fake_run(cmd, *args, **kwargs):
+        if cmd[:2] == ["git", "rev-parse"]:
+            class R:
+                returncode = 128
+                stdout = ""
+                stderr = "fatal"
+            return R()
+        raise RuntimeError("unexpected subprocess call")
+
+    monkeypatch.setattr(cap.subprocess, "run", fake_run)
+    rc = cap.main(["something"])
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert "no project repo detected" in captured.err
+
+
+def test_main_project_flag(tmp_path: Path, capsys, monkeypatch):
+    projects_root = tmp_path / "projects"
+    projects_root.mkdir()
+    (projects_root / "myproj").mkdir()
+    monkeypatch.setattr(cap, "PROJECTS_ROOT", projects_root)
+    rc = cap.main(["-p", "myproj", "Hello"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert out.strip() == "A-001"
+    assert (projects_root / "myproj" / "ACTIONS.md").exists()


### PR DESCRIPTION
## Summary

- Adds `bin/cap`, a Python CLI that appends action items to a project's `ACTIONS.md` file. Layer 1 of a layered capture system — deterministic, offline, no AI, no database.
- 8-column schema mirrored from `~/projects/sweetprocess/ACTIONS.md`. Preserves the trailing ` · Next issue: **#N**` footer token unchanged when present.
- cwd-based project detection (`git rev-parse --show-toplevel` first, then walk up looking for `ACTIONS.md` or `CLAUDE.md`), with `-p`/`--project NAME` to override. Errors out if no project resolves.

## What `cap` does

```bash
cap "Re-check the training video link"           # one action, current project
cap "Fix bug X" "Add test Y" "Update docs"       # N actions
echo -e "thing 1\nthing 2" | cap                 # stdin, one per line
cap --owner Laura "Search SharePoint videos"     # explicit owner
cap --src M1 "..."                               # explicit source ref
cap --project sweetprocess "..."                 # target a specific project
```

On success: prints assigned IDs (`A-011`, etc.), one per line. Nothing else. Errors go to stderr with non-zero exit.

## Decisions taken on the open questions in the brief

- **Python over Bash** — both are fast enough; Python wins on argparse, atomic writes, and testability.
- **Install path** `~/agents/bin/cap`. README has a one-line `PATH` snippet.
- **Owner default** silently `Jason`.
- **No inbox fallback** (changed mid-build at user request) — `cap` errors out if no project resolves, instead of routing to `~/.actions/inbox.md`.
- **Auto-create `ACTIONS.md`** from a template when the resolved project has none.
- **Match the new 8-column schema** (Issue column blank by default), not the older 7-column form in the brief. The Issue column is reserved for a future `gh issue create` integration; `cap` itself stays offline.
- **Independent from `/capture` skill** — the existing slash command writes to the Knowledge MCP inbox; `cap` writes to per-project `ACTIONS.md`. They serve different surfaces and don't sync. v2 plan: an MCP tool that exposes `ACTIONS.md` to `/dashboard` at query time (option A from the discussion thread).

## Out of scope (v2/v3)

Documented in `bin/README.md`:
- MCP bridge so `/dashboard` sees `ACTIONS.md` rows.
- Other capture surfaces (iOS Shortcut, voice, email).
- `-e` editor mode.
- TODO comment scanner.

## Test Plan

- [x] `python3 -m pytest bin/tests/` — 23 passed (format, parsing, atomicity, project detection, end-to-end via `main()`).
- [x] Smoke test against `~/projects/sweetprocess/ACTIONS.md` (then reverted with `git checkout`):
  - `cap "Smoke test: single action"` → `A-011`
  - `cap "Smoke test: two" "Smoke test: three"` → `A-012` `A-013`
  - `cd /tmp && cap "..."` → errors with `cap: error: no project repo detected from cwd.` (exit 1)
  - `cap --owner Laura --src M1 -p sweetprocess "..."` → `A-014`, owner/src cells populated
  - `printf '...\n...\n' | cap -p sweetprocess` → `A-015` `A-016`
  - Footer became `Next ID: **A-017** · Next issue: **#11**` (issue token preserved unchanged).
- [x] Atomicity: no `*.tmp` files left behind in the project dir; unit test covers `os.replace` failure leaving the original file intact.
- [x] Verified only relevant files in `git diff --name-only origin/main`.

## Notes

- `.pytest_cache/` added to `.gitignore` (this is the first project-level pytest setup outside `node_modules` / venv directories).
- A pre-existing WIP on `main` (`claude-config/settings.json` modification + an untracked `docs/STACK_COMPARISON_MULTIUSER.md`) was stashed before branching: `stash@{0}: On main: wip-before-cap-feature: settings.json + STACK_COMPARISON_MULTIUSER.md`. Pop it after merge with `git stash pop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)