### PR TITLE
feat(action): auto-commit/push on mutation with multi-device safety

### DIFF
--- a/action/cli.py
+++ b/action/cli.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import argparse
 import json
 import re
+import subprocess
 import sys
 from dataclasses import dataclass
 from datetime import date
@@ -17,6 +18,12 @@ from pathlib import Path
 HOME = Path.home()
 KNOWLEDGE_PROJECTS_DIR = HOME / "agents" / "knowledge" / "projects"
 SUBSCRIPTIONS_PATH = Path.home() / ".claude" / "dashboard-subscriptions.json"
+GIT_OK            = "ok"
+GIT_NETWORK_ERROR = "network_error"
+GIT_CONFLICT      = "conflict"
+GIT_NOT_A_REPO    = "not_a_git_repo"
+GIT_PUSH_REJECTED = "push_rejected"
+
 ALLOWED_STATUS = ("open", "wip", "blocked", "done", "cancelled")
 TERMINAL_STATUS = ("done", "cancelled")
 ID_RE = re.compile(r"^A-\d+$")
@@ -65,6 +72,9 @@ Project resolution:
                                        (~/agents → agents, ~/projects/X → X)
   --no-prompt                          Skip interactive picker; error instead
                                        (set automatically by non-TTY callers)
+  --no-commit                          Skip all git ops (pull + push); write file locally
+  --strict                             Abort if git pull fails (network down); default
+                                       is warn-and-continue
 Picker: when project is unresolved or unknown and stdin is a TTY, a numbered
 list of known projects is shown. Ctrl-C, EOF, or blank input aborts.
 
@@ -302,6 +312,21 @@ def parse_file(path: Path) -> FileModel:
     )
 
 
+def parse_next_id_from_data(content: str) -> int:
+    """Scan all table rows in content; return max(IDs) + 1 or 1 if none found.
+
+    This is the authoritative ID-derivation path. The marker line is kept for
+    human readability but the data always wins on mutation.
+    """
+    lines = content.split("\n")
+    ids: list[int] = []
+    for line in lines:
+        cells = split_row(line)
+        if cells and ID_RE.match(cells[0]):
+            ids.append(int(cells[0].split("-")[1]))
+    return (max(ids) + 1) if ids else 1
+
+
 # ---------- mutations ----------
 
 def replace_row(model: FileModel, line_idx: int, cells: dict[str, str], cols: list[str]) -> None:
@@ -536,7 +561,8 @@ def cmd_new(args: argparse.Namespace, path: Path) -> int:
     if status not in ALLOWED_STATUS:
         raise ActionError(f'invalid status "{status}" — must be one of {", ".join(ALLOWED_STATUS)}')
     model = parse_file(path)
-    aid = f"A-{model.next_id_num:03d}"
+    current_max = parse_next_id_from_data("\n".join(model.lines))
+    aid = f"A-{current_max:03d}"
     notes = f"{today()}: {escape_pipes(args.note)}" if args.note else ""
     files: list[str] = []
     for raw in collect_attach_args(args):
@@ -565,7 +591,7 @@ def cmd_new(args: argparse.Namespace, path: Path) -> int:
         insert_closed_row(model, closed_cells)
     else:
         insert_open_row(model, cells)
-    bump_next_id(model, model.next_id_num + 1)
+    bump_next_id(model, current_max + 1)
     model.write()
     suffix = f" [+{len(files)} file{'s' if len(files) != 1 else ''}]" if files else ""
     print(f"created {aid}: {args.new} [Owner: {args.owner}]{suffix}")
@@ -609,6 +635,103 @@ def remove_attachment(files: list[str], query: str) -> tuple[list[str], str]:
             + ", ".join(matches)
         )
     raise ActionError(f'no attachment matches "{query}"')
