### PR TITLE
fix(action): auto-register project on first use; picker honors subscriptions

### DIFF
--- a/action/cli.py
+++ b/action/cli.py
@@ -7,6 +7,7 @@ For shell use directly: alias action='python3 ~/agents/action/cli.py'.
 from __future__ import annotations
 
 import argparse
+import json
 import re
 import sys
 from dataclasses import dataclass
@@ -15,6 +16,7 @@ from pathlib import Path
 
 HOME = Path.home()
 KNOWLEDGE_PROJECTS_DIR = HOME / "agents" / "knowledge" / "projects"
+SUBSCRIPTIONS_PATH = Path.home() / ".claude" / "dashboard-subscriptions.json"
 ALLOWED_STATUS = ("open", "wip", "blocked", "done", "cancelled")
 TERMINAL_STATUS = ("done", "cancelled")
 ID_RE = re.compile(r"^A-\d+$")
@@ -363,8 +365,16 @@ def resolve_project(args: argparse.Namespace) -> str:
 
 
 def list_known_projects() -> list[str]:
-    """Return sorted list of project name stems from knowledge/projects/*.yaml."""
-    return sorted(p.stem for p in KNOWLEDGE_PROJECTS_DIR.glob("*.yaml"))
+    """Return sorted list of project names, filtered by this machine's subscriptions.
+
+    Falls back to all registered yamls if subscriptions file is missing or empty.
+    """
+    all_registered = sorted(p.stem for p in KNOWLEDGE_PROJECTS_DIR.glob("*.yaml"))
+    subs = read_subscriptions()
+    if not subs:
+        return all_registered
+    filtered = [p for p in all_registered if p in subs]
+    return filtered if filtered else all_registered
 
 
 def _interactive_pick(candidates: list[str], header: str) -> str:
@@ -430,11 +440,24 @@ def resolve_project_with_picker(args: argparse.Namespace) -> str:
     if args.project in known:
         return args.project
 
-    # Unknown project name
+    # Unknown project name — check if disk dir exists → auto-register
+    if project_dir_exists(args.project):
+        register_project(args.project)
+        print(f'registered new project "{args.project}" on this machine')
+        return args.project
+
+    # No disk dir — picker or error (Rule 3)
     if sys.stdin.isatty() and not args.no_prompt:
         return _interactive_pick(known, f'unknown project "{args.project}". Pick one:')
+    subs = read_subscriptions()
+    subscribed_str = ", ".join(subs) if subs else "(none)"
     raise ActionError(
-        f'unknown project "{args.project}" — known projects: {", ".join(known)}'
+        f'unknown project "{args.project}"\n'
+        f"  - not registered (knowledge/projects/{args.project}.yaml missing)\n"
+        f"  - no repo at ~/projects/{args.project}/\n"
+        f"  To add: clone the repo to ~/projects/{args.project}, "
+        f'or register manually.\n'
+        f"  Subscribed on this machine: {subscribed_str}"
     )
 
 
@@ -442,6 +465,66 @@ def project_path(name: str) -> Path:
     if name == "agents":
         return HOME / "agents" / "ACTIONS.md"
     return HOME / "projects" / name / "ACTIONS.md"
+
+
+def project_dir_exists(name: str) -> bool:
+    """Return True if a local repo directory exists for this project name."""
+    if name == "agents":
+        return (HOME / "agents").is_dir()
+    return (HOME / "projects" / name).is_dir()
+
+
+def read_subscriptions() -> list[str]:
+    """Read subscribed project names from dashboard-subscriptions.json.
+
+    Returns [] on missing file, malformed JSON, or absent/empty subscribed key.
+    """
+    try:
+        data = json.loads(SUBSCRIPTIONS_PATH.read_text())
+        subs = data.get("subscribed", [])
+        return [s for s in subs if isinstance(s, str)]
+    except (FileNotFoundError, json.JSONDecodeError, AttributeError):
+        return []
+
+
+def add_subscription(name: str) -> None:
+    """Append name to dashboard-subscriptions.json, creating the file if absent."""
+    try:
+        data = json.loads(SUBSCRIPTIONS_PATH.read_text())
+    except (FileNotFoundError, json.JSONDecodeError):
+        data = {}
+    subs: list[str] = data.get("subscribed", [])
+    if name not in subs:
+        subs.append(name)
+    data["subscribed"] = subs
+    SUBSCRIPTIONS_PATH.write_text(json.dumps(data, indent=2) + "\n")
+
+
+def register_project(name: str) -> Path:
+    """Write a default yaml to knowledge/projects/<name>.yaml and subscribe this machine.
+
+    Raises FileExistsError if yaml already exists (prevents double-registration).
+    Returns the path to the created yaml.
+    """
+    yaml_path = KNOWLEDGE_PROJECTS_DIR / f"{name}.yaml"
+    if yaml_path.exists():
+        raise FileExistsError(f"project yaml already exists: {yaml_path}")
+    today_str = date.today().isoformat()
+    content = (
+        f"project: {name}\n"
+        f"status: active\n"
+        f'focus: ""\n'
+        f"next_steps: []\n"
+        f"blockers: []\n"
+        f"open_questions: []\n"
+        f"specs: []\n"
+        f"dependencies: []\n"
+        f'updated_at: "{today_str}"\n'
+        f"updated_by: jason\n"
+    )
+    yaml_path.write_text(content)
+    add_subscription(name)
+    return yaml_path
 
 
 # ---------- commands ----------

