### PR TITLE
fix(cap): preserve blank line on empty-template insert

### DIFF
--- a/bin/cap
+++ b/bin/cap
@@ -24,7 +24,7 @@ AGENTS_DIR = Path.home() / "agents"
 
 NEXT_ID_RE = re.compile(r"^(Next ID:\s*\*\*)A-(\d+)(\*\*.*?)$", re.MULTILINE)
 OPEN_HEADER_RE = re.compile(r"^## Open\s*$", re.MULTILINE)
-TABLE_HEADER_RE = re.compile(r"^\| ID \|.*\n\|[-| :]+\|\s*\n", re.MULTILINE)
+TABLE_HEADER_RE = re.compile(r"^\| ID \|.*\n\|[-| :]+\|[ \t]*\n", re.MULTILINE)
 
 
 class CapError(Exception):

--- a/bin/tests/test_cap.py
+++ b/bin/tests/test_cap.py
@@ -138,6 +138,24 @@ def test_capture_creates_file_when_missing(tmp_path: Path):
     assert "Next ID: **A-002**" in content
 
 
+def test_capture_empty_template_layout_is_correct(tmp_path: Path):
+    """Regression for #110: blank line must sit between last row and `## Recently Closed`,
+    NOT between the separator and the first row."""
+    project_dir = tmp_path / "myproj"
+    project_dir.mkdir()
+
+    cap.capture(["first", "second"], project_dir, "Jason", "", today="2026-05-04")
+    content = (project_dir / "ACTIONS.md").read_text()
+
+    separator = "|----|-------|--------|-------|--------|--------|-----|-------|"
+    assert f"{separator}\n| A-001 |" in content
+    assert (
+        "| A-002 |  | second | Jason | open | 2026-05-04 |  |  |\n\n## Recently Closed"
+        in content
+    )
+    assert f"{separator}\n\n| A-001" not in content
+
+
 def test_capture_preserves_sections(tmp_path: Path):
     actions_path = tmp_path / "ACTIONS.md"
     _seed_actions_md(actions_path, next_id=1)


### PR DESCRIPTION
## Summary
- `TABLE_HEADER_RE` used `\s*\n` which greedily consumed the blank line between the separator and `## Recently Closed` when no rows existed, causing rows to be inserted in the wrong position. Tightened to `[ \t]*\n`.
- Added regression test `test_capture_empty_template_layout_is_correct` covering the empty-template path (every prior test seeded at least one row, which is why this slipped through).

## Test plan
- [x] `python3 -m pytest bin/tests/test_cap.py -q` — 24/24 passing
- [x] Smoke: `mkdir /tmp/captest && cd /tmp/captest && git init -q && python3 ~/agents/bin/cap "first" "second"` produces layout matching the issue's Expected block byte-for-byte
- [x] `git diff --name-only origin/main` — exactly `bin/cap`, `bin/tests/test_cap.py`

## Notes
- `agents/ACTIONS.md` will need to be regenerated (or its blank line manually moved) once this lands — out of scope for this PR.

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)