### PR TITLE
feat(telemetry): capture first-pass-correctness via /correction (#179)

### DIFF
--- a/claude-config/commands/correction.md
+++ b/claude-config/commands/correction.md
@@ -1,0 +1,78 @@
+---
+description: Mark a just-PASSED issue as first_pass_incorrect and record what was missed
+argument-hint: <issue-number> "<what was missed>"
+---
+
+# Correction Command
+
+Records a post-PROVE correction turn — a defect not caught by PROVE that required
+follow-up work. This makes first-pass-correctness measurable over time.
+
+## Usage
+
+```bash
+/correction 179 "forgot to wire the new check into main()"
+/correction 184 "missed that the MCP reader needed a backward-compat note"
+```
+
+## When to Use
+
+After running /orchestrate on an issue and then discovering a missed wiring,
+an overlooked requirement, or a logic error that PROVE did not catch — before
+or after /ship. Run once per correction turn; multiple corrections for the
+same issue append to the `corrections` list.
+
+## Process
+
+### Step 1: Parse Arguments
+
+Extract issue number and reason from the command arguments. The first argument
+is the issue number; everything after it (quoted or unquoted) is the reason.
+
+### Step 2: Flip the Metrics Record
+
+```bash
+python3 - <<'PYEOF'
+import sys, os
+sys.path.insert(0, os.path.expanduser('~/.claude/hooks'))
+from state_manager import flip_to_correction
+from pathlib import Path
+
+issue = int("$ISSUE")
+reason = "$REASON"
+
+ok = flip_to_correction(Path('.'), issue, reason, emit_failure=True)
+if ok:
+    print(f"Recorded correction for issue #{issue}: first_pass_correct=false")
+    print(f"Reason: {reason}")
+    print(f"A FIRST_PASS_DEFECT entry was also appended to failures.jsonl.")
+else:
+    print(f"WARNING: No metrics record found for issue #{issue}.")
+    print("Run /orchestrate first or verify the issue number.")
+PYEOF
+```
+
+### Step 3: Confirm
+
+After the flip, verify the record was written:
+
+```bash
+tail -5 .claude/memory/metrics.jsonl | python3 -c "
+import sys, json
+for line in sys.stdin:
+    line = line.strip()
+    if not line:
+        continue
+    r = json.loads(line)
+    if r.get('first_pass_correct') == False:
+        print(f\"  Issue #{r['issue']}: first_pass_correct=false, corrections={r['corrections']}\")
+"
+```
+
+## Notes
+
+- The original PASS record is preserved in metrics.jsonl as history.
+- The appended correction record is the canonical state (most-recent wins).
+- /learn and /metrics will count this issue as first_pass_correct=false.
+- The Stop hook in verify_completion.py will hint at this command when it
+  detects a probable correction turn (fix-branch + recent unflipped PASS).

--- a/claude-config/hooks/state_manager.py
+++ b/claude-config/hooks/state_manager.py
@@ -219,6 +219,8 @@ def record_metrics(
     root_cause: str | None = None,
     blocking_agent: str | None = None,
     agent_versions: dict[str, str] | None = None,
+    first_pass_correct: bool | None = None,
+    corrections: list | None = None,
 ) -> None:
     """Append a single record to ``.claude/memory/metrics.jsonl``.
 
@@ -227,8 +229,9 @@ def record_metrics(
          "complexity":"...","stack":"...","agents_run":[...]}
 
     Optional fields (root_cause, blocking_agent, duration_seconds,
-    agent_versions) are included only when supplied — keeps a PASS
-    record compact and parseable by /learn's existing jq filters.
+    agent_versions, first_pass_correct, corrections) are included only
+    when supplied — keeps a PASS record compact and parseable by
+    /learn's existing jq filters.
 
     Args:
         project_dir: Project root. The file lives at
@@ -245,6 +248,12 @@ def record_metrics(
         blocking_agent: Which agent surfaced the BLOCKED outcome
             (usually "PROVE"). Recorded only when status is BLOCKED.
         agent_versions: Optional version map, e.g. {"prove": "1.5"}.
+        first_pass_correct: True if the issue required no post-PROVE
+            corrections; False if a correction was recorded via
+            /correction. Absent on the initial PASS record (field
+            added retroactively by flip_to_correction).
+        corrections: List of correction reason strings. Only present
+            after /correction has been run at least once.
 
     Returns: None. Errors are logged to ``~/.claude/hooks.log``; the
     function never raises into the orchestrator.
@@ -265,6 +274,10 @@ def record_metrics(
         record["blocking_agent"] = blocking_agent
     if agent_versions:
         record["agent_versions"] = dict(agent_versions)
+    if first_pass_correct is not None:
+        record["first_pass_correct"] = first_pass_correct
+    if corrections is not None:
+        record["corrections"] = list(corrections)
 
     target = _memory_dir(project_dir) / "metrics.jsonl"
     try:
@@ -328,6 +341,84 @@ def record_failure(
         _append_jsonl(target, record)
     except OSError as e:
         logging.warning(f"record_failure: could not append to {target}: {e}")
+
+
+def flip_to_correction(
+    project_dir: Path,
+    issue: int,
+    reason: str,
+    emit_failure: bool = True,
+) -> bool:
+    """Find the most-recent metrics record for ``issue`` and append a
+    corrected copy with ``first_pass_correct=False`` and
+    ``corrections=[reason]``.
+
+    The original record is preserved (append-only invariant). The new
+    record is the canonical one — /learn and agent_metrics read the
+    most-recent record per issue.
+
+    Args:
+        project_dir: Project root.
+        issue: GitHub issue number to flip.
+        reason: Human-readable description of what was missed.
+        emit_failure: If True (default), also append a
+            FIRST_PASS_DEFECT entry to failures.jsonl.
+
+    Returns:
+        True if a record was found and the correction was appended.
+        False if no record for ``issue`` was found (logs a warning).
+        Fails open on IOError (logs warning, returns False).
+    """
+    issue = int(issue)
+    target = _memory_dir(project_dir) / "metrics.jsonl"
+    try:
+        if not target.exists():
+            logging.warning(
+                f"flip_to_correction: metrics.jsonl not found at {target}"
+            )
+            return False
+
+        lines = [l for l in target.read_text(encoding="utf-8").splitlines() if l.strip()]
+        last_record: dict | None = None
+        for line in lines:
+            try:
+                rec = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if rec.get("issue") == issue:
+                last_record = rec
+
+        if last_record is None:
+            logging.warning(
+                f"flip_to_correction: no metrics record found for issue #{issue}"
+            )
+            return False
+
+        # Build the corrected record from the last one.
+        corrected = dict(last_record)
+        corrected["date"] = datetime.now().strftime("%Y-%m-%d")
+        corrected["first_pass_correct"] = False
+        existing = corrected.get("corrections")
+        if isinstance(existing, list):
+            corrected["corrections"] = existing + [reason]
+        else:
+            corrected["corrections"] = [reason]
+
+        _append_jsonl(target, corrected)
+
+        if emit_failure:
+            record_failure(
+                project_dir,
+                issue,
+                "FIRST_PASS_DEFECT",
+                details=reason,
+            )
+
+        return True
+
+    except OSError as e:
+        logging.warning(f"flip_to_correction: IOError for issue #{issue}: {e}")
+        return False
 
 
 # ---------------------------------------------------------------------------

--- a/claude-config/hooks/verify_completion.py
+++ b/claude-config/hooks/verify_completion.py
@@ -9,11 +9,13 @@ Always exits 0 to avoid feedback loops. The output is visible to the user
 as context for whether to continue the conversation.
 """
 
+import json
 import os
+import re
 import shlex
 import subprocess
 import sys
-from datetime import datetime
+from datetime import datetime, timedelta
 
 
 def log(msg: str) -> None:
@@ -106,6 +108,75 @@ def check_todos_in_changes() -> str | None:
     return None
 
 
+def check_correction_needed() -> str | None:
+    """Heuristic: warn if a recent PASS record has no correction recorded yet
+    and the current branch looks like a follow-up fix for that issue.
+
+    Signal: branch name contains "fix" (case-insensitive) AND an issue number
+    is extractable from the branch name AND metrics.jsonl has a record for
+    that issue with status=PASS, no ``first_pass_correct`` field, and a date
+    within the last 7 days.
+
+    Advisory only — never raises; returns None on any error.
+    """
+    try:
+        code, branch = run("git branch --show-current 2>/dev/null")
+        if code != 0 or not branch or "fix" not in branch.lower():
+            return None
+
+        m = re.search(r"issue[-/](\d+)", branch, re.IGNORECASE)
+        if not m:
+            # Also accept plain numeric segment: fix/179-slug
+            m = re.search(r"[-/](\d+)[-/]", branch)
+        if not m:
+            return None
+        issue_num = int(m.group(1))
+
+        # Locate metrics.jsonl relative to CWD (project root).
+        metrics_path = os.path.join(os.getcwd(), ".claude", "memory", "metrics.jsonl")
+        if not os.path.exists(metrics_path):
+            return None
+
+        cutoff = datetime.now() - timedelta(days=7)
+        last_record = None
+        with open(metrics_path, encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    rec = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if rec.get("issue") == issue_num:
+                    last_record = rec
+
+        if last_record is None:
+            return None
+
+        if last_record.get("status") != "PASS":
+            return None
+
+        if "first_pass_correct" in last_record:
+            return None  # correction already recorded
+
+        try:
+            rec_date = datetime.strptime(last_record.get("date", ""), "%Y-%m-%d")
+        except ValueError:
+            return None
+
+        if rec_date < cutoff:
+            return None
+
+        return (
+            f"issue #{issue_num} has a recent PASS but no correction recorded — "
+            f"if this is a correction turn, run: "
+            f'/correction {issue_num} "<what was missed>"'
+        )
+    except Exception:
+        return None
+
+
 def main() -> None:
     issues = []
 
@@ -124,6 +195,10 @@ def main() -> None:
     todos = check_todos_in_changes()
     if todos:
         issues.append(todos)
+
+    correction_hint = check_correction_needed()
+    if correction_hint:
+        issues.append(correction_hint)
 
     if issues:
         # Advisory only — print warnings but always exit 0 to avoid loops


### PR DESCRIPTION
## Summary
Makes the real defect rate visible. Adds `first_pass_correct` + `corrections` to the metrics schema and a `/correction <issue> "<missed>"` command to flip a just-PASSED issue, plus an advisory Stop-hook nudge. Closes #179.

## Changes
- `state_manager.py`: optional `first_pass_correct`/`corrections` kwargs on `record_metrics()`; new `flip_to_correction()` (locates latest metric for issue, flips + appends reason, optional FIRST_PASS_DEFECT failure record; fails open).
- `verify_completion.py`: advisory `check_correction_needed()` (branch "fix" + recent PASS lacking the field → hint); always exits 0.
- `commands/correction.md`: new micro-command.

## Test Plan
- `py_compile` both hooks; `pytest tests/ -q` → 25/25.
- End-to-end temp-dir flip test: PASS record preserved, corrected record has `first_pass_correct=false` + reason, `failures.jsonl` got FIRST_PASS_DEFECT, MCP `agent_metrics` parsed mixed records cleanly (backward-compatible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)