### PR TITLE
docs(spec-workflow): add code-reality manifest discipline from owner_onboarding retro

### DIFF
--- a/claude-config/agents/spec-reviewer.md
+++ b/claude-config/agents/spec-reviewer.md
@@ -4,7 +4,7 @@ description: Analyzes specifications against the codebase and proposes GitHub is
 tools: Read, Grep, Glob, Bash
 model: sonnet
 agent: "SPEC-REVIEWER"
-version: 1.1
+version: 1.2
 extends: _base.md
 purpose: "Analyze specs against codebase, generate GitHub issues"
 output: ".agents/outputs/spec-review-{spec-name}-{mmddyy}.md"
@@ -26,11 +26,74 @@ max_lines: 400
 
 ---
 
+## Critical review discipline (read first)
+
+These three rules came out of the owner_onboarding_v1 8-round review loop
+(May 2026). Apply them on every review. They are why this agent's verdict
+is supposed to be reliable.
+
+### Rule 1: Trace EXECUTION ORDER, not just symbol locations
+
+When the spec cites "operation X happens via function Y," locating function Y
+at the cited line is **not** verification. Read 50+ lines around the cited
+line, including:
+- Pre-write guards (early `return None` / `raise` / blocked-path branches)
+- Conditional branches that may bypass the named operation
+- Helper calls that themselves can short-circuit
+
+Concrete example from the round-7 finding: V1.6 claimed `add_edge()` does
+canonical supersession via `SUPERSESSION_MAP`. The supersession code at
+`crud.py:1211` does exist. BUT `find_relationship_conflict()` at
+`crud.py:1090` fires first and returns `None` for the romantic conflict
+group `{spouse_of, partner_of, ex_partner_of}` — making the supersession
+path unreachable for the very relations the spec was built around. A
+file-reading reviewer that located both lines but didn't trace order
+between them missed this for 2 rounds.
+
+**On every "X happens via Y" claim: trace order. State explicitly what
+guards/branches you verified are not in the way.**
+
+### Rule 2: Check for a code-reality manifest companion
+
+If `specs/<feature>.code-reality.md` exists, read it FIRST. The spec author
+should have filled it with verbatim signatures, columns, enum values, and
+CHECK constraint values from the codebase. Your review then becomes:
+
+1. Verify the spec's claims match the manifest (cheap — both are text).
+2. Spot-verify the manifest's claims match actual code (sample ~20% of
+   entries; flag any drift).
+
+If `<feature>.code-reality.md` does NOT exist, that is itself a Round 1
+finding — flag it as `B (process)` and recommend the spec author create
+one before proceeding (see `~/.claude/rules/spec-review-workflow.md` §2).
+A spec without a manifest is being written speculatively; expect a high
+density of code-reality errors (the owner_onboarding spec without one
+generated ~14 findings across 8 rounds, 6 of them latent V1.0-era).
+
+### Rule 3: Look for INTERNAL contradictions across sections
+
+Round 8 of owner_onboarding found a fact-correction-model contradiction
+spanning §7.2, §7.5, §11.4, §12.3 — present since V1.0, undetected for 7
+rounds because each round focused on deltas, not whole-spec coherence.
+
+Pick the 4–6 sections most likely to drift:
+- Architecture description vs. acceptance criteria
+- Schema definition vs. rollback semantics
+- Helper signature definitions vs. usage sites
+- "What we DO" sections vs. "What we DO NOT" sections
+
+Read them in sequence in one pass. If two sections describe the same
+mechanism differently, that is a B-severity finding regardless of whether
+either description matches the code in isolation.
+
+---
+
 ## Pre-Flight (from _base.md)
 
 1. Load patterns via MCP `failure_patterns_v1()` (fallback: `cat .claude/memory/patterns.md`)
 2. Read the spec file completely
-3. Check for existing issues: `gh issue list --label "from-spec" --search "SPEC_NAME"`
+3. **Read the code-reality manifest** at `specs/<feature>.code-reality.md` if it exists; flag absence as a process finding if not (see Rule 2 above)
+4. Check for existing issues: `gh issue list --label "from-spec" --search "SPEC_NAME"`
 
 ---
 