--- a/action/tests/test_cli.py
+++ b/action/tests/test_cli.py
@@ -22,14 +22,13 @@ def _args(**kwargs) -> argparse.Namespace:
 # ---------- list_known_projects ----------
 
 def test_list_known_projects():
-    """Returns a sorted list of stems from knowledge/projects/*.yaml."""
+    """Returns a sorted non-empty list filtered by subscriptions (or all if no subs)."""
     projects = cli.list_known_projects()
     assert isinstance(projects, list)
     assert projects == sorted(projects), "list must be sorted"
     assert len(projects) > 0, "must find at least one project"
-    # All items known at time of writing; spot-check a few
+    # 'agents' is always subscribed on this machine
     assert "agents" in projects
-    assert "buddy" in projects
 
 
 def test_list_known_projects_tmp(tmp_path, monkeypatch):
@@ -151,9 +150,15 @@ def test_unknown_project_with_tty(monkeypatch, tmp_path):
 
 
 def test_unknown_project_without_tty(monkeypatch, tmp_path):
-    """--project typo + isatty=False → ActionError with known projects listed."""
+    """--project typo + isatty=False + no disk dir → ActionError with Rule 3 message."""
     monkeypatch.setattr(cli.sys.stdin, "isatty", lambda: False)
     monkeypatch.setattr(cli, "KNOWLEDGE_PROJECTS_DIR", tmp_path)
+    # Redirect HOME so project_dir_exists("typo-project") → False
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setattr(cli, "HOME", fake_home)
+    # Also redirect SUBSCRIPTIONS_PATH so read_subscriptions returns []
+    monkeypatch.setattr(cli, "SUBSCRIPTIONS_PATH", tmp_path / "subs.json")
     (tmp_path / "alpha.yaml").write_text("")
     args = _args(project="typo-project")
     try:
@@ -161,7 +166,7 @@ def test_unknown_project_without_tty(monkeypatch, tmp_path):
         assert False, "should have raised ActionError"
     except cli.ActionError as e:
         assert 'unknown project "typo-project"' in str(e)
-        assert "alpha" in str(e)
+        assert "not registered" in str(e)
 
 
 def test_resolve_cwd_projects_subdir(monkeypatch, tmp_path):
@@ -173,3 +178,194 @@ def test_resolve_cwd_projects_subdir(monkeypatch, tmp_path):
     args = _args()
     result = cli.resolve_project(args)
     assert result == "buddy"
