### PR TITLE
fix(ci): drop dead knowledge.db build step

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -35,11 +35,6 @@ jobs:
           SETTINGS_PATH: ${{ github.workspace }}/claude-config/settings.json
         run: python3 claude-config/scripts/validate-hooks.py
 
-      - name: Build knowledge.db (catches duplicate pattern IDs + schema drift)
-        run: |
-          cd knowledge
-          python3 sync.py build
-
       - name: Verify pattern ID slug format
         run: |
           set -e


### PR DESCRIPTION
## Summary

- Remove the broken `validate` workflow step `Build knowledge.db (catches duplicate pattern IDs + schema drift)` that has been failing on every PR since 2026-05-07
- Root cause: `knowledge/sync.py` was deleted in \`af9852d\` (#146 — phase-6c) when the Knowledge MCP server was retired, but `validate.yml` was not updated to match
- The remaining "Verify pattern ID slug format" step (lines 38–53) still enforces `id == \"pat-\$stem\"` against `knowledge/patterns/*.yaml`, which implicitly catches duplicate IDs since filenames are unique on disk
- Schema-drift detection that the dead step provided is an accepted coverage loss — the Knowledge MCP infrastructure that needed it has been retired

## Test plan

- [ ] **This PR's own CI run is the test** — `validate` should turn green for the first time since 2026-05-07
- [x] Workflow YAML is structurally intact (5-line deletion only, no new triggers / steps)
- [x] Slug-format check still triggers on `knowledge/**` changes via the existing `paths:` filter

Closes #153