### PR TITLE
docs(plan): Phase 6 — toolchain consolidation decision record

### DIFF
--- a/ACTIONS.md
+++ b/ACTIONS.md
@@ -18,6 +18,9 @@ _(none yet)_
 
 | ID | Issue | Action | Owner | Status | Opened | Src | Files | Notes |
 |----|----|----|----|----|----|----|----|----|
+| A-010 |  | Phase 6A — port /dashboard to Python CLI at ~/agents/dashboard/cli.py; /dashboard skill becomes thin wrapper; share ACTIONS.md parser with action CLI | Jason | open | 2026-05-07 | spec-toolchain-consolidation |  |  |
+| A-011 |  | Phase 6B — audit all knowledge-mcp consumers (skills, plugins, anything in ~/agents/); per-tool decide port-to-CLI / keep / kill; output a follow-up plan | Jason | open | 2026-05-07 | spec-toolchain-consolidation |  |  |
+| A-012 |  | Phase 6C — archive ~/agents/knowledge-mcp/, drop MCP registration from settings.json, update PLAN.md target architecture (gated on 6B) | Jason | open | 2026-05-07 | spec-toolchain-consolidation |  |  |
 
 ## Recently Closed
 
@@ -38,4 +41,4 @@ _(none yet)_
 _(none yet)_
 
 ---
-Next ID: **A-010**
+Next ID: **A-013**

--- a/ACTIONS.md
+++ b/ACTIONS.md
@@ -21,6 +21,7 @@ _(none yet)_
 | A-010 |  | Phase 6A — port /dashboard to Python CLI at ~/agents/dashboard/cli.py; /dashboard skill becomes thin wrapper; share ACTIONS.md parser with action CLI | Jason | open | 2026-05-07 | spec-toolchain-consolidation |  |  |
 | A-011 |  | Phase 6B — audit all knowledge-mcp consumers (skills, plugins, anything in ~/agents/); per-tool decide port-to-CLI / keep / kill; output a follow-up plan | Jason | open | 2026-05-07 | spec-toolchain-consolidation |  |  |
 | A-012 |  | Phase 6C — archive ~/agents/knowledge-mcp/, drop MCP registration from settings.json, update PLAN.md target architecture (gated on 6B) | Jason | open | 2026-05-07 | spec-toolchain-consolidation |  |  |
+| A-013 |  | Phase 7 — investigate cross-device project state; evaluate git-as-sync vs SSH-based remote read vs centralized store; output decision doc at specs/cross-device-state.md (gated on 6A complete) | Jason | open | 2026-05-07 | spec-toolchain-consolidation |  |  |
 
 ## Recently Closed
 
@@ -41,4 +42,4 @@ _(none yet)_
 _(none yet)_
 
 ---
-Next ID: **A-013**
+Next ID: **A-014**

--- a/PLAN.md
+++ b/PLAN.md
@@ -41,8 +41,14 @@ Codex delegation, content-brain-style phase discipline).
 Multi-agent channels were dropped in Phase 2 (Option B). Codex delegation
 is the converged multi-agent pattern.
 
+Phase 6 will collapse the project-state interface to Python CLIs over
+filesystem YAMLs and retire the Knowledge MCP server (TypeScript). After
+Phase 6C, the diagram above simplifies to **YAMLs ← Python CLIs ← thin
+Claude-skill wrappers + Codex delegation**.
+
 Reference specs:
 - `specs/phase0-usage-report.md` — what got measured, what didn't, why Phase 3 was deferred
+- `specs/toolchain-consolidation.md` — Phase 6 decision record (Option 3: collapse to Python CLIs)
 
 ---
 
@@ -151,6 +157,25 @@ agent dispatch), let it accumulate, then revisit cuts with real data.
 
 ---
 
