### PR TITLE
fix(install): make MCP registration idempotent

### DIFF
--- a/claude-config/install.sh
+++ b/claude-config/install.sh
@@ -285,17 +285,21 @@ MCP_SERVERS_TOTAL=0
 if command -v claude &>/dev/null; then
     register_mcp() {
         # register_mcp <name> <command> [args...]
-        # Always re-registers — claude mcp add is idempotent and overwrites,
-        # which ensures paths stay correct if the repo moves.
+        # `claude mcp add` is NOT idempotent — it exits 1 with "already exists"
+        # if the server is registered. Remove first (no-op if absent), then add,
+        # so paths stay correct if REPO_DIR moved between runs.
         local name="$1"
         shift
         MCP_SERVERS_TOTAL=$((MCP_SERVERS_TOTAL + 1))
 
-        if claude mcp add --scope user "$name" -- "$@" 2>/dev/null; then
+        claude mcp remove --scope user "$name" >/dev/null 2>&1 || true
+
+        local err
+        if err=$(claude mcp add --scope user "$name" -- "$@" 2>&1); then
             echo "  ✓ $name registered"
             MCP_SERVERS_REGISTERED=$((MCP_SERVERS_REGISTERED + 1))
         else
-            echo "  ✗ Failed to register $name"
+            echo "  ✗ Failed to register $name: $err"
         fi
     }
 


### PR DESCRIPTION
## Summary

- Phase 2.6 was reporting `Failed to register vault-metrics / context7 / apple-mcp` on every post-merge install run, while all three were actually registered and connected
- Root cause: `claude mcp add --scope user <name>` exits 1 with `"already exists in user config"` when the entry is present. The comment in `register_mcp` claimed it was idempotent, but it isn't
- Fix: `claude mcp remove --scope user <name>` first (no-op if absent, suppressed stderr), then `add`
- Also captures stderr from `add` and surfaces it on real failures (was being discarded via `2>/dev/null`)

## Verification

```
Before: MCP Servers: 0/3 registered in ~/.claude.json (false alarm — they were connected)
After:  MCP Servers: 3/3 registered in ~/.claude.json
```

MCP processes in the running session are unaffected (config-file change, not process-level), so this is safe to land while a Claude session is open.

## Test plan

- [x] `bash -n install.sh` passes
- [x] Running `install.sh` twice in a row yields 3/3 both times (idempotent)
- [x] All three MCPs report `✓ Connected` via `claude mcp list` after install
- [x] Running session's MCP tools still work (verified via `claude mcp list` from within Claude Code)
- [ ] Future repo move would re-register with new path — not tested in this session, but matches the documented contract