+
+
+# ---------- project_dir_exists ----------
+
+def test_project_dir_exists_agents(monkeypatch, tmp_path):
+    """project_dir_exists('agents') returns True when HOME/agents/ exists."""
+    agents_dir = tmp_path / "agents"
+    agents_dir.mkdir()
+    monkeypatch.setattr(cli, "HOME", tmp_path)
+    assert cli.project_dir_exists("agents") is True
+
+
+def test_project_dir_exists_regular(monkeypatch, tmp_path):
+    """project_dir_exists('foo') returns True when HOME/projects/foo/ exists."""
+    (tmp_path / "projects" / "foo").mkdir(parents=True)
+    monkeypatch.setattr(cli, "HOME", tmp_path)
+    assert cli.project_dir_exists("foo") is True
+
+
+def test_project_dir_exists_missing(monkeypatch, tmp_path):
+    """project_dir_exists('bar') returns False when HOME/projects/bar/ does not exist."""
+    monkeypatch.setattr(cli, "HOME", tmp_path)
+    assert cli.project_dir_exists("bar") is False
+
+
+# ---------- read_subscriptions ----------
+
+def test_read_subscriptions_normal(monkeypatch, tmp_path):
+    """Valid JSON with subscribed list → returns list of strings."""
+    subs_file = tmp_path / "subs.json"
+    subs_file.write_text('{"subscribed": ["agents", "paul-jason"]}')
+    monkeypatch.setattr(cli, "SUBSCRIPTIONS_PATH", subs_file)
+    result = cli.read_subscriptions()
+    assert result == ["agents", "paul-jason"]
+
+
+def test_read_subscriptions_missing_file(monkeypatch, tmp_path):
+    """Missing subscriptions file → returns []."""
+    monkeypatch.setattr(cli, "SUBSCRIPTIONS_PATH", tmp_path / "nonexistent.json")
+    assert cli.read_subscriptions() == []
+
+
+def test_read_subscriptions_empty_array(monkeypatch, tmp_path):
+    """subscribed: [] → returns []."""
+    subs_file = tmp_path / "subs.json"
+    subs_file.write_text('{"subscribed": []}')
+    monkeypatch.setattr(cli, "SUBSCRIPTIONS_PATH", subs_file)
+    assert cli.read_subscriptions() == []
+
+
+# ---------- add_subscription ----------
+
+def test_add_subscription_creates_file(monkeypatch, tmp_path):
+    """add_subscription creates file if absent and writes [name]."""
+    subs_file = tmp_path / "subs.json"
+    monkeypatch.setattr(cli, "SUBSCRIPTIONS_PATH", subs_file)
+    cli.add_subscription("sweetprocess")
+    import json as _json
+    data = _json.loads(subs_file.read_text())
+    assert data["subscribed"] == ["sweetprocess"]
+
+
+def test_add_subscription_appends(monkeypatch, tmp_path):
+    """add_subscription appends to existing list and does not duplicate."""
+    subs_file = tmp_path / "subs.json"
+    subs_file.write_text('{"subscribed": ["agents"]}')
+    monkeypatch.setattr(cli, "SUBSCRIPTIONS_PATH", subs_file)
+    cli.add_subscription("sweetprocess")
+    cli.add_subscription("sweetprocess")  # second call must not duplicate
+    import json as _json
+    data = _json.loads(subs_file.read_text())
+    assert data["subscribed"] == ["agents", "sweetprocess"]
+
+
+# ---------- register_project ----------
+
+def test_register_project_creates_yaml(monkeypatch, tmp_path):
+    """register_project writes correct yaml defaults and calls add_subscription."""
+    projects_dir = tmp_path / "projects"
+    projects_dir.mkdir()
+    subs_file = tmp_path / "subs.json"
+    monkeypatch.setattr(cli, "KNOWLEDGE_PROJECTS_DIR", projects_dir)
+    monkeypatch.setattr(cli, "SUBSCRIPTIONS_PATH", subs_file)
+
+    result_path = cli.register_project("myproj")
+
+    assert result_path == projects_dir / "myproj.yaml"
+    content = result_path.read_text()
+    assert "project: myproj" in content
+    assert "status: active" in content
+    assert 'focus: ""' in content
+    assert 'updated_at: "' in content  # must be quoted
+    assert "updated_by: jason" in content
+
+    import json as _json
+    subs = _json.loads(subs_file.read_text())
+    assert "myproj" in subs["subscribed"]
+
+
+def test_register_project_already_exists(monkeypatch, tmp_path):
+    """register_project raises FileExistsError if yaml already exists."""
+    projects_dir = tmp_path / "projects"
+    projects_dir.mkdir()
+    (projects_dir / "existing.yaml").write_text("project: existing\n")
+    monkeypatch.setattr(cli, "KNOWLEDGE_PROJECTS_DIR", projects_dir)
+    try:
+        cli.register_project("existing")
+        assert False, "should have raised FileExistsError"
+    except FileExistsError:
+        pass
+
+
+# ---------- list_known_projects with subscriptions ----------
+
+def test_list_known_projects_filters_subs(monkeypatch, tmp_path):
+    """list_known_projects returns only registered+subscribed projects."""
+    projects_dir = tmp_path / "projects"
+    projects_dir.mkdir()
+    for name in ["alpha", "beta", "gamma"]:
+        (projects_dir / f"{name}.yaml").write_text("")
+    subs_file = tmp_path / "subs.json"
+    subs_file.write_text('{"subscribed": ["alpha", "gamma"]}')
+    monkeypatch.setattr(cli, "KNOWLEDGE_PROJECTS_DIR", projects_dir)
+    monkeypatch.setattr(cli, "SUBSCRIPTIONS_PATH", subs_file)
+    result = cli.list_known_projects()
+    assert result == ["alpha", "gamma"]
+
+
+def test_list_known_projects_empty_subs_fallback(monkeypatch, tmp_path):
+    """list_known_projects returns all registered when subscriptions are empty."""
+    projects_dir = tmp_path / "projects"
+    projects_dir.mkdir()
+    for name in ["alpha", "beta"]:
+        (projects_dir / f"{name}.yaml").write_text("")
+    subs_file = tmp_path / "subs.json"
+    subs_file.write_text('{"subscribed": []}')
+    monkeypatch.setattr(cli, "KNOWLEDGE_PROJECTS_DIR", projects_dir)
+    monkeypatch.setattr(cli, "SUBSCRIPTIONS_PATH", subs_file)
+    result = cli.list_known_projects()
+    assert result == ["alpha", "beta"]
+
+
+# ---------- auto-register on resolve ----------
+
+def test_auto_register_on_resolve(monkeypatch, tmp_path, capsys):
+    """resolve_project_with_picker auto-registers when disk dir exists for unknown project."""
+    # Setup: HOME with projects/newproj dir, knowledge/projects dir, subs file
+    projects_dir = tmp_path / "projects"
+    projects_dir.mkdir()
+    (tmp_path / "projects" / "newproj").mkdir()
+    knowledge_dir = tmp_path / "knowledge"
+    knowledge_dir.mkdir()
+    subs_file = tmp_path / "subs.json"
+
+    monkeypatch.setattr(cli, "HOME", tmp_path)
+    monkeypatch.setattr(cli, "KNOWLEDGE_PROJECTS_DIR", knowledge_dir)
+    monkeypatch.setattr(cli, "SUBSCRIPTIONS_PATH", subs_file)
+    monkeypatch.setattr(cli.sys.stdin, "isatty", lambda: False)
+
+    args = _args(project="newproj", no_prompt=True)
+    result = cli.resolve_project_with_picker(args)
+
+    assert result == "newproj"
+    captured = capsys.readouterr()
+    assert 'registered new project "newproj"' in captured.out
+    assert (knowledge_dir / "newproj.yaml").exists()
+
+
+def test_no_disk_dir_no_tty_error_message(monkeypatch, tmp_path):
+    """No disk dir, not tty → ActionError with Rule 3 text."""
+    projects_dir = tmp_path / "knowledge"
+    projects_dir.mkdir()
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    subs_file = tmp_path / "subs.json"
+    subs_file.write_text('{"subscribed": ["agents"]}')
+
+    monkeypatch.setattr(cli, "HOME", fake_home)
+    monkeypatch.setattr(cli, "KNOWLEDGE_PROJECTS_DIR", projects_dir)
+    monkeypatch.setattr(cli, "SUBSCRIPTIONS_PATH", subs_file)
+    monkeypatch.setattr(cli.sys.stdin, "isatty", lambda: False)
+
+    args = _args(project="ghostproject", no_prompt=True)
+    try:
+        cli.resolve_project_with_picker(args)
+        assert False, "should have raised ActionError"
+    except cli.ActionError as e:
+        msg = str(e)
+        assert "not registered" in msg
+        assert "no repo at" in msg
+        assert "Subscribed on this machine:" in msg