+
+
+# ---------- git helpers ----------
+
+def _git_detect_repo(repo_path: Path) -> bool:
+    """Return True if repo_path is inside a git repo."""
+    r = subprocess.run(
+        ["git", "-C", str(repo_path), "rev-parse", "--show-toplevel"],
+        capture_output=True, timeout=10,
+    )
+    return r.returncode == 0
+
+
+def _git_current_branch(repo_path: Path) -> str:
+    """Return current branch name, or 'main' as fallback."""
+    r = subprocess.run(
+        ["git", "-C", str(repo_path), "rev-parse", "--abbrev-ref", "HEAD"],
+        capture_output=True, text=True, timeout=10,
+    )
+    return r.stdout.strip() if r.returncode == 0 else "main"
+
+
+def _git_pull_rebase(repo_path: Path) -> str:
+    """Pull with --rebase. Returns GIT_OK, GIT_NETWORK_ERROR, GIT_CONFLICT, or GIT_NOT_A_REPO."""
+    if not _git_detect_repo(repo_path):
+        return GIT_NOT_A_REPO
+    branch = _git_current_branch(repo_path)
+    r = subprocess.run(
+        ["git", "-C", str(repo_path), "pull", "--rebase", "origin", branch],
+        capture_output=True, text=True, timeout=10,
+    )
+    if r.returncode == 0:
+        return GIT_OK
+    combined = (r.stdout + r.stderr).lower()
+    if "conflict" in combined:
+        return GIT_CONFLICT
+    if any(phrase in combined for phrase in (
+        "could not resolve host", "unable to access", "network is unreachable", "timed out"
+    )):
+        return GIT_NETWORK_ERROR
+    # fail-open: treat any other non-zero as a network error
+    return GIT_NETWORK_ERROR
+
+
+def _git_commit_and_push(repo_path: Path, actions_md: Path, message: str) -> str:
+    """Stage, commit, and push ACTIONS.md. Returns GIT_OK, GIT_PUSH_REJECTED, or GIT_NETWORK_ERROR."""
+    branch = _git_current_branch(repo_path)
+
+    # Stage
+    r = subprocess.run(
+        ["git", "-C", str(repo_path), "add", str(actions_md)],
+        capture_output=True, timeout=10,
+    )
+    if r.returncode != 0:
+        return GIT_NETWORK_ERROR
+
+    # Commit
+    r = subprocess.run(
+        ["git", "-C", str(repo_path), "commit", "-m", message],
+        capture_output=True, text=True, timeout=10,
+    )
+    if r.returncode != 0:
+        if "nothing to commit" in (r.stdout + r.stderr).lower():
+            return GIT_OK  # idempotent
+        return GIT_NETWORK_ERROR
+
+    # Push
+    r = subprocess.run(
+        ["git", "-C", str(repo_path), "push", "--force-with-lease", "origin", branch],
+        capture_output=True, text=True, timeout=10,
+    )
+    if r.returncode == 0:
+        return GIT_OK
+    combined = (r.stdout + r.stderr).lower()
+    if "rejected" in combined or "non-fast-forward" in combined:
+        return GIT_PUSH_REJECTED
+    return GIT_NETWORK_ERROR
+
+
+def _commit_message_for(
+    verb: str,
+    action_id: str,
+    owner: str | None = None,
+    status: str | None = None,
+) -> str:
+    """Build a conventional commit message for an ACTIONS.md mutation."""
+    if verb == "add":
+        tail = f"add {action_id} ({owner})" if owner else f"add {action_id}"
+    elif verb == "close":
+        tail = f"close {action_id} → {status}" if status else f"close {action_id}"
+    elif verb == "reopen":
+        tail = f"reopen {action_id}"
+    elif verb == "note":
+        tail = f"note on {action_id}"
+    else:
+        tail = f"update {action_id}"
+    return f"chore(action): {tail}"
 
 
 def cmd_list(args: argparse.Namespace, path: Path) -> int:
@@ -792,6 +915,8 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     p.add_argument("--unattach", action="append", default=[])
     p.add_argument("--project")
     p.add_argument("--no-prompt", action="store_true", default=False)
+    p.add_argument("--no-commit", action="store_true", default=False)
+    p.add_argument("--strict", action="store_true", default=False)
     args = p.parse_args(argv)
 
     # validation
@@ -820,17 +945,102 @@ def main(argv: list[str] | None = None) -> int:
     try:
         project = resolve_project_with_picker(args)
         path = project_path(project)