--- a/claude-config/install.sh
+++ b/claude-config/install.sh
@@ -110,6 +110,7 @@ link_item "$SCRIPT_DIR/commands"            "$CLAUDE_DIR/commands"            "c
 link_item "$SCRIPT_DIR/agents"              "$CLAUDE_DIR/agents"              "agents/"
 link_item "$SCRIPT_DIR/rules"               "$CLAUDE_DIR/rules"              "rules/"
 link_item "$SCRIPT_DIR/skills"              "$CLAUDE_DIR/skills"              "skills/"
+link_item "$SCRIPT_DIR/templates"           "$CLAUDE_DIR/templates"           "templates/"
 link_item "$SCRIPT_DIR/statusline.py"       "$CLAUDE_DIR/statusline.py"       "statusline.py"
 
 echo ""
@@ -507,7 +508,7 @@ echo "Phase 4: Verify"
 ERRORS=0
 
 # Verify symlinks resolve
-for link in settings.json hooks commands agents rules skills statusline.py; do
+for link in settings.json hooks commands agents rules skills templates statusline.py; do
     target="$CLAUDE_DIR/$link"
     if [ -L "$target" ] && [ -e "$target" ]; then
         : # OK

--- a/claude-config/rules/spec-review-workflow.md
+++ b/claude-config/rules/spec-review-workflow.md
@@ -4,11 +4,179 @@ paths: ["**/specs/**", "**/.agents/**"]
 
 # Spec Review Workflow & Best Practices
 
-This document defines the **specification review and issue creation workflow** based on lessons learned from the flow-of-funds specification process (December 2025).
+This document defines the **specification review and issue creation workflow** based on lessons learned from the flow-of-funds specification process (December 2025) and the owner_onboarding_v1 8-round review loop (May 2026).
 
 ## Overview
 
 The spec review workflow ensures specifications are **finalized and validated** before creating GitHub issues, preventing wasted effort and maintaining consistency between specs and implementation work.
