### PR TITLE
feat(agents): early live reality-check probe for DB/LLM work (#183)

### DIFF
--- a/claude-config/agents/map-plan.md
+++ b/claude-config/agents/map-plan.md
@@ -4,7 +4,7 @@ description: Combined investigator+planner for TRIVIAL/SIMPLE orchestrate tasks.
 tools: Read, Grep, Glob, Bash, Write
 model: sonnet
 agent: "MAP-PLAN"
-version: 1.1
+version: 1.2
 phase: "1+2"
 extends: _base.md
 purpose: "Combined investigation + planning for TRIVIAL/SIMPLE tasks"
@@ -57,6 +57,8 @@ Before proceeding with analysis, ALWAYS complete these verification steps:
 - [ ] Verify EACH assumption by reading actual code (use Read tool)
 - [ ] Document what was verified and the result
 - [ ] Never assume structure—always confirm with Read tool
+- [ ] For DB/LLM-schema tasks: run the Live Reality-Check (Step 3.5) — don't assume
+      table names, column sets, or Pool/Connection types.
 
 ### 3. Ambiguity Resolution
 - [ ] If multiple valid approaches exist, pick ONE
@@ -124,6 +126,49 @@ find backend/backend -name "*.py" | xargs grep -l "KEYWORD"
 # Frontend
 find frontend/src -name "*.jsx" -o -name "*.js" | xargs grep -l "KEYWORD"
 ```
+
+### 3.5 Live Reality-Check (skip if no DB or LLM schema involved)
+
+**Skip this step** for frontend-only, docs, config, and rename tasks.
+**Run this step** when the task touches DB models, migrations, asyncpg calls,
+or an OpenAI structured-output schema.
+
+```bash
+# 1. Confirm tables and columns exist as the plan assumes
+source .env 2>/dev/null || true
+psql "$DATABASE_URL" -c "\dt" 2>/dev/null        # list all tables — verify name
+psql "$DATABASE_URL" -c "\d <table_name>"        # columns, types, constraints
+
+# 2. Confirm Pool vs Connection for asyncpg callers
+grep -n "def get_pool\|def get_connection\|async_sessionmaker\|create_pool" \
+  backend/backend/database.py backend/backend/db/*.py 2>/dev/null | head -10
+
+# 3. Dry-run strict JSON schema (only if task uses response_format json_schema)
+python - <<'PY'
+import json, sys
+schema = { }  # paste planned schema here
+assert schema.get("additionalProperties") == False, "additionalProperties must be false"
+for k, v in schema.get("properties", {}).items():
+    assert "type" in v, f"property {k!r} missing 'type'"
+print("Schema OK")
+PY
+```
+
+**Record findings** in the MAP-PLAN artifact under a "Reality-Check Findings" section:
+
+```markdown
+### Reality-Check Findings
+- Tables confirmed: `entity` (not `grid_entity`), `grid_fact` — both present
+- `get_pool()` returns `asyncpg.Pool`; `.transaction()` requires a `Connection` —
+  must call `pool.acquire()` first
+- Strict schema dry-run: `additionalProperties: false` confirmed, all properties
+  have `type` — OK
+```
+
+If any check fails (table absent, wrong type, schema invalid), **STOP and report**
+before continuing to Step 4.
+
+---
 
 ### 4. Document Component APIs (if frontend)
 

--- a/claude-config/agents/map.md
+++ b/claude-config/agents/map.md
@@ -4,7 +4,7 @@ description: Read-only investigator for COMPLEX orchestrate workflow phase 1. Ma
 tools: Read, Grep, Glob, Bash, Write
 model: haiku
 agent: "MAP"
-version: 1.1
+version: 1.2
 phase: 1
 extends: _base.md
 purpose: "Read-only investigation - understand current state before planning"
@@ -72,6 +72,49 @@ find backend/tests -name "test_*.py" | xargs grep -l "KEYWORD"
 # Components, hooks, contexts
 find frontend/src -name "*.jsx" -o -name "*.js" | xargs grep -l "KEYWORD"
 ```
+
+### 3.5 Live Reality-Check (skip if no DB or LLM schema involved)
+
+**Skip this step** for frontend-only, docs, config, and rename tasks.
+**Run this step** when the task touches DB models, migrations, asyncpg calls,
+or an OpenAI structured-output schema.
+
+```bash
+# 1. Confirm tables and columns exist as the plan assumes
+source .env 2>/dev/null || true
+psql "$DATABASE_URL" -c "\dt" 2>/dev/null        # list all tables — verify name
+psql "$DATABASE_URL" -c "\d <table_name>"        # columns, types, constraints
+
+# 2. Confirm Pool vs Connection for asyncpg callers
+grep -n "def get_pool\|def get_connection\|async_sessionmaker\|create_pool" \
+  backend/backend/database.py backend/backend/db/*.py 2>/dev/null | head -10
+
+# 3. Dry-run strict JSON schema (only if task uses response_format json_schema)
+python - <<'PY'
+import json, sys
+schema = { }  # paste planned schema here
+assert schema.get("additionalProperties") == False, "additionalProperties must be false"
+for k, v in schema.get("properties", {}).items():
+    assert "type" in v, f"property {k!r} missing 'type'"
+print("Schema OK")
+PY
+```
+
+**Record findings** in the MAP artifact under a "Reality-Check Findings" section:
+
+```markdown
+### Reality-Check Findings
+- Tables confirmed: `entity` (not `grid_entity`), `grid_fact` — both present
+- `get_pool()` returns `asyncpg.Pool`; `.transaction()` requires a `Connection` —
+  must call `pool.acquire()` first
+- Strict schema dry-run: `additionalProperties: false` confirmed, all properties
+  have `type` — OK
+```
+
+If any check fails (table absent, wrong type, schema invalid), **STOP and report**
+before continuing to Step 4.
+
+---
 
 ### 4. Document Reusable Components (MANDATORY for frontend)
 

--- a/claude-config/agents/patch.md
+++ b/claude-config/agents/patch.md
@@ -4,7 +4,7 @@ description: Implements the approved PLAN with minimal diffs. Phase 3 of orchest
 tools: Read, Edit, Write, MultiEdit, Grep, Glob, Bash
 model: sonnet
 agent: "PATCH"
-version: 1.5
+version: 1.6
 phase: 3
 extends: _base.md
 purpose: "Implement the PLAN with minimal diffs"
@@ -32,6 +32,9 @@ ls .agents/outputs/contract-${ISSUE_NUMBER}-*.md 2>/dev/null || echo "BLOCKED: C
 
 ```markdown
 - [ ] Read PLAN/MAP-PLAN artifact
+- [ ] If backend/DB/LLM task: read "Reality-Check Findings" from MAP/MAP-PLAN
+      artifact — verify table names, Pool vs Connection type, and schema validity
+      before writing any code.
 - [ ] Read CONTRACT artifact (MANDATORY if fullstack — STOP if missing)
 - [ ] Read `.claude/rules.md`
 - [ ] **NOT on main branch** (`git branch --show-current`)


### PR DESCRIPTION
## Summary
Adds a pre-implementation, ACTIVE reality-check (Step 3.5) to MAP/MAP-PLAN for DB/LLM-schema tasks — probe live infra before writing code, killing the live-only failure DNA (wrong table, reserved word, Pool-vs-Connection, OpenAI strict-schema 400). Complements (does not duplicate) #182's post-implementation wiring checklist. Closes #183.

## Changes
- `agents/map.md` (1.1→1.2) + `agents/map-plan.md` (1.1→1.2): new Step 3.5 with skip condition + 3 concrete probes (psql `\dt`/`\d`, Pool-vs-Connection grep, strict-JSON-schema validator) + findings template + STOP-on-failure.
- `agents/patch.md` (1.5→1.6): one Pre-Implementation bullet referencing the recorded findings; #182 wiring checklist untouched.

## Test Plan
- Markers + version strings grep-verified path:line; #182 checklist confirmed intact; `Reality-Check` appears once in patch.md (no command duplication).
- `pytest tests/ -q` → 25/25. Exactly 3 files changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)