### PR TITLE
chore(orchestrate): wire TaskCreate into orchestrator runtime

### DIFF
--- a/claude-config/commands/orchestrate.md
+++ b/claude-config/commands/orchestrate.md
@@ -261,6 +261,41 @@ if [ "$BRANCH" = "main" ]; then
 fi
 ```
 
+### Step 2.5: Initialize Task Tracking (TaskCreate)
+
+After classification and stack detection, before agent dispatch, register a
+TaskCreate todo list with one task per phase that will actually run. This
+surfaces progress as a visible checklist instead of burying it in tool output.
+
+**Phases to register** (omit any flag-gated or stack-gated phase not running):
+
+| Tier | Tasks in order |
+|------|----------------|
+| SIMPLE  | DISCUSS¹ → MAP-PLAN → TEST-PLANNER¹ → CONTRACT² → PLAN-CHECK → PATCH → PROVE → Record-Outcome |
+| COMPLEX | DISCUSS¹ → MAP → PLAN → TEST-PLANNER¹ → CONTRACT² → PLAN-CHECK → PATCH → PROVE → Record-Outcome |
+
+¹ Only when the corresponding flag is set (`--discuss`, `--with-tests`).
+² Only when CONTRACT-full applies (Step 1.6). CONTRACT-lite is inline — no task.
+
+**Per task**:
+- `subject`: phase + issue, e.g. `"MAP-PLAN issue #184"`
+- `description`: one-line phase purpose
+- `activeForm`: gerund for the spinner, e.g. `"Running MAP-PLAN"`
+
+**Dependencies**: chain sequentially with `addBlockedBy`. Exception: documented
+parallel patterns from Step 1.7's swarm table (e.g. PLAN-CHECK + TEST-PLANNER
+fan-out) share a single upstream blocker and do not block each other.
+
+**During Step 3 dispatch**: before each `Task()` call, mark the corresponding
+task `in_progress`. After artifact validation passes, mark it `completed`. If
+a phase fails, leave the task `in_progress` and STOP per Failure Handling —
+the in-flight task documents where the run halted.
+
+**At Step 5**: every task should be `completed`. `Record-Outcome` wraps Step 4.
+
+Skip this step entirely on `--resume` runs unless the resumed phase has no
+existing task (re-create only the missing tail of the chain).
+
 ### Step 3: Spawn Agents (Task Tool)
 
 **CRITICAL**: Use the Task tool to spawn each phase agent via **native subagent


### PR DESCRIPTION
## Summary

- Add **Step 2.5: Initialize Task Tracking (TaskCreate)** to `commands/orchestrate.md`
- Register one task per phase that will actually run; transition `in_progress` → `completed` around each `Task()` dispatch in Step 3
- Phase set is tier-aware (SIMPLE/COMPLEX), respects `--discuss`, `--with-tests`, and CONTRACT-full vs CONTRACT-lite
- Sequential `addBlockedBy` chain with an explicit exception for the documented Step 1.7 swarm patterns (PLAN-CHECK + TEST-PLANNER fan-out)
- Failed phase leaves its task `in_progress` so the halt point stays visible in TaskList
- `--resume` only fills the missing tail of the chain — no duplicate tasks

## Why

Orchestrate runs span minutes-to-hours of agent dispatch. Without TaskCreate, progress is buried in tool output and you have to scroll to see which phase is active. With this change, the user gets a visible checklist updated in real time.

Pre-existing CI failure on \`validate\` (knowledge/sync.py removed in #146) tracked separately in #153 — not caused by this change.

## Test plan

- [x] Single-file change, JSON-free (markdown-only) — no syntax risk
- [ ] Confirm task list appears on next \`/orchestrate\` run
- [ ] Verify task transitions correctly on phase artifact validation
- [ ] Verify failed-phase behavior leaves task \`in_progress\` (manually fail PROVE)
- [ ] Verify \`--resume\` only re-creates missing tail