### PR TITLE
chore(agents): grant Write tool + require artifact persistence

### DIFF
--- a/claude-config/agents/contract.md
+++ b/claude-config/agents/contract.md
@@ -1,7 +1,7 @@
 ---
 name: orchestrate-contract
 description: Designs backend↔frontend API contracts for FULLSTACK orchestrate work. Phase 2.5. Use only when dispatched by /orchestrate for fullstack issues; do not auto-invoke.
-tools: Read, Grep, Glob, Bash
+tools: Read, Grep, Glob, Bash, Write
 model: sonnet
 agent: "CONTRACT"
 version: 1.1
@@ -15,6 +15,17 @@ max_lines: 250
 
 # CONTRACT Agent
 
+## Persisting Your Output (CRITICAL)
+
+You have the **Write** tool. Before returning your response, you MUST persist your final output to the path declared in your frontmatter `output:` field, using the Write tool.
+
+Substitution rules for the path:
+- `{issue}` → the issue number (e.g. `22`)
+- `{mmddyy}` → today's date in MMDDYY format (e.g. `050526` for 2026-05-05)
+
+If you skip this step, the orchestrator cannot read your output and the workflow stalls. Always Write the artifact BEFORE emitting `AGENT_RETURN`.
+
+---
 **Role**: Interface Designer (SPEC-ONLY)
 
 ## When to Run

--- a/claude-config/agents/discuss.md
+++ b/claude-config/agents/discuss.md
@@ -1,7 +1,7 @@
 ---
 name: orchestrate-discuss
 description: Identifies gray areas and gathers implementation decisions before planning. Use only when explicitly dispatched by /orchestrate --discuss; do not auto-invoke.
-tools: Read, Grep, Glob, Bash
+tools: Read, Grep, Glob, Bash, Write
 model: sonnet
 agent: "DISCUSS"
 version: 1.1
@@ -15,6 +15,17 @@ max_lines: 120
 
 # DISCUSS Agent
 
+## Persisting Your Output (CRITICAL)
+
+You have the **Write** tool. Before returning your response, you MUST persist your final output to the path declared in your frontmatter `output:` field, using the Write tool.
+
+Substitution rules for the path:
+- `{issue}` → the issue number (e.g. `22`)
+- `{mmddyy}` → today's date in MMDDYY format (e.g. `050526` for 2026-05-05)
+
+If you skip this step, the orchestrator cannot read your output and the workflow stalls. Always Write the artifact BEFORE emitting `AGENT_RETURN`.
+
+---
 **Role**: Decision Capturer (READ-ONLY — no code changes)
 
 ## When to Run

--- a/claude-config/agents/map-plan.md
+++ b/claude-config/agents/map-plan.md
@@ -1,7 +1,7 @@
 ---
 name: orchestrate-map-plan
 description: Combined investigator+planner for TRIVIAL/SIMPLE orchestrate tasks. Phase 1+2 of the SIMPLE pipeline. Use only when dispatched by /orchestrate; do not auto-invoke.
-tools: Read, Grep, Glob, Bash
+tools: Read, Grep, Glob, Bash, Write
 model: sonnet
 agent: "MAP-PLAN"
 version: 1.1
@@ -15,6 +15,17 @@ max_lines: 450
 
 # MAP-PLAN Agent
 
+## Persisting Your Output (CRITICAL)
+
+You have the **Write** tool. Before returning your response, you MUST persist your final output to the path declared in your frontmatter `output:` field, using the Write tool.
+
+Substitution rules for the path:
+- `{issue}` → the issue number (e.g. `22`)
+- `{mmddyy}` → today's date in MMDDYY format (e.g. `050526` for 2026-05-05)
+
+If you skip this step, the orchestrator cannot read your output and the workflow stalls. Always Write the artifact BEFORE emitting `AGENT_RETURN`.
+
+---
 **Role**: Investigator + Architect (TRIVIAL/SIMPLE only)
 
 ## Artifact Validation

--- a/claude-config/agents/map.md
+++ b/claude-config/agents/map.md
@@ -1,7 +1,7 @@
 ---
 name: orchestrate-map
 description: Read-only investigator for COMPLEX orchestrate workflow phase 1. Maps current code state before planning. Use only when dispatched by /orchestrate; do not auto-invoke.
-tools: Read, Grep, Glob, Bash
+tools: Read, Grep, Glob, Bash, Write
 model: haiku
 agent: "MAP"
 version: 1.1
@@ -15,6 +15,17 @@ max_lines: 200
 
 # MAP Agent
 
+## Persisting Your Output (CRITICAL)
+
+You have the **Write** tool. Before returning your response, you MUST persist your final output to the path declared in your frontmatter `output:` field, using the Write tool.
+
+Substitution rules for the path:
+- `{issue}` → the issue number (e.g. `22`)
+- `{mmddyy}` → today's date in MMDDYY format (e.g. `050526` for 2026-05-05)
+
+If you skip this step, the orchestrator cannot read your output and the workflow stalls. Always Write the artifact BEFORE emitting `AGENT_RETURN`.
+
+---
 **Role**: Investigator (READ-ONLY)
 
 ## Artifact Validation

--- a/claude-config/agents/plan-checker.md
+++ b/claude-config/agents/plan-checker.md
@@ -1,7 +1,7 @@
 ---
 name: orchestrate-plan-check
 description: Validates plan completeness and contract presence before PATCH. Phase 2.8 of the COMPLEX orchestrate pipeline. Use only when dispatched by /orchestrate; do not auto-invoke.
-tools: Read, Grep, Glob, Bash
+tools: Read, Grep, Glob, Bash, Write
 model: haiku
 agent: "PLAN-CHECK"
 version: 1.1
@@ -15,6 +15,17 @@ max_lines: 120
 
 # PLAN-CHECK Agent
 
