### PR TITLE
chore(agents): close out Phase 2 — drop multi-agent channels (Option B)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -36,12 +36,10 @@ Codex delegation, content-brain-style phase discipline).
                        │  Codex delegation  │  parallel work,
                        │  (rescue/review)   │  reviews, rescue
                        └────────────────────┘
-
-                       ┌────────────────────┐
-                       │  Channel MCP       │  inter-agent comms
-                       │  (TBD — see Phase 2)│  awaiting decision
-                       └────────────────────┘
 ```
+
+Multi-agent channels were dropped in Phase 2 (Option B). Codex delegation
+is the converged multi-agent pattern.
 
 Reference specs:
 - `specs/phase0-usage-report.md` — what got measured, what didn't, why Phase 3 was deferred
@@ -90,21 +88,32 @@ exists.
 
 ---
 
-## Phase 2 — Channels decision ⏸ BLOCKED (awaits user input)
+## Phase 2 — Channels decision ✅ DONE (2026-05-06) — Option B
 
-**Issue:** `channel-mcp/index.ts` requires `CENTRAL_SERVER_URL` and is a
-client of the Flotilla central server. Archiving Flotilla also kills
-inter-agent channel communication.
+**Decision:** Drop multi-agent channels. Archive Flotilla.
 
-**Options on the table:**
-- **A. Slim Flotilla to transport-only** (~8k → ~1.5k lines). Keep
-  channels working. Strip dashboard.py, captures*, daily_summary,
-  planned_work, project_metrics, devices, terminal, scaffold,
-  github_sync, health_monitor, tech_stack, migration, React UI.
-- **B. Drop multi-agent channels entirely.** Archive Flotilla wholesale.
-- **C. Defer.** Leave Flotilla as-is. /dashboard already unhooked.
+**Rationale:**
+- 90 days of session history shows **0 real `channel-mcp` tool invocations**
+  (`send_message`, `check_messages`, `report_status`).
+- Flotilla central server was not running; `channel-mcp` was not registered
+  in any `settings.json`. The infrastructure was effectively cold.
+- Codex delegation (`/codex:rescue`, `/codex:adversarial-review`) — 1,379
+  invocations over 90d per Phase 0 — is the converged multi-agent pattern.
+  Channels was the speculative design that lost to it.
+- Option A (slim Flotilla to transport-only) would have been ~1–2 days of
+  cuts to keep a capability nothing was using. Net negative.
 
-**Decision needed:** A vs B vs C — see "Open Decisions" below.
+**What shipped:**
+- `~/projects/flotilla` archived (moved to `~/projects/_archived/flotilla`).
+- `channel-mcp` archived with the Flotilla repo (lived inside it).
+- Knowledge MCP: `flotilla` project flipped to `done`; `agents` project
+  blockers + channels-related open questions cleared.
+
+**Exit criteria:**
+- [x] Decision recorded with usage data.
+- [x] Flotilla local clone archived (GitHub repo retained as history).
+- [x] PLAN.md target architecture diagram updated (Channel MCP box dropped).
+- [x] `/dashboard` continues to function — Phase 1 already unwired Flotilla.
 
 ---
 
@@ -171,17 +180,15 @@ agent dispatch), let it accumulate, then revisit cuts with real data.
 
 ## Open Decisions
 
-- [ ] **Channels: A vs B vs C** (Phase 2 blocker). User input required.
 - [ ] **Usage logger design** (Phase 3 prerequisite). When/how to add.
 - [ ] **Per-project PLAN.md rollout cadence.** Adopt as projects come up
       in active rotation, or seed all at once?
 
 ## Sequencing Discipline
 
-Phases 0, 1, 4, 5 shipped this session. Phase 2 awaits user decision on
-channels. Phase 3 explicitly deferred to give measurement infrastructure
-time to mature.
+Phases 0, 1, 2, 4, 5 shipped. Phase 3 explicitly deferred to give
+measurement infrastructure time to mature.
 
 Pre-consolidation rollback SHAs (per `specs/phase0-usage-report.md`):
 - `~/agents` HEAD pre-Phase 1: `fec005d`
-- `~/projects/flotilla` HEAD: `e786eac`
+- `~/projects/flotilla` HEAD pre-archival: `e786eac`

--- a/knowledge/projects/agents.yaml
+++ b/knowledge/projects/agents.yaml
@@ -1,25 +1,16 @@
 project: agents
-status: blocked
-focus: Stack consolidation — Phase 1, 4, 5 shipped 2026-04-19; Phase 2 awaits
-  channels decision
+status: active
+focus: Stack consolidation complete (Phases 0, 1, 2, 4, 5 shipped). Phase 3
+  (artifact pruning) deferred until usage logger lands.
 next_steps:
-  - Phase 2a — extract channel-mcp to ~/agents/channel-mcp (depends on A/B/C
-    choice)
-  - Phase 2b — archive or slim Flotilla repo (depends on A/B/C choice)
   - Phase 3 — add usage logger to orchestrate (one JSONL line per agent
     dispatch), run 30d, then revisit artifact pruning
-  - "Per-project PLAN.md adoption: flotilla, buddy, mymoney-dev, temper — opt-in
-    as each comes back into rotation"
-blockers:
-  - "Phase 2 channels: pick A (slim Flotilla to transport-only ~8k→~1.5k LOC), B
-    (drop multi-agent channels, archive Flotilla), or C (defer entirely).
-    channel-mcp depends on Flotilla central server — see ~/agents/PLAN.md"
+  - "Per-project PLAN.md adoption: buddy, mymoney-dev, temper — opt-in as
+    each comes back into rotation"
+blockers: []
 open_questions:
-  - Which option (A/B/C) for Phase 2 channels?
-  - Do you actively use inter-agent channel communication in current daily
-    workflow, or is it a leftover from the strategic-agents experiment?
   - Should Phase 3 usage logger live in orchestrate skill or in a separate hook?
 specs: []
 dependencies: []
-updated_at: 2026-04-20
+updated_at: 2026-05-06
 updated_by: jason

--- a/knowledge/projects/flotilla.yaml
+++ b/knowledge/projects/flotilla.yaml
@@ -1,23 +1,20 @@
 project: flotilla
-status: active
-focus: Phase 4 automation complete — auto-blockers, auto-status, auto-journal,
-  stale prompts live
-next_steps:
-  - Test automation end-to-end across all projects
-  - Plan Phase 3 (multi-env + client engagement setup) when needed
-  - Monitor dashboard for drift over a week of real use
+status: done
+focus: Archived 2026-05-06 as part of agents Phase 2 (Option B — drop
+  multi-agent channels). Local clone moved to ~/projects/_archived/flotilla.
+  GitHub repo retained as history. Last shipped commit e786eac.
+next_steps: []
 blockers: []
-open_questions:
-  - Should /weekly digest auto-post to Slack or just render in terminal?
+open_questions: []
 specs:
   - path: specs/cross-env-platform.md
     version: v2.0
     status: final
-    summary: Two-layer platform architecture
+    summary: Two-layer platform architecture (historical)
   - path: specs/add-project.md
     version: v1.0
     status: draft
-    summary: Add Project modal — Create New and Add Existing
+    summary: Add Project modal — Create New and Add Existing (historical)
 dependencies: []
-updated_at: 2026-04-18
+updated_at: 2026-05-06
 updated_by: jason


### PR DESCRIPTION
## Summary
Closes the long-running blocker on the `agents` consolidation. Phase 2 was waiting on a A/B/C channels decision; usage data forced the call.

**Decision: Option B** — drop multi-agent channels, archive Flotilla.

## Why B (data, not vibes)
- **0** real `channel-mcp` tool invocations (`send_message`/`check_messages`/`report_status`) in 90 days of session history.
- Flotilla central server **not running** locally; `channel-mcp` **not registered** in any `settings.json`. Infrastructure was effectively cold.
- **Codex delegation** (`/codex:rescue`, `/codex:adversarial-review`) — 1,379 invocations / 90d per Phase 0 — is the converged multi-agent pattern. Channels lost.
- Option A (slim Flotilla to transport-only ~1.5k LOC) would have been ~1–2 days of cuts to keep a cold capability. Net negative.

## What changed in this PR
| File | Change |
|---|---|
| `PLAN.md` | Phase 2 marked ✅ DONE with rationale; Channel MCP box removed from target architecture; Open Decisions / Sequencing updated. |
| `knowledge/projects/agents.yaml` | `blocked` → `active`. Channels blocker + 2 channels-related open_questions cleared. `next_steps` reduced to remaining Phase 3 work. |
| `knowledge/projects/flotilla.yaml` | `active` → `done`. Focus reflects archival; specs retained as historical. |

## What changed outside this PR
- `~/projects/flotilla` → `~/projects/_archived/flotilla` (local move, history + untracked specs preserved).
- `jwj2002/flotilla` GitHub repo retained — not archived on GitHub. (Easy follow-up if you want.)

## Test plan
- [x] `git -C ~/projects/_archived/flotilla log --oneline -2` shows the expected `e786eac` HEAD.
- [x] `~/projects/flotilla` no longer exists; `~/projects/_archived/flotilla/specs/add-project.md` still does.
- [x] `action --list` and existing test suite unaffected (this PR is docs/state-only — no code changed).
- [ ] After merge: `/dashboard agents` should show the project as `ACTIVE`, blockers gone.

## Follow-ups (not in this PR)
- Phase 3 (usage logger) — still deferred per `PLAN.md`.
- Optional: `gh repo archive jwj2002/flotilla` to mark the GitHub repo as archived.

🤖 Generated with [Claude Code](https://claude.com/claude-code)