### PR TITLE
docs(knowledge): map surfaces + standardize schema_version (Phase 6 follow-up)

### DIFF
--- a/ACTIONS.md
+++ b/ACTIONS.md
@@ -21,6 +21,9 @@ _(none yet)_
 | A-012 |  | Phase 6C — archive ~/agents/knowledge-mcp/, drop MCP registration from settings.json, update PLAN.md target architecture (gated on 6B) | Jason | open | 2026-05-07 | spec-toolchain-consolidation |  |  |
 | A-013 |  | Phase 7 — investigate cross-device project state; evaluate git-as-sync vs SSH-based remote read vs centralized store; output decision doc at specs/cross-device-state.md (gated on 6A complete) | Jason | open | 2026-05-07 | spec-toolchain-consolidation |  |  |
 | A-018 |  | Phase 6B P-4 — port /review-session skill to Python CLI at ~/agents/review-session/cli.py; SKILL.md becomes thin wrapper (gates on P-3) | Jason | open | 2026-05-07 | spec-phase6b-mcp-audit |  |  |
+| A-019 |  | Build decision-writer CLI: 'decision new --project X --topic Y --title Z' that writes knowledge/decisions/D-NNN.yaml + updates index.yaml. Closes the writer-gap surfaced in specs/knowledge-surfaces.md. | Jason | open | 2026-05-07 | spec-knowledge-surfaces |  |  |
+| A-020 |  | Connect SessionStart hook to knowledge/patterns/*.yaml: filter by tier=critical AND lifecycle.status in (validated, pilot); emit alongside the hardcoded patterns-critical.md. Closes the reader-gap. | Jason | open | 2026-05-07 | spec-knowledge-surfaces |  |  |
+| A-021 |  | Drop dead knowledge/ subdirs (velocity/, project-summaries/, knowledge/specs/, sync.py, schema.sql, .agents/, __pycache__) alongside Phase 6C MCP archival (A-012). | Jason | open | 2026-05-07 | spec-knowledge-surfaces |  |  |
 
 ## Recently Closed
 
@@ -47,4 +50,4 @@ _(none yet)_
 _(none yet)_
 
 ---
-Next ID: **A-019**
+Next ID: **A-022**

--- a/ACTIONS.md
+++ b/ACTIONS.md
@@ -20,14 +20,10 @@ _(none yet)_
 |----|----|----|----|----|----|----|----|----|
 | A-012 |  | Phase 6C — archive ~/agents/knowledge-mcp/, drop MCP registration from settings.json, update PLAN.md target architecture (gated on 6B) | Jason | open | 2026-05-07 | spec-toolchain-consolidation |  |  |
 | A-013 |  | Phase 7 — investigate cross-device project state; evaluate git-as-sync vs SSH-based remote read vs centralized store; output decision doc at specs/cross-device-state.md (gated on 6A complete) | Jason | open | 2026-05-07 | spec-toolchain-consolidation |  |  |
-<<<<<<< HEAD
-| A-018 |  | Phase 6B P-4 — port /review-session skill to Python CLI at ~/agents/review-session/cli.py; SKILL.md becomes thin wrapper (gates on P-3) | Jason | open | 2026-05-07 | spec-phase6b-mcp-audit |  |  |
+| A-018 |  | Phase 6B P-4 — port /review-session skill to Python CLI at ~/agents/review-session/cli.py; SKILL.md becomes thin wrapper (gates on P-3) | Jason | open | 2026-05-07 | spec-phase6b-mcp-audit |  | 2026-05-07: GH issue #142 filed; PR incoming |
 | A-019 |  | Build decision-writer CLI: 'decision new --project X --topic Y --title Z' that writes knowledge/decisions/D-NNN.yaml + updates index.yaml. Closes the writer-gap surfaced in specs/knowledge-surfaces.md. | Jason | open | 2026-05-07 | spec-knowledge-surfaces |  |  |
 | A-020 |  | Connect SessionStart hook to knowledge/patterns/*.yaml: filter by tier=critical AND lifecycle.status in (validated, pilot); emit alongside the hardcoded patterns-critical.md. Closes the reader-gap. | Jason | open | 2026-05-07 | spec-knowledge-surfaces |  |  |
 | A-021 |  | Drop dead knowledge/ subdirs (velocity/, project-summaries/, knowledge/specs/, sync.py, schema.sql, .agents/, __pycache__) alongside Phase 6C MCP archival (A-012). | Jason | open | 2026-05-07 | spec-knowledge-surfaces |  |  |
-=======
-| A-018 |  | Phase 6B P-4 — port /review-session skill to Python CLI at ~/agents/review-session/cli.py; SKILL.md becomes thin wrapper (gates on P-3) | Jason | open | 2026-05-07 | spec-phase6b-mcp-audit |  | 2026-05-07: GH issue #142 filed; PR incoming |
->>>>>>> origin/main
 
 ## Recently Closed
 

--- a/claude-config/commands/discover-patterns.md
+++ b/claude-config/commands/discover-patterns.md
@@ -70,9 +70,10 @@ Write to `knowledge/patterns/pat-<slug>.yaml`. Slug rules:
 - 3-6 words describing the rule (`pat-permission-dependency`, not `pat-auth`)
 - Filename and `id` field MUST match (slug invariant — see `sync.py` duplicate-id guard)
 
-Required fields (per `sync.py` PATTERN_REQUIRED — build rejects anything missing):
+Required fields (per `sync.py` PATTERN_REQUIRED — build rejects anything missing). `schema_version: 1` is required by the agents-repo schema convention (see `specs/knowledge-surfaces.md`):
 
 ```yaml
+schema_version: 1
 id: pat-<slug>
 category: <auth | database | api | frontend | infrastructure | workflow | testing | observability>
 name: <short human label, ≤10 words>

--- a/knowledge/decisions/D-015.yaml
+++ b/knowledge/decisions/D-015.yaml
@@ -1,3 +1,4 @@
+schema_version: 1
 id: D-015
 date: '2026-02-20'
 project: vitalailabs

--- a/knowledge/decisions/D-034.yaml
+++ b/knowledge/decisions/D-034.yaml
@@ -1,3 +1,4 @@
+schema_version: 1
 id: D-034
 date: '2026-04-03'
 project: flotilla

--- a/knowledge/decisions/D-042.yaml
+++ b/knowledge/decisions/D-042.yaml
@@ -1,3 +1,4 @@
+schema_version: 1
 id: D-042
 date: '2026-03-28'
 project: docketiq

--- a/knowledge/decisions/D-087.yaml
+++ b/knowledge/decisions/D-087.yaml
@@ -1,3 +1,4 @@
+schema_version: 1
 id: D-087
 date: '2026-04-04'
 project: docketiq

--- a/knowledge/decisions/D-091.yaml
+++ b/knowledge/decisions/D-091.yaml
@@ -1,3 +1,4 @@
+schema_version: 1
 id: D-091
 date: '2026-04-02'
 project: docketiq

--- a/knowledge/decisions/D-095.yaml
+++ b/knowledge/decisions/D-095.yaml
@@ -1,3 +1,4 @@
+schema_version: 1
 id: D-095
 date: '2026-04-07'
 project: flotilla

--- a/knowledge/decisions/D-096.yaml
+++ b/knowledge/decisions/D-096.yaml
@@ -1,3 +1,4 @@
+schema_version: 1
 id: D-096
 date: '2026-04-07'
 project: flotilla

--- a/knowledge/decisions/D-097.yaml
+++ b/knowledge/decisions/D-097.yaml
@@ -1,3 +1,4 @@
+schema_version: 1
 id: D-097
 date: '2026-04-07'
 project: flotilla

--- a/knowledge/decisions/D-098.yaml
+++ b/knowledge/decisions/D-098.yaml
@@ -1,3 +1,4 @@
+schema_version: 1
 id: D-098
 date: '2026-04-08'
 project: flotilla

--- a/knowledge/learning-rules/LR-001.yaml
+++ b/knowledge/learning-rules/LR-001.yaml
@@ -1,3 +1,4 @@
+schema_version: 1
 id: LR-001
 rule: Always use custom exception classes per module. Never use bare Exception.
 source: 14 human corrections across docketiq and vitalailabs

--- a/knowledge/learning-rules/LR-002.yaml
+++ b/knowledge/learning-rules/LR-002.yaml
@@ -1,3 +1,4 @@
+schema_version: 1
 id: LR-002
 rule: When fixing a concurrency bug, scan all projects for the same pattern.
 source: Post-incident from D-091. Bug existed in temper, docketiq, vitalailabs.

--- a/knowledge/learning-rules/LR-003.yaml
+++ b/knowledge/learning-rules/LR-003.yaml
@@ -1,3 +1,4 @@
+schema_version: 1
 id: LR-003
 rule: Use decimal.Decimal for all money amounts, never float.
 source: 3 human corrections on billing code

--- a/knowledge/learning-rules/LR-004.yaml
+++ b/knowledge/learning-rules/LR-004.yaml
@@ -1,3 +1,4 @@
+schema_version: 1
 id: LR-004
 rule: Frontend work packages must include API response shapes for every endpoint referenced. Never let a project agent guess field names.
 source: "AdminAgentCards failure 2026-04-07: agent wrote device.device_id instead of device.id because API shape was not in the work package"

--- a/knowledge/learning-rules/LR-005.yaml
+++ b/knowledge/learning-rules/LR-005.yaml
@@ -1,3 +1,4 @@
+schema_version: 1
 id: LR-005
 rule: Project agents must never commit directly to main. Always branch → PR → squash merge. The admin agent spawn command must include this instruction explicitly.
 source: "AdminAgentCards failure 2026-04-07: one-shot agent committed two commits directly to main, bypassing git workflow"

--- a/knowledge/learning-rules/LR-006.yaml
+++ b/knowledge/learning-rules/LR-006.yaml
@@ -1,3 +1,4 @@
+schema_version: 1
 id: LR-006
 rule: Work package completion requires validation against the original contract before reporting done. Validate branch used, PR merged, files match, code builds.
 source: "AdminAgentCards failure 2026-04-07: admin reported complete without checking if code worked or workflow was followed"

--- a/knowledge/patterns/agent-verification-gates.yaml
+++ b/knowledge/patterns/agent-verification-gates.yaml
@@ -1,3 +1,4 @@
+schema_version: 1
 id: pat-agent-verification-gates
 legacy_id: PAT-022
 category: agent-infrastructure

--- a/knowledge/patterns/annotated-deps.yaml
+++ b/knowledge/patterns/annotated-deps.yaml
@@ -1,3 +1,4 @@
+schema_version: 1
 id: pat-annotated-deps
 legacy_id: PAT-032
 category: dependency-injection

--- a/knowledge/patterns/auth-context.yaml
+++ b/knowledge/patterns/auth-context.yaml
@@ -1,3 +1,4 @@
+schema_version: 1
 id: pat-auth-context
 legacy_id: PAT-029
 category: frontend

--- a/knowledge/patterns/auth-jwt.yaml
+++ b/knowledge/patterns/auth-jwt.yaml
@@ -1,3 +1,4 @@
+schema_version: 1
 id: pat-auth-jwt
 legacy_id: PAT-001
 category: auth

--- a/knowledge/patterns/auth-redis-sessions.yaml
+++ b/knowledge/patterns/auth-redis-sessions.yaml
@@ -1,3 +1,4 @@
+schema_version: 1
 id: pat-auth-redis-sessions
 legacy_id: PAT-002
 category: auth

--- a/knowledge/patterns/behavioral-evals.yaml
+++ b/knowledge/patterns/behavioral-evals.yaml
@@ -1,3 +1,4 @@
+schema_version: 1
 id: pat-behavioral-evals
 legacy_id: PAT-023
 category: workflow

--- a/knowledge/patterns/caching-redis-ttl.yaml
+++ b/knowledge/patterns/caching-redis-ttl.yaml
@@ -1,3 +1,4 @@
+schema_version: 1
 id: pat-caching-redis-ttl
 legacy_id: PAT-003
 category: caching

--- a/knowledge/patterns/codex-delegation.yaml
+++ b/knowledge/patterns/codex-delegation.yaml
@@ -1,3 +1,4 @@
+schema_version: 1
 id: pat-codex-delegation
 legacy_id: PAT-024
 category: workflow

--- a/knowledge/patterns/core-failure-patterns.yaml
+++ b/knowledge/patterns/core-failure-patterns.yaml
@@ -1,3 +1,4 @@
+schema_version: 1
 id: pat-core-failure-patterns
 legacy_id: PAT-025
 category: workflow

--- a/knowledge/patterns/database-asyncpg.yaml
+++ b/knowledge/patterns/database-asyncpg.yaml
@@ -1,3 +1,4 @@
+schema_version: 1
 id: pat-database-asyncpg
 legacy_id: PAT-004
 category: database

--- a/knowledge/patterns/dev-scripts.yaml
+++ b/knowledge/patterns/dev-scripts.yaml
@@ -1,3 +1,4 @@
+schema_version: 1
 id: pat-dev-scripts
 legacy_id: PAT-033
 category: infrastructure

--- a/knowledge/patterns/dnd-kit-schedule.yaml
+++ b/knowledge/patterns/dnd-kit-schedule.yaml
@@ -1,3 +1,4 @@
+schema_version: 1
 id: pat-dnd-kit-schedule
 legacy_id: PAT-030
 category: frontend

--- a/knowledge/patterns/error-handling.yaml
+++ b/knowledge/patterns/error-handling.yaml
@@ -1,3 +1,4 @@
+schema_version: 1
 id: pat-error-handling
 legacy_id: PAT-006
 category: error-handling

--- a/knowledge/patterns/export-streaming.yaml
+++ b/knowledge/patterns/export-streaming.yaml
@@ -1,3 +1,4 @@
+schema_version: 1
 id: pat-export-streaming
 legacy_id: PAT-005
 category: export

--- a/knowledge/patterns/fastapi-alembic-setup.yaml
+++ b/knowledge/patterns/fastapi-alembic-setup.yaml
@@ -1,3 +1,4 @@
+schema_version: 1
 id: pat-fastapi-alembic-setup
 legacy_id: PAT-015
 category: migrations

--- a/knowledge/patterns/fastapi-auth-wiring.yaml
+++ b/knowledge/patterns/fastapi-auth-wiring.yaml
@@ -1,3 +1,4 @@
+schema_version: 1
 id: pat-fastapi-auth-wiring
 legacy_id: PAT-016
 category: auth

--- a/knowledge/patterns/fastapi-base-model.yaml
+++ b/knowledge/patterns/fastapi-base-model.yaml
@@ -1,3 +1,4 @@
+schema_version: 1
 id: pat-fastapi-base-model
 legacy_id: PAT-008
 category: database

--- a/knowledge/patterns/fastapi-database-layer.yaml
+++ b/knowledge/patterns/fastapi-database-layer.yaml
@@ -1,3 +1,4 @@
+schema_version: 1
 id: pat-fastapi-database-layer
 legacy_id: PAT-007
 category: database

--- a/knowledge/patterns/fastapi-dev-infrastructure.yaml
+++ b/knowledge/patterns/fastapi-dev-infrastructure.yaml
@@ -1,3 +1,4 @@
+schema_version: 1
 id: pat-fastapi-dev-infrastructure
 legacy_id: PAT-039
 category: infrastructure

--- a/knowledge/patterns/fastapi-error-handling.yaml
+++ b/knowledge/patterns/fastapi-error-handling.yaml
@@ -1,3 +1,4 @@
+schema_version: 1
 id: pat-fastapi-error-handling
 legacy_id: PAT-013
 category: error-handling

--- a/knowledge/patterns/fastapi-generic-repository.yaml
+++ b/knowledge/patterns/fastapi-generic-repository.yaml
@@ -1,3 +1,4 @@
+schema_version: 1
 id: pat-fastapi-generic-repository
 legacy_id: PAT-010
 category: repository

--- a/knowledge/patterns/fastapi-module.yaml
+++ b/knowledge/patterns/fastapi-module.yaml
@@ -1,3 +1,4 @@
+schema_version: 1
 id: pat-fastapi-module
 legacy_id: PAT-034
 category: architecture

--- a/knowledge/patterns/fastapi-router-layer.yaml
+++ b/knowledge/patterns/fastapi-router-layer.yaml
@@ -1,3 +1,4 @@
+schema_version: 1
 id: pat-fastapi-router-layer
 legacy_id: PAT-012
 category: router

--- a/knowledge/patterns/fastapi-schema-layer.yaml
+++ b/knowledge/patterns/fastapi-schema-layer.yaml
@@ -1,3 +1,4 @@
+schema_version: 1
 id: pat-fastapi-schema-layer
 legacy_id: PAT-009
 category: schema

--- a/knowledge/patterns/fastapi-service-layer.yaml
+++ b/knowledge/patterns/fastapi-service-layer.yaml
@@ -1,3 +1,4 @@
+schema_version: 1
 id: pat-fastapi-service-layer
 legacy_id: PAT-011
 category: service

--- a/knowledge/patterns/fastapi-tenant-scoping.yaml
+++ b/knowledge/patterns/fastapi-tenant-scoping.yaml
@@ -1,3 +1,4 @@
+schema_version: 1
 id: pat-fastapi-tenant-scoping
 legacy_id: PAT-017
 category: auth

--- a/knowledge/patterns/fastapi-test-fixtures.yaml
+++ b/knowledge/patterns/fastapi-test-fixtures.yaml
@@ -1,3 +1,4 @@
+schema_version: 1
 id: pat-fastapi-test-fixtures
 legacy_id: PAT-014
 category: testing

--- a/knowledge/patterns/flotilla-channel-agent-setup.yaml
+++ b/knowledge/patterns/flotilla-channel-agent-setup.yaml
@@ -1,3 +1,4 @@
+schema_version: 1
 id: pat-flotilla-channel-agent-setup
 legacy_id: PAT-018
 category: agent-infrastructure

--- a/knowledge/patterns/git-workflow.yaml
+++ b/knowledge/patterns/git-workflow.yaml
@@ -1,3 +1,4 @@
+schema_version: 1
 id: pat-git-workflow
 legacy_id: PAT-026
 category: workflow

--- a/knowledge/patterns/implementation-routing.yaml
+++ b/knowledge/patterns/implementation-routing.yaml
@@ -1,3 +1,4 @@
+schema_version: 1
 id: pat-implementation-routing
 legacy_id: PAT-027
 category: workflow

--- a/knowledge/patterns/nested-read-schemas.yaml
+++ b/knowledge/patterns/nested-read-schemas.yaml
@@ -1,3 +1,4 @@
+schema_version: 1
 id: pat-nested-read-schemas
 legacy_id: PAT-035
 category: schemas

--- a/knowledge/patterns/optimistic-concurrency.yaml
+++ b/knowledge/patterns/optimistic-concurrency.yaml
@@ -1,3 +1,4 @@
+schema_version: 1
 id: pat-optimistic-concurrency
 legacy_id: PAT-036
 category: concurrency

--- a/knowledge/patterns/pagination-response.yaml
+++ b/knowledge/patterns/pagination-response.yaml
@@ -1,3 +1,4 @@
+schema_version: 1
 id: pat-pagination-response
 legacy_id: PAT-037
 category: schemas

--- a/knowledge/patterns/react-query-hook.yaml
+++ b/knowledge/patterns/react-query-hook.yaml
@@ -1,3 +1,4 @@
+schema_version: 1
 id: pat-react-query-hook
 legacy_id: PAT-028
 category: frontend

--- a/knowledge/patterns/schema-trio.yaml
+++ b/knowledge/patterns/schema-trio.yaml
@@ -1,3 +1,4 @@
+schema_version: 1
 id: pat-schema-trio
 legacy_id: PAT-038
 category: schemas

--- a/knowledge/patterns/strategic-agent-chain.yaml
+++ b/knowledge/patterns/strategic-agent-chain.yaml
@@ -1,3 +1,4 @@
+schema_version: 1
 id: pat-strategic-agent-chain
 legacy_id: PAT-020
 category: agent-infrastructure

--- a/knowledge/patterns/transcript-summary-detail.yaml
+++ b/knowledge/patterns/transcript-summary-detail.yaml
@@ -1,3 +1,4 @@
+schema_version: 1
 id: pat-transcript-summary-detail
 legacy_id: PAT-021
 category: agent-infrastructure

--- a/knowledge/patterns/websocket-singleton.yaml
+++ b/knowledge/patterns/websocket-singleton.yaml
@@ -1,3 +1,4 @@
+schema_version: 1
 id: pat-websocket-singleton
 legacy_id: PAT-031
 category: frontend

--- a/knowledge/patterns/work-package-issue-template.yaml
+++ b/knowledge/patterns/work-package-issue-template.yaml
@@ -1,3 +1,4 @@
+schema_version: 1
 id: pat-work-package-issue-template
 legacy_id: PAT-019
 category: agent-infrastructure

--- a/knowledge/projects/agents.yaml
+++ b/knowledge/projects/agents.yaml
@@ -1,3 +1,4 @@
+schema_version: 1
 project: agents
 status: active
 focus: Stack consolidation complete (Phases 0, 1, 2, 4, 5 shipped). Phase 3

--- a/knowledge/projects/buddy.yaml
+++ b/knowledge/projects/buddy.yaml
@@ -1,3 +1,4 @@
+schema_version: 1
 project: buddy
 status: paused
 focus: "Meeting transcription pipeline"

--- a/knowledge/projects/flotilla.yaml
+++ b/knowledge/projects/flotilla.yaml
@@ -1,3 +1,4 @@
+schema_version: 1
 project: flotilla
 status: done
 focus: Archived 2026-05-06 as part of agents Phase 2 (Option B — drop

--- a/knowledge/projects/mymoney-dev.yaml
+++ b/knowledge/projects/mymoney-dev.yaml
@@ -1,3 +1,4 @@
+schema_version: 1
 project: mymoney-dev
 status: paused
 focus: "Financial planning platform"

--- a/knowledge/projects/paul-jason.yaml
+++ b/knowledge/projects/paul-jason.yaml
@@ -1,3 +1,4 @@
+schema_version: 1
 project: paul-jason
 status: active
 focus: Paul and Jason recurring one-on-one

--- a/knowledge/projects/prd-generator.yaml
+++ b/knowledge/projects/prd-generator.yaml
@@ -1,3 +1,4 @@
+schema_version: 1
 project: prd-generator
 status: paused
 focus: "PRD generator for product requirements"

--- a/knowledge/projects/temper.yaml
+++ b/knowledge/projects/temper.yaml
@@ -1,3 +1,4 @@
+schema_version: 1
 project: temper
 status: paused
 focus: "AI SDLC Orchestrator — spec-to-PR pipeline"

--- a/lib/project_resolver.py
+++ b/lib/project_resolver.py
@@ -94,6 +94,7 @@ def register_project(name: str, owner: str = "jason") -> Path:
         raise FileExistsError(f"project yaml already exists: {yaml_path}")
     today_str = date.today().isoformat()
     content = (
+        f"schema_version: 1\n"
         f"project: {name}\n"
         f"status: active\n"
         f'focus: ""\n'

--- a/project/cli.py
+++ b/project/cli.py
@@ -46,6 +46,7 @@ from lib.project_resolver import (  # noqa: E402
 
 ALLOWED_STATUS = ("active", "paused", "blocked", "done")
 PROJECT_FIELDS_ORDER = [
+    "schema_version",
     "project", "status", "focus", "next_steps", "blockers",
     "open_questions", "specs", "dependencies", "updated_at", "updated_by",
 ]

--- a/project/tests/test_cli.py
+++ b/project/tests/test_cli.py
@@ -269,6 +269,39 @@ def test_atomic_write_no_temp_left_behind(monkeypatch, tmp_path):
     assert leftover == []
 
 
+def test_schema_version_preserved_on_write(monkeypatch, tmp_path):
+    """An existing schema_version field must survive apply_updates round-trip.
+
+    The agents-repo YAML schema convention (specs/knowledge-surfaces.md) puts
+    schema_version first; any write path that drops it would silently break
+    forward-compat tooling.
+    """
+    versioned_yaml = "schema_version: 1\n" + _MIN_YAML
+    yaml_path = _patch_resolver(monkeypatch, tmp_path, "testproj", versioned_yaml)
+    rc = cli.main(["testproj", "--focus", "round-tripped", "--no-prompt"])
+    assert rc == 0
+    text = yaml_path.read_text()
+    assert "schema_version: 1" in text
+    # And it remains the first non-comment field.
+    first_field = text.lstrip().splitlines()[0]
+    assert first_field.startswith("schema_version:")
+
+
+def test_register_project_writes_schema_version(monkeypatch, tmp_path):
+    """register_project (auto-create on first --subscribe of a known repo dir)
+    must seed schema_version: 1."""
+    from lib import project_resolver as pr
+
+    projects_dir = tmp_path / "knowledge" / "projects"
+    projects_dir.mkdir(parents=True)
+    subs_file = tmp_path / "subs.json"
+    monkeypatch.setattr(pr, "KNOWLEDGE_PROJECTS_DIR", projects_dir)
+    monkeypatch.setattr(pr, "SUBSCRIPTIONS_PATH", subs_file)
+    yaml_path = pr.register_project("brandnew", owner="jason")
+    text = yaml_path.read_text()
+    assert text.splitlines()[0] == "schema_version: 1"
+
+
 # ---------- argparse / mode resolution ----------
 
 def test_no_args_no_writes_is_read_mode(monkeypatch, tmp_path, capsys):

--- a/specs/knowledge-surfaces.md
+++ b/specs/knowledge-surfaces.md
@@ -1,0 +1,225 @@
+# Knowledge Surfaces — Authority Map & Scoping Rules
+
+> **Status**: FINAL — 2026-05-07
+> **Context**: Phase 6 follow-up. After collapsing the Knowledge MCP into
+> filesystem-native CLIs, knowledge state is spread across multiple
+> directories with no single source of truth doc. This spec maps every
+> surface to "authoritative for X / written by Y / read by Z," locks in
+> the per-project vs. global scoping rules, and standardizes a
+> `schema_version` field for forward compatibility.
+
+---
+
+## TL;DR
+
+| Surface | Scope | Status | Authoritative for |
+|---|---|---|---|
+| `knowledge/projects/<name>.yaml` | per-project | ALIVE | project tracker (focus, status, blockers, next_steps, open_questions) |
+| `knowledge/decisions/D-NNN.yaml` | per-project (`project:` field) | DORMANT — no writer | architecturally significant decisions |
+| `knowledge/patterns/pat-<slug>.yaml` | global (no `project:` field) | CATALOG-ONLY — no live reader | reusable code patterns + lifecycle (pilot → validated) |
+| `knowledge/learning-rules/LR-NNN.yaml` | global | DORMANT — no recent writer | failure-derived rules surfaced at SessionStart |
+| `knowledge/decisions/index.yaml` | global index | maintained | by-project / by-topic index of decisions |
+| `~/.claude/memory/patterns-critical.md` | global, per-machine | ALIVE — loaded by SessionStart | "Top 3 critical patterns" injection |
+| `~/.claude/projects/<…>/memory/MEMORY.md` | per-Claude-session, per-machine | ALIVE — auto-memory | conversation-spanning user/feedback/project memories |
+| `<repo>/ACTIONS.md` | per-repo | ALIVE — `action` CLI writes | open and recently-closed actions |
+| `<repo>/specs/*.md` | per-repo | ALIVE — hand-edited | architectural decision docs (this file is one) |
+| `<repo>/PLAN.md` | per-repo | ALIVE — hand-edited | phased delivery plan |
+| `~/.claude/dashboard-subscriptions.json` | per-machine | ALIVE — `project --subscribe` writes | which projects this machine sees in `/dashboard` |
+| `~/.claude/pending_focus_reviews.json` | per-machine | ALIVE — session-end hook writes | session activity awaiting focus update |
+| `knowledge.db` (+ `.db-shm`, `.db-wal`) | DB | DEAD — dies in 6C | (no live readers; archived with knowledge-mcp/) |
+| `knowledge/velocity/V-*.yaml` | per-project | DEAD — no writer or reader | (cancelled — drop) |
+| `knowledge/project-summaries/` | empty | DEAD | (drop) |
+| `knowledge/specs/` | orphan | DEAD — design docs from before | (move or drop in 6C cleanup) |
+
+---
+
+## Audit findings (2026-05-07)
+
+| Surface | File count | Most recent write | Notes |
+|---|---|---|---|
+| `knowledge/projects/` | 7 | 2026-05-06 | Schema: project, status, focus, next_steps, blockers, open_questions, specs, dependencies, updated_at, updated_by |
+| `knowledge/decisions/` | 9 D-NNN + index.yaml | 2026-04-17 (D-098) | Already has `project:` field. Last written 20 days ago. **No writer in claude-config/skills/ or any CLI.** |
+| `knowledge/patterns/` | 40+ pat-*.yaml | 2026-04-28 (mass restore) | No `project:` field. Rich lifecycle states. **SessionStart loads `patterns-critical.md` (hardcoded MD), not these YAMLs.** |
+| `knowledge/learning-rules/` | 6 LR-NNN | 2026-04-07 (LR-006) | Schema: id, rule, source, confidence, applies_to, approved, created_at |
+| `knowledge.db` (WAL alone is 4MB) | DB tables | 2026-05-06 (timestamp) | Phase 6B audit: 18/20 MCP tools have zero callers; remaining 2 are now ported. **Dies in 6C.** |
+| `knowledge/velocity/` | 2 V-NNN | 2026-04-06 | No writer, no reader, drop. |
+| `knowledge/project-summaries/` | 0 | — | Empty directory, drop. |
+| `knowledge/specs/` | 2 *.md | 2026-04-28 (timestamp) | Old knowledge-base design docs from pre-Phase 6. **Not the same as `~/agents/specs/`.** Move or drop. |
+
+**Two structural gaps to surface:**
+
+1. **No writer for decisions.** Last `D-NNN.yaml` was 20 days ago. The `save_decision` MCP tool had zero callers in the Phase 6B audit (`specs/phase6b-mcp-audit.md`); the documented fallback is "hand-edit," and at the rate decisions are made, that's not happening. Without a writer the `decisions/` surface decays into a graveyard.
+2. **No reader for the pattern catalog.** SessionStart hook loads `~/.claude/memory/patterns-critical.md` (a curated markdown file) but never opens `knowledge/patterns/*.yaml`. The lifecycle (`status: pilot|validated|deprecated`, `consecutive_successes` counter) is unused — patterns can be marked validated but nothing acts on the marking.
+
+These are filed as follow-up actions (A-019, A-020). They are **out of scope for this spec PR**, which is decision-only.
+
+---
+
+## Scoping rules (FINAL)
+
+These rules are observed in the existing data and codified here so future work doesn't drift.
+
+### Per-project surfaces
+
+A surface is **per-project** if its records are scoped to a single project's lifecycle.
+
+| Surface | Mechanism |
+|---|---|
+| `knowledge/projects/<name>.yaml` | Filename = project name. One file per project. |
+| `knowledge/decisions/D-NNN.yaml` | `project:` field inside each YAML (e.g. D-042 → `docketiq`). Cross-references via `linked.related_decisions`. |
+| `<repo>/ACTIONS.md` | Lives in the project repo. |
+| `<repo>/specs/`, `<repo>/PLAN.md` | Live in the project repo. |
+
+**Rule for new decisions:** every `D-NNN.yaml` MUST have a `project:` field. If a decision spans projects, list the primary project and reference others via `linked.related_decisions`.
+
+### Global surfaces
+
+A surface is **global** (cross-project) if its records describe knowledge that applies across multiple projects.
+
+| Surface | Mechanism |
+|---|---|
+| `knowledge/patterns/pat-<slug>.yaml` | No `project:` field. Patterns are intentionally project-agnostic; `when_to_use` describes applicability. |
+| `knowledge/learning-rules/LR-NNN.yaml` | No `project:` field. `applies_to` is a free-text scope (e.g. `"all projects with frontend + API"`). |
+| `~/.claude/memory/patterns-critical.md` | Hardcoded "Top 3" curated for global injection. |
+
+**Rule for new patterns:** never add a `project:` field. If a pattern is genuinely project-specific, it belongs in `<repo>/knowledge/patterns/` (per-repo via `/discover-patterns`), not in the agents-repo central catalog.
+
+### Per-machine surfaces
+
+These never get committed; they describe the local view, not shared knowledge.
+
+| Surface | Why per-machine |
+|---|---|
+| `~/.claude/dashboard-subscriptions.json` | Each laptop subscribes to a different subset |
+| `~/.claude/pending_focus_reviews.json` | Session-end hook writes from this machine's commit history |
+| `~/.claude/projects/<…>/memory/MEMORY.md` | Auto-memory tied to this machine's Claude sessions |
+
+These are intentionally NOT in `~/agents/` — they don't sync via git. This was the explicit Phase 6A decision and stays.
+
+---
+
+## Schema versioning (FINAL)
+
+Every YAML form gets a `schema_version` field. Reasoning: the schemas WILL evolve (the `dependencies` and `specs` arrays in project YAMLs are already underused; pattern lifecycle may consolidate states). Without a version field, tooling can't tell v1 from v2 records, and migrations become guesswork.
+
+### Decision
+
+Add `schema_version: 1` as the **first non-comment line** of every YAML file in:
+
+- `knowledge/projects/*.yaml`
+- `knowledge/decisions/D-NNN.yaml` (NOT `index.yaml` — that's an index, not a record)
+- `knowledge/patterns/pat-*.yaml`
+- `knowledge/learning-rules/LR-NNN.yaml`
+
+### Writer responsibility
+
+- `lib/project_resolver.register_project()` (called by `project` CLI auto-register and by future scaffolders) must write `schema_version: 1` on creation.
+- Any future decision-writer (A-019) must write `schema_version: 1`.
+- `/discover-patterns` skill must write `schema_version: 1` in new pattern files.
+
+### Backfill
+
+Existing files get `schema_version: 1` injected at the top, in this PR's follow-up implementation work (separate from this decision doc, per the decision-first workflow).
+
+### When to bump
+
+- `schema_version` increments **only when fields are removed or their meaning changes**.
+- Adding new optional fields → no bump.
+- Renaming a field → bump.
+- Changing a field's type or semantics → bump.
+
+When bumping, writers must emit the new version; readers must accept both during a deprecation window (≥30 days).
+
+---
+
+## What stays / what dies
+
+### Stays (alive or fixable)
+
+| Surface | Action |
+|---|---|
+| `knowledge/projects/` | No change. Add `schema_version`. |
+| `knowledge/decisions/` (D-NNN + index) | **Fix the writer gap** (A-019). Add `schema_version`. |
+| `knowledge/patterns/` | **Fix the reader gap** (A-020). Add `schema_version`. |
+| `knowledge/learning-rules/` | Reader: SessionStart already loads via state_manager (verify in A-020 work). Add `schema_version`. |
+| `~/.claude/memory/patterns-critical.md` | Curated injection layer. Stays. |
+
+### Dies (with Phase 6C archive, A-012)
+
+| Surface | Disposition |
+|---|---|
+| `knowledge.db` + `.db-wal` + `.db-shm` | Archived with `~/agents/knowledge-mcp/` (A-012). No data migrated; the audit confirmed no live readers. |
+| `knowledge/velocity/` | Drop directory. |
+| `knowledge/project-summaries/` | Drop empty directory. |
+| `knowledge/specs/` (the orphan one inside knowledge/) | Move surviving content (if any) to `~/agents/specs/` or drop. |
+| `knowledge/sync.py`, `knowledge/schema.sql` | Drop with the MCP server in 6C. |
+| `knowledge/.agents/`, `knowledge/.pytest_cache/`, `knowledge/__pycache__/` | Drop with the MCP server in 6C. |
+
+These dispositions are bundled into the A-012 archival PR; not this spec.
+
+---
+
+## Follow-up actions (file separately)
+
+These are scoped here so the gaps don't become permanent and the spec PR stays decision-only.
+
+### A-019 — build a decision-writer
+
+**Why:** the `decisions/` surface decays into a graveyard without a writer. Last D-NNN.yaml was 20 days ago.
+
+**Options:**
+
+- **(a)** New `decision` CLI: `decision new --project X --topic auth --title "..." --context "..."` → writes `knowledge/decisions/D-NNN.yaml` and updates `index.yaml`.
+- **(b)** `--decide` subcommand on `action` CLI: reuses the YAML-write plumbing already there, plus the project resolver.
+- **(c)** Lightweight `/decision` skill that prompts the user through fields and writes the YAML. (Most discoverable but heaviest to maintain.)
+
+**Recommendation:** (a) — same shape as `action`/`project`/`dashboard`/`review-session`. Keeps the converged-pattern story clean.
+
+**Sizing:** SIMPLE — ~250 LOC + tests. Reuses `lib/project_resolver.py`.
+
+### A-020 — connect SessionStart to YAML patterns
+
+**Why:** the `lifecycle` and `consecutive_successes` machinery in `knowledge/patterns/*.yaml` is theoretical until something reads it.
+
+**Scope:** extend `claude-config/hooks/sessionstart_restore_state.py` to:
+
+1. Read `knowledge/patterns/*.yaml` filtered by `tier: critical` AND `lifecycle.status in (validated, pilot)`.
+2. Emit a compact summary into the SessionStart context (next to `patterns-critical.md`).
+3. Keep the hardcoded `patterns-critical.md` as the curated injection (the YAMLs are richer reference, not replacement).
+
+**Sizing:** SIMPLE — hook edit + one new function. Need to verify token budget impact (SessionStart aims for ~500 tokens total).
+
+### A-021 — clean up the dead knowledge/ subdirs
+
+**Why:** `velocity/`, `project-summaries/`, `knowledge/specs/` are confusing dead surfaces.
+
+**Scope:** drop these in the same PR as 6C archival (A-012), since they're all retired together.
+
+**Sizing:** TRIVIAL — `git rm -r`.
+
+---
+
+## Out of scope for this spec
+
+- Cross-device project state (Phase 7 / A-013). Per-machine surfaces are intentional; the cross-device problem is a separate decision in `specs/cross-device-state.md` if/when that work happens.
+- Splitting `<repo>/knowledge/patterns/` (per-repo) from `~/agents/knowledge/patterns/` (central) into a unified catalog. Today these are independent. If pattern fragmentation becomes a real pain, a future spec can address it.
+- Migrating any data out of `knowledge.db` before 6C archive. The audit confirmed nothing in there is being read; the user can extract specific tables manually if anything is wanted.
+
+---
+
+## Acceptance
+
+- [x] Audit captured (this doc).
+- [x] Scoping rules formalized (per-project / global / per-machine).
+- [x] `schema_version` decision recorded (start at 1; bump only on breaking changes).
+- [x] Writer/reader gaps explicitly named (A-019, A-020).
+- [x] Dead surfaces explicitly named for 6C cleanup (A-021).
+
+## Sign-off
+
+Decision-only. No code in this spec PR. Implementation rolls in:
+
+- This PR (or a follow-up): `schema_version: 1` backfill across all alive forms + writer updates.
+- A-019 PR: decision writer.
+- A-020 PR: pattern-catalog reader at SessionStart.
+- A-012 / A-021: drop dead surfaces alongside 6C archival.


### PR DESCRIPTION
## Summary
Phase 6 follow-up. Knowledge state had spread across multiple directories with no source-of-truth doc. This PR:

- Adds **`specs/knowledge-surfaces.md`** — audit + map + scoping rules + schema-versioning standard + identified gaps.
- Backfills **`schema_version: 1`** to all 61 alive YAMLs (7 projects, 9 decisions, 39 patterns, 6 learning rules). Skips `decisions/index.yaml` (it's an index, not a record).
- Updates writers: `lib/project_resolver.register_project`, `project/cli.py PROJECT_FIELDS_ORDER` (field-first for round-trip), `claude-config/commands/discover-patterns.md` template.
- 2 new round-trip safety tests.
- Files **A-019** (decision-writer), **A-020** (SessionStart pattern reader), **A-021** (drop dead knowledge/ subdirs in 6C) so the writer/reader gaps don't ossify.

## Scoping rules formalized (already encoded in the data)
- **per-project**: `knowledge/projects/<name>.yaml`, `knowledge/decisions/D-NNN.yaml` (`project:` field), `<repo>/ACTIONS.md`, `<repo>/specs/`, `<repo>/PLAN.md`
- **global**: `knowledge/patterns/pat-*.yaml` (no `project:` field by intent), `knowledge/learning-rules/LR-*.yaml`, `~/.claude/memory/patterns-critical.md`
- **per-machine**: `~/.claude/dashboard-subscriptions.json`, `~/.claude/pending_focus_reviews.json` (intentionally not synced)

## Notable findings (in spec)
- Decisions surface dormant — no writer; last D-NNN.yaml 20 days ago. Filed A-019.
- Pattern catalog has rich lifecycle data but SessionStart loads hardcoded MD instead. Filed A-020.
- Several `knowledge/` subdirs (`velocity/`, `project-summaries/`, `knowledge/specs/`) are dead. Filed A-021.

## Out of scope
- Building the decision writer (A-019).
- Wiring SessionStart to YAML patterns (A-020).
- Dropping dead subdirs (A-021, bundled with 6C).
- Cross-device project state (Phase 7 / A-013).

## Closes
Closes #144. Closes A-NNN follow-ups filed today (A-019, A-020, A-021 remain open).

## Test plan
- [x] `pytest project/tests/ action/tests/ review_session/tests/` — 79 pass (2 new schema_version tests added)
- [x] Backfill round-trip verified via `yaml.safe_load` on every modified file
- [x] `cd knowledge && python3 sync.py build` succeeds (39 patterns, 9 decisions, 6 rules built)
- [x] User's real `~/.claude/dashboard-subscriptions.json` not polluted
- [x] No rogue test YAMLs in real `knowledge/projects/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)