### PR TITLE
feat(dashboard): replace skill spec with thin shell-out wrapper (Phase 6A.2)

### DIFF
--- a/claude-config/skills/dashboard/SKILL.md
+++ b/claude-config/skills/dashboard/SKILL.md
@@ -1,633 +1,93 @@
 ---
 name: dashboard
-version: 6.1
-description: Cross-project status overview (or single-project deep view via cwd detection / explicit name) with windowed activity (daily/weekly/monthly/full), owner filter, and markdown digest format for agent-to-agent email
+version: 7.0
+description: Cross-project status overview (or single-project deep view via cwd detection / explicit name) — pure-read CLI wrapper. Subscription-filtered in multi-project mode; flags --window daily|weekly|monthly|full, --for owner, --status, --format terminal|markdown.
 ---
 
 # /dashboard
 
-Show project status. Source of truth is **Knowledge MCP**. Operational
-signals (last commit, open issues) come from `git`/`gh` directly, not
-from a separate service.
+Thin Claude wrapper around `~/agents/dashboard/cli.py`. The Python script
+is the single source of truth for behavior; this skill just dispatches.
 
-Two modes:
+## Execution
 
-- **Single-project deep view** — full focus, all next steps, all issues,
-  recent journal, recent decisions. Triggered by cwd auto-detection or
-  explicit project name.
-- **Multi-project overview** — active cards with full listings, paused
-  cards condensed, blocked cards show only blockers. Triggered by
-  running outside any tracked project. Always filtered by per-machine
-  subscriptions (no bypass — see "Per-Machine Subscriptions").
-
-## Usage
-
-```
-/dashboard                          # cwd-detect; window=daily by default
-/dashboard flotilla                 # explicit single-project deep view
-/dashboard --status active          # multi-project, filter by status
-
-# Activity window — applies to issues, actions, decisions, journal, patterns
-/dashboard --window daily           # open + closed/created in last 24h (DEFAULT)
-/dashboard --window weekly          # open + closed/created in last 7d
-/dashboard --window monthly         # open + closed/created in last 30d
-/dashboard --window full            # no window — show all states / full history
-
-# Owner filter (Actions only — issues/decisions/journal stay shared)
-/dashboard paul-jason --for Paul    # actions where Owner=Paul; shared context untouched
-
-# Output format
-/dashboard --format terminal        # ASCII boxes (DEFAULT)
-/dashboard --format markdown        # parseable markdown digest with stable header
-                                    # — used as body for agent-to-agent email digests
-
-# Common combos
-/dashboard paul-jason --window weekly --for Paul --format markdown
-/dashboard --window daily --format markdown   # multi-project markdown digest
-```
-
-## Activity Window
-
-Every multi-row section (issues, actions, decisions, journal, patterns) is
-filtered by an **activity window**. Default is `daily`.
-
-| Window  | Open items | "In window" closed/created items |
-|---------|------------|-----------------------------------|
-| daily   | always     | last 24h                          |
-| weekly  | always     | last 7d                           |
-| monthly | always     | last 30d                          |
-| full    | always     | no filter — full history          |
-
-What "in window" means per source:
-
-- **Issues (gh)**: `closedAt >= now - window` (closed in window) OR
-  `state=open`. Always include open. For `full`, include all states.
-- **Actions (ACTIONS.md)**: `## Open` table is always included; `## Recently
-  Closed` rows are included if `Closed >= now - window`. For `full`, also
-  include `## Archive` rows.
-- **Decisions**: `created_at >= now - window`. For `full`, show all (still
-  cap multi-project rendering at 10 most-recent for sanity).
-- **Journal**: `created_at >= now - window`. For `full`, show last 20.
-- **Patterns**: same as decisions — filter by `created_at`. Section is
-  hidden when zero rows in window (most days).
-
-Closed-in-window rows render with `✓` and the closed date suffix in
-terminal mode.
-
-## Owner Filter
-
-`--for <owner>` filters **Actions only** to rows where `Owner == <owner>`
-(case-insensitive). Issues, decisions, journal, blockers, and questions
-are shared context and are not filtered. This lets a digest sent *to Paul*
-foreground Paul's actions without losing the surrounding context.
-
-`--for` is silently ignored in multi-project mode unless combined with
-`--format markdown` (where it filters Action counts per card).
-
-## Output Format Selector
-
-`--format` controls the rendering surface:
-
-- `terminal` (default): ASCII boxes, friendly to read in a terminal. May
-  truncate long Action text to fit card width.
-- `markdown`: parseable markdown with explicit tables and a stable
-  digest header. **No truncation** — emit the full content so a recipient
-  agent can sync it back into its own state.
-
-The markdown digest always begins with a stable HTML comment so a
-downstream agent can recognize and idempotently consume it:
-
-```
-<!-- dashboard-digest v1 {project_or_multi} {window} {YYYY-MM-DD} -->
-```
-
-For multi-project markdown the project segment is the literal `multi`.
-
-## Per-Machine Subscriptions
-
-Multi-project mode is filtered by a per-machine subscription file at
-`~/.claude/dashboard-subscriptions.json`. This keeps the shared knowledge DB
-free of machine-specific view state — different laptops can subscribe to
-different projects.
-
-File format:
-
-```json
-{
-  "subscribed": ["agents", "paul-jason"]
-}
-```
-
-Filter rules (multi-project mode only):
-
-- File **exists** with non-empty `subscribed` array → show only those projects.
-  If a subscribed name isn't in the tracker, silently skip it (no error).
-  If **every** subscribed name is missing from the tracker, error per below.
-- File **missing**, malformed, or `subscribed` is empty/absent → **error**:
-
-  ```
-  error: ~/.claude/dashboard-subscriptions.json is missing or empty.
-    Subscribe with: /project NAME --subscribe
-    Or hand-edit:   { "subscribed": ["agents", "buddy"] }
-  ```
-
-- There is **no bypass flag**. Subscriptions are authoritative for
-  multi-project mode; `--all` was removed in v6.1.
-
-Single-project mode is **not** filtered — explicit `/dashboard <name>` and
-cwd-detection always work even if the project isn't subscribed on this
-machine.
-
-Manage subscriptions with `/project <name> --subscribe` and `--unsubscribe`.
-
-## Mode Selection
-
-1. If a positional argument is present (e.g. `flotilla`) → single-project mode for that name.
-2. Otherwise: read `pwd`. Strip `$HOME/projects/` prefix; if remaining path's first segment matches a tracked project, single-project mode for that name. Special case: `$HOME/agents` → `agents` project.
-3. If no match → multi-project mode (subscription-filtered).
-
-If single-project mode resolves to a project that isn't in the tracker,
-emit a one-line notice ("project `X` not tracked — use `/project X --focus
-\"...\"` to add it") and fall back to multi-project mode (subject to the
-same subscription filter).
-
-## Data Sources
-
-### Knowledge MCP (REQUIRED)
-
-**Multi-project mode:**
-1. `mcp__knowledge__get_dashboard` — returns projects with focus,
-   next_steps, blockers, open_questions, updated_at + `inbox_open` count.
-2. `mcp__knowledge__get_inbox` with `status: "open"` — flat list. Group by
-   `project` client-side.
-
-**Single-project mode:**
-1. `mcp__knowledge__get_project_context` with the resolved project name —
-   returns focus, status, next_steps, blockers, open_questions, plus
-   `recent_journal` (last 20) and `recent_decisions` (last 10).
-2. `mcp__knowledge__get_inbox` with `project: "<name>", status: "open"` —
-   only this project's captures.
-
-### ACTIONS.md overlay (OPTIONAL — per-project repo file)
-
-For each project, look for an `ACTIONS.md` at the resolved repo path
-(`~/projects/{name}/ACTIONS.md`, special case `agents` →
-`~/agents/ACTIONS.md`). If present, parse three tables:
-
-**`## Open`** — open work:
-```
-| ID | Issue | Action | Owner | Status | Opened | Src | Files | Notes |
-```
-
-**`## Recently Closed`** — closed within ~30d:
-```
-| ID | Issue | Action | Owner | Closed | Files | Notes |
-```
-
-The `Files` column (added in v2 of the schema) holds comma-separated
-absolute paths managed by `/action --attach`. Older files without the
-`Files` column (8-col Open / 6-col Closed) still parse — treat the
-column as empty. The `/action` script auto-migrates on first write.
-
-**`## Archive`** — closed beyond Recently Closed window. Only read for
-`--window full`.
-
-Rules:
-
-- From `## Open`: include rows whose `Status` is `open`, `wip`, or
-  `blocked`. Skip `done`/`cancelled` (they belong in Recently Closed).
-- From `## Recently Closed`: include rows whose `Closed >= now - window`.
-- From `## Archive`: only when `--window full`.
-- A row is parsed if it has at least the `ID`, `Action`, `Owner`, and
-  status-or-closed cell. Missing optional cells are fine.
-- Trim whitespace; treat empty cells as missing.
-- Apply `--for <owner>` filter (case-insensitive) to Action rows only.
-- If a file is missing or has no parseable rows, treat as zero (no error).
-
-Status indicators when rendering (terminal):
-- `open` → no prefix
-- `wip` → ` ⚙` suffix
-- `blocked` → ` ⛔` suffix
-- closed-in-window → ` ✓ {YYYY-MM-DD}` suffix
-
-### git/gh overlay (OPTIONAL — graceful degradation per project)
-
-For each project, attempt to resolve a local repo path using the convention
-`~/projects/{project_name}`. Special case: `agents` → `~/agents`. If the
-path doesn't exist or isn't a git repo, skip overlay for that project (no
-error, just no commit/issue fields rendered).
-
-**Active projects (per project, parallel):**
+When invoked, run:
 
 ```bash
-git -C <repo> log -1 --format='%s|%ar' 2>/dev/null
-
-# open issues (always)
-gh -R <github_slug> issue list --state open --limit 100 \
-    --json number,title 2>/dev/null
-
-# closed-in-window issues (skip when --window full → use --state all)
-gh -R <github_slug> issue list --state closed \
-    --search "closed:>=$WINDOW_START_DATE" \
-    --limit 50 --json number,title,closedAt 2>/dev/null
-
-# total open count
-gh -R <github_slug> issue list --state open --json number \
-    -q 'length' 2>/dev/null
+python3 ~/agents/dashboard/cli.py "$@"
 ```
 