+## Phase 6 — Toolchain consolidation (Python CLIs, retire MCP server) ⏳ PLANNED
+
+Decision: collapse to one canonical interface — Python CLIs over the
+filesystem YAMLs that already are the source of truth. Knowledge MCP
+server (TypeScript) retires once every caller has a CLI counterpart.
+
+Full decision record: `specs/toolchain-consolidation.md`.
+
+**Three sub-phases (each independently shippable):**
+- **6A** — port `/dashboard` to a Python CLI; skill becomes thin wrapper. Tracked as A-010.
+- **6B** — audit remaining `mcp__knowledge__*` consumers; per-tool decide port / keep / kill. Tracked as A-011.
+- **6C** — archive `~/agents/knowledge-mcp/`; drop MCP from `settings.json`; update target architecture. Tracked as A-012, gated on 6B.
+
+Sequencing: 6A first (prototype + parallel-period validation); 6B only
+after 6A is in real use ≥1 week; 6C once 6B's inventory shows zero
+programmatic callers.
+
+---
+
 ## Phase 5 — PLAN.md discipline ✅ DONE (template); ongoing per project
 
 **What shipped:**
@@ -187,8 +212,10 @@ agent dispatch), let it accumulate, then revisit cuts with real data.
 ## Sequencing Discipline
 
 Phases 0, 1, 2, 4, 5 shipped. Phase 3 explicitly deferred to give
-measurement infrastructure time to mature.
+measurement infrastructure time to mature. Phase 6 planned —
+implementation begins with 6A (dashboard CLI).
 
 Pre-consolidation rollback SHAs (per `specs/phase0-usage-report.md`):
 - `~/agents` HEAD pre-Phase 1: `fec005d`
 - `~/projects/flotilla` HEAD pre-archival: `e786eac`
+- `~/agents` HEAD pre-Phase 6: TBD at start of 6A.

--- a/PLAN.md
+++ b/PLAN.md
@@ -163,6 +163,8 @@ Decision: collapse to one canonical interface — Python CLIs over the
 filesystem YAMLs that already are the source of truth. Knowledge MCP
 server (TypeScript) retires once every caller has a CLI counterpart.
 
+**Phase 6 is single-machine.** Cross-device project state is Phase 7.
+
 Full decision record: `specs/toolchain-consolidation.md`.
 
 **Three sub-phases (each independently shippable):**
@@ -173,6 +175,47 @@ Full decision record: `specs/toolchain-consolidation.md`.
 Sequencing: 6A first (prototype + parallel-period validation); 6B only
 after 6A is in real use ≥1 week; 6C once 6B's inventory shows zero
 programmatic callers.