+
+**Target:** converge in ≤ 3 adversarial review rounds. If you find yourself heading toward round 4+, something upstream (drafting discipline, manifest completeness, reviewer scope) is wrong — fix that instead of doing another surgical round. See §4.
+
+---
+
+## 1. Why these rules exist
+
+The owner_onboarding_v1 spec required **8 rounds** of adversarial review (Codex + Claude in parallel) before reaching a clean state. Risk trajectory was non-monotonic (8 → 8 → 7 → 6 → 5 → 7 → 8 → 7) — risk **rose** in three rounds because each "surgical fix" introduced new code-reality errors.
+
+Of ~14 distinct findings across 8 rounds, **6 were latent bugs from V1.0–V1.2 era** — pre-existing claims that no reviewer caught for 5+ rounds. The remaining ~8 findings were errors introduced by surgical-fix drafts that I never verified against the codebase before re-submitting.
+
+The single highest-leverage fix is: **do code-reality verification at drafting time, not as a side-effect of review.** The next three sections operationalize this.
+
+---
+
+## 2. Pre-V1.0 Code-Reality Manifest (mandatory before drafting)
+
+Before writing any spec that touches existing code, produce a companion file:
+
+```
+specs/<feature>.md                  ← the spec
+specs/<feature>.code-reality.md     ← the manifest (this section)
+```
+
+Use the template at `~/.claude/templates/code-reality-manifest.md`. Fill it in by reading the actual codebase — `Read`, `Grep`, `Bash` to query the DB if needed. Do NOT skip this step on the assumption that "I roughly know the code."
+
+The manifest captures, verbatim from the source files:
+
+- **§1 Functions cited** — every function the spec calls/extends, with signature AND surrounding pre-write guards/branches/early returns (the round-7 lesson: locating a symbol ≠ tracing what reaches it; read 50+ lines around each cited line)
+- **§2 Tables / columns** — every table the spec writes to or queries, with exact column list and unique/partial indexes
+- **§3 Enums** — every enum value the spec uses, copied verbatim
+- **§4 CHECK constraints** — current values for any constraint the spec extends
+- **§5 Cross-module helpers** — every contract that spans modules
+- **§6 Migration provenance** — for every "already in production" claim, the actual owning migration file:line
+- **§7 Negative manifest** — things that look like they should exist but DON'T (prevents re-invention)
+
+**Cost:** 30–60 minutes one-shot. **Savings:** 3–6 review rounds (the owner_onboarding spec's rounds 1, 6, 7, 8 were all manifest failures — together that's 4 rounds × 2 reviewers × ~15 min ≈ 2 hours of compute, plus drafting time).
+
+The manifest is NOT itself an implementation deliverable. It's a drafting precondition. After spec lock, the manifest stays as a companion file so future implementation work can verify the spec against it.
+
+---
+
+## 3. Self-Review Checklist (before submitting V1.0 for review)
+
+Before invoking any reviewer, the spec author runs this checklist. It takes ~15 minutes and catches the majority of grade-A errors that adversarial review would otherwise spend a full round on.
+
+### 3.1 Spec ↔ manifest cross-check
+
+```bash
+# For every symbol the spec cites, confirm it's in the manifest with verified shape
+grep -E "`[A-Za-z_][A-Za-z0-9_]*`" specs/<feature>.md | sort -u
+# → cross-check each hit against specs/<feature>.code-reality.md
+```
+
+Any symbol in the spec but NOT in the manifest is either (a) a load-bearing claim that wasn't verified, or (b) prose that doesn't need to be in the spec. Either way: address before submission.
+
+### 3.2 Execution-order trace
+
+For every claim in the spec of the form "operation X happens via path Y":
+
+- [ ] I read 50+ lines around Y in the actual source.
+- [ ] I confirmed that no pre-write guard / early return / conditional branch can prevent X from reaching the cited line.
+- [ ] If guards exist, the spec either (a) explicitly notes they apply, or (b) explains why the spec's call path bypasses them.
+
+This is the discipline that would have caught the V1.6 `add_edge() SUPERSESSION` claim: the function exists, the SUPERSESSION code at `:1211` exists, but `find_relationship_conflict()` at `:1090` returns None first for the romantic conflict group.
+
+### 3.3 Internal consistency
+
+Pick the 4–6 sections of the spec most likely to drift apart (typical pairs: architecture vs. acceptance criteria, schema vs. rollback semantics, helper signatures vs. their usage sites). Read them in sequence. They should tell one story.
+
+The V1.7→V1.8 round-8 finding was a fact-correction-model contradiction across §7.2, §7.5, §11.4, §12.3 — present since V1.0, undetected for 7 rounds because each round focused on deltas, not whole-spec coherence.
+
+### 3.4 Output
+
+If anything in §3.1–§3.3 fails, V1.0 is not ready. Fix and re-check before involving reviewers. Reviewers are an expensive resource (each round ≈ 20 min of agent compute + your synthesis time); don't burn them on errors you could have caught in 15 minutes.
+
+---
+
+## 4. Adversarial Review — Convergence Rules
+
+### 4.1 Round cadence and reviewer count
+
+| Round | Reviewers | Why |
+|---|---|---|
+| R1 | **1 reviewer** (default: Codex via `/codex:adversarial-review`) | First-pass errors are gross; one reviewer catches >90%. Two in parallel at R1 is wasteful. |
+| R2 | 2 reviewers in parallel (Codex + spec-reviewer agent) | Convergence check. Two reviewers catching the same issue independently is your lock signal (§4.3). |
+| R3 | 2 reviewers | Final pass. If R3 is not clean, go to §4.4 — do NOT do R4. |
+
+### 4.2 Risk trajectory as a signal
+
+Track Codex's `RISK: N/10` across rounds. The trajectory tells you what's happening:
+
+- **Monotonic descent (8 → 6 → 4 → PROCEED):** healthy convergence. Continue.
+- **Plateau (6 → 6 → 6):** reviewers are sampling, not exhausting. Either the spec is large enough that one pass isn't covering it, or the same class of issue keeps surfacing. Re-scope reviewer prompt.
+- **Rising (e.g., 5 → 7):** a "fix" introduced new errors, or surfaced latent ones. **STOP.** Do NOT continue surgical fixes. Go to §4.4.
+
+### 4.3 Convergence (lock) signal
+
+Lock the spec when **both** of these hold:
+
+1. Both reviewers return PROCEED (or PROCEED-WITH-EDITS with only nits/m findings).
+2. Their findings are **convergent** — if any are non-trivial, both reviewers found them independently.
+
+Reviewer **divergence** (one says clean, the other says BLOCK) is NOT a tiebreaker question. Resolve it by reading the underlying code/docs yourself, 5 minutes max. The owner_onboarding round-8 divergence on `ON CONFLICT DO NOTHING` semantics was settled by reading PG docs — Claude was wrong, Codex was right. Without that manual resolution, picking either reviewer would have been wrong.
+
+### 4.4 Stop conditions (use BEFORE round 4)
+
+If round 3 doesn't lock, choose ONE of:
+
+- **(a) Full hygiene pass.** One exhaustive read of the entire spec against the manifest + codebase, finding all remaining latent bugs in one pass. Then submit ONE final review round. Use when most remaining findings are pre-existing-but-undetected (the owner_onboarding pattern).
+- **(b) Architectural rethink.** If risk is rising or the same kind of issue keeps surfacing, the underlying design may be wrong. Step back from text edits and reconsider whether the spec's premise is reachable in the current codebase. Use when round-over-round findings include "this path is unreachable / this feature doesn't compose with X."
+- **(c) Lock with known-issues addendum.** Accept the spec at current state, add §N "Known V1 implementation gaps" listing remaining findings as work-to-do in implementation tickets. Use when the architecture is right but details are noisy and implementation work would naturally close them.
+
+R4+ of pure surgical fixes is almost never the right answer. It's what we did with owner_onboarding (8 rounds) and it cost ~7 hours.
+
+---
+
+## 5. Drafting → Review → Lock — the end-to-end happy path
+
+```
+┌────────────────────────────────────────────┐
+│ 1. Code-Reality Manifest (§2)              │
+│    30-60 min, read actual code             │
+│    → specs/<feature>.code-reality.md       │
+└──────────────────┬─────────────────────────┘
+                   │
+┌──────────────────┴─────────────────────────┐
+│ 2. Draft V1.0 from manifest                │
+│    Every claim sourced from §1-§7          │
+└──────────────────┬─────────────────────────┘
+                   │
+┌──────────────────┴─────────────────────────┐
+│ 3. Self-Review Checklist (§3)              │
+│    15 min, spec ↔ manifest grep            │
+│    Execution-order trace + internal        │
+│    consistency check                        │
+└──────────────────┬─────────────────────────┘
+                   │
+┌──────────────────┴─────────────────────────┐
+│ 4. R1: Single reviewer (§4.1)              │
+│    /codex:adversarial-review               │
+└──────────────────┬─────────────────────────┘
+                   │
+              ┌────┴────┐
+              │ Clean?  │
+              └────┬────┘
+            yes ◄──┴──► no → fix → R2: 2 reviewers
+              │
+              ▼
+       ┌─────────────┐
+       │ Convergence?│
+       │  (§4.3)     │
+       └─────┬───────┘
+       yes  ◄┴► no → resolve divergence (5 min) → re-check
+              │
+              ▼
+       ┌─────────────┐
+       │ R3 final    │
+       │ confirmation│
+       └─────┬───────┘
+             │
+             ▼
+       LOCK + tag + create issues (§6+)
+```
+
+If you're at R4 or risk has risen between rounds, route to §4.4 instead of continuing this happy path.
+
+---
 
 ## Workflow Pattern
 

