### PR TITLE
feat(statusline): ambient rate-limit display (#181)

### DIFF
--- a/claude-config/statusline.py
+++ b/claude-config/statusline.py
@@ -5,6 +5,7 @@ import sys
 import getpass
 from datetime import datetime
 
+
 def main():
     # Read JSON input from stdin
     input_data = json.load(sys.stdin)
@@ -27,13 +28,16 @@ def main():
 
     # Current working directory, home-relative (cyan)
     import os
+
     home = os.path.expanduser("~")
     cwd_raw = os.getcwd()
-    cwd_display = "~" + cwd_raw[len(home):] if cwd_raw.startswith(home) else cwd_raw
+    cwd_display = "~" + cwd_raw[len(home) :] if cwd_raw.startswith(home) else cwd_raw
     cwd = f"{CYAN}{cwd_display}{RESET}"
 
     # Agent name (orange) — from .mcp.json in cwd, agent config, or env
-    agent_name = input_data.get("agent", {}).get("name") or os.environ.get("AGENT_NAME") or ""
+    agent_name = (
+        input_data.get("agent", {}).get("name") or os.environ.get("AGENT_NAME") or ""
+    )
     if not agent_name:
         try:
             mcp_path = os.path.join(os.getcwd(), ".mcp.json")
@@ -61,10 +65,49 @@ def main():
     else:
         context_display = f"{GREEN}0.0%{RESET}"
 
+    # Rate-limit ambient display — only shown when >= 70% of a quota window is used.
+    # Suppressed entirely when rate_limits is absent (older CC, API key users).
+    rate_segments = []
+    try:
+        rate_limits = input_data.get("rate_limits")
+        if isinstance(rate_limits, dict):
+            windows = [
+                ("5h", rate_limits.get("fiveHour")),
+                ("7d", rate_limits.get("sevenDay")),
+            ]
+            for label, window in windows:
+                if not isinstance(window, dict):
+                    continue
+                pct = window.get("used_percentage")
+                if not isinstance(pct, (int, float)):
+                    continue
+                if pct < 70:
+                    continue
+                # Pick color by threshold
+                rl_color = RED if pct >= 90 else ORANGE
+                # Append reset time (HH:MM local) when critical
+                resets_at = window.get("resets_at")
+                reset_str = ""
+                if pct >= 90 and isinstance(resets_at, str):
+                    try:
+                        reset_dt = datetime.fromisoformat(
+                            resets_at.replace("Z", "+00:00")
+                        )
+                        reset_local = reset_dt.astimezone()
+                        reset_str = f"@{reset_local.strftime('%H:%M')}"
+                    except Exception:
+                        pass
+                rate_segments.append(f"{rl_color}{pct:.1f}%{reset_str} {label}{RESET}")
+    except Exception:
+        pass  # Never crash statusline on malformed rate_limits data
+
+    rate_display = (" | " + " ".join(rate_segments)) if rate_segments else ""
+
     # Build status line
-    status_line = f"{server} | {username} | {cwd} | {current_date} | {context_display} ctx{agent_display}"
+    status_line = f"{server} | {username} | {cwd} | {current_date} | {context_display} ctx{rate_display}{agent_display}"
 
     print(status_line)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
Diagnosis: the 2,820 `/rate-limit-options` history entries were a **one-time Claude Code bug** (auto-open loop on 2026-01-23, 2,806 entries in 94s, since fixed upstream) + 14 manual checks that stopped after a plan upgrade. **Zero in the 9,601 entries since** — nothing live to remove. Preventive fix instead: surface quota ambiently in the statusline so manual checking is never needed. Closes #181.

## Changes
- `claude-config/statusline.py`: consume the `rate_limits` stdin field (CC v2.1.80+). Show nothing <70%; orange 70–89%; red ≥90% with reset time. Fully exception-guarded.

## Test Plan
- `py_compile` + `ruff` clean; `pytest tests/ -q` 25/25.
- Piped real stdin: <70 suppressed, 75 orange, 95 red+reset, boundary-exact (69.9/70.0, 89.9/90.0).
- Backward-compat: absent key, string/int value, missing `used_percentage`, null window, bad ISO date — zero crashes, baseline output preserved. `history.jsonl` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)