### PR TITLE
feat(spec): frontend-component + design-token manifests (#185)

### DIFF
--- a/claude-config/commands/spec-draft.md
+++ b/claude-config/commands/spec-draft.md
@@ -41,6 +41,36 @@ manifest — 4 of those rounds were manifest failures. Do not skip this gate.
 
 ---
 
+## Pre-Condition: Frontend-Component Manifest (HARD GATE — UI/Fullstack features only)
+
+**Skip this gate entirely for backend-only features.**
+
+For any feature whose type (Step 1) is **UI Component**, **Fullstack**, or any
+**Enhancement / Integration** that touches frontend code, verify that a
+frontend-component manifest exists:
+
+```
+specs/<feature>.frontend-manifest.md
+```
+
+If it does not exist:
+1. **STOP.** Do not proceed to Step 1.
+2. Tell the user: "A frontend-component manifest is required before drafting a
+   UI-touching spec. Please produce `specs/<feature>.frontend-manifest.md` using
+   the template at `~/.claude/templates/frontend-component-manifest.md` (§1–§8),
+   then re-run `/spec-draft`."
+3. Before filling the manifest, run `/discover-patterns frontend` in the target
+   repo to surface reusable components, hooks, and design tokens. Cite the output
+   in §1–§4 of the manifest.
+4. Do NOT draft the spec or move to Step 1 until the manifest file exists and the
+   §8 self-verification checklist is complete.
+
+**Rationale**: UI specs that don't cite real prop contracts or design tokens by name
+lead to re-implemented one-off components and visual inconsistency — the frontend
+parallel to the `owner_onboarding` backend manifest failures.
+
+---
+
 ## Process
 
 ### Step 1: Classify Feature Type
@@ -75,6 +105,18 @@ grep -l "account_id" backend/backend/*/models.py
 # Find existing enums
 grep -r "class.*Enum" backend/backend/*/enums.py
 ```
+
+**For UI/frontend features** — before reporting findings, run:
+
+```bash
+/discover-patterns frontend
+```
+
+This surfaces reusable components, shared hooks, and design tokens from the
+project's `frontend/src/` tree. Results must be cited in the
+`specs/<feature>.frontend-manifest.md` §1–§4 before the spec can proceed.
+If a `knowledge/design-tokens.yaml` does not yet exist in this repo, create one
+using `~/.claude/templates/design-tokens.yaml` as the schema.
 
 Report findings:
 ```

--- a/claude-config/rules/spec-review-workflow.md
+++ b/claude-config/rules/spec-review-workflow.md
@@ -86,9 +86,25 @@ Pick the 4–6 sections of the spec most likely to drift apart (typical pairs: a
 
 The V1.7→V1.8 round-8 finding was a fact-correction-model contradiction across §7.2, §7.5, §11.4, §12.3 — present since V1.0, undetected for 7 rounds because each round focused on deltas, not whole-spec coherence.
 
-### 3.4 Output
+### 3.4 Frontend component-API verification (UI/Fullstack features only)
 
-If anything in §3.1–§3.3 fails, V1.0 is not ready. Fix and re-check before involving reviewers. Reviewers are an expensive resource (each round ≈ 20 min of agent compute + your synthesis time); don't burn them on errors you could have caught in 15 minutes.
+**Skip for backend-only specs.**
+
+For any spec that touches frontend code:
+
+- [ ] Every component cited in the spec is in `specs/<feature>.frontend-manifest.md` §1
+      with a verified prop contract (PropTypes or TypeScript interface, not assumed).
+- [ ] Every hook cited is in §2 with a verified return shape.
+- [ ] Every design token referenced matches the project's `knowledge/design-tokens.yaml`
+      (or `specs/<feature>.frontend-manifest.md` §3 if the yaml doesn't exist yet).
+- [ ] §5 of the manifest explicitly maps spec requirements to real, existing components.
+- [ ] §6 of the manifest lists any component the spec considered but found absent.
+
+If any box is unchecked and the spec is UI/Fullstack, V1.0 is not ready.
+
+### 3.5 Output
+
+If anything in §3.1–§3.4 fails, V1.0 is not ready. Fix and re-check before involving reviewers. Reviewers are an expensive resource (each round ≈ 20 min of agent compute + your synthesis time); don't burn them on errors you could have caught in 15 minutes.
 
 ---
 

--- a/claude-config/templates/design-tokens.yaml
+++ b/claude-config/templates/design-tokens.yaml
@@ -1,0 +1,84 @@
+# design-tokens.yaml
+# Per-project design token registry.
+#
+# Convention:
+#   Location  : knowledge/design-tokens.yaml (repo root of each frontend project)
+#   Spec ref  : Add `design_tokens: knowledge/design-tokens.yaml` to spec frontmatter.
+#   Populate  : Run `/discover-patterns frontend` and choose "design tokens" as the
+#               focus area, OR extract manually from the design system config file.
+#   Maintain  : Update `meta.verified_at` + `meta.verified_commit` whenever the
+#               design system changes (tailwind config, globals.css theme block, etc.).
+#
+# This file is a SCHEMA EXAMPLE. Replace all placeholder <value> entries with actuals
+# from the target project before referencing this file in a spec manifest.
+
+meta:
+  project: "<repo-name>"
+  design_system: "<Tailwind | shadcn/ui | custom | MUI | ...>"
+  source_file: "<frontend/tailwind.config.js | src/styles/globals.css | ...>"
+  verified_at: "<YYYY-MM-DD>"
+  verified_commit: "<hash>"
+
+colors:
+  # CSS variable name → resolved value.
+  # Prefer semantic names (--color-primary) over raw palette (--blue-500).
+  primary: "<value>"              # e.g. "oklch(0.65 0.24 264)"
+  primary_foreground: "<value>"
+  background: "<value>"
+  foreground: "<value>"
+  muted: "<value>"
+  muted_foreground: "<value>"
+  accent: "<value>"
+  accent_foreground: "<value>"
+  destructive: "<value>"
+  border: "<value>"
+  ring: "<value>"
+  # Add project-specific semantic tokens below
+
+spacing:
+  # Numeric scale or named steps from the design system.
+  base: "<value>"                 # e.g. "4px" or "0.25rem" (1 Tailwind unit)
+  sm: "<value>"                   # e.g. "0.5rem"
+  md: "<value>"                   # e.g. "1rem"
+  lg: "<value>"                   # e.g. "1.5rem"
+  xl: "<value>"                   # e.g. "2rem"
+
+typography:
+  font_sans: "<value>"            # e.g. "Inter, system-ui, sans-serif"
+  font_mono: "<value>"            # e.g. "JetBrains Mono, monospace"
+  size_xs: "<value>"              # e.g. "0.75rem"
+  size_sm: "<value>"              # e.g. "0.875rem"
+  size_base: "<value>"            # e.g. "1rem"
+  size_lg: "<value>"              # e.g. "1.125rem"
+  size_xl: "<value>"              # e.g. "1.25rem"
+  size_2xl: "<value>"             # e.g. "1.5rem"
+  weight_normal: "<value>"        # e.g. "400"
+  weight_medium: "<value>"        # e.g. "500"
+  weight_semibold: "<value>"      # e.g. "600"
+  weight_bold: "<value>"          # e.g. "700"
+  line_height_tight: "<value>"    # e.g. "1.25"
+  line_height_normal: "<value>"   # e.g. "1.5"
+  line_height_relaxed: "<value>"  # e.g. "1.75"
+
+shadows:
+  sm: "<value>"                   # e.g. "0 1px 2px 0 rgb(0 0 0 / 0.05)"
+  md: "<value>"                   # e.g. "0 4px 6px -1px rgb(0 0 0 / 0.1)"
+  lg: "<value>"                   # e.g. "0 10px 15px -3px rgb(0 0 0 / 0.1)"
+
+radii:
+  sm: "<value>"                   # e.g. "0.25rem"
+  md: "<value>"                   # e.g. "0.5rem"
+  lg: "<value>"                   # e.g. "0.75rem"
+  full: "9999px"                  # pill / circle shapes
+
+breakpoints:
+  sm: "640px"
+  md: "768px"
+  lg: "1024px"
+  xl: "1280px"
+  "2xl": "1536px"
+
+# Usage in a spec manifest (specs/<feature>.frontend-manifest.md §3):
+#   Cite tokens by key and resolved value so reviewers can verify without
+#   opening the config file.
+#   Example row: colors.primary | colors | "oklch(0.65 0.24 264)" | Button bg

--- a/claude-config/templates/frontend-component-manifest.md
+++ b/claude-config/templates/frontend-component-manifest.md
@@ -1,0 +1,135 @@
+---
+purpose: "Fillable companion to a UI spec — captures verified frontend reality BEFORE drafting"
+companion_to: "specs/<spec-name>.md"
+filename_convention: "specs/<spec-name>.frontend-manifest.md"
+---
+
+# Frontend-Component Manifest — `<spec-name>`
+
+**Verified as of:** YYYY-MM-DD against commit `<hash>`
+
+This document is a **drafting precondition**, not a spec deliverable. Fill it in
+BEFORE writing the spec. Every load-bearing claim the spec makes about reusable
+components, hooks, or design tokens must be backed by an entry here, copied
+verbatim from the actual source files.
+
+When the spec cites a component, hook, or token, the reviewer should be able to
+look here first and confirm the claim against the manifest, rather than re-tracing
+from scratch every round.
+
+Rationale: see `~/.claude/rules/spec-review-workflow.md` §3.4 (Frontend
+component-API verification). UI specs that name vague component intent rather
+than real prop contracts lead to re-implemented one-off components and visual
+inconsistency — the frontend parallel to the `owner_onboarding_v1` backend
+manifest failures.
+
+---
+
+## 1. Reusable components
+
+For every component the spec uses or extends:
+
+| Component | Path:Line | Props (verbatim from PropTypes/interface) | Relevant states | Notes |
+|---|---|---|---|---|
+| `Button` | `frontend/src/components/ui/button.jsx:12` | `variant, size, disabled, onClick, children` | `disabled` grays out + blocks click | shadcn/ui wrapper; variant values: `"default" \| "destructive" \| "outline" \| "ghost"` |
+| ... | | | | |
+
+**Trace rule:** for any component you cite, read the PropTypes/TypeScript interface
+AND at least 30 lines of the render return — default prop values and conditional
+rendering affect whether a prop is actually required or optional.
+
+---
+
+## 2. Shared hooks and state patterns
+
+For every hook or global state pattern the spec relies on:
+
+| Hook | Path:Line | Return shape (verbatim) | Side effects | Notes |
+|---|---|---|---|---|
+| `useEntity` | `frontend/src/hooks/useEntity.js:8` | `{ entity, loading, error, refresh }` | Fetches on mount; re-fetches on `entityId` change | Backed by `/api/entities/:id`; no local cache TTL |
+| ... | | | | |
+
+---
+
+## 3. Design tokens
+
+Point to the project's `knowledge/design-tokens.yaml` (see schema at
+`~/.claude/templates/design-tokens.yaml`). List only the tokens this spec
+will use, copied verbatim from that file.
+
+**Token source:** `knowledge/design-tokens.yaml` (or `frontend/tailwind.config.js` / `src/styles/globals.css`)
+
+| Token | Category | Value | Notes |
+|---|---|---|---|
+| `colors.primary` | colors | `oklch(0.65 0.24 264)` | Button backgrounds, active indicators |
+| `spacing.md` | spacing | `1rem` | Card padding, section gaps |
+| ... | | | |
+
+If `knowledge/design-tokens.yaml` does not yet exist in this repo, create it
+using `~/.claude/templates/design-tokens.yaml` as the schema, then populate by
+running `/discover-patterns frontend` and choosing "design tokens" as the focus.
+
+---
+
+## 4. Layout primitives
+
+For grid wrappers, page shells, drawer/modal scaffolds, and responsive containers
+the spec relies on:
+
+| Component / CSS class | Path or file | Purpose | Notes |
+|---|---|---|---|
+| `PageShell` | `frontend/src/layouts/PageShell.jsx:1` | Provides nav sidebar + main content area with correct z-index | All top-level pages wrap in this |
+| `DrawerPanel` | `frontend/src/components/ui/DrawerPanel.jsx:1` | Slide-in panel from right, 480px wide on lg+ | Used for detail views |
+| ... | | | |
+
+---
+
+## 5. Components to reuse for this feature
+
+Synthesis section — which items from §1–§4 map directly onto this feature's
+requirements. This is where the spec author demonstrates the reuse intent before
+writing the spec.
+
+| Component | Why / which prop contract it satisfies |
+|---|---|
+| `Button` (variant="destructive") | Confirms delete action — `onClick` handler triggers the service call; `disabled` set while request in flight |
+| `useEntity` hook | Populates the detail view — `entity` shape matches the card props; `loading` drives the skeleton state |
+| ... | |
+
+---
+
+## 6. Components NOT available (negative manifest)
+
+Explicitly list components that look like they should exist but don't. Prevents
+spec authors from referencing a `<DataGrid />` that lives only in imagination.
+
+- `<DataGrid />` — NOT in `frontend/src/components/`. Closest: `<Table />` at `frontend/src/components/ui/table.jsx`. Use that instead.
+- `useInfiniteScroll` hook — NOT in `frontend/src/hooks/`. Closest: react-query `useInfiniteQuery` (already a dep).
+- ... etc.
+
+---
+
+## 7. Design system source
+
+Record which design system files and token sources were consulted and at what
+commit:
+
+| Token source | Path | Verified at commit |
+|---|---|---|
+| Tailwind config | `frontend/tailwind.config.js` | `<hash>` |
+| shadcn theme | `frontend/src/styles/globals.css:1-40` | `<hash>` |
+| Design tokens yaml | `knowledge/design-tokens.yaml` | `<hash>` |
+
+---
+
+## 8. Self-verification checklist (before submitting V1.0)
+
+- [ ] Every reused component in the spec is in §1 with a verified prop contract (PropTypes or TypeScript interface, not assumed)
+- [ ] Every hook or global state pattern used is in §2 with a verified return shape
+- [ ] Every design token referenced is in §3, copied verbatim from the project's `knowledge/design-tokens.yaml` or design system source
+- [ ] Every layout primitive is in §4
+- [ ] §5 explicitly maps spec requirements to real, existing components
+- [ ] §6 lists every component the spec considered but found absent
+- [ ] §7 records where tokens and component APIs were verified and at what commit
+
+If any box is unchecked, V1.0 is not ready for adversarial review.


### PR DESCRIPTION
## Summary
Closes the frontend/reuse blind spot in specs. Adds a frontend-component manifest template + design-tokens.yaml convention (parallel to the code-reality manifest), and wires `/discover-patterns frontend` into spec-draft. UI specs must now cite reusable components/tokens by name; backend-only specs are unaffected. Closes #185.

## Changes
- `templates/frontend-component-manifest.md` (new) — 8 sections incl. negative manifest + self-verification checklist.
- `templates/design-tokens.yaml` (new) — 6 token categories + per-project convention.
- `commands/spec-draft.md` — second HARD GATE (UI/Fullstack only) after the #182 code-reality gate + Step-2 discover-patterns prompt.
- `rules/spec-review-workflow.md` — new §3.4 frontend component-API check (skip for backend-only).

## Test Plan
- design-tokens.yaml validated; both gates coexist; all new requirements conditional on UI features; agents-repo `pytest tests/` 25/25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)