--- a/claude-config/templates/code-reality-manifest.md
+++ b/claude-config/templates/code-reality-manifest.md
@@ -1,0 +1,128 @@
+---
+purpose: "Fillable companion to a spec — captures verified code reality BEFORE drafting"
+companion_to: "specs/<spec-name>.md"
+filename_convention: "specs/<spec-name>.code-reality.md"
+---
+
+# Code-Reality Manifest — `<spec-name>`
+
+**Verified as of:** YYYY-MM-DD against commit `<hash>`
+
+This document is a **drafting precondition**, not a spec deliverable. Fill it in
+BEFORE writing the spec. Every load-bearing claim the spec makes about existing
+code must be backed by an entry here, copied verbatim from the actual file.
+
+When the spec cites a function, table, enum, or constraint, the reviewer should
+be able to look here first and confirm the claim against the manifest, rather
+than re-tracing from scratch every round.
+
+Rationale: see `~/.claude/rules/spec-review-workflow.md` §2 (Pre-V1.0 Code-Reality
+Manifest). The owner_onboarding_v1 spec went through 8 review rounds in part
+because V1.0 was written without one of these.
+
+---
+
+## 1. Functions cited
+
+For every function the spec calls or claims to extend:
+
+| Symbol | Path:Line | Signature (verbatim) | Pre-write guards / early returns | Notes |
+|---|---|---|---|---|
+| `add_edge` | `src/buddy/services/grid/crud.py:1007` | `async def add_edge(pool, source_id, target_id, relation_type, *, properties=..., strength=..., bidirectional=..., source=..., inferred_from=..., session_id=...)` | `:1076` self-loop guard returns early; `:1090` `find_relationship_conflict()` returns None on conflict BEFORE the SUPERSESSION delete at `:1211` | Onboarding cannot rely on SUPERSESSION_MAP — guard fires first |
+| `_apply_update` | `src/buddy/services/extraction/grid_extractor.py:718` | `async def _apply_update(pool, fact_id, new_value, confidence) -> str \| None` | None — single UPDATE in a transaction | In-place UPDATE only (writes `previous_value` for audit); does NOT flip `is_active` or insert a new row |
+| ... | | | | |
+
+**Trace rule (from round-7 of the onboarding loop):** for any function you
+cite, read **50+ lines around the cited line** — guards, branches, early
+returns. Locating a symbol is not the same as tracing what reaches it.
+
+---
+
+## 2. Tables / columns cited
+
+For every table the spec writes to or queries:
+
+| Table | Source | Columns (relevant subset) | Unique / partial indexes | Notes |
+|---|---|---|---|---|
+| `grid_fact` | `scripts/init-db.sql:1609-1674` | `id, entity_id, layer, fact_key, fact_value, confidence, source, source_ref jsonb, is_active, superseded_by, superseded_at, previous_value, created_at, updated_at, updated_by` | Partial unique `idx_grid_fact_unique_single ON (entity_id, layer, fact_key) WHERE is_active=TRUE AND fact_key NOT IN (multi)`; partial unique `idx_grid_fact_unique_multi ON (entity_id, layer, fact_key, fact_value) WHERE is_active=TRUE AND fact_key IN ('sibling_of', 'children', 'parent', 'attendees', 'participants')` | Targetless `ON CONFLICT DO NOTHING RETURNING *` works against partial unique indexes |
+| `grid_edge` | `scripts/init-db.sql:1685-1699` | `id, source_entity_id, target_entity_id, relation_type, properties jsonb, strength, source, inferred_from, session_id, created_at, updated_at` | UNIQUE `(source_entity_id, target_entity_id, relation_type)` unconditional | NO `is_active` column; supersession is HARD DELETE at `crud.py:1211` |
+| ... | | | | |
+
+---
+
+## 3. Enums cited
+
+For every enum value the spec uses:
+
+| Enum | Path:Line | Values (verbatim) | Notes |
+|---|---|---|---|
+| `MaritalStatus` | `src/buddy/entities/enums.py:11-16` | `single, married, divorced, widowed, partnered, separated` | No `engaged` or `dating` — those need separate `relationship_status` fact |
+| `RelationshipType` | `src/buddy/entities/relationships.py:?` | (paste full list) | See SUPERSESSION_MAP and CONFLICT_GROUPS below |
+| ... | | | |
+
+---
+
+## 4. CHECK constraints cited
+
+For every CHECK constraint the spec extends or relies on:
+
+| Table.column | Path:Line | Current values | Notes |
+|---|---|---|---|
+| `grid_fact.source` | `scripts/init-db.sql:1666` | `('extracted', 'stated', 'inferred', 'probed', 'seeded')` | Add `'onboarding_owner'` via migration |
+| `grid_edge.source` | `scripts/init-db.sql:1699` | `('stated', 'extracted', 'inferred', 'seeded')` | No `'probed'`; add `'onboarding_owner'` via migration |
+| ... | | | |
+
+---
+
+## 5. Cross-module helpers / contracts
+
+For helpers the spec invokes from a different module, or contracts that span
+modules (e.g., a queue payload schema, a published event shape):
+
+| Helper / Contract | Path | Shape | Notes |
+|---|---|---|---|
+| `resolve_or_create_entity` | `src/buddy/services/entity_merge.py:?` | `(pool, name, entity_type, ...) -> Entity` | Already fixed in PR #1453; bypasses `grid_write_queue` |
+| `enqueue_grid_write` | `src/buddy/services/grid/write_queue.py:?` | `(payload, source, ...)` | NOT used by onboarding — synchronous writes only |
+| `find_relationship_conflict` | `src/buddy/entities/relationships.py:101` | `(existing_types: set[str], new_type: str) -> str \| None` | Treats `{spouse_of, partner_of, ex_partner_of}` as mutually exclusive (CONFLICT_GROUPS at `:64`) — onboarding cannot transition between them via `add_edge` |
+| ... | | | |
+
+---
+
+## 6. Migration provenance
+
+For every column / constraint the spec claims is "already in production":
+
+| Object | Owning migration | Path |
+|---|---|---|
+| `grid_fact.source_ref jsonb` | `20260513000800_memory_v1_schema_gaps.sql:39` | `db/migrations/` |
+| `grid_edge.source_ref` | NOT YET PRESENT — this spec adds it | (new in V1) |
+| ... | | |
+
+---
+
+## 7. Negative manifest (things that do NOT exist)
+
+Explicitly list things that look like they should exist but don't. The
+owner_onboarding loop's round 1 found V1.0 calling `add_fact()` which has
+never existed. List confirmed non-existence to prevent future re-invention:
+
+- `add_fact(pool, ...)` — NOT in `services/grid/crud.py`. Closest: `upsert_fact` at `:287`. Onboarding cannot use a function that doesn't exist.
+- `bypass_vocabulary_review` parameter — NOT on `enqueue_grid_write`.
+- `grid_edge.is_active` column — NOT in `init-db.sql`. Edges have no soft-delete state.
+- `SUPERSESSION_MAP[EX_PARTNER_OF] = {PARTNER_OF}` — NOT present; only `{SPOUSE_OF}` is.
+- ... etc.
+
+---
+
+## 8. Self-verification checklist (before submitting V1.0)
+
+- [ ] Every function name in the spec is in §1 with verified signature
+- [ ] Every table.column reference is in §2 with verified shape
+- [ ] Every enum value is in §3 with verified existence
+- [ ] Every CHECK constraint extension is in §4 with current values
+- [ ] Every cross-module helper is in §5
+- [ ] Every "already in production" claim is in §6 with the actual owning migration
+- [ ] Section 7 explicitly lists what the spec considered but is NOT writing because it doesn't exist
+- [ ] For any "operation X happens via Y" claim in the spec: I read the 50 lines around Y in §1, including guards/branches/early returns
+
+If any box is unchecked, V1.0 is not ready for adversarial review.


