### PR TITLE
chore(settings): allow auto-memory writes + set dark theme

### DIFF
--- a/claude-config/settings.json
+++ b/claude-config/settings.json
@@ -29,7 +29,9 @@
       "Bash(glab:*)",
       "Bash(curl -s -H PRIVATE-TOKEN:*)",
       "Bash(curl -s -X POST -H PRIVATE-TOKEN:*)",
-      "Bash(curl -s -X PUT -H PRIVATE-TOKEN:*)"
+      "Bash(curl -s -X PUT -H PRIVATE-TOKEN:*)",
+      "Write(/home/jjob/.claude/projects/*/memory/**)",
+      "Edit(/home/jjob/.claude/projects/*/memory/**)"
     ],
     "deny": [
       "Read(./.env)",
@@ -139,5 +141,6 @@
       }
     }
   },
-  "skipDangerousModePermissionPrompt": true
+  "skipDangerousModePermissionPrompt": true,
+  "theme": "dark"
 }


### PR DESCRIPTION
## Summary
- Add `Write(/home/jjob/.claude/projects/*/memory/**)` and `Edit(...)` to `permissions.allow` so the auto-memory system can persist memory files without permission prompts.
- Add `"theme": "dark"`.

## Context
The auto-memory system writes per-project memory files under `~/.claude/projects/*/memory/`. Currently each write/edit prompts for permission, which interrupts conversation flow. Pre-allowing these paths is safe — the directory is owned by Claude Code itself.

## Test plan
- [x] JSON validates as `settings.json`
- [x] No changes outside the two intended additions

🤖 Generated with [Claude Code](https://claude.com/claude-code)