+
+---
+
+## Phase 7 — Cross-device project state ⏳ INVESTIGATION
+
+The dashboard CLI ported in Phase 6A is **local-only** — it reads files
+on the machine it runs on. Cross-device visibility (e.g., seeing jbox06
+project state from the laptop) needs separate design work; the MCP→CLI
+swap by itself does not address it.
+
+**What partially works today (via git sync of the agents repo):**
+- `knowledge/projects/*.yaml` — focus, blockers, next-steps, status —
+  syncs across machines that pull `~/agents/`. Already cross-device
+  visible from any machine that pulled.
+
+**What does NOT work today and Phase 6A won't add:**
+- Per-project `ACTIONS.md` from a project repo cloned only on the other
+  machine (e.g., laptop wanting to see jbox06's `~/app-repos/<name>/ACTIONS.md`).
+- `git log` / open-issue counts from the remote project repo.
+- A subscription model that distinguishes which-host a project lives on.
+
+**Solution shapes to evaluate (in A-013):**
+- **A. Git-as-sync** — extend the "agents repo carries state" pattern;
+  cheapest, partially already in place; doesn't cover ACTIONS.md when
+  the project repo isn't cloned locally.
+- **B. SSH-based remote read** — `dashboard --host jbox06`; CLI
+  installed on both machines; subscriptions take host qualification
+  (`jbox06:agents`); medium effort.
+- **C. Centralized store** — each machine writes state to a shared
+  location; heaviest; only justifies for ≥3 devices or web-aggregation
+  needs.
+
+**Tracked as:** A-013 (investigation). **Gated on:** Phase 6A complete
+(need a clean local CLI to extend before introducing remote concerns).
+
+**Exit criteria:**
+- [ ] Cross-device requirements articulated (which projects, which
+      direction, which fields).
+- [ ] Decision recorded at `specs/cross-device-state.md` (modeled on
+      `specs/toolchain-consolidation.md`).
+- [ ] Implementation actions filed for the chosen option.
 
 ---
 
@@ -213,7 +256,8 @@ programmatic callers.
 
 Phases 0, 1, 2, 4, 5 shipped. Phase 3 explicitly deferred to give
 measurement infrastructure time to mature. Phase 6 planned —
-implementation begins with 6A (dashboard CLI).
+implementation begins with 6A (dashboard CLI). Phase 7 (cross-device
+project state) is investigation-only until Phase 6A completes.
 
 Pre-consolidation rollback SHAs (per `specs/phase0-usage-report.md`):
 - `~/agents` HEAD pre-Phase 1: `fec005d`

--- a/specs/toolchain-consolidation.md
+++ b/specs/toolchain-consolidation.md
@@ -73,6 +73,13 @@ talks MCP.
 
 The `~/agents/knowledge-mcp/` server is **not** in the target state.
 
+**Scope note — Phase 6 is single-machine.** The CLIs above read files
+from the local filesystem of the machine they're run on. Cross-device
+project state (e.g., laptop pulling jbox06's project data) is **out of
+scope for Phase 6** and tracked as Phase 7 in `PLAN.md`. Swapping MCP
+for a Python CLI does not, by itself, change cross-device behavior —
+both implementations are local-only readers of local files.
+
 ---
 
 ## Options considered
@@ -140,6 +147,8 @@ prior phase.
 - [ ] Side-by-side comparison run for ≥1 week against real projects;
       no behavior regressions noted.
 - [ ] `knowledge.db` decision pinned (see Open Decisions).
+- [ ] **Local-only reaffirmed.** No `--host` flag, no remote-read
+      capability. Cross-device is Phase 7's problem, not 6A's.
 
 ### Phase 6B — Audit & port remaining MCP consumers
 
@@ -220,6 +229,13 @@ prior phase.
   Refactor for shared helpers only.
 - **Replacing Knowledge MCP with a different MCP server.** The point is
   to drop the MCP layer, not swap implementations.
+- **Cross-device project state.** Phase 6A is local-only — the dashboard
+  CLI reads files from the local filesystem of the machine it runs on.
+  Cross-device reading (e.g., laptop pulling jbox06's project state)
+  has its own design concerns (host qualification, transport, auth,
+  network failure modes) and is tracked separately as Phase 7 in
+  `PLAN.md`. The MCP→CLI swap on its own does not change cross-device
+  behavior.
 - **Touching the obsidian-agent.** `~/agents/obsidian-agent/` reads the
   vault, not the knowledge YAMLs. Out of scope.
 - **Auto-archiving the Knowledge MCP GitHub repo (if any).** If it's a

--- a/specs/toolchain-consolidation.md
+++ b/specs/toolchain-consolidation.md
@@ -1,0 +1,261 @@
+# Toolchain Consolidation — Phase 6
+
+> Decision record for collapsing the project-state toolchain to a single
+> Python-CLI surface. Knowledge MCP server retires once all callers have
+> CLI counterparts.
+
+**Status:** Decided 2026-05-07. Phase 6A pending implementation.
+**Modeled on:** `~/projects/content-brain/PLAN.md` decision-doc style.
+
+---
+
+## Why this exists
+
+`agents` consolidation Phases 0–5 collapsed two project-state stacks onto
+Knowledge MCP and slimmed `~/agents/claude-config/` to artifacts that earn
+their cost. After Phase 2 (Flotilla archived) and the recent
+`cap → action --new` consolidation, the converged pattern across all
+shipped work is **Python CLI + thin Claude-skill wrapper that shells out**.
+
+`/dashboard` is the only large-scale Claude skill that still implements
+its own logic in markdown rather than delegating to a CLI. It calls
+`mcp__knowledge__*` tools (TypeScript MCP server) and runs ~620 lines of
+spec each invocation. This costs Claude tokens on every call, runs only
+inside Claude sessions (no shell / cron / status-bar callers), and
+duplicates state-reading logic that already exists in the `action` CLI's
+project resolver.
+
+Phase 6 finishes the consolidation: collapse to one canonical interface
+(Python CLIs over filesystem YAMLs), retire the duplicate (TypeScript MCP
+server), and let Claude skills reduce to thin shell-outs.
+
+---
+
+## Decision
+
+**Adopt the "Python CLI + thin Claude-skill wrapper" pattern as the
+canonical interface for all project-state operations on this machine.**
+Filesystem YAMLs (and per-project `ACTIONS.md`) remain the single source
+of truth. Python CLIs read and write them directly. Claude skills become
+short shell-out wrappers (the `/action` skill is the model: ~5 lines).
+
+The Knowledge MCP server (`~/agents/knowledge-mcp/`, TypeScript) retires
+once every caller has a CLI counterpart and nothing programmatic still
+talks MCP.
+
+---
+
+## Architecture (target state)
+
+```
+            filesystem (canonical, git-tracked)
+            ├── knowledge/projects/*.yaml
+            ├── knowledge/decisions/*.yaml
+            ├── knowledge/patterns/*.yaml
+            ├── knowledge/inbox/*.json
+            ├── knowledge/learning_rules/*.yaml
+            └── ~/projects/<name>/ACTIONS.md
+                          │
+                          ▼
+            ┌──────────────────────────────┐
+            │  ~/agents/<tool>/cli.py      │  Python CLIs
+            │  (action, dashboard, …)      │
+            └──────────────────────────────┘
+                          │
+        ┌─────────────────┼──────────────────┐
+        ▼                 ▼                  ▼
+  ┌───────────┐   ┌────────────────┐   ┌──────────────┐
+  │ shell /   │   │ Claude Code    │   │ cron / status│
+  │ pipes     │   │ skills (thin   │   │ bar / other  │
+  │           │   │ wrappers)      │   │ scripts      │
+  └───────────┘   └────────────────┘   └──────────────┘
+```
+
+The `~/agents/knowledge-mcp/` server is **not** in the target state.
+
+---
+
+## Options considered
+
+### Option 1 — Build dashboard CLI alongside the existing MCP server
+
+Dashboard CLI reads YAMLs directly. MCP server stays for any caller that
+wants it. Two readers of the same files, indefinitely.
+
+**Rejected.** Drift trap. Same data flow served by two implementations
+in two languages — divergence is only a matter of time. Doesn't match the
+consolidation theme of every other shipped phase.
+
+### Option 2 — Shared `knowledge_lib` module; both CLIs and MCP wrap it
+
+Refactor MCP server's YAML reading + filtering into a shared library;
+both Python CLIs and the TypeScript MCP server consume it.
+
+**Rejected.** Architecturally pure but expensive: TypeScript MCP would
+need either a Python rewrite or a TS↔Python bridge. Significant upfront
+work to preserve a server that has few real callers and would itself be
+on the chopping block once Claude skills become CLI wrappers.
+
+### Option 3 — Collapse to Python CLIs; retire MCP server (CHOSEN)
+
+Build CLI counterparts for every MCP tool that has a real caller. Migrate
+each Claude skill to a thin shell-out wrapper. When nothing calls the
+MCP server programmatically, archive it.
+
+**Chosen.** Matches every consolidation we've shipped this session. Drops
+TypeScript/Node from the toolchain. Single language across the stack.
+Filesystem-as-truth aligns with `PLAN.md`'s stated source-of-truth.
+
+---
+
+## Three-phase rollout
+
+Each phase is independently shippable and gated on real-world use of the
+prior phase.
+
+### Phase 6A — `dashboard` CLI
+
+**Tracked as:** A-010
+
+- New `~/agents/dashboard/cli.py` reading `knowledge/projects/*.yaml`,
+  per-project `ACTIONS.md`, and `git`/`gh` directly.
+- Refactor `action`'s ACTIONS.md parser into a shared module (e.g.
+  `~/agents/lib/actions_md.py`) that both CLIs consume.
+- `/dashboard` skill becomes a thin wrapper (~5 lines, `/action` model).
+- Multi-project mode: subscription-filtered (already authoritative per
+  `#129/#130`).
+- Single-project mode: full deep-view, unchanged behavior.
+- Output formats: terminal cards + markdown digest (existing contract).
+- Parallelize per-project `git`/`gh` with `concurrent.futures` so the
+  CLI matches the skill's natural parallelism.
+- Tests: per-mode rendering snapshots; window/owner/status filters;
+  subscription-filter error cases.
+
+**Sizing:** ~600–700 lines + ~150 lines of tests. MODERATE tier.
+
+**Exit criteria:**
+- [ ] `dashboard` CLI matches the existing skill's output for a defined
+      set of fixture projects.
+- [ ] `/dashboard` skill is a thin wrapper.
+- [ ] Side-by-side comparison run for ≥1 week against real projects;
+      no behavior regressions noted.
+- [ ] `knowledge.db` decision pinned (see Open Decisions).
+
+### Phase 6B — Audit & port remaining MCP consumers
+
+**Tracked as:** A-011
+
+- Inventory every caller of `mcp__knowledge__*` tools across:
+  - `~/agents/claude-config/skills/` (every SKILL.md)
+  - `~/agents/claude-config/commands/`
+  - `~/agents/claude-config/agents/` (orchestrate sub-agents)
+  - Any plugin under `~/.claude/plugins/`
+  - Settings files (`~/.claude/settings*.json`)
+- Per tool: decide **port-to-CLI / keep-on-MCP / kill**.
+- Likely candidates for port: `/project`, `/capture`, `/inbox`, `/learn`,
+  `/discover-patterns`, `/metrics`.
+- Output: a follow-up plan listing each MCP tool, decision, and
+  destination. May spawn one or more PRs of its own.
+
+**Sizing:** SIMPLE — investigation + planning, not implementation.
+
+**Exit criteria:**
+- [ ] Complete inventory of MCP consumers documented.
+- [ ] Per-tool decision recorded in this spec or a follow-up.
+- [ ] Migration plan for any MCP tool slated for port.
+
+### Phase 6C — Archive `knowledge-mcp/`
+
+**Tracked as:** A-012, gated on 6B.
+
+- Verify zero remaining programmatic callers.
+- Move `~/agents/knowledge-mcp/` to `~/agents/_archived/knowledge-mcp/`
+  (parallel to Flotilla's archival).
+- Drop the MCP server registration from `~/.claude/settings.json` (and
+  `claude-config/settings.json` source-of-truth).
+- Update `PLAN.md` target architecture diagram — replace the
+  `Knowledge MCP server` box with `filesystem YAMLs` directly.
+- Update any docs that still reference `mcp__knowledge__*` as a
+  programmatic interface.
+
+**Sizing:** SIMPLE.
+
+**Exit criteria:**
+- [ ] No `mcp__knowledge__*` tool calls in any active code path.
+- [ ] MCP server registration removed from settings.
+- [ ] `~/agents/knowledge-mcp/` archived; `claude-config` settings clean.
+- [ ] `PLAN.md` reflects post-MCP architecture.
+
+---
+
+## Risks
+
+1. **External callers we don't know about.** Codex plugins or other tools
+   in `~/agents/` might call knowledge MCP. Phase 6B's audit must be
+   exhaustive — false-clean = breakage on archive.
+2. **MCP-only features.** Some MCP tools may do something a CLI can't
+   match cleanly (long-running streams, structured tool responses Claude
+   needs as objects rather than text). Phase 6B will surface these. If
+   any exist and matter, they stay on MCP and Phase 6C narrows scope to
+   "archive everything else."
+3. **Phase 6A scope creep.** Tempting to refactor the world while
+   building the dashboard CLI. Discipline: just dashboard. The shared
+   `actions_md.py` module is in scope; rewriting the `action` CLI is
+   not.
+4. **`knowledge.db` ambiguity.** SQLite cache is rebuilt by the
+   post-merge hook. CLIs need a decision: read from `knowledge.db` (fast,
+   needs cache freshness logic) or from YAMLs (canonical, slower for
+   bulk queries). See Open Decisions.
+5. **Side-by-side period regression risk.** During the ≥1-week parallel
+   period in Phase 6A, the user may notice rendering drift. Mitigation:
+   define a fixture-based output comparison early; rerun before merge.
+
+---
+
+## What we're NOT doing
+
+- **Building new project-state features.** This is a re-platforming, not
+  a feature push. Existing `/dashboard` behavior is the contract.
+- **Rewriting `action`.** `action` already follows the target shape.
+  Refactor for shared helpers only.
+- **Replacing Knowledge MCP with a different MCP server.** The point is
+  to drop the MCP layer, not swap implementations.
+- **Touching the obsidian-agent.** `~/agents/obsidian-agent/` reads the
+  vault, not the knowledge YAMLs. Out of scope.
+- **Auto-archiving the Knowledge MCP GitHub repo (if any).** If it's a
+  separate repo, that's a manual cleanup decision after Phase 6C lands.
+
+---
+
+## Open Decisions
+
+- [ ] **`knowledge.db` role for CLIs.** Primary read path or query
+      optimization? Recommend YAMLs primary, `knowledge.db` only if
+      profile shows a real hot path. Pin in Phase 6A.
+- [ ] **Migration strategy for Phase 6A.** Big-bang (CLI + skill-as-wrapper
+      in one PR, like `cap → action`) or parallel period (ship CLI
+      alongside, compare for a week, then collapse)? Recommend **parallel
+      period for a 600-line replacement**. Pin before Phase 6A starts.
+- [ ] **Shared library home.** `~/agents/lib/`, `~/agents/_lib/`, or
+      `~/agents/common/`? Affects import paths. Pin in Phase 6A.
+- [ ] **Test fixtures location.** Per-tool `tests/fixtures/` or a shared
+      `~/agents/tests/fixtures/`? Affects how tests share project YAML
+      mocks. Pin in Phase 6A.
+
+---
+
+## Sequencing Discipline
+
+Phase 6A ships first because everything else gates on it: the dashboard
+CLI is the prototype for "MCP-tool-replaced-by-Python-CLI", and its
+real-world behavior under a parallel period is the signal for whether
+the pattern holds. Phase 6B is investigation and may surface findings
+that change Phase 6C's scope. Phase 6C is mechanical once 6B's
+inventory is clean.
+
+Do **not** start Phase 6B before Phase 6A's CLI is being used in real
+flows for ≥1 week — premature audit would be planning against an
+unverified pattern.
+
+Pre-Phase-6 SHAs (for rollback):
+- `~/agents` HEAD pre-6A: TBD at start of A-010 implementation.


### PR DESCRIPTION
## Summary
Capture the long-term architectural decision for project-state tooling on this machine: **collapse to Python CLIs over filesystem YAMLs; retire the Knowledge MCP server.** This is a decision PR — no code changes here, only the durable rationale and a tracked rollout.

## Decision

**Option 3 (chosen): Python CLI + thin Claude-skill wrapper, filesystem YAMLs as canonical.**

Two alternatives were considered and rejected:
- **Option 1** — build dashboard CLI alongside MCP server. Rejected as a drift trap.
- **Option 2** — shared `knowledge_lib` module wrapping both Python CLIs and TS MCP. Rejected as architecturally pure but expensive to refactor TypeScript across the boundary.

Full reasoning in `specs/toolchain-consolidation.md`.

## Three-phase rollout (each independently shippable)

| Phase | Action | Tier | Gates on |
|---|---|---|---|
| **6A** dashboard CLI; skill becomes wrapper | A-010 | MODERATE | — |
| **6B** audit & port remaining MCP consumers | A-011 | SIMPLE | 6A in real use ≥1 week |
| **6C** archive `~/agents/knowledge-mcp/` | A-012 | SIMPLE | 6B inventory shows zero programmatic callers |

## Files in this PR

| File | Δ |
|---|---|
| `specs/toolchain-consolidation.md` | new, 261 lines (decision record) |
| `PLAN.md` | +28 / -2 (register Phase 6, link spec, update target-architecture note + sequencing) |
| `ACTIONS.md` | +3 rows (A-010, A-011, A-012) |

## Open decisions pinned (to resolve at start of 6A)

- `knowledge.db` role: read-path or query optimization?
- Migration strategy: big-bang vs parallel period (recommend parallel for 600-line replacement)
- Shared library home: `~/agents/lib/` ?
- Test fixtures location

## Test plan
- [x] Spec is internally consistent — all three phases referenced consistently across spec / PLAN.md / ACTIONS.md.
- [x] No code changes; existing test suite unaffected (45 in action/tests, no other test surfaces touched).
- [ ] Manual: `/dashboard agents` (after merge) should still work — Phase 6 is planned, not started.
- [ ] After 6A starts: pin the four open decisions in the spec.

## Sequencing
This PR ships the **decision**. The next PR ships **6A** (the dashboard CLI). Phase 6 is the last open phase in the agents consolidation; once 6A/6B/6C land, the consolidation is structurally complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)