### PR DESCRIPTION
## Summary
- Adds the **code-reality manifest** drafting discipline distilled from the owner_onboarding_v1 8-round adversarial review loop (May 2026). Risk trajectory was non-monotonic (8→8→7→6→5→7→8→7); 6 of 14 findings were latent V1.0–V1.2 bugs reviewers excavated slowly across rounds.
- Extends `rules/spec-review-workflow.md` with §1 (lessons), §2 (mandatory manifest), §3 (self-review checklist), §4 (convergence rules: cap at 3 rounds, risk-trajectory + divergence signals, stop-conditions before R4), §5 (end-to-end happy path).
- Updates `agents/spec-reviewer.md` with three critical review rules: trace execution order (not just symbol locations), check for manifest companion, look for cross-section contradictions. Version 1.1 → 1.2.
- New `templates/code-reality-manifest.md` — fillable companion: Functions / Tables / Enums / CHECK constraints / Cross-module helpers / Migration provenance / Negative manifest.
- `install.sh`: symlink `templates/` into `~/.claude/` (was missing — would have left the manifest reference unresolved).

## Why
8 rounds of review × 2 reviewers ≈ 7 hours per spec. Target is ≤3 rounds. The single highest-leverage fix is moving code-reality verification from review-time to drafting-time. Every grade-A finding across rounds 1, 6, 7, 8 of the onboarding loop would have been caught at zero cost by a filled-in manifest.

## Test plan
- [x] `./install.sh` runs cleanly; Phase 4 verifier reports all 9 symlinks resolve
- [x] `~/.claude/templates/code-reality-manifest.md` is readable via the new symlink
- [x] `rules/spec-review-workflow.md` paths frontmatter unchanged (`**/specs/**`, `**/.agents/**`) — still auto-loads on spec work
- [x] `agents/spec-reviewer.md` frontmatter unchanged (registered subagent name + tools)
- [ ] Next spec authored uses the manifest discipline; should converge in ≤3 rounds (validation pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)