-`$WINDOW_START_DATE` = today minus 1d/7d/30d depending on `--window`. For
-`--window full`, drop the `--state closed --search ...` call and instead
-fetch `--state all` paginated.
+Pass through every argument unchanged (positional project name, all
+`--*` flags, any quoted values). Print the script's stdout verbatim in
+your reply; print stderr verbatim too if non-empty. Use the script's
+exit code to decide whether the command succeeded — any non-zero is an
+error you should surface to the user.
 
-Resolve `<github_slug>` from `git -C <repo> config --get remote.origin.url`
-(parse `owner/repo` from either `git@github.com:owner/repo.git` or
-`https://github.com/owner/repo.git`).
+Do **not** re-implement any logic on top of the script. Do **not** parse
+or paraphrase the output — give the user the raw text the script
+emitted. The point of this wrapper is that Claude burns minimal tokens
+and behavior stays identical to the shell-only path.
 
-**Paused/blocked projects:** skip the closed-issue and title queries; just
-get the open count. Counts in window-aware form: `Issues: N open` (no
-closed segment for paused cards — they're paused).
+## When the user could just run the shell command
 
-**Timeout:** 3 seconds per command. If anything times out, that project
-just shows the Knowledge MCP fields without overlay.
+The script is also runnable directly:
 
-## Output Format
-
-### Single-Project Deep View (terminal)
-
-Wider card (~80 chars). All rows uncapped. Window-scoped sections:
-
-```
-PROJECT: flotilla                                              ACTIVE
-┌──────────────────────────────────────────────────────────────────────────────┐
-│ Focus:  Phase 4 automation complete — auto-blockers, auto-status,        1d │
-│         auto-journal, stale prompts live                                     │
-│ Last:   feat: ProjectView Context section (#199)                        33h │
-│                                                                              │
-│ Next Steps:                                                                  │
-│ 1. Test automation end-to-end across all projects                            │
-│ 2. Plan Phase 3 (multi-env + client engagement setup) when needed            │
-│ 3. Monitor dashboard for drift over a week of real use                       │
-│                                                                              │
-│ Issues (1 open):                                                             │
-│   #16  feat: admin agent should escalate blocked messages to human via      │
-│        dashboard                                                             │
-│                                                                              │
-│ Actions (3 open):                                                            │
-│   A-001  Jason  Review material Paul sent (transcripts, PRD, debrief...)    │
-│   A-002  Jason  Get v0.5B running on JBox                                ⚙  │
-│   A-009  Paul   Finish & freeze v0.6 by tonight                          ⛔  │
-│                                                                              │
-│ Captures (1 open):                                                           │
-│   #2 [idea]  Add dark/light theme toggle to flotilla dashboard              │
-│                                                                              │
-│ ? Open Questions:                                                            │
-│   Should /weekly digest auto-post to Slack or just render in terminal?      │
-│                                                                              │
-│ Recent Journal (5):                                                          │
-│   2026-04-18  focus_change  Phase 4 automation complete — auto-blockers     │
-│   2026-04-18  commit        feat: ProjectView Context section (#199)        │
-│   2026-04-18  focus_change  Phase 2 integration complete                    │
-│   ...                                                                        │
-│                                                                              │
-│ Recent Decisions (5):                                                        │
-│   D-098  2026-04-08  Federated flotilla instances with WebSocket bridge     │
-│   D-095  2026-04-07  Orchestration accountability — strategic creates...    │
-│   ...                                                                        │
-└──────────────────────────────────────────────────────────────────────────────┘
+```bash
+python3 ~/agents/dashboard/cli.py [args]
+# or with the alias in ~/.zshrc:
+alias dashboard='python3 ~/agents/dashboard/cli.py'
+dashboard
+dashboard agents --window weekly
+dashboard --format markdown
 ```
 
-Single-project view rules:
-- All next_steps shown (not capped)
-- **Issues**: all open + all closed-in-window. Closed rows render with
-  `✓ {YYYY-MM-DD}`. Header: `Issues (N open, M closed-{window})`.
-- **Actions**: all open `## Open` rows + all closed-in-window
-  `## Recently Closed` rows (and `## Archive` rows when `--window full`).
-  Format `{ID}  {Owner}  {Action}` with status suffix. Apply `--for`
-  filter to this section only. Header: `Actions (N open, M closed-{window})`
-  — or `Actions (N for {Owner}; M closed-{window})` when `--for` is set.
-- **Captures**: all open captures (no window filter — captures are
-  ephemeral inbox items and stay until triaged).
-- **Decisions (in window)**: filter `recent_decisions` by `created_at >=
-  now - window`. Show `{id}  {date}  {title}`. Section omitted if zero.
-  For `--window full`: show last 10.
-- **Patterns (in window)**: query `mcp__knowledge__get_patterns`, filter
-  by created/touched-in-window. Section omitted if zero.
-- **Journal (in window)**: filter `recent_journal` by `created_at >= now -
-  window`. Show `{date}  {entry_type}  {entry}`. For `--window full`:
-  show last 20.
-- Status label appears top-right (`ACTIVE` / `PAUSED` / `BLOCKED` / `DONE`)
-- Inbox footer shows project-scoped count only (not the cross-project sum)
-- Stale prompt suppressed (single-project mode is implicitly focused)
-- Window label appears under status, e.g. `window: daily (since 2026-05-04)`
+If the user invokes /dashboard and you suspect they'd be better served
+running it directly in the shell (tight loops, piping to mail, scripting),
+mention the alias once — but only once per session, and never if they
+seem to be deliberately using the slash-command form.
 
-### Active Projects — Full Listing
+## Surface
 
-```
-ACTIVE
-┌─ flotilla ─────────────────────────────────────────────────────┐
-│ Focus: Phase 2 integration complete                       now │
-│ Last:  feat: ProjectView Context section (#199)           now │
-│                                                                │
-│ Next Steps:                                                    │
-│ 1. Build MCP tools for dashboard, project context             │
-│ 2. Create CLI skills (/dashboard, /project, /capture)          │
-│ 3. Flotilla integration — Context section in ProjectView       │
-│                                                                │
-│ Issues (1 open):                                               │
-│   #16  feat: admin agent should escalate blocked messages     │
-│                                                                │
-│ Captures (1 open):                                             │
-│   #2 [idea]  Add dark/light theme toggle to flotilla          │
-│                                                                │
-│ ! Blockers:                                                    │
-│   AD connection details from infra                             │
-│                                                                │
-│ ? Open Questions:                                              │
-│   Should /weekly auto-post to Slack?                           │
-└────────────────────────────────────────────────────────────────┘
-```
+For the full command surface, run `python3 ~/agents/dashboard/cli.py --help`
+(the script prints help verbatim). Summary:
 
-### Paused Projects — Condensed View
-
-Paused cards do **not** apply the window — they show open counts only.
-The whole point of paused is "no recent activity expected."
-
-```
-PAUSED
-┌─ buddy ────────────────────────────────────────────────────────┐
-│ Focus: Meeting transcription pipeline          ⚠ 10d stale   │
-│ Last:  fix(config): strip voice_unified_reasoning         19d │
-│ Next:  Fix audio chunking > Add speaker labels                │
-│ Issues: 1 open  |  Captures: 0                                │
-└────────────────────────────────────────────────────────────────┘
-```
-
-### Blocked Projects — Show Blockers
-
-```
-BLOCKED
-┌─ project-name ─────────────────────────────────────────────────┐
-│ Focus: Current focus                             ⚠ 5d stale  │
-│ ! Blockers:                                                    │
-│   Waiting on client API contract                               │
-└────────────────────────────────────────────────────────────────┘
-```
-
-### Footer
-
-```
-INBOX (2 open — triage with /inbox)
-```
-
-### Stale Project Prompt
-
-After rendering the dashboard, if any **active** project has `updated_at`
->48h ago, append a prompt:
-
-```
-⚠ Stale context detected:
-  - flotilla (3d since last update)
-  - routeiq (5d since last update)
-
-To update: /project {name} --focus "..."
-```
-
-Only active projects trigger this. Paused projects are expected to be stale.
-This is a passive notice — no blocking interaction.
-
-### Post-Session Review Nudge
-
-Check `~/.claude/pending_focus_reviews.json`. If it exists with non-empty
-entries, show a one-line notice at the TOP of the dashboard output:
-
-```
-📝 2 projects have session activity to review — run /review-session
-```
-
-Count = number of project keys in the pending file. Don't list them — that's
-/review-session's job. This is a gentle nudge, not a blocker.
-
-No notice shown if the file doesn't exist or has no entries.
-
-## Rendering Rules
-
-### All Cards
-- `Focus` line: focus + right-aligned staleness (⚠ Nd stale if >48h, else relative time)
-- `Last` line: last commit message truncated + relative time (omitted if no repo overlay)
-
-### Active Cards
-- **Next Steps**: numbered list, first 3 items (full text, not truncated)
-- **Issues**: up to 3 most recent open + up to 3 closed-in-window.
-  Format `#N  title`; closed rows have ` ✓ {date}` suffix. Header:
-  `(N open, M closed-{window})`. If either count exceeds 3, add a
-  `+{rest} more` line. Omit entirely if no repo overlay.
-- **Actions** (from ACTIONS.md): up to 5 open + up to 5 closed-in-window
-  rows. Header `(N open, M closed-{window})`. Honors `--for` if set.
-  Omit if no ACTIONS.md.
-- **Decisions (in window)**: up to 5 most-recent within window.
-  Section omitted if zero.
-- **Captures**: all open captures for this project (usually <5), format
-  `#N [type]  content`. Header `(N open)`.
-- **Blockers**: all blockers, format `  {blocker text}`. Shown if any.
-- **Open Questions**: all questions, format `  {question text}`. Shown if any.
-
-### Paused Cards
-- Focus + Last + Next (first 1-2 joined with ` > `) + counts only
-- `Issues: N open | Actions: N open | Captures: N` — only include the
-  segments whose count is > 0; join with ` | `. Omit line entirely if all
-  zero.
-- Window not applied to paused cards (open counts only).
-- Issue count comes from `gh` overlay if available, else omitted
-- Actions count comes from ACTIONS.md overlay if present, else omitted
-
-### Blocked Cards
-- Focus + Blockers (full list). Issues/captures/next hidden — fix the blocker first.
-
-## Markdown Digest Format
-
-When `--format markdown`, emit a parseable digest instead of ASCII boxes.
-**No truncation** — the digest is a wire format for downstream agents.
-
-### Single-project markdown
-
-```markdown
-<!-- dashboard-digest v1 paul-jason daily 2026-05-05 -->
-# paul-jason — daily summary (2026-05-05)
-
-**Status:** ACTIVE
-**Focus:** Paul and Jason recurring one-on-one
-**Window:** daily (since 2026-05-04)
-**Owner filter:** Paul          <!-- omitted when --for not set -->
-
-## Next Steps
-1. ...
-
-## Issues
-
-### Open (N)
-| #  | Title | Updated |
-|----|-------|---------|
-
-### Closed in window (M)
-| #  | Title | Closed |
-|----|-------|--------|
-
-## Actions
-
-### Open (N)
-| ID | Owner | Action | Status | Opened | Notes |
-|----|-------|--------|--------|--------|-------|
-
-### Closed in window (M)
-| ID | Owner | Action | Closed | Notes |
-|----|-------|--------|--------|-------|
-
-## Decisions in window (N)
-| ID | Date | Title |
-|----|------|-------|
-
-## Patterns in window (N)        <!-- section omitted when zero -->
-| ID | Date | Title |
-
-## Blockers                      <!-- omitted when none -->
-- ...
-
-## Open Questions                <!-- omitted when none -->
-- ...
-
-## Journal in window (N)
-| Date | Type | Entry |
-
-## Captures (N open)             <!-- omitted when zero -->
-- #2 [idea] ...
-```
-
-### Multi-project markdown
-
-```markdown
-<!-- dashboard-digest v1 multi daily 2026-05-05 -->
-# Multi-project — daily summary (2026-05-05)
-
-**Window:** daily (since 2026-05-04)
-**Subscriptions:** agents, paul-jason  <!-- when filter active -->
-
-## paul-jason (ACTIVE)
-**Focus:** Paul and Jason recurring one-on-one
-**Counts:** Issues 0 open / 0 closed | Actions 16 open / 0 closed | Decisions 0 | Captures 0
-
-[…repeat single-project sections inline, with H3 headers instead of H2…]
-
-## agents (BLOCKED)
-**Focus:** Stack consolidation — …
-**Blockers:** Phase 2 channels: pick A/B/C
-```
-
-Rules:
-- Counts line on each project header with the per-window numbers.
-- Sections that would be empty are **omitted** (not rendered as "0").
-- The first line is always the stable header comment so a downstream
-  agent can recognize the digest. Header format:
-  `dashboard-digest v1 {project_or_multi} {window} {YYYY-MM-DD}`.
-
-## Graceful Degradation
-
-1. **Knowledge MCP unreachable**:
-   - Error message: "Knowledge MCP unavailable — /dashboard cannot render"
-   - No fallback. Knowledge MCP is the single source of truth.
-
-2. **Repo path missing or not a git repo for a project**:
-   - Skip git/gh calls for that project
-   - Card renders with Knowledge MCP fields only (no Last/Issues lines)
-
-3. **`gh` not authenticated or rate-limited**:
-   - Per-project: card renders without Issues line
-   - No global error — the dashboard always returns
-
-4. **Per-command timeout (3s)**:
-   - Command result discarded for that project
-   - Card renders with whatever else succeeded
-
-## Execution Order
-
-### Step 0 — Mode resolution
-
-1. Parse args:
-   - `--status <s>`, positional project name (mode selectors)
-   - `--window daily|weekly|monthly|full` (default: `daily`)
-   - `--for <owner>` (default: none)
-   - `--format terminal|markdown` (default: `terminal`)
-2. If positional name → single-project mode for that name.
-3. Else: read `pwd`. If `pwd == $HOME/agents` or starts with `$HOME/agents/`, mode = single-project (`agents`). If `pwd` starts with `$HOME/projects/`, take the first segment after; if it matches a tracked project, mode = single-project (that name).
-4. Else → multi-project mode.
-5. Compute `WINDOW_START` = today minus 1d/7d/30d, or null for `full`.
-
-### Single-project mode
-
-1. `mcp__knowledge__get_project_context` with the resolved name.
-2. If null/error → emit `project "<name>" not tracked — use /project <name> --focus "..." to add it`, then fall through to multi-project mode.
-3. `mcp__knowledge__get_inbox` with `project: "<name>", status: "open"`.
-4. Resolve repo path (same convention).
-   - Read `{repo_path}/ACTIONS.md` if present; parse `## Open` (always),
-     `## Recently Closed` (filter rows by `Closed >= WINDOW_START`), and
-     `## Archive` (only when `--window full`). Apply `--for` filter.
-     Repo without `.git` is fine — ACTIONS.md is independent of git.
-   - If the path is a git repo: parallel
-     - `git log -1 --format='%s|%ar'`
-     - `gh issue list --state open --limit 100 --json number,title,updatedAt`
-     - For `daily`/`weekly`/`monthly`:
-       `gh issue list --state closed --search "closed:>=$WINDOW_START_DATE" --limit 50 --json number,title,closedAt`
-     - For `full`: `gh issue list --state all --limit 200 --json number,title,state,closedAt`
-5. Filter Knowledge MCP fields by window:
-   - `recent_decisions` → keep where `created_at >= WINDOW_START` (or all
-     for `full`)
-   - `recent_journal` → keep where `created_at >= WINDOW_START` (or all
-     for `full`)
-6. Optional patterns query: `mcp__knowledge__get_patterns`, filter by
-   in-window timestamps. Section omitted when empty.
-7. Render per `--format`:
-   - `terminal` → Single-Project Deep View card
-   - `markdown` → Single-project markdown digest with stable header.
-
-### Multi-project mode
-
-1. `mcp__knowledge__get_dashboard` (with `status` if provided)
-2. **Apply subscription filter (mandatory)**: read
-   `~/.claude/dashboard-subscriptions.json`.
-   - If the file parses to an object with a non-empty `subscribed` array,
-     drop any project whose name isn't in that array.
-   - If the file is missing, malformed, or has no/empty `subscribed`, **error
-     immediately** with the instructive message in "Per-Machine Subscriptions"
-     (do not render a dashboard, do not fall through to all-projects).
-   - If filtering leaves zero projects (every subscribed name is missing
-     from the tracker), error with: `subscribed projects (X, Y) are not in
-     the tracker — use /project X --focus "..." to register them, or
-     /project X --unsubscribe`.
-3. `mcp__knowledge__get_inbox` with `status: "open"` — group by project
-   client-side, then drop entries whose project was filtered out above.
-4. For each project in result:
-   - Resolve repo path (`~/projects/{name}`, special case `agents` → `~/agents`)
-   - Read `{repo_path}/ACTIONS.md` if present:
-     - For **active** projects: count open + count closed-in-window
-     - For **paused/blocked**: count open only (no window)
-   - If repo exists and is a git repo:
-     - Resolve github slug from origin URL
-     - For **active** projects: parallel `git log` + `gh issue list --limit 3 --state open` + `gh issue list -q 'length'` + `gh issue list --state closed --search "closed:>=$WINDOW_START_DATE" --limit 3` (skip closed query for `--window full`; use `--state all` instead)
-     - For **paused/blocked** projects: parallel `git log` + `gh issue list -q 'length'` only
-5. Filter Knowledge data per project: in-window decisions count; in-window
-   patterns count (active projects only).
-6. Merge all overlays with Knowledge MCP data per project.
-7. Render per Output Format. With `--format markdown`, emit the
-   Multi-project markdown digest with stable header. With
-   `--format terminal`, render ASCII cards (active/paused/blocked shapes).
-8. Append inbox footer + stale prompt + review nudge as applicable
-   (terminal only — markdown digest skips the trailing nudges).
+- **Single-project deep view**: `dashboard <name>`, or invoke from cwd
+  inside `~/agents/` or `~/projects/<name>/`. Renders frame, actions,
+  issues, decisions, captures.
+- **Multi-project overview**: `dashboard` from elsewhere — subscription-
+  filtered. Subscriptions live in `~/.claude/dashboard-subscriptions.json`
+  and are **authoritative** (no `--all` bypass; missing/empty/all-stale
+  → instructive error).
+- **Filters**: `--window daily|weekly|monthly|full` (default daily),
+  `--for <owner>` (Actions only — Issues/Decisions/Captures stay shared),
+  `--status active|paused|blocked|done` (multi-project filter).
+- **Format**: `--format terminal` (default ASCII cards) or
+  `--format markdown` (parseable digest with stable
+  `<!-- dashboard-digest v1 {project_or_multi} {window} {YYYY-MM-DD} -->`
+  header for downstream agent consumption — e.g. `/email-digest`).
 
 ## Notes
 
-- This skill replaces the prior Flotilla-API-based dashboard. There is no
-  longer a service to keep running for `/dashboard` to work.
-- Across machines, the convention `~/projects/{name}` should hold; if a
-  machine puts repos elsewhere, the skill silently degrades to Knowledge-only.
-- If you need WIP/agent-work tracking, use `git branch --list 'feature/*'` —
-  there is no Flotilla equivalent in the consolidated stack.
+- The script is **pure-read**. Writes to project state belong to other
+  surfaces:
+  - `action` CLI for ACTIONS.md (auto-commits per #121)
+  - `gh issue create/close` and `/orchestrate` for GitHub issues
+  - `/learn`, `mcp__knowledge__save_decision`, hand-edit for decisions
+  - `/capture`, `mcp__knowledge__capture` for inbox
+  - `/project --focus`, hand-edit for project YAML frame
+- The script **does not run** the legacy automation
+  (`syncBlockers`, `recomputeStatus`, `autoJournalCommits`) that the
+  previous MCP-backed /dashboard ran on every call. If those automations
+  are still useful, Phase 6B audit (A-011) will decide where they live —
+  likely a separate `automation.py` invoked from a hook/cron, not on
+  every dashboard render.
+- Sources: `knowledge/projects/*.yaml`, `knowledge/decisions/*.yaml`,
+  per-project `ACTIONS.md`, `gh issue list` per resolved repo. Inbox
+  reads from `knowledge/knowledge.db` (the one knowledge subsystem
+  without a YAML form yet).
+- Specification of behavior, modes, filters, rendering, and degradation
+  rules lives in `~/agents/dashboard/cli.py`'s module docstring + the
+  test suite at `~/agents/dashboard/tests/test_cli.py`. If you need to
+  change behavior, edit the Python — never re-add logic to this skill.
+- This is a single-machine CLI. Cross-device project state is Phase 7
+  (see `~/agents/PLAN.md` and `specs/toolchain-consolidation.md`).


### PR DESCRIPTION
Closes #135. Completes Phase 6A.

## Summary
- Replace `claude-config/skills/dashboard/SKILL.md` (615-line spec) with a 93-line wrapper that shells out to `~/agents/dashboard/cli.py`.
- Same pattern as the existing `/action` skill.
- Skill version `6.1 → 7.0`.
- **No code changes**, no test changes. The Python script shipped in #134 is the contract; this PR just makes the Claude skill dispatch to it instead of re-interpreting a 615-line markdown spec.

## Diff shape
| File | Δ |
|---|---|
| `claude-config/skills/dashboard/SKILL.md` | -614 / +73 (net **-541 lines**) |

## Why this completes Phase 6A
- Spec exit criteria from `specs/toolchain-consolidation.md`:
  - [x] CLI matches the existing skill's output for fixture projects (verified in #134)
  - [x] `/dashboard` skill is a thin wrapper *(this PR)*
  - [ ] Side-by-side comparison run for ≥1 week — **explicitly skipped per user direction; the user is the only validator and "good enough" was the validation signal**
  - [x] `knowledge.db` decision pinned (revised in #134: ignore for projects/decisions, read for inbox)
  - [x] Local-only reaffirmed (no `--host` flag)
- After this lands, A-011 (Phase 6B audit) is unblocked.

## What stays in the wrapper SKILL.md
- The dispatch contract (run the script, print stdout verbatim, surface non-zero exit)
- "When the user could just run the shell command" tip (mention alias once per session)
- Brief surface summary (modes, filters, formats — *not* the full spec)
- Notes on what's in scope (read-only; what writes from where; what automations are NOT replicated; pointer to the cli.py docstring + tests as the durable spec; pointer to Phase 7 for cross-device)

## Test plan
- [x] Diff is 1 file, markdown only — nothing to break in Python.
- [x] `python3 ~/agents/dashboard/cli.py agents --window weekly` works at the exact path the wrapper invokes (smoke).
- [x] New skill description live in the skill list (harness picks up the SKILL.md change at load).
- [ ] Manual after merge: `/dashboard agents --window weekly` produces identical output to running the CLI directly.
- [ ] Manual after merge: `/dashboard --format markdown` digest header is preserved verbatim.

## Risk + reversibility
- Pure markdown change in one file.
- If the wrapper's dispatch turns out to behave wrong in some edge case, revert the PR — the old skill returns intact.
- The CLI itself is unchanged from #134.

## Skipped: parallel period
The spec called for ≥1 week of side-by-side use before this step. User direction: skip. Honest tradeoff acknowledged in commit body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)