### PR DESCRIPTION
## Summary
- `--project xxx` auto-registers when `~/projects/xxx/` exists: writes a default `knowledge/projects/xxx.yaml` AND adds `xxx` to this machine's `~/.claude/dashboard-subscriptions.json`. Prints `registered new project "xxx" on this machine`.
- Picker now respects `dashboard-subscriptions.json` (intersection of registered yamls ∩ subscribed). Falls back to all registered when subscription file missing/empty.
- Improved Rule 3 error when `--project foo` matches no disk dir AND no registry entry — surfaces what's subscribed on this machine and how to register manually.

## Why
Regression from #116 (issue #115): the picker's registry-validation gate broke `--project sweetprocess` even though `~/projects/sweetprocess/ACTIONS.md` exists. Auto-registration matches the user's mental model — projects you actively use get tracked automatically — without surprises (the disk-existence guard prevents registering typos).

The subscription filter is the second gap: this machine subscribes to `agents` and `paul-jason`, but the picker was listing all 7 registered projects (including personal projects on other machines).

## Test plan
- [x] `pytest action/tests/test_cli.py` — 28/28 passing (14 existing + 14 new)
- [x] `pytest bin/tests/test_cap.py` — 24/24 passing (no regression)
- [x] Smoke: `--project agents` and `--project paul-jason` succeed (registered + subscribed)
- [x] Smoke: `--project buddy` errors per Rule 3 (registered but not subscribed; no `~/projects/buddy/`)

## Notes
- PROVE flagged a minor cosmetic improvement: the Rule 3 error says "not registered" for projects that ARE registered but just not subscribed on this machine. Behavior is correct (rejects); message could be more precise. Worth a polish follow-up, out of scope here.
- `focus` field continues to be deprecated as a required field — separate issue.

Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)