### PR TITLE
fix(action): make bin/action symlink portable across machines

### DIFF
--- a/bin/action
+++ b/bin/action
@@ -1,1 +1,1 @@
-/home/jjob/agents/action/cli.py
+../action/cli.py


### PR DESCRIPTION
## Summary
- `bin/action` was a symlink to `/home/jjob/agents/action/cli.py` — a hard-coded jbox06 absolute path that didn't resolve on any other host (notably this laptop).
- Switch the target to a relative path (`../action/cli.py`) so the entry point works wherever the repo is cloned.

## Test plan
- [x] `readlink bin/action` → `../action/cli.py`
- [x] `bin/action --help` prints usage on macOS
- [ ] Verify it still resolves on jbox06 after merge (relative paths work the same there)

🤖 Generated with [Claude Code](https://claude.com/claude-code)