-        if args.new:
-            return cmd_new(args, path)
+
+        # Read-only operations: no git
         if args.list:
             return cmd_list(args, path)
         if args.id and not any([
             args.status, args.note, args.owner, args.reopen, args.attach, args.unattach,
         ]):
             return cmd_show(args, path)
-        if args.id:
-            return cmd_update(args, path)
-        raise ActionError("no operation specified — use --help for usage")
+
+        # Mutation operations: wrap with git pull/push unless --no-commit
+        is_mutation = args.new or args.id
+        if not is_mutation:
+            raise ActionError("no operation specified — use --help for usage")
+
+        repo_path = path.parent
+        # _do_push: True when a post-write commit+push should happen
+        _do_push = True
+
+        if not args.no_commit:
+            pull_result = _git_pull_rebase(repo_path)
+            if pull_result == GIT_CONFLICT:
+                print(
+                    f"error: cannot sync ACTIONS.md — pull conflict on this file.\n"
+                    f"  Resolve manually:\n"
+                    f"    cd {repo_path}\n"
+                    f"    git status\n"
+                    f"    # edit ACTIONS.md, then:\n"
+                    f"    git add ACTIONS.md && git rebase --continue\n"
+                    f"  Then retry the action.",
+                    file=sys.stderr,
+                )
+                return 1
+            elif pull_result == GIT_NETWORK_ERROR:
+                if args.strict:
+                    print(
+                        "error: cannot sync — offline. Pass --no-commit to write locally without git.",
+                        file=sys.stderr,
+                    )
+                    return 1
+                print(
+                    "WARNING: offline — could not pull latest. Writing locally.\n"
+                    "  Sync manually with `git push` when network returns."
+                )
+                _do_push = False
+            elif pull_result == GIT_NOT_A_REPO:
+                _do_push = False
+            # GIT_OK: proceed normally (push will run)
+
+        # Dispatch mutation
+        if args.new:
+            verb = "add"
+            rc = cmd_new(args, path)
+            commit_msg = _commit_message_for(verb, "", owner=args.owner)
+            # Re-derive the ID that was just written for the commit message
+            # (we need to read what cmd_new wrote; parse back from file)
+            try:
+                _m = parse_file(path)
+                # The new ID is current_max - 1 (the one we just wrote)
+                _written_num = parse_next_id_from_data(path.read_text()) - 1
+                written_id = f"A-{_written_num:03d}"
+                commit_msg = _commit_message_for("add", written_id, owner=args.owner)
+            except Exception:
+                pass
+        else:
+            rc = cmd_update(args, path)
+            # Determine verb from args
+            if args.reopen:
+                verb = "reopen"
+            elif args.status in TERMINAL_STATUS if args.status else False:
+                verb = "close"
+            elif args.note and not args.status and not args.owner:
+                verb = "note"
+            else:
+                verb = "update"
+            commit_msg = _commit_message_for(verb, args.id, status=args.status)
+
+        if rc != 0:
+            return rc
+
+        if not args.no_commit and _do_push:
+            push_result = _git_commit_and_push(repo_path, path, commit_msg)
+            if push_result == GIT_PUSH_REJECTED:
+                print(
+                    "error: push rejected — another device wrote between rebase and commit.\n"
+                    "  Run the same command again to retry.",
+                    file=sys.stderr,
+                )
+                return 1
+            elif push_result == GIT_NETWORK_ERROR:
+                # Non-fatal: file already written locally
+                print(
+                    "WARNING: could not push — network error. File written locally.\n"
+                    "  Sync manually with `git push` when network returns."
+                )
+
+        return 0
     except ActionError as e:
         print(f"error: {e}", file=sys.stderr)
         return 1

--- a/action/tests/test_cli.py
+++ b/action/tests/test_cli.py
@@ -369,3 +369,314 @@ def test_no_disk_dir_no_tty_error_message(monkeypatch, tmp_path):
         assert "not registered" in msg
         assert "no repo at" in msg
         assert "Subscribed on this machine:" in msg
