### PR TITLE
feat(action): interactive project picker when --project missing or unknown

### DIFF
--- a/action/cli.py
+++ b/action/cli.py
@@ -14,6 +14,7 @@ from datetime import date
 from pathlib import Path
 
 HOME = Path.home()
+KNOWLEDGE_PROJECTS_DIR = HOME / "agents" / "knowledge" / "projects"
 ALLOWED_STATUS = ("open", "wip", "blocked", "done", "cancelled")
 TERMINAL_STATUS = ("done", "cancelled")
 ID_RE = re.compile(r"^A-\d+$")
@@ -60,6 +61,10 @@ Create:
 Project resolution:
   --project <name>                     Override; otherwise inferred from cwd
                                        (~/agents → agents, ~/projects/X → X)
+  --no-prompt                          Skip interactive picker; error instead
+                                       (set automatically by non-TTY callers)
+Picker: when project is unresolved or unknown and stdin is a TTY, a numbered
+list of known projects is shown. Ctrl-C, EOF, or blank input aborts.
 
 Status values: open · wip · blocked · done · cancelled
 """
@@ -357,6 +362,82 @@ def resolve_project(args: argparse.Namespace) -> str:
     )
 
 
+def list_known_projects() -> list[str]:
+    """Return sorted list of project name stems from knowledge/projects/*.yaml."""
+    return sorted(p.stem for p in KNOWLEDGE_PROJECTS_DIR.glob("*.yaml"))
+
+
+def _interactive_pick(candidates: list[str], header: str) -> str:
+    """Print numbered menu, prompt for 1-based selection.
+
+    Reprompts up to 3 times on out-of-range or non-numeric input.
+    Raises ActionError on Ctrl-C, EOF, blank input, or exhausted retries.
+    """
+    print(header)
+    for i, name in enumerate(candidates, 1):
+        print(f"  {i}) {name}")
+    for attempt in range(3):
+        try:
+            raw = input(f"Enter number (1-{len(candidates)}): ").strip()
+        except (EOFError, KeyboardInterrupt):
+            raise ActionError("project selection cancelled")
+        if not raw:
+            raise ActionError("project selection cancelled")
+        try:
+            choice = int(raw)
+        except ValueError:
+            if attempt < 2:
+                print(f"  invalid input — enter a number between 1 and {len(candidates)}")
+                continue
+            raise ActionError("too many invalid inputs — project selection aborted")
+        if 1 <= choice <= len(candidates):
+            return candidates[choice - 1]
+        if attempt < 2:
+            print(f"  out of range — enter a number between 1 and {len(candidates)}")
+        else:
+            raise ActionError("too many invalid inputs — project selection aborted")
+    raise ActionError("too many invalid inputs — project selection aborted")
+
+
+def resolve_project_with_picker(args: argparse.Namespace) -> str:
+    """Wrap resolve_project(); apply validation + interactive picker where appropriate.
+
+    Validation order:
+      1. cwd inference (via resolve_project) — if resolved, return immediately.
+      2. --project <name>: if supplied AND in known list, return it.
+      3. --project <name>: if supplied BUT NOT in known list, picker with
+         header 'unknown project "<name>". Pick one:'.
+      4. No project resolved: picker with header 'no project resolved. Pick one:'.
+      5. Picker only fires when sys.stdin.isatty() AND NOT args.no_prompt.
+         Otherwise raises ActionError with existing message.
+    """
+    # If --project not supplied, try cwd inference first.
+    if not args.project:
+        try:
+            return resolve_project(args)
+        except ActionError:
+            pass
+        # cwd inference failed — offer picker or hard error
+        if sys.stdin.isatty() and not args.no_prompt:
+            candidates = list_known_projects()
+            return _interactive_pick(candidates, "no project resolved. Pick one:")
+        raise ActionError(
+            "no project resolved — pass --project <name> or run from inside the project directory"
+        )
+
+    # --project was supplied — validate against known list
+    known = list_known_projects()
+    if args.project in known:
+        return args.project
+
+    # Unknown project name
+    if sys.stdin.isatty() and not args.no_prompt:
+        return _interactive_pick(known, f'unknown project "{args.project}". Pick one:')
+    raise ActionError(
+        f'unknown project "{args.project}" — known projects: {", ".join(known)}'
+    )
+
+
 def project_path(name: str) -> Path:
     if name == "agents":
         return HOME / "agents" / "ACTIONS.md"
@@ -627,6 +708,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     p.add_argument("--attach", action="append", default=[])
     p.add_argument("--unattach", action="append", default=[])
     p.add_argument("--project")
+    p.add_argument("--no-prompt", action="store_true", default=False)
     args = p.parse_args(argv)
 
     # validation
@@ -653,7 +735,7 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     try:
-        project = resolve_project(args)
+        project = resolve_project_with_picker(args)
         path = project_path(project)
         if args.new:
             return cmd_new(args, path)

--- a/action/tests/test_cli.py
+++ b/action/tests/test_cli.py
@@ -1,0 +1,175 @@
+"""Tests for action/cli.py — project picker and resolution logic."""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+# Ensure action package is importable without an action/__init__.py
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
+import action.cli as cli
+
+
+# ---------- helpers ----------
+
+def _args(**kwargs) -> argparse.Namespace:
+    """Build a minimal Namespace with defaults for fields used by resolution logic."""
+    defaults = {"project": None, "no_prompt": False}
+    defaults.update(kwargs)
+    return argparse.Namespace(**defaults)
+
+
+# ---------- list_known_projects ----------
+
+def test_list_known_projects():
+    """Returns a sorted list of stems from knowledge/projects/*.yaml."""
+    projects = cli.list_known_projects()
+    assert isinstance(projects, list)
+    assert projects == sorted(projects), "list must be sorted"
+    assert len(projects) > 0, "must find at least one project"
+    # All items known at time of writing; spot-check a few
+    assert "agents" in projects
+    assert "buddy" in projects
+
+
+def test_list_known_projects_tmp(tmp_path, monkeypatch):
+    """list_known_projects uses KNOWLEDGE_PROJECTS_DIR, which can be overridden."""
+    (tmp_path / "alpha.yaml").write_text("")
+    (tmp_path / "gamma.yaml").write_text("")
+    (tmp_path / "beta.yaml").write_text("")
+    monkeypatch.setattr(cli, "KNOWLEDGE_PROJECTS_DIR", tmp_path)
+    result = cli.list_known_projects()
+    assert result == ["alpha", "beta", "gamma"]
+
+
+# ---------- resolve_project (existing, unchanged) ----------
+
+def test_resolve_project_cwd_agents(monkeypatch):
+    """cwd = ~/agents → resolves to 'agents' without touching the picker."""
+    monkeypatch.chdir(cli.HOME / "agents")
+    args = _args()
+    assert cli.resolve_project(args) == "agents"
+
+
+def test_resolve_project_explicit_known(monkeypatch):
+    """--project supplied directly bypasses cwd logic (existing behavior)."""
+    args = _args(project="agents")
+    # resolve_project just returns it — no validation against known list
+    assert cli.resolve_project(args) == "agents"
+
+
+# ---------- _interactive_pick ----------
+
+def test_interactive_pick_valid(monkeypatch):
+    """Input '2' selects second candidate."""
+    monkeypatch.setattr("builtins.input", lambda _: "2")
+    result = cli._interactive_pick(["alpha", "beta", "gamma"], "Pick one:")
+    assert result == "beta"
+
+
+def test_interactive_pick_out_of_range_then_valid(monkeypatch):
+    """Two bad inputs (out of range, non-numeric) then valid → returns project."""
+    responses = iter(["99", "abc", "1"])
+    monkeypatch.setattr("builtins.input", lambda _: next(responses))
+    result = cli._interactive_pick(["alpha", "beta"], "Pick one:")
+    assert result == "alpha"
+
+
+def test_interactive_pick_exhausted(monkeypatch):
+    """Three consecutive bad inputs → ActionError."""
+    monkeypatch.setattr("builtins.input", lambda _: "99")
+    try:
+        cli._interactive_pick(["alpha", "beta"], "Pick one:")
+        assert False, "should have raised ActionError"
+    except cli.ActionError as e:
+        assert "aborted" in str(e) or "invalid" in str(e)
+
+
+def test_interactive_pick_blank(monkeypatch):
+    """Blank input → ActionError immediately."""
+    monkeypatch.setattr("builtins.input", lambda _: "")
+    try:
+        cli._interactive_pick(["alpha", "beta"], "Pick one:")
+        assert False, "should have raised ActionError"
+    except cli.ActionError as e:
+        assert "cancelled" in str(e)
+
+
+def test_interactive_pick_ctrl_c(monkeypatch):
+    """EOFError from input → ActionError (Ctrl-C / EOF behaviour)."""
+    def raise_eof(_):
+        raise EOFError
+    monkeypatch.setattr("builtins.input", raise_eof)
+    try:
+        cli._interactive_pick(["alpha", "beta"], "Pick one:")
+        assert False, "should have raised ActionError"
+    except cli.ActionError as e:
+        assert "cancelled" in str(e)
+
+
+# ---------- resolve_project_with_picker ----------
+
+def test_no_prompt_skips_picker_even_with_tty(monkeypatch, tmp_path):
+    """isatty=True but --no-prompt → hard error (no picker)."""
+    monkeypatch.setattr(cli.sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr(cli, "KNOWLEDGE_PROJECTS_DIR", tmp_path)
+    (tmp_path / "alpha.yaml").write_text("")
+    # cwd not in any known project dir, no --project
+    monkeypatch.chdir(tmp_path)
+    args = _args(no_prompt=True)
+    try:
+        cli.resolve_project_with_picker(args)
+        assert False, "should have raised ActionError"
+    except cli.ActionError as e:
+        assert "no project resolved" in str(e)
+
+
+def test_non_tty_skips_picker(monkeypatch, tmp_path):
+    """isatty=False, no --no-prompt → hard error (no picker)."""
+    monkeypatch.setattr(cli.sys.stdin, "isatty", lambda: False)
+    monkeypatch.setattr(cli, "KNOWLEDGE_PROJECTS_DIR", tmp_path)
+    (tmp_path / "alpha.yaml").write_text("")
+    monkeypatch.chdir(tmp_path)
+    args = _args()
+    try:
+        cli.resolve_project_with_picker(args)
+        assert False, "should have raised ActionError"
+    except cli.ActionError as e:
+        assert "no project resolved" in str(e)
+
+
+def test_unknown_project_with_tty(monkeypatch, tmp_path):
+    """--project typo + isatty=True → picker fires, returns selected project."""
+    monkeypatch.setattr(cli.sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr(cli, "KNOWLEDGE_PROJECTS_DIR", tmp_path)
+    (tmp_path / "alpha.yaml").write_text("")
+    (tmp_path / "beta.yaml").write_text("")
+    monkeypatch.setattr("builtins.input", lambda _: "1")
+    args = _args(project="typo-project")
+    result = cli.resolve_project_with_picker(args)
+    assert result == "alpha"
+
+
+def test_unknown_project_without_tty(monkeypatch, tmp_path):
+    """--project typo + isatty=False → ActionError with known projects listed."""
+    monkeypatch.setattr(cli.sys.stdin, "isatty", lambda: False)
+    monkeypatch.setattr(cli, "KNOWLEDGE_PROJECTS_DIR", tmp_path)
+    (tmp_path / "alpha.yaml").write_text("")
+    args = _args(project="typo-project")
+    try:
+        cli.resolve_project_with_picker(args)
+        assert False, "should have raised ActionError"
+    except cli.ActionError as e:
+        assert 'unknown project "typo-project"' in str(e)
+        assert "alpha" in str(e)
+
+
+def test_resolve_cwd_projects_subdir(monkeypatch, tmp_path):
+    """cwd = ~/projects/buddy/subdir → resolve_project returns 'buddy'."""
+    buddy_sub = tmp_path / "projects" / "buddy" / "subdir"
+    buddy_sub.mkdir(parents=True)
+    monkeypatch.setattr(cli, "HOME", tmp_path)
+    monkeypatch.chdir(buddy_sub)
+    args = _args()
+    result = cli.resolve_project(args)
+    assert result == "buddy"

--- a/claude-config/skills/action/SKILL.md
+++ b/claude-config/skills/action/SKILL.md
@@ -14,7 +14,7 @@ the single source of truth for behavior; this skill just dispatches.
 When invoked, run:
 
 ```bash
-python3 /home/jjob/agents/action/cli.py "$@"
+python3 /home/jjob/agents/action/cli.py --no-prompt "$@"
 ```
 
 Pass through every argument unchanged (including the positional ID, the


### PR DESCRIPTION
## Summary
- New `--no-prompt` flag (default off) so the CLI errors fast instead of hanging when stdin isn't a TTY.
- New helpers in `action/cli.py`: `list_known_projects()`, `_interactive_pick()`, `resolve_project_with_picker()`.
- Picker fires when `--project` is omitted (and cwd doesn't infer) OR when `--project foo` doesn't match any registered project — but only in TTY + when `--no-prompt` is not set.
- `/action` skill dispatch now passes `--no-prompt` defensively so Claude's Bash subprocesses never hang.
- 14 new tests in `action/tests/test_cli.py`.

## Test plan
- [x] `pytest action/tests/test_cli.py` — 14/14 passing
- [x] `pytest bin/tests/test_cap.py` — 24/24 passing (no regression)
- [x] Smoke: CLI errors fast (no hang) when stdin isn't a TTY
- [x] Help text shows new flag and picker behavior

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)