### PR TITLE
chore(settings): allowlist ruff + read-only MCP tools

### DIFF
--- a/claude-config/settings.json
+++ b/claude-config/settings.json
@@ -30,6 +30,12 @@
       "Bash(curl -s -H PRIVATE-TOKEN:*)",
       "Bash(curl -s -X POST -H PRIVATE-TOKEN:*)",
       "Bash(curl -s -X PUT -H PRIVATE-TOKEN:*)",
+      "Bash(ruff check:*)",
+      "Bash(ruff format --check:*)",
+      "mcp__plugin_playwright_playwright__browser_snapshot",
+      "mcp__knowledge__get_inbox",
+      "mcp__knowledge__get_dashboard",
+      "mcp__knowledge__get_project_context",
       "Write(/home/jjob/.claude/projects/*/memory/**)",
       "Edit(/home/jjob/.claude/projects/*/memory/**)"
     ],


### PR DESCRIPTION
## Summary

- Allowlist 6 high-frequency read-only tools surfaced by `/fewer-permission-prompts` on a 50-transcript scan
- 2 Bash patterns (`ruff check`, `ruff format --check`), 4 MCP tools (playwright snapshot + 3 knowledge reads)
- Skipped `git fetch` (already allowlisted) and all mutations / interpreters per the skill's read-only-only rule

## Test plan

- [x] JSON validity verified (`python3 -c "import json; json.load(...)"`)
- [x] Schema preserved — only `permissions.allow` array extended; `deny`, hooks, statusLine, plugins untouched
- [x] Symlink at `~/.claude/settings.json` already points at this file — change is live without `install.sh` rerun
- [ ] Confirm reduced prompt count on next `/orchestrate` run with ruff-touching code