+
+
+# ---------- git helpers (unit tests) ----------
+
+def _make_subprocess_mock(outcomes: list[tuple[int, str, str]]):
+    """
+    outcomes: list of (returncode, stdout, stderr) tuples consumed in order.
+    Returns a callable suitable for monkeypatching subprocess.run.
+    """
+    import subprocess as _subprocess
+    calls = list(outcomes)
+    def _mock(*args, **kwargs):
+        rc, out, err = calls.pop(0)
+        return _subprocess.CompletedProcess(args[0] if args else [], rc, out, err)
+    return _mock
+
+
+_ACTIONS_CONTENT = """\
+# Test Project ACTIONS
+
+Next ID: **A-002**
+
+## Open
+
+| ID | Issue | Action | Owner | Status | Opened | Src | Files | Notes |
+|----|-------|--------|-------|--------|--------|-----|-------|-------|
+| A-001 | | Test action | Jason | open | 2026-01-01 | | | |
+
+## Recently Closed
+
+| ID | Issue | Action | Owner | Closed | Files | Notes |
+|----|-------|--------|-------|--------|-------|-------|
+"""
+
+
+def _make_actions_file(tmp_path: Path) -> Path:
+    """Write a minimal ACTIONS.md with one open row A-001 and marker A-002."""
+    p = tmp_path / "ACTIONS.md"
+    p.write_text(_ACTIONS_CONTENT)
+    return p
+
+
+def _patch_project(monkeypatch, tmp_path: Path):
+    """Wire resolve_project_with_picker and project_path to use tmp_path."""
+    actions_file = _make_actions_file(tmp_path)
+    monkeypatch.setattr(cli, "resolve_project_with_picker", lambda args: "testproject")
+    monkeypatch.setattr(cli, "project_path", lambda name: actions_file)
+    return actions_file
+
+
+# T1: --new triggers subprocess in the right order (detect, branch, pull, branch, add, commit, push)
+def test_new_calls_git_pull_commit_push(monkeypatch, tmp_path):
+    """main() with --new calls subprocess for detect, pull, add, commit, push; exit 0."""
+    actions_file = _patch_project(monkeypatch, tmp_path)
+    original_content = actions_file.read_text()
+
+    # Outcomes in call order:
+    # 1. rev-parse --show-toplevel (detect_repo → success)
+    # 2. rev-parse --abbrev-ref HEAD (current_branch for pull → "main")
+    # 3. pull --rebase (→ success)
+    # 4. rev-parse --abbrev-ref HEAD (current_branch for commit_and_push → "main")
+    # 5. git add (→ success)
+    # 6. git commit (→ success)
+    # 7. git push --force-with-lease (→ success)
+    outcomes = [
+        (0, "", ""),   # rev-parse --show-toplevel
+        (0, "main\n", ""),  # rev-parse --abbrev-ref HEAD (pull)
+        (0, "", ""),   # pull --rebase
+        (0, "main\n", ""),  # rev-parse --abbrev-ref HEAD (push)
+        (0, "", ""),   # git add
+        (0, "1 file changed", ""),  # git commit
+        (0, "", ""),   # git push
+    ]
+    mock_called = []
+    import subprocess as _subprocess
+
+    def _recording_mock(*args, **kwargs):
+        rc, out, err = outcomes[len(mock_called)]
+        mock_called.append(args[0] if args else [])
+        return _subprocess.CompletedProcess(args[0] if args else [], rc, out, err)
+
+    monkeypatch.setattr(cli.subprocess, "run", _recording_mock)
+
+    rc = cli.main(["--new", "Test new action", "--owner", "Jason", "--no-prompt"])
+    assert rc == 0
+    # File must have been written (new row added)
+    new_content = actions_file.read_text()
+    assert "A-002" in new_content
+    assert "Test new action" in new_content
+    # subprocess must have been called (pull + push path)
+    assert len(mock_called) > 0
+    # push with --force-with-lease must appear
+    all_args = [str(a) for call in mock_called for a in call]
+    assert "--force-with-lease" in all_args
+
+
+# T2: --no-commit skips all git, file still written
+def test_no_commit_skips_all_git(monkeypatch, tmp_path):
+    """--no-commit: subprocess never called; file written; exit 0."""
+    actions_file = _patch_project(monkeypatch, tmp_path)
+    called = []
+    monkeypatch.setattr(cli.subprocess, "run", lambda *a, **kw: called.append(a) or (_ for _ in ()).throw(AssertionError("subprocess.run called with --no-commit")))
+
+    # Use a lambda that records and raises so we detect any call
+    def no_git(*args, **kwargs):
+        called.append(args)
+        raise AssertionError(f"subprocess.run should not be called, got: {args}")
+
+    monkeypatch.setattr(cli.subprocess, "run", no_git)
+
+    rc = cli.main(["--new", "No-commit action", "--owner", "Jason", "--no-prompt", "--no-commit"])
+    assert rc == 0
+    assert "No-commit action" in actions_file.read_text()
+    assert called == []
+
+
+# T3: pull conflict → abort before write
+def test_pull_conflict_aborts_write(monkeypatch, tmp_path, capsys):
+    """pull returns conflict → file unchanged; stderr contains 'cannot sync ACTIONS.md'; exit 1."""
+    actions_file = _patch_project(monkeypatch, tmp_path)
+    original_content = actions_file.read_text()
+
+    import subprocess as _subprocess
+    outcomes = [
+        (0, "", ""),           # rev-parse --show-toplevel (detect)
+        (0, "main\n", ""),     # rev-parse --abbrev-ref HEAD (branch)
+        (1, "CONFLICT (content): Merge conflict in ACTIONS.md", "CONFLICT"),  # pull
+    ]
+    monkeypatch.setattr(cli.subprocess, "run", _make_subprocess_mock(outcomes))
+
+    rc = cli.main(["--new", "Conflict action", "--owner", "Jason", "--no-prompt"])
+    assert rc == 1
+    captured = capsys.readouterr()
+    assert "cannot sync ACTIONS.md" in captured.err
+    assert actions_file.read_text() == original_content  # file unchanged
+
+
+# T4: pull network failure → warning printed, file written, push skipped
+def test_pull_network_failure_warns_and_writes(monkeypatch, tmp_path, capsys):
+    """pull returns network error → warning to stdout; file IS written; push NOT attempted; exit 0."""
+    actions_file = _patch_project(monkeypatch, tmp_path)
+
+    import subprocess as _subprocess
+    call_count = [0]
+
+    def _mock(*args, **kwargs):
+        n = call_count[0]
+        call_count[0] += 1
+        if n == 0:
+            return _subprocess.CompletedProcess(args[0], 0, "", "")   # detect
+        if n == 1:
+            return _subprocess.CompletedProcess(args[0], 0, "main\n", "")  # branch
+        if n == 2:
+            return _subprocess.CompletedProcess(args[0], 1, "", "Could not resolve host: github.com")  # pull fails
+        raise AssertionError(f"unexpected subprocess call #{n}: {args[0]}")
+
+    monkeypatch.setattr(cli.subprocess, "run", _mock)
+
+    rc = cli.main(["--new", "Network action", "--owner", "Jason", "--no-prompt"])
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert "offline" in captured.out or "WARNING" in captured.out
+    assert "Network action" in actions_file.read_text()
+    # Only 3 subprocess calls (detect + branch + pull); no push
+    assert call_count[0] == 3
+
+
+# T5: push rejected → abort with retry message, exit 1
+def test_push_rejected_aborts_with_retry_message(monkeypatch, tmp_path, capsys):
+    """pull succeeds; commit succeeds; push rejected → stderr 'push rejected'; exit 1."""
+    actions_file = _patch_project(monkeypatch, tmp_path)
+
+    import subprocess as _subprocess
+    outcomes = [
+        (0, "", ""),           # detect
+        (0, "main\n", ""),     # branch (pull)
+        (0, "", ""),           # pull
+        (0, "main\n", ""),     # branch (push)
+        (0, "", ""),           # git add
+        (0, "1 file", ""),     # git commit
+        (1, "", "rejected: non-fast-forward"),  # push rejected
+    ]
+    monkeypatch.setattr(cli.subprocess, "run", _make_subprocess_mock(outcomes))
+
+    rc = cli.main(["--new", "Rejected action", "--owner", "Jason", "--no-prompt"])
+    assert rc == 1
+    captured = capsys.readouterr()
+    assert "push rejected" in captured.err
+
+
+# T6: --strict + network failure → abort before write, exit 1
+def test_strict_network_failure_aborts(monkeypatch, tmp_path, capsys):
+    """--strict + pull network error: file unchanged; stderr 'cannot sync — offline'; exit 1."""
+    actions_file = _patch_project(monkeypatch, tmp_path)
+    original_content = actions_file.read_text()
+
+    import subprocess as _subprocess
+    outcomes = [
+        (0, "", ""),           # detect
+        (0, "main\n", ""),     # branch
+        (1, "", "Could not resolve host: github.com"),  # pull fails
+    ]
+    monkeypatch.setattr(cli.subprocess, "run", _make_subprocess_mock(outcomes))
+
+    rc = cli.main(["--new", "Strict action", "--owner", "Jason", "--no-prompt", "--strict"])
+    assert rc == 1
+    captured = capsys.readouterr()
+    assert "cannot sync — offline" in captured.err
+    assert actions_file.read_text() == original_content  # file must be unchanged
+
+
+# T7: --list does NOT call subprocess
+def test_list_does_not_call_git(monkeypatch, tmp_path):
+    """main() with --list: subprocess never called; exit 0."""
+    actions_file = _patch_project(monkeypatch, tmp_path)
+
+    def no_git(*args, **kwargs):
+        raise AssertionError(f"subprocess.run should not be called on --list, got: {args}")
+
+    monkeypatch.setattr(cli.subprocess, "run", no_git)
+    rc = cli.main(["--list", "--no-prompt"])
+    assert rc == 0
+
+
+# T8: show (A-001) does NOT call subprocess
+def test_show_does_not_call_git(monkeypatch, tmp_path):
+    """main() with A-001 (show): subprocess never called; exit 0."""
+    actions_file = _patch_project(monkeypatch, tmp_path)
+
+    def no_git(*args, **kwargs):
+        raise AssertionError(f"subprocess.run should not be called on show, got: {args}")
+
+    monkeypatch.setattr(cli.subprocess, "run", no_git)
+    rc = cli.main(["A-001", "--no-prompt"])
+    assert rc == 0
+
+
+# T9: non-git directory → detect returns NOT_A_REPO → write succeeds, no further git calls
+def test_non_git_dir_write_succeeds(monkeypatch, tmp_path):
+    """rev-parse returns non-zero (not a git repo) → file still written; no further git calls."""
+    actions_file = _patch_project(monkeypatch, tmp_path)
+
+    import subprocess as _subprocess
+    call_count = [0]
+
+    def _mock(*args, **kwargs):
+        n = call_count[0]
+        call_count[0] += 1
+        if n == 0:
+            # rev-parse --show-toplevel → non-zero = not a git repo
+            return _subprocess.CompletedProcess(args[0], 128, "", "not a git repository")
+        raise AssertionError(f"unexpected subprocess call #{n} after non-git detect")
+
+    monkeypatch.setattr(cli.subprocess, "run", _mock)
+
+    rc = cli.main(["--new", "Non-git action", "--owner", "Jason", "--no-prompt"])
+    assert rc == 0
+    assert "Non-git action" in actions_file.read_text()
+    # Only 1 call (the detect)
+    assert call_count[0] == 1
+
+
+# T10: stale marker → data wins → new item is A-004
+def test_stale_marker_uses_data_id(monkeypatch, tmp_path):
+    """ACTIONS.md has rows A-001, A-002, A-003 but marker says A-002; --new creates A-004."""
+    stale_content = """\
+# Stale Project
+
+Next ID: **A-002**
+
+## Open
+
+| ID | Issue | Action | Owner | Status | Opened | Src | Files | Notes |
+|----|-------|--------|-------|--------|--------|-----|-------|-------|
+| A-001 | | Action one | Jason | open | 2026-01-01 | | | |
+| A-002 | | Action two | Jason | open | 2026-01-02 | | | |
+| A-003 | | Action three | Jason | open | 2026-01-03 | | | |
+
+## Recently Closed
+
+| ID | Issue | Action | Owner | Closed | Files | Notes |
+|----|-------|--------|-------|--------|-------|-------|
+"""
+    actions_file = tmp_path / "ACTIONS.md"
+    actions_file.write_text(stale_content)
+    monkeypatch.setattr(cli, "resolve_project_with_picker", lambda args: "testproject")
+    monkeypatch.setattr(cli, "project_path", lambda name: actions_file)
+
+    # parse_next_id_from_data inline assertion
+    assert cli.parse_next_id_from_data(stale_content) == 4  # max(1,2,3) + 1
+
+    monkeypatch.setattr(cli.subprocess, "run", lambda *a, **kw: __import__("subprocess").CompletedProcess(a[0] if a else [], 128, "", "not a repo"))
+
+    rc = cli.main(["--new", "Fourth action", "--owner", "Jason", "--no-prompt"])
+    assert rc == 0
+    new_content = actions_file.read_text()
+    assert "A-004" in new_content
+    # Marker must have been updated to A-005
+    assert "A-005" in new_content
+
+
+# T11: _commit_message_for verb table
+def test_commit_message_for_verbs():
+    """Unit test _commit_message_for for all documented verb patterns."""
+    assert cli._commit_message_for("add", "A-008", owner="Jason") == "chore(action): add A-008 (Jason)"
+    assert cli._commit_message_for("close", "A-005", status="done") == "chore(action): close A-005 → done"
+    assert cli._commit_message_for("reopen", "A-003") == "chore(action): reopen A-003"
+    assert cli._commit_message_for("note", "A-002") == "chore(action): note on A-002"
+    assert cli._commit_message_for("update", "A-005") == "chore(action): update A-005"
+    # owner-only add (no owner)
+    assert cli._commit_message_for("add", "A-001") == "chore(action): add A-001"

