### PR TITLE
feat(host-field): Phase 7.1 cross-device foundation — decision doc + host: field (A-013)

### DIFF
--- a/ACTIONS.md
+++ b/ACTIONS.md
@@ -18,7 +18,6 @@ _(none yet)_
 
 | ID | Issue | Action | Owner | Status | Opened | Src | Files | Notes |
 |----|----|----|----|----|----|----|----|----|
-| A-013 |  | Phase 7 — investigate cross-device project state; evaluate git-as-sync vs SSH-based remote read vs centralized store; output decision doc at specs/cross-device-state.md (gated on 6A complete) | Jason | open | 2026-05-07 | spec-toolchain-consolidation |  |  |
 | A-018 |  | Phase 6B P-4 — port /review-session skill to Python CLI at ~/agents/review-session/cli.py; SKILL.md becomes thin wrapper (gates on P-3) | Jason | open | 2026-05-07 | spec-phase6b-mcp-audit |  | 2026-05-07: GH issue #142 filed; PR incoming |
 | A-020 |  | Connect SessionStart hook to knowledge/patterns/*.yaml: filter by tier=critical AND lifecycle.status in (validated, pilot); emit alongside the hardcoded patterns-critical.md. Closes the reader-gap. | Jason | open | 2026-05-07 | spec-knowledge-surfaces |  |  |
 
@@ -44,6 +43,7 @@ _(none yet)_
 | A-012 |  | Phase 6C — archive ~/agents/knowledge-mcp/, drop MCP registration from settings.json, update PLAN.md target architecture (gated on 6B) | Jason | 2026-05-07 |  | 2026-05-07: PR #146 incoming |
 | A-021 |  | Drop dead knowledge/ subdirs (velocity/, project-summaries/, knowledge/specs/, sync.py, schema.sql, .agents/, __pycache__) alongside Phase 6C MCP archival (A-012). | Jason | 2026-05-07 |  | 2026-05-07: Bundled in PR #146 |
 | A-019 |  | Build decision-writer CLI: 'decision new --project X --topic Y --title Z' that writes knowledge/decisions/D-NNN.yaml + updates index.yaml. Closes the writer-gap surfaced in specs/knowledge-surfaces.md. | Jason | 2026-05-07 |  | 2026-05-07: Shipped in PR #148-incoming. New decision/cli.py + thin SKILL.md wrapper. 23 unit tests + smoke against existing 9 decisions. |
+| A-013 |  | Phase 7 — investigate cross-device project state; evaluate git-as-sync vs SSH-based remote read vs centralized store; output decision doc at specs/cross-device-state.md (gated on 6A complete) | Jason | 2026-05-08 |  | 2026-05-08: Phase 7.1 shipped in PR #150-incoming. Decision doc + host: field + ~/.claude/host-name mechanism. 7.2/7.3 deferred until trigger conditions met (per spec). |
 
 ## Archive
 

--- a/knowledge/projects/agents.yaml
+++ b/knowledge/projects/agents.yaml
@@ -1,5 +1,6 @@
 schema_version: 1
 project: agents
+host: jns-mac
 status: active
 focus: Stack consolidation complete (Phases 0, 1, 2, 4, 5 shipped). Phase 3
   (artifact pruning) deferred until usage logger lands.

--- a/knowledge/projects/buddy.yaml
+++ b/knowledge/projects/buddy.yaml
@@ -1,5 +1,6 @@
 schema_version: 1
 project: buddy
+host: jns-mac
 status: paused
 focus: "Meeting transcription pipeline"
 next_steps:

--- a/knowledge/projects/flotilla.yaml
+++ b/knowledge/projects/flotilla.yaml
@@ -1,5 +1,6 @@
 schema_version: 1
 project: flotilla
+host: jns-mac
 status: done
 focus: Archived 2026-05-06 as part of agents Phase 2 (Option B — drop
   multi-agent channels). Local clone moved to ~/projects/_archived/flotilla.

--- a/knowledge/projects/mymoney-dev.yaml
+++ b/knowledge/projects/mymoney-dev.yaml
@@ -1,5 +1,6 @@
 schema_version: 1
 project: mymoney-dev
+host: jns-mac
 status: paused
 focus: "Financial planning platform"
 next_steps: []

--- a/knowledge/projects/paul-jason.yaml
+++ b/knowledge/projects/paul-jason.yaml
@@ -1,5 +1,6 @@
 schema_version: 1
 project: paul-jason
+host: jns-mac
 status: active
 focus: Paul and Jason recurring one-on-one
 next_steps: []

--- a/knowledge/projects/prd-generator.yaml
+++ b/knowledge/projects/prd-generator.yaml
@@ -1,5 +1,6 @@
 schema_version: 1
 project: prd-generator
+host: jns-mac
 status: paused
 focus: "PRD generator for product requirements"
 next_steps: []

--- a/knowledge/projects/temper.yaml
+++ b/knowledge/projects/temper.yaml
@@ -1,5 +1,6 @@
 schema_version: 1
 project: temper
+host: jns-mac
 status: paused
 focus: "AI SDLC Orchestrator — spec-to-PR pipeline"
 next_steps:

--- a/lib/project_resolver.py
+++ b/lib/project_resolver.py
@@ -1,4 +1,4 @@
-"""Project name resolution + registration + per-machine subscriptions.
+"""Project name resolution + registration + per-machine subscriptions + host name.
 
 Tool-agnostic. Used by `action/cli.py`, `project/cli.py`, and any future
 CLI that needs to resolve a project name from cwd / --project flag and
@@ -11,7 +11,9 @@ Public API:
 - project_dir_exists(name) -> bool
 - read_subscriptions() -> list[str]
 - add_subscription(name) / remove_subscription(name)
-- register_project(name, owner='jason') -> Path  (writes default YAML)
+- get_host_name() -> str  (reads ~/.claude/host-name, falls back to gethostname)
+- set_host_name(name) -> None  (writes the file)
+- register_project(name, owner='jason', host=None) -> Path  (writes default YAML)
 - interactive_pick(candidates, header) -> str  (TTY)
 - resolve_with_picker(name, no_prompt=False) -> str  (combined resolver)
 
@@ -21,6 +23,7 @@ their own user-facing error type.
 from __future__ import annotations
 
 import json
+import socket
 import sys
 from datetime import date
 from pathlib import Path
@@ -28,6 +31,7 @@ from pathlib import Path
 HOME = Path.home()
 KNOWLEDGE_PROJECTS_DIR = HOME / "agents" / "knowledge" / "projects"
 SUBSCRIPTIONS_PATH = HOME / ".claude" / "dashboard-subscriptions.json"
+HOST_NAME_PATH = HOME / ".claude" / "host-name"
 
 
 class ProjectResolutionError(Exception):
@@ -84,8 +88,11 @@ def list_known_projects() -> list[str]:
     return filtered if filtered else all_registered
 
 
-def register_project(name: str, owner: str = "jason") -> Path:
+def register_project(name: str, owner: str = "jason", host: str | None = None) -> Path:
     """Write a default YAML to knowledge/projects/<name>.yaml + subscribe this machine.
+
+    `host` declares which host owns this project (Phase 7.1; see
+    specs/cross-device-state.md). If None, autodetected via get_host_name().
 
     Raises FileExistsError if YAML already exists. Returns the YAML path.
     """
@@ -93,9 +100,11 @@ def register_project(name: str, owner: str = "jason") -> Path:
     if yaml_path.exists():
         raise FileExistsError(f"project yaml already exists: {yaml_path}")
     today_str = date.today().isoformat()
+    host_str = host if host is not None else get_host_name()
     content = (
         f"schema_version: 1\n"
         f"project: {name}\n"
+        f"host: {host_str}\n"
         f"status: active\n"
         f'focus: ""\n'
         f"next_steps: []\n"
@@ -110,6 +119,36 @@ def register_project(name: str, owner: str = "jason") -> Path:
     yaml_path.write_text(content)
     add_subscription(name)
     return yaml_path
+
+
+# ---------- per-machine host name ----------
+
+def get_host_name() -> str:
+    """Read the canonical host name for this machine.
+
+    Reads `~/.claude/host-name` (one line). Falls back to a sanitized
+    `socket.gethostname()` if the file is absent — lowercased, first
+    segment only (strips `.local`, `.localdomain`, `.lan`, etc.).
+
+    Phase 7.1 — see specs/cross-device-state.md for context.
+    """
+    try:
+        text = HOST_NAME_PATH.read_text().strip()
+        if text:
+            return text
+    except FileNotFoundError:
+        pass
+    fallback = socket.gethostname() or "unknown"
+    return fallback.lower().split(".")[0]
+
+
+def set_host_name(name: str) -> None:
+    """Write the canonical host name to `~/.claude/host-name`. Idempotent."""
+    name = name.strip()
+    if not name:
+        raise ValueError("host name must be non-empty")
+    HOST_NAME_PATH.parent.mkdir(parents=True, exist_ok=True)
+    HOST_NAME_PATH.write_text(name + "\n")
 
 
 # ---------- subscriptions ----------

--- a/project/cli.py
+++ b/project/cli.py
@@ -38,16 +38,18 @@ from lib import project_resolver  # noqa: E402
 from lib.project_resolver import (  # noqa: E402
     ProjectResolutionError,
     add_subscription,
+    get_host_name,
     project_yaml_path,
     register_project,
     remove_subscription,
     resolve_with_picker,
+    set_host_name,
 )
 
 ALLOWED_STATUS = ("active", "paused", "blocked", "done")
 PROJECT_FIELDS_ORDER = [
     "schema_version",
-    "project", "status", "focus", "next_steps", "blockers",
+    "project", "host", "status", "focus", "next_steps", "blockers",
     "open_questions", "specs", "dependencies", "updated_at", "updated_by",
 ]
 DEFAULT_OWNER = "jason"
@@ -198,10 +200,11 @@ def render(data: dict) -> str:
     name = data.get("project", "?")
     status = (data.get("status") or "?").upper()
     updated = data.get("updated_at", "?")
+    host = data.get("host") or "?"
     lines = [
         f"PROJECT: {name}",
         "─" * width,
-        f"Status:    {status}    Updated: {updated}",
+        f"Status:    {status}    Host: {host}    Updated: {updated}",
     ]
     focus = (data.get("focus") or "").strip()
     if focus:
@@ -255,6 +258,11 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
                    help="Add to ~/.claude/dashboard-subscriptions.json (this machine).")
     p.add_argument("--unsubscribe", action="store_true",
                    help="Remove from ~/.claude/dashboard-subscriptions.json.")
+    p.add_argument("--set-host", dest="set_host", default=None,
+                   help="Set the project's host: field (e.g., jns-mac, vitalai-laptop, jbox06).")
+    p.add_argument("--register-host", dest="register_host", default=None, metavar="HOSTNAME",
+                   help="Write ~/.claude/host-name with the canonical name for THIS machine. "
+                        "Does not require a project name.")
     p.add_argument("--no-prompt", action="store_true", default=False,
                    help="Skip interactive picker; error if name is missing/unknown.")
     return p.parse_args(argv)
@@ -267,6 +275,15 @@ def main(argv: list[str] | None = None) -> int:
         argv = sys.argv[1:]
     try:
         args = parse_args(argv)
+
+        # Short-circuit: --register-host writes ~/.claude/host-name and exits.
+        # No project name required.
+        if args.register_host is not None:
+            set_host_name(args.register_host)
+            print(f"this machine is now registered as host: {args.register_host}")
+            print(f"  wrote {Path.home() / '.claude' / 'host-name'}")
+            print(f"  current autodetect: {get_host_name()}")
+            return 0
 
         # Resolve project name (cwd / explicit / picker / auto-register).
         name = resolve_with_picker(args.name, no_prompt=args.no_prompt)
@@ -281,9 +298,10 @@ def main(argv: list[str] | None = None) -> int:
             args.blocker, args.unblock,
             args.question, args.unquestion,
         ])
+        host_flag = args.set_host is not None
         sub_flags = args.subscribe or args.unsubscribe
 
-        if not write_flags and not sub_flags:
+        if not write_flags and not sub_flags and not host_flag:
             # Read mode.
             data = load_yaml(path)
             sys.stdout.write(render(data))
@@ -298,6 +316,18 @@ def main(argv: list[str] | None = None) -> int:
                 data["updated_at"] = today_iso()
                 data["updated_by"] = data.get("updated_by") or DEFAULT_OWNER
                 write_yaml(path, data)
+
+        # --set-host is operational (which host owns this project), not content.
+        # No updated_at bump — same precedent as --subscribe.
+        if host_flag:
+            data = load_yaml(path)
+            old_host = data.get("host")
+            if old_host == args.set_host:
+                applied.append(f"host already {args.set_host} for {name} (no-op)")
+            else:
+                data["host"] = args.set_host
+                write_yaml(path, data)
+                applied.append(f"host: {old_host or '(unset)'} → {args.set_host}")
 
         # Subscription flags (machine-local; never touch the YAML).
         if args.subscribe:

--- a/project/tests/test_cli.py
+++ b/project/tests/test_cli.py
@@ -295,11 +295,161 @@ def test_register_project_writes_schema_version(monkeypatch, tmp_path):
     projects_dir = tmp_path / "knowledge" / "projects"
     projects_dir.mkdir(parents=True)
     subs_file = tmp_path / "subs.json"
+    host_file = tmp_path / "host-name"
+    host_file.write_text("test-host\n")
     monkeypatch.setattr(pr, "KNOWLEDGE_PROJECTS_DIR", projects_dir)
     monkeypatch.setattr(pr, "SUBSCRIPTIONS_PATH", subs_file)
+    monkeypatch.setattr(pr, "HOST_NAME_PATH", host_file)
     yaml_path = pr.register_project("brandnew", owner="jason")
     text = yaml_path.read_text()
     assert text.splitlines()[0] == "schema_version: 1"
+
+
+# ---------- host: field (Phase 7.1) ----------
+
+def test_register_project_stamps_host_from_file(monkeypatch, tmp_path):
+    from lib import project_resolver as pr
+
+    projects_dir = tmp_path / "knowledge" / "projects"
+    projects_dir.mkdir(parents=True)
+    subs_file = tmp_path / "subs.json"
+    host_file = tmp_path / "host-name"
+    host_file.write_text("jns-mac\n")
+    monkeypatch.setattr(pr, "KNOWLEDGE_PROJECTS_DIR", projects_dir)
+    monkeypatch.setattr(pr, "SUBSCRIPTIONS_PATH", subs_file)
+    monkeypatch.setattr(pr, "HOST_NAME_PATH", host_file)
+
+    yaml_path = pr.register_project("hostproj")
+    data = yaml.safe_load(yaml_path.read_text())
+    assert data["host"] == "jns-mac"
+
+
+def test_register_project_falls_back_to_gethostname(monkeypatch, tmp_path):
+    """host-name file absent → gethostname() lowercased + first segment."""
+    from lib import project_resolver as pr
+
+    projects_dir = tmp_path / "knowledge" / "projects"
+    projects_dir.mkdir(parents=True)
+    subs_file = tmp_path / "subs.json"
+    monkeypatch.setattr(pr, "KNOWLEDGE_PROJECTS_DIR", projects_dir)
+    monkeypatch.setattr(pr, "SUBSCRIPTIONS_PATH", subs_file)
+    monkeypatch.setattr(pr, "HOST_NAME_PATH", tmp_path / "no-host-file")
+    monkeypatch.setattr(pr.socket, "gethostname", lambda: "Some-Host.local")
+
+    yaml_path = pr.register_project("fallback")
+    data = yaml.safe_load(yaml_path.read_text())
+    assert data["host"] == "some-host"  # lowercased + .local stripped
+
+
+def test_register_project_explicit_host_override(monkeypatch, tmp_path):
+    """register_project(host='jbox06') wins over the file/fallback."""
+    from lib import project_resolver as pr
+
+    projects_dir = tmp_path / "knowledge" / "projects"
+    projects_dir.mkdir(parents=True)
+    subs_file = tmp_path / "subs.json"
+    host_file = tmp_path / "host-name"
+    host_file.write_text("jns-mac\n")
+    monkeypatch.setattr(pr, "KNOWLEDGE_PROJECTS_DIR", projects_dir)
+    monkeypatch.setattr(pr, "SUBSCRIPTIONS_PATH", subs_file)
+    monkeypatch.setattr(pr, "HOST_NAME_PATH", host_file)
+
+    yaml_path = pr.register_project("override", host="jbox06")
+    data = yaml.safe_load(yaml_path.read_text())
+    assert data["host"] == "jbox06"
+
+
+def test_get_host_name_handles_empty_file(monkeypatch, tmp_path):
+    """Empty host-name file → fallback (file has empty content; we should not return '')."""
+    from lib import project_resolver as pr
+
+    host_file = tmp_path / "host-name"
+    host_file.write_text("\n")
+    monkeypatch.setattr(pr, "HOST_NAME_PATH", host_file)
+    monkeypatch.setattr(pr.socket, "gethostname", lambda: "Fallback-Host")
+    assert pr.get_host_name() == "fallback-host"
+
+
+def test_set_host_name_writes_file(monkeypatch, tmp_path):
+    from lib import project_resolver as pr
+
+    host_file = tmp_path / "host-name"
+    monkeypatch.setattr(pr, "HOST_NAME_PATH", host_file)
+    pr.set_host_name("jns-mac")
+    assert host_file.read_text().strip() == "jns-mac"
+    # idempotent
+    pr.set_host_name("jns-mac")
+    assert host_file.read_text().strip() == "jns-mac"
+
+
+def test_set_host_name_rejects_empty(monkeypatch, tmp_path):
+    from lib import project_resolver as pr
+
+    monkeypatch.setattr(pr, "HOST_NAME_PATH", tmp_path / "host-name")
+    with pytest.raises(ValueError):
+        pr.set_host_name("")
+    with pytest.raises(ValueError):
+        pr.set_host_name("   ")
+
+
+def test_register_host_flag_writes_file(monkeypatch, tmp_path, capsys):
+    """`project --register-host <name>` writes ~/.claude/host-name."""
+    host_file = tmp_path / "host-name"
+    monkeypatch.setattr(cli.project_resolver, "HOST_NAME_PATH", host_file)
+    rc = cli.main(["--register-host", "jns-mac"])
+    assert rc == 0
+    assert host_file.read_text().strip() == "jns-mac"
+    out = capsys.readouterr().out
+    assert "registered as host: jns-mac" in out
+
+
+def test_set_host_flag_updates_existing(monkeypatch, tmp_path):
+    versioned_yaml = "schema_version: 1\nproject: testproj\nhost: jns-mac\n" + _MIN_YAML
+    yaml_path = _patch_resolver(monkeypatch, tmp_path, "testproj", versioned_yaml)
+    rc = cli.main(["testproj", "--set-host", "jbox06", "--no-prompt"])
+    assert rc == 0
+    data = yaml.safe_load(yaml_path.read_text())
+    assert data["host"] == "jbox06"
+
+
+def test_set_host_flag_does_not_bump_updated_at(monkeypatch, tmp_path):
+    """--set-host is operational, not content. Same precedent as --subscribe."""
+    versioned_yaml = "schema_version: 1\nproject: testproj\nhost: jns-mac\n" + _MIN_YAML
+    yaml_path = _patch_resolver(monkeypatch, tmp_path, "testproj", versioned_yaml)
+    original_updated_at = yaml.safe_load(yaml_path.read_text())["updated_at"]
+    rc = cli.main(["testproj", "--set-host", "jbox06", "--no-prompt"])
+    assert rc == 0
+    new_updated_at = yaml.safe_load(yaml_path.read_text())["updated_at"]
+    assert new_updated_at == original_updated_at
+
+
+def test_set_host_flag_idempotent(monkeypatch, tmp_path, capsys):
+    versioned_yaml = "schema_version: 1\nproject: testproj\nhost: jns-mac\n" + _MIN_YAML
+    _patch_resolver(monkeypatch, tmp_path, "testproj", versioned_yaml)
+    rc = cli.main(["testproj", "--set-host", "jns-mac", "--no-prompt"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "no-op" in out
+
+
+def test_field_order_includes_host_between_project_and_status(monkeypatch, tmp_path):
+    versioned_yaml = "schema_version: 1\nproject: testproj\nhost: jns-mac\n" + _MIN_YAML
+    yaml_path = _patch_resolver(monkeypatch, tmp_path, "testproj", versioned_yaml)
+    cli.main(["testproj", "--focus", "trigger write", "--no-prompt"])
+    text = yaml_path.read_text()
+    project_idx = text.index("project:")
+    host_idx = text.index("host:")
+    status_idx = text.index("status:")
+    assert project_idx < host_idx < status_idx
+
+
+def test_render_includes_host(monkeypatch, tmp_path, capsys):
+    versioned_yaml = "schema_version: 1\nproject: testproj\nhost: jbox06\n" + _MIN_YAML
+    _patch_resolver(monkeypatch, tmp_path, "testproj", versioned_yaml)
+    rc = cli.main(["testproj", "--no-prompt"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Host: jbox06" in out
 
 
 # ---------- argparse / mode resolution ----------

--- a/specs/cross-device-state.md
+++ b/specs/cross-device-state.md
@@ -1,0 +1,252 @@
+# Cross-Device Project State
+
+> **Status**: FINAL — 2026-05-08 (Phase 7.1 only; 7.2 + 7.3 stubs reserved)
+> **Context**: A-013 closed the investigation half of `PLAN.md` Phase 7.
+> This doc is the architectural decision record. Implementation is split:
+> Phase 7.1 (this PR) is the spec + the cheap-insurance schema field;
+> Phase 7.2 (separate PR, triggered when needed) is the SSH-bridge
+> implementation that lets a single dashboard render see project state
+> across hosts.
+
+---
+
+## TL;DR
+
+- **Agents repo is the central state substrate.** All cross-cutting state
+  (`knowledge/projects/*.yaml`, `knowledge/decisions/*.yaml`, patterns,
+  learning rules, agents-repo-level `ACTIONS.md`) syncs across machines via
+  GitHub.
+- **Each project YAML carries a `host:` field** declaring which host owns
+  the project. Per-project `ACTIONS.md` lives inside the project's repo on
+  that host; cross-host visibility for it is a Phase 7.2 concern.
+- **Per-machine canonical name** lives in `~/.claude/host-name` (one line
+  of text). The `lib/project_resolver` autodetect reads this file or falls
+  back to a sanitized `socket.gethostname()`.
+- **No SSH bridge today.** Phase 7.1 is the schema decision and the
+  bookkeeping field. Phase 7.2 implements `lib/host_resolver.py` and the
+  dashboard's multi-host merge; ship it when an actual non-`jns-mac`
+  project is added and the asymmetry becomes felt.
+- **No write-from-anywhere today.** Existing pattern (Claude on a laptop
+  SSHs into the host and runs the CLI there) covers it. Phase 7.3 only if
+  that becomes a real friction point.
+
+---
+
+## Workflow context
+
+User's actual two-laptop, multi-host pattern (captured 2026-05-07/08):
+
+| Laptop | Class | Use |
+|---|---|---|
+| `vitalai-laptop` | work (WSL) | Primary daily driver. Runs Claude. SSHs into work hosts to manage codebases. |
+| `jns-mac` | personal (this MacBook) | Secondary. Same Claude-into-SSH pattern, lower frequency. |
+
+| Remote host | Class | Reachability |
+|---|---|---|
+| `jbox06` | work | LAN-only (172.16.20.58). Internal GitLab projects (172.16.20.50). Off-LAN today (laptop is at 10.20.30.54), `jbox06` is unreachable. |
+| `et01` | work | TBD network shape. |
+| `spark` | work | TBD network shape. |
+| `jns-server` | personal | LAN via `jns` (192.168.1.100). Cloudflare-tunneled via `jns-remote` (`mavisssh.jasonjob.com`) — reachable from anywhere. |
+
+The laptops both reach **GitHub** (HTTP 200, ~80ms). Internal GitLab is
+reachable only from `jbox06`'s network. Cloudflare-tunneled SSH (`jns-remote`)
+is reachable from anywhere.
+
+The user's verbalized usage pattern: *"I run Claude on the work laptop and
+have Claude ssh into the device to modify the codebase. This is a daily
+pattern. I do not do this as much from this MacBook. I intend to add
+projects to the jns-server in the near future and may do similar work
+pattern."*
+
+**Implications:**
+
+1. **Laptops are the state-management surface; remote hosts are runtime.**
+   Project tracker YAMLs, decisions, patterns, learning-rules — all live
+   on a laptop and sync via GitHub. Remote hosts run code; they don't
+   typically run `dashboard` or `decision new`.
+2. **Per-project `ACTIONS.md` is the asymmetric piece.** It lives inside
+   each project's repo (e.g., `~/app-repos/<vitalai-app>/ACTIONS.md` on
+   `jbox06`), reachable only on the host that clones the repo.
+3. **Reachability is mixed.** GitHub-reachable everywhere; LAN-only
+   `jbox06`; tunnel-reachable `jns-server`. A robust solution must
+   degrade gracefully when a host is unreachable.
+
+---
+
+## Architectural decisions
+
+### D-S1 — Agents repo is the central state substrate
+
+All cross-cutting state lives under `~/agents/knowledge/` and syncs via
+GitHub from any host that can reach GitHub. This includes:
+
+- `knowledge/projects/<name>.yaml` (per-project tracker)
+- `knowledge/decisions/D-NNN.yaml` + `index.yaml`
+- `knowledge/patterns/pat-*.yaml`
+- `knowledge/learning-rules/LR-*.yaml`
+- `~/agents/ACTIONS.md` (the agents repo's own actions)
+- `~/agents/PLAN.md`, `~/agents/specs/*.md`, `~/agents/CLAUDE.md`
+
+**Why:** GitHub is universally reachable. Git's merge-on-pull handles the
+low collision rate (different machines tend to edit different YAMLs).
+Filesystem-as-truth keeps tooling independent of any sync service.
+
+**How to apply:** every new laptop in the user's set should clone the
+agents repo. Pulls/pushes happen on the cadence the user prefers
+(typically post-merge hooks already trigger reinstall on changed config).
+
+### D-S2 — `host:` field on project YAMLs
+
+Every `knowledge/projects/<name>.yaml` MUST have a `host:` field whose
+value is the canonical name of the host that owns the project (where its
+repo is cloned and where its per-project `ACTIONS.md` lives).
+
+**Field position:** between `project:` and `status:` (declared in
+`project/cli.py PROJECT_FIELDS_ORDER`).
+
+**Allowed values:** any host name the user uses. Current canonical set:
+
+| Name | Class |
+|---|---|
+| `jns-mac` | personal — this MacBook |
+| `jns-server` | personal — home server |
+| `vitalai-laptop` | work — WSL laptop |
+| `jbox06` | work — internal LAN host |
+| `et01` | work — TBD |
+| `spark` | work — TBD |
+
+**Why:** Without this field, future tooling (dashboard SSH-bridge in
+Phase 7.2) has to guess where a project lives based on
+`~/projects/<name>` directory existence, which won't work cross-machine.
+The field is cheap insurance and decouples Phase 7.1 (decision +
+bookkeeping) from Phase 7.2 (implementation).
+
+**How to apply:**
+
+- New projects: `register_project()` autodetects the host and stamps it.
+- Existing projects: backfilled to `host: jns-mac` in this PR (the only
+  host any of them currently lives on).
+- Migration: `project <name> --set-host <new-host>` updates the field
+  without bumping `updated_at` (host is operational, not content).
+
+### D-S3 — Per-machine canonical name in `~/.claude/host-name`
+
+Each machine declares its own canonical name in `~/.claude/host-name`
+(one line of text). The `lib/project_resolver.get_host_name()` function
+reads this file; if absent, falls back to a sanitized `socket.gethostname()`
+(lowercased, first-segment-only).
+
+**Why:** OS hostnames don't match the user's mental model.
+`socket.gethostname()` on this MacBook returns
+`Jasons-MacBook-Pro-1805.local`, not the desired `jns-mac`. Hard-coding a
+mapping is brittle. A per-machine override file is the cleanest solution
+and matches the existing per-machine convention
+(`dashboard-subscriptions.json`, `pending_focus_reviews.json`).
+
+**How to apply:**
+
+- Each laptop runs `project --register-host <canonical-name>` once on setup.
+- The CLI never asks Claude (or any LLM) for the host name — it's a
+  three-line file read.
+
+### D-S4 — SSH bridge is Phase 7.2, not Phase 7.1
+
+Phase 7.1 captures the architecture and adds the schema field. It does
+**not** implement multi-host reads in `dashboard/cli.py`.
+
+**Why:**
+
+- Today, all 7 tracked projects are on `jns-mac`. Multi-host read has
+  zero data points to operate on.
+- Empirical-usage discipline (the same one that killed `/capture` and
+  `/inbox`) says: don't build for theoretical needs.
+- Phase 7.2 is real work (~400-600 LOC across `lib/host_resolver.py`,
+  dashboard integration, caching, tests). Stacking it on the architecture
+  decision blurs the review boundary.
+
+**Trigger to ship Phase 7.2:** a `knowledge/projects/<name>.yaml` is added
+with `host:` other than `jns-mac` (e.g., when the first `jns-server`
+project is tracked). When that happens, refile A-013 with Phase 7.2
+scope — see "Phase 7.2 sketch" below.
+
+### D-S5 — Write-from-anywhere is Phase 7.3, deferred indefinitely
+
+The user's existing pattern of "Claude on the laptop SSHs into the host
+and runs the CLI there" already provides write-from-anywhere semantically.
+A native multi-host write (`dashboard --host jbox06 --action-new "..."`)
+would be more convenient but adds significant scope (auth handling,
+remote command construction, error propagation).
+
+**Trigger to ship Phase 7.3:** real friction with the SSH-then-run pattern
+becomes felt and articulated. Not until.
+
+---
+
+## Phase 7.2 sketch (NOT in this PR)
+
+For when the trigger fires:
+
+### `lib/host_resolver.py` (new)
+- `is_reachable(host: str, timeout: float = 3.0) -> bool` — TCP check on
+  port 22; respects `~/.ssh/config` aliases.
+- `read_remote(host: str, cmd: list[str]) -> tuple[int, str, str]` — runs
+  `ssh <host> <cmd>` with a timeout; returns `(returncode, stdout, stderr)`.
+- Optional: ~5 minute LRU cache for results, keyed by `(host, cmd)`.
+- Optional: `~/.claude/host-map.json` for nicknames / preferred-tunnel
+  routing (e.g., always use `jns-remote` for `jns-server` if local LAN
+  resolution fails).
+
+### `dashboard/cli.py` integration
+- New flag `--include-host <name>` (repeatable) or auto-aggregate via
+  the subscription file plus the per-project `host:` field.
+- Per-project rendering checks `host`:
+  - `host == get_host_name()` → read locally as today.
+  - `host` reachable → SSH out, read remote `ACTIONS.md` + `git log` +
+    `gh issue list` from the project's checkout location on that host.
+  - `host` not reachable → render a placeholder line: `(remote
+    unreachable; switch to LAN or use jns-remote tunnel)`.
+
+### Tests
+- Mock `subprocess.run` to simulate reachable / unreachable / timeout.
+- Cache TTL behavior.
+- Multi-host aggregation order (local first, remote alphabetical).
+
+Sizing: ~400–500 LOC + tests. One PR, MODERATE tier.
+
+---
+
+## What stays out of scope forever (or until really proven)
+
+- Centralized state server / database. Agents-repo-on-GitHub already plays
+  that role for the only data that needs to be shared.
+- Auto-cloning project repos on multiple hosts. Repos live where they live;
+  cross-host visibility is via Phase 7.2 SSH bridge, not via parallel
+  clones.
+- Renaming the existing per-machine subscription file. Subscriptions
+  remain "which projects this machine sees" independent of `host:`.
+
+---
+
+## Acceptance for Phase 7.1 (this PR)
+
+- [x] `host:` field added to all 7 existing project YAMLs (`host: jns-mac`).
+- [x] `lib/project_resolver.register_project` autodetects host via
+      `get_host_name()`; accepts explicit `host=` override.
+- [x] `~/.claude/host-name` mechanism documented + bootstrapped for this
+      machine (`jns-mac`).
+- [x] `project <name> --set-host <hostname>` updates the field without
+      bumping `updated_at`.
+- [x] `project --register-host <hostname>` writes the per-machine file.
+- [x] `project <name>` read mode renders `Host: <name>` on the status
+      line.
+- [x] `specs/knowledge-surfaces.md` updated to reflect `host:` in the
+      project YAML schema row.
+- [x] Tests covering autodetect, override, fallback, `--set-host`,
+      `--register-host`, field-order preservation.
+- [x] No regressions in `pytest project/ action/ review_session/ decision/`.
+
+## Sign-off
+
+Decision-only architecture record + cheap-insurance schema field.
+Phase 7.2 (SSH bridge) and 7.3 (write-from-anywhere) are explicitly
+deferred with documented trigger conditions.

--- a/specs/knowledge-surfaces.md
+++ b/specs/knowledge-surfaces.md
@@ -14,7 +14,7 @@
 
 | Surface | Scope | Status | Authoritative for |
 |---|---|---|---|
-| `knowledge/projects/<name>.yaml` | per-project | ALIVE | project tracker (focus, status, blockers, next_steps, open_questions) |
+| `knowledge/projects/<name>.yaml` | per-project | ALIVE | project tracker (focus, host, status, blockers, next_steps, open_questions). `host:` declares which host owns the project — see `specs/cross-device-state.md` (Phase 7.1). |
 | `knowledge/decisions/D-NNN.yaml` | per-project (`project:` field) | DORMANT — no writer | architecturally significant decisions |
 | `knowledge/patterns/pat-<slug>.yaml` | global (no `project:` field) | CATALOG-ONLY — no live reader | reusable code patterns + lifecycle (pilot → validated) |
 | `knowledge/learning-rules/LR-NNN.yaml` | global | DORMANT — no recent writer | failure-derived rules surfaced at SessionStart |


### PR DESCRIPTION
## Summary

Decision-record + cheap-insurance schema field + per-machine canonical-name mechanism. SSH-bridge implementation deferred per the trigger condition documented in `specs/cross-device-state.md`.

**Closes #150. Closes A-013** (Phase 7.1 portion). Phase 7.2 + 7.3 will be filed when triggered by real non-`jns-mac` project additions.

## What's in the PR

| Surface | Change |
|---|---|
| `specs/cross-device-state.md` | New architecture decision doc (read this carefully — it's the long-lived artifact) |
| `specs/knowledge-surfaces.md` | Project YAML schema row notes the `host:` field + cross-references the new spec |
| `lib/project_resolver.py` | `get_host_name()` / `set_host_name()` read/write `~/.claude/host-name`; `register_project()` gains optional `host=` override + autodetects via `get_host_name()` |
| `project/cli.py` | `PROJECT_FIELDS_ORDER` inserts `host` between `project` and `status`. New `--set-host` (no `updated_at` bump — operational, not content) and `--register-host` flags. Render line shows `Host: <name>` |
| 7 project YAMLs | Backfilled `host: jns-mac` |
| `project/tests/test_cli.py` | 11 new tests |
| `ACTIONS.md` | A-013 closed |

## Workflow context

User runs Claude on two laptops (`vitalai-laptop` primary, `jns-mac` secondary) and SSHs into multiple remote dev hosts (`jbox06`, `et01`, `spark`, `jns-server`). The architecture decision is: agents repo as central state substrate via GitHub, `host:` field on each project YAML to declare ownership, per-machine canonical name resolved via `~/.claude/host-name`. Cloudflare-tunneled hosts (`jns-server` via `jns-remote`) are reachable from anywhere; LAN-only hosts (`jbox06`) gracefully unreachable when off-LAN.

## Out of scope (explicit)

- **Phase 7.2** — `lib/host_resolver.py`, `dashboard --include-host`, multi-host rendering, SSH caching. Separate issue + PR. Triggered when a `host:` other than `jns-mac` appears in a project YAML.
- **Phase 7.3** — write-from-anywhere over SSH. Deferred indefinitely; current "Claude SSHs into the host and runs the CLI there" pattern already covers it.

## Behavior change for the user (after merge)

- `/project foo` shows `Host: jns-mac` on the status line.
- New projects auto-stamp `host:` from `~/.claude/host-name` (already set to `jns-mac` on this machine).
- `project foo --set-host jbox06` updates the field for migration.
- `project --register-host vitalai-laptop` is what you run on the WSL laptop after pulling this branch there.

## Test plan

- [x] `pytest project/tests/ action/tests/ review_session/tests/ decision/tests/` — **135 pass**
- [x] All 7 existing `knowledge/projects/*.yaml` verified to have `host: jns-mac`
- [x] `project agents --set-host jns-mac` → idempotent no-op (no `updated_at` bump)
- [x] `project agents --no-prompt` renders `Host: jns-mac`
- [x] `~/.claude/host-name` bootstrapped to `jns-mac` on this Mac
- [x] No rogue YAMLs in real `knowledge/projects/`
- [x] `~/.claude/dashboard-subscriptions.json` untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)