### PR TITLE
feat(action): show metadata in --list output by default

### DIFF
--- a/action/cli.py
+++ b/action/cli.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import argparse
 import json
 import re
+import shutil
 import subprocess
 import sys
 from dataclasses import dataclass
@@ -40,7 +41,9 @@ HELP_TEXT = """\
 
 Read:
   action --help                       Show this help
-  action --list                       List open actions in current project
+  action --list                       List open actions (wide table with metadata)
+  action --list --short               Compact format: ID Owner Status Action
+  action --list --no-trunc            Don't truncate the Action column
   action --list --status <s>          Filter by status (open|wip|blocked|done|cancelled|closed)
   action --list --owner <name>        Filter by owner (case-insensitive)
   action --list --closed              Show Recently Closed table
@@ -766,12 +769,60 @@ def cmd_list(args: argparse.Namespace, path: Path) -> int:
         print("(no matching actions)")
         return 0
 
-    for lbl, c in rows:
+    if args.short:
+        for lbl, c in rows:
+            if lbl == "closed":
+                status_col = f"closed:{c.get('Closed', '?')}"
+            else:
+                status_col = c.get("Status", "?")
+            print(f"{c.get('ID', '?'):<6} {c.get('Owner', '?'):<8} {status_col:<14} {c.get('Action', '')}")
+        return 0
+
+    def _cell(c: dict[str, str], key: str, default: str = "-") -> str:
+        val = (c.get(key, "") or "").strip()
+        return val if val else default
+
+    def _status(lbl: str, c: dict[str, str]) -> str:
         if lbl == "closed":
-            status_col = f"closed:{c.get('Closed', '?')}"
-        else:
-            status_col = c.get("Status", "?")
-        print(f"{c.get('ID', '?'):<6} {c.get('Owner', '?'):<8} {status_col:<14} {c.get('Action', '')}")
+            return f"closed:{c.get('Closed', '?')}"
+        return _cell(c, "Status")
+
+    def _files_count(c: dict[str, str]) -> str:
+        files = parse_files_cell(c.get("Files", ""))
+        return str(len(files)) if files else "-"
+
+    rendered = [
+        {
+            "ID":     _cell(c, "ID", "?"),
+            "Owner":  _cell(c, "Owner"),
+            "Status": _status(lbl, c),
+            "Opened": _cell(c, "Opened"),
+            "Src":    _cell(c, "Src"),
+            "Issue":  _cell(c, "Issue"),
+            "Files":  _files_count(c),
+            "Action": _cell(c, "Action", ""),
+        }
+        for lbl, c in rows
+    ]
+
+    fixed_cols = ["ID", "Owner", "Status", "Opened", "Src", "Issue", "Files"]
+    widths = {col: max(len(col), max(len(r[col]) for r in rendered)) for col in fixed_cols}
+
+    term_width = shutil.get_terminal_size((120, 24)).columns
+    fixed_width = sum(widths.values()) + 2 * len(fixed_cols)  # 2-space gutter after each fixed col
+    action_budget = max(20, term_width - fixed_width)
+
+    def _join(values: list[str]) -> str:
+        parts = [v.ljust(widths[col]) for col, v in zip(fixed_cols, values[:-1])]
+        parts.append(values[-1])
+        return "  ".join(parts)
+
+    print(_join([*fixed_cols, "Action"]))
+    for r in rendered:
+        action = r["Action"]
+        if not args.no_trunc and len(action) > action_budget:
+            action = action[: action_budget - 1] + "…"
+        print(_join([r[c] for c in fixed_cols] + [action]))
     return 0
 
 
@@ -917,6 +968,8 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     p.add_argument("--no-prompt", action="store_true", default=False)
     p.add_argument("--no-commit", action="store_true", default=False)
     p.add_argument("--strict", action="store_true", default=False)
+    p.add_argument("--short", action="store_true", default=False)
+    p.add_argument("--no-trunc", action="store_true", default=False)
     args = p.parse_args(argv)
 
     # validation

--- a/action/tests/test_cli.py
+++ b/action/tests/test_cli.py
@@ -670,6 +670,115 @@ Next ID: **A-002**
     assert "A-005" in new_content
 
 
+# ---------- --list rendering ----------
+
+_RICH_ACTIONS_CONTENT = """\
+# Rich Test Project
+
+Next ID: **A-003**
+
+## Open
+
+| ID | Issue | Action | Owner | Status | Opened | Src | Files | Notes |
+|----|-------|--------|-------|--------|--------|-----|-------|-------|
+| A-001 | #42 | Short action | Jason | open | 2026-05-01 | M1 | /tmp/a.txt, /tmp/b.txt | |
+| A-002 |  | This is a deliberately long action description that should exceed any reasonable terminal width budget so that the truncation logic kicks in and we can verify that the trailing ellipsis is appended correctly | Paul | wip | 2026-05-02 |  |  | |
+
+## Recently Closed
+
+| ID | Issue | Action | Owner | Closed | Files | Notes |
+|----|-------|--------|-------|--------|-------|-------|
+"""
+
+
+def _patch_rich_project(monkeypatch, tmp_path: Path):
+    p = tmp_path / "ACTIONS.md"
+    p.write_text(_RICH_ACTIONS_CONTENT)
+    monkeypatch.setattr(cli, "resolve_project_with_picker", lambda args: "rich")
+    monkeypatch.setattr(cli, "project_path", lambda name: p)
+    return p
+
+
+def test_list_default_shows_metadata_columns(monkeypatch, tmp_path, capsys):
+    """Default --list shows the wide tabular header with metadata columns."""
+    _patch_rich_project(monkeypatch, tmp_path)
+    monkeypatch.setattr(cli.subprocess, "run", lambda *a, **kw: None)
+    rc = cli.main(["--list", "--no-prompt"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    header = out.splitlines()[0]
+    for col in ("ID", "Owner", "Status", "Opened", "Src", "Issue", "Files", "Action"):
+        assert col in header, f"missing column {col!r} in header: {header!r}"
+
+
+def test_list_default_renders_metadata_values(monkeypatch, tmp_path, capsys):
+    """Row data populates Opened, Src, Issue, Files (count) cells."""
+    _patch_rich_project(monkeypatch, tmp_path)
+    monkeypatch.setattr(cli.subprocess, "run", lambda *a, **kw: None)
+    rc = cli.main(["--list", "--no-prompt"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    a001 = next(line for line in out.splitlines() if line.startswith("A-001"))
+    # row populated: opened date, src, issue link, files count = 2
+    assert "2026-05-01" in a001
+    assert "M1" in a001
+    assert "#42" in a001
+    assert " 2 " in a001 or a001.endswith(" 2") or " 2  " in a001  # files count
+
+
+def test_list_dash_for_empty_metadata(monkeypatch, tmp_path, capsys):
+    """A row with no Issue/Src/Files renders '-' in those cells."""
+    _patch_rich_project(monkeypatch, tmp_path)
+    monkeypatch.setattr(cli.subprocess, "run", lambda *a, **kw: None)
+    rc = cli.main(["--list", "--no-prompt"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    a002 = next(line for line in out.splitlines() if line.startswith("A-002"))
+    # Issue, Src, Files are all empty for A-002 → all rendered as "-"
+    # Action text is long so it appears at the end; the metadata block before it must contain "-"
+    assert "-" in a002
+
+
+def test_list_short_keeps_compact_format(monkeypatch, tmp_path, capsys):
+    """--short preserves the legacy compact format (no header row)."""
+    _patch_rich_project(monkeypatch, tmp_path)
+    monkeypatch.setattr(cli.subprocess, "run", lambda *a, **kw: None)
+    rc = cli.main(["--list", "--short", "--no-prompt"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    lines = out.splitlines()
+    # No header row in short mode
+    assert not lines[0].startswith("ID "), f"unexpected header in --short output: {lines[0]!r}"
+    # First line is A-001 row, compact 4-col format
+    assert lines[0].startswith("A-001  Jason")
+
+
+def test_list_default_truncates_long_action(monkeypatch, tmp_path, capsys):
+    """Default --list truncates a long Action with an ellipsis."""
+    _patch_rich_project(monkeypatch, tmp_path)
+    monkeypatch.setattr(cli.subprocess, "run", lambda *a, **kw: None)
+    # Force a small terminal so truncation is guaranteed
+    monkeypatch.setattr(cli.shutil, "get_terminal_size", lambda fallback=(120, 24): __import__("os").terminal_size((100, 24)))
+    rc = cli.main(["--list", "--no-prompt"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    a002 = next(line for line in out.splitlines() if line.startswith("A-002"))
+    assert a002.endswith("…"), f"expected trailing ellipsis on truncated row: {a002!r}"
+
+
+def test_list_no_trunc_preserves_full_action_text(monkeypatch, tmp_path, capsys):
+    """--no-trunc emits the full Action text regardless of terminal width."""
+    _patch_rich_project(monkeypatch, tmp_path)
+    monkeypatch.setattr(cli.subprocess, "run", lambda *a, **kw: None)
+    monkeypatch.setattr(cli.shutil, "get_terminal_size", lambda fallback=(120, 24): __import__("os").terminal_size((80, 24)))
+    rc = cli.main(["--list", "--no-trunc", "--no-prompt"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    a002 = next(line for line in out.splitlines() if line.startswith("A-002"))
+    assert "trailing ellipsis is appended correctly" in a002
+    assert not a002.endswith("…")
+
+
 # T11: _commit_message_for verb table
 def test_commit_message_for_verbs():
     """Unit test _commit_message_for for all documented verb patterns."""


### PR DESCRIPTION
## Summary
- Default `action --list` now renders a wide tabular view: `ID Owner Status Opened Src Issue Files Action` — empty cells render as `-`.
- Action text truncated to terminal width with trailing `…`; full text via `--no-trunc`.
- Legacy compact format preserved behind `--short` (script-friendly).
- 6 new tests; full suite (45 tests) green.

Closes #124. Local action: A-007.

## Test plan
- [x] `action --list` shows the new wide table for `agents/ACTIONS.md`
- [x] `action --list --short` matches the previous one-line-per-row format
- [x] `action --list --no-trunc` emits full Action text when terminal is narrow
- [x] `action --list --closed` works with the new format
- [x] `pytest action/tests/` — 45 passed
- [ ] Visual eyeball after merge in a real terminal

🤖 Generated with [Claude Code](https://claude.com/claude-code)