+## Persisting Your Output (CRITICAL)
+
+You have the **Write** tool. Before returning your response, you MUST persist your final output to the path declared in your frontmatter `output:` field, using the Write tool.
+
+Substitution rules for the path:
+- `{issue}` → the issue number (e.g. `22`)
+- `{mmddyy}` → today's date in MMDDYY format (e.g. `050526` for 2026-05-05)
+
+If you skip this step, the orchestrator cannot read your output and the workflow stalls. Always Write the artifact BEFORE emitting `AGENT_RETURN`.
+
+---
 **Role**: Plan Validator (READ-ONLY — no code changes)
 
 ## Artifact Validation (MANDATORY)

--- a/claude-config/agents/plan.md
+++ b/claude-config/agents/plan.md
@@ -1,7 +1,7 @@
 ---
 name: orchestrate-plan
 description: Architect for COMPLEX orchestrate workflow phase 2. Converts MAP findings into a file-by-file implementation plan. Use only when dispatched by /orchestrate; do not auto-invoke.
-tools: Read, Grep, Glob, Bash
+tools: Read, Grep, Glob, Bash, Write
 model: sonnet
 agent: "PLAN"
 version: 1.1
@@ -15,6 +15,17 @@ max_lines: 450
 
 # PLAN Agent
 
+## Persisting Your Output (CRITICAL)
+
+You have the **Write** tool. Before returning your response, you MUST persist your final output to the path declared in your frontmatter `output:` field, using the Write tool.
+
+Substitution rules for the path:
+- `{issue}` → the issue number (e.g. `22`)
+- `{mmddyy}` → today's date in MMDDYY format (e.g. `050526` for 2026-05-05)
+
+If you skip this step, the orchestrator cannot read your output and the workflow stalls. Always Write the artifact BEFORE emitting `AGENT_RETURN`.
+
+---
 **Role**: Architect (DESIGN-ONLY)
 
 ## Artifact Validation (MANDATORY)

--- a/claude-config/agents/prove.md
+++ b/claude-config/agents/prove.md
@@ -1,7 +1,7 @@
 ---
 name: orchestrate-prove
 description: Verifies implementation by running tests and capturing evidence. Phase 4 of orchestrate. Records outcomes for the self-learning loop. Use only when dispatched by /orchestrate; do not auto-invoke.
-tools: Read, Grep, Glob, Bash
+tools: Read, Grep, Glob, Bash, Write
 model: sonnet
 agent: "PROVE"
 version: 1.5
@@ -15,6 +15,17 @@ max_lines: 300
 
 # PROVE Agent
 
+## Persisting Your Output (CRITICAL)
+
+You have the **Write** tool. Before returning your response, you MUST persist your final output to the path declared in your frontmatter `output:` field, using the Write tool.
+
+Substitution rules for the path:
+- `{issue}` → the issue number (e.g. `22`)
+- `{mmddyy}` → today's date in MMDDYY format (e.g. `050526` for 2026-05-05)
+
+If you skip this step, the orchestrator cannot read your output and the workflow stalls. Always Write the artifact BEFORE emitting `AGENT_RETURN`.
+
+---
 **Role**: Reviewer / QA (VERIFICATION + LEARNING)
 
 ## Artifact Validation (MANDATORY)

--- a/claude-config/agents/test-planner.md
+++ b/claude-config/agents/test-planner.md
@@ -1,7 +1,7 @@
 ---
 name: orchestrate-test-planner
 description: Plans tests and generates edge cases before implementation. Phase 1.5 of orchestrate. Use only when dispatched by /orchestrate --with-tests or /test-plan; do not auto-invoke.
-tools: Read, Grep, Glob, Bash
+tools: Read, Grep, Glob, Bash, Write
 model: sonnet
 agent: "TEST-PLANNER"
 version: 1.1
@@ -15,6 +15,17 @@ max_lines: 350
 
 # TEST-PLANNER Agent
 
+## Persisting Your Output (CRITICAL)
+
+You have the **Write** tool. Before returning your response, you MUST persist your final output to the path declared in your frontmatter `output:` field, using the Write tool.
+
+Substitution rules for the path:
+- `{issue}` → the issue number (e.g. `22`)
+- `{mmddyy}` → today's date in MMDDYY format (e.g. `050526` for 2026-05-05)
+
+If you skip this step, the orchestrator cannot read your output and the workflow stalls. Always Write the artifact BEFORE emitting `AGENT_RETURN`.
+
+---
 **Role**: Test Architect (TDD approach - runs BEFORE PATCH)
 
 ## Artifact Validation (MANDATORY)


### PR DESCRIPTION
## Summary
- Each orchestrate agent now lists `Write` in its `tools:` frontmatter so it can persist artifacts.
- Each agent carries a new **Persisting Your Output (CRITICAL)** section directing it to Write its final output to the configured `output:` path (`{issue}` and `{mmddyy}` substituted) before emitting `AGENT_RETURN`.
- Files: `contract`, `discuss`, `map-plan`, `map`, `plan-checker`, `plan`, `prove`, `test-planner`.

## Why
Pairs with the orchestrator-side fix landed in PR #116 (orchestrate skill now spawns agents via the Task tool). Without this agent-side change, agents have no Write tool and no instruction to persist artifacts — the orchestrator spawns them but cannot read their output, and the workflow stalls. See `claude-config/rules/orchestrate-workflow.md` "Critical Fix: Task Tool Invocation" for context.

## Test plan
- [x] Diff is purely additive — 8 identical-shape edits, +12/-1 each
- [x] Already validated empirically: `orchestrate-prove` ran successfully in this session against issue #110 (artifact written to `.agents/outputs/prove-110-050526.md`) using the in-memory snapshot of these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)