--- a/claude-config/skills/action/SKILL.md
+++ b/claude-config/skills/action/SKILL.md
@@ -14,7 +14,7 @@ the single source of truth for behavior; this skill just dispatches.
 When invoked, run:
 
 ```bash
-python3 /home/jjob/agents/action/cli.py --no-prompt "$@"
+python3 /home/jjob/agents/action/cli.py --no-prompt --no-commit "$@"
 ```
 
 Pass through every argument unchanged (including the positional ID, the


### PR DESCRIPTION
## Summary
- Every successful `action` mutation now runs `git pull --rebase` (L1) → write → `git commit` → `git push --force-with-lease` (L2). ACTIONS.md stays synced across devices automatically.
- New `--no-commit` flag (default off) skips all git operations — used by the `/action` skill defensively so Claude sessions don't auto-commit.
- New `--strict` flag makes network failures during pull fatal instead of warnings (default warns + continues offline).
- Read-only commands (`--list`, `--show`, `--help`) are guaranteed not to touch git.
- `Next ID` now derived from data (`max(IDs across all 3 tables) + 1`), not the marker line. Marker is silently corrected on the next mutation if stale — meaningful safety against merge resolutions that leave the marker behind.
- Conflict during pre-write rebase aborts the action with a clear message; push rejection (race window) aborts with retry message and leaves the local commit in place for the next invocation to integrate.

## Why
ACTIONS.md is committed in every project (policy from PR #112). On multi-device workflows, manual `git push`/`pull` after every action edit is friction and a duplicate-`A-NNN` race risk. Auto-sync on mutation eliminates both. The layered defenses (rebase before, `--force-with-lease` after, data-derived next-ID) handle the realistic conflict cases without server-side coordination.

## Test plan
- [x] `pytest action/tests/test_cli.py` — 39/39 passing (28 existing + 11 new)
- [x] `pytest bin/tests/test_cap.py` — 24/24 passing (no regression)
- [x] Read-only commands verified by code path: never reach the git wrapper
- [x] `--no-commit` short-circuits both pull and push; `--strict` gates only network-failure handling
- [x] `cmd_new` uses `parse_next_id_from_data` (data wins over stale marker)

## Heads-up
Once merged, the next `action` mutation on any device with this code will trigger real `git pull --rebase` + `git push --force-with-lease`. If you want to sanity-check first, pass `--no-commit` on the first invocation.

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)