### PR TITLE
feat(learn): automate weekly /learn + patterns-full re-injection (#186)

### DIFF
--- a/claude-config/commands/learn.md
+++ b/claude-config/commands/learn.md
@@ -1,6 +1,6 @@
 ---
 description: Analyze failure patterns and update learned knowledge base
-argument-hint: [--since YYYY-MM-DD] [--dry-run] [--verbose]
+argument-hint: [--since YYYY-MM-DD] [--dry-run] [--verbose] [--apply] [--validate] [--cross-project]
 ---
 
 # Learn Command
@@ -28,7 +28,7 @@ Analyzes accumulated failures and successes to extract patterns and update the k
 2. **Clusters failures** by root cause
 3. **Calculates metrics** (success rates, trends)
 4. **Extracts new patterns** from recurring failures
-5. **Updates patterns.md** with learned knowledge
+5. **Updates patterns-full.md** with learned knowledge
 6. **Suggests agent updates** for high-frequency patterns
 
 ---
@@ -127,9 +127,9 @@ Calculate by dimension:
 - By stack (backend/frontend/fullstack)
 - By week (trend analysis)
 
-### Step 5: Generate Updated patterns.md
+### Step 5: Generate Updated patterns-full.md
 
-Create new version of `.claude/memory/patterns.md`:
+Create new version of `.claude/memory/patterns-full.md`:
 
 ```markdown
 # Learned Patterns
@@ -163,7 +163,11 @@ Create new version of `.claude/memory/patterns.md`:
 
 ### Step 6: Identify Agent Update Candidates
 
-For patterns with 5+ occurrences:
+For patterns by occurrence count:
+
+- **≥5 occurrences** → eligible for `--apply` (auto-apply when flag is set)
+- **2–4 occurrences** → surface as proposals in the summary; NEVER auto-applied
+- **<2 occurrences** → mention in raw output only; no action
 
 ```markdown
 ## Suggested Agent Updates
@@ -225,12 +229,20 @@ For each suggested agent update from Step 6:
    + - [ ] Document VALUE strings in MAP-PLAN artifact
    ```
 
-5. **Apply changes**:
-   - If `--dry-run`: Show diff only, do NOT write
-   - If `--apply`: Write changes, bump agent version (minor increment in YAML frontmatter)
+5. **Apply changes** (occurrence-gated):
+   - If `--dry-run`: Show diff only, do NOT write regardless of count
+   - If occurrence count is **2–4**: Print proposal block only — do NOT write to agent file
+     ```
+     [PROPOSAL — 3 occurrences, needs ≥5 to auto-apply]
+     Pattern: {ROOT_CAUSE}
+     Suggested change: {agent file} — {description}
+     Run /learn --apply again once count reaches 5+.
+     ```
+   - If occurrence count is **≥5** and `--apply` flag is set: Write changes,
+     bump agent version (minor increment in YAML frontmatter)
    - Record application in `.claude/memory/pattern-events.jsonl`:
      ```json
-     {"date":"YYYY-MM-DD","pattern":"ENUM_VALUE","action":"applied","target":"agents/map-plan.md","version_before":"1.0","version_after":"1.1"}
+     {"date":"YYYY-MM-DD","pattern":"ENUM_VALUE","action":"applied","target":"agents/map-plan.md","version_before":"1.0","version_after":"1.1","occurrences":12}
      ```
 
 6. **After all updates applied**, report:
@@ -268,14 +280,14 @@ Success rate trend:
   • Week 4:     91% ↑ Improving!
 
 Files updated:
-  ✓ .claude/memory/patterns.md
+  ✓ .claude/memory/patterns-full.md
 
 Suggested agent updates (5+ occurrence patterns):
   1. MAP agent:   Add enum VALUE verification (12 failures)
   2. PATCH agent: Add multi-model detection (6 failures)
 
 Next steps:
-  • Review updated patterns.md
+  • Review updated patterns-full.md
   • Manually apply suggested agent updates
   • Continue using /orchestrate to gather more data
 ═══════════════════════════════════════════════════════════
@@ -291,7 +303,7 @@ With `--dry-run`, the command:
 - Does NOT modify any files
 
 ```
-[DRY RUN] Would update: .claude/memory/patterns.md
+[DRY RUN] Would update: .claude/memory/patterns-full.md
 [DRY RUN] Changes:
   + New pattern: SCOPE_CREEP (3 occurrences)
   ~ Updated: ENUM_VALUE (12 → 15 occurrences)
@@ -367,7 +379,7 @@ done
 
 - Group by `root_cause` across all projects
 - Note contributing projects for each pattern
-- Write to global `~/.claude/memory/patterns.md` (not project-local)
+- Write to global `~/.claude/memory/patterns-full.md` (not project-local)
 - Merge same root_cause counts from different projects
 
 Example output:
@@ -405,6 +417,24 @@ Pattern Validation Results:
   COMPONENT_API:   81% → 85% (+4%)  ✅ Minor improvement
   SCOPE_CREEP:     88% → 86% (-2%)  ⚠️ No improvement — review pattern
 ```
+
+**Auto-revert** (only when `--apply` and `--validate` are both set):
+
+For each applied pattern where success rate delta is **≤ 0%**:
+
+1. Remove the `## Learned Prevention: {ROOT_CAUSE}` block from the agent file
+2. Revert agent version (minor decrement in YAML frontmatter)
+3. Record revert in `pattern-events.jsonl`:
+   ```json
+   {"date":"YYYY-MM-DD","pattern":"SCOPE_CREEP","action":"reverted","reason":"no_improvement","delta":-0.02,"target":"agents/patch.md"}
+   ```
+4. Report in summary:
+   ```
+   AUTO-REVERTED: SCOPE_CREEP — 88% → 86% (-2%) in agents/patch.md
+   ```
+
+Patterns that are reverted twice are permanently marked `blocked` in
+`pattern-events.jsonl` and will not be auto-applied again.
 
 ---
 

--- a/claude-config/hooks/load_learning_rules.py
+++ b/claude-config/hooks/load_learning_rules.py
@@ -13,6 +13,29 @@ except ImportError:
     sys.exit(0)  # No PyYAML, skip silently
 
 RULES_DIR = Path.home() / "agents" / "knowledge" / "learning-rules"
+PATTERNS_FULL_CAP = 800  # ~12K chars; prevents unbounded context growth
+
+
+def load_patterns_full() -> "str | None":
+    """Return content of patterns-full.md if present, else None.
+
+    Searches: ~/.claude/memory/patterns-full.md
+    Capped at PATTERNS_FULL_CAP lines to avoid bloating SessionStart context.
+    Fail-open: returns None on any error or missing file.
+    """
+    candidate = Path.home() / ".claude" / "memory" / "patterns-full.md"
+    if not candidate.exists():
+        return None
+    try:
+        lines = candidate.read_text(encoding="utf-8").splitlines()
+        if len(lines) > PATTERNS_FULL_CAP:
+            lines = lines[:PATTERNS_FULL_CAP]
+            lines.append(
+                f"\n... [truncated at {PATTERNS_FULL_CAP} lines — see full file] ..."
+            )
+        return "\n".join(lines)
+    except Exception:
+        return None
 
 
 def load_approved_rules():
@@ -33,15 +56,17 @@ def load_approved_rules():
 
 def main():
     rules = load_approved_rules()
-    if not rules:
+    patterns = load_patterns_full()
+
+    if not rules and not patterns:
         return
 
-    output = {
-        "title": "Learning Rules (auto-loaded)",
-        "body": "## Active Learning Rules\n\n" + "\n".join(rules)
-    }
+    if rules:
+        print("## Restored Context\n\n### Learning Rules (auto-loaded)\n\n" + "\n".join(rules))
 
-    print(f"## Restored Context\n\n### Learning Rules (auto-loaded)\n\n" + "\n".join(rules))
+    if patterns:
+        print("\n## Applied Patterns (patterns-full.md)\n")
+        print(patterns)
 
 
 if __name__ == "__main__":

--- a/claude-config/launchd/com.claude-learn.weekly.plist
+++ b/claude-config/launchd/com.claude-learn.weekly.plist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.claude-learn.weekly</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>-lc</string>
+        <string>claude --print "/learn --apply --cross-project --validate" >> "$HOME/Library/Logs/claude-learn/weekly.log" 2>&amp;1</string>
+    </array>
+    <key>WorkingDirectory</key>
+    <string>/Users/jasonjob/agents</string>
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Weekday</key>
+        <integer>5</integer>
+        <key>Hour</key>
+        <integer>22</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+    </dict>
+    <key>StandardOutPath</key>
+    <string>/Users/jasonjob/Library/Logs/claude-learn/weekly.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/jasonjob/Library/Logs/claude-learn/weekly.err</string>
+    <key>RunAtLoad</key>
+    <false/>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
Closes the learning loop. Re-injection: `load_learning_rules.py` now loads `patterns-full.md` (fail-open, 800-line cap) so applied patterns reach agents next session. `learn.md`: ≥5-occurrence patterns auto-apply with `--validate` + auto-revert on non-improvement; 2–4 are proposed only. Fixes the `patterns.md`→`patterns-full.md` naming gap (hooks expected the -full name). Weekly launchd schedule. Closes #186.

## Changes
- `hooks/load_learning_rules.py` — `load_patterns_full()`.
- `commands/learn.md` — tier gate (≥5 apply / 2–4 propose) + auto-revert + naming fix (all bare `patterns.md` → `patterns-full.md`).
- `launchd/com.claude-learn.weekly.plist` (new) — Fri 22:00 `/learn --apply --cross-project --validate`.

## Post-merge ops (one-time)
`cp claude-config/launchd/com.claude-learn.weekly.plist ~/Library/LaunchAgents/ && launchctl load ~/Library/LaunchAgents/com.claude-learn.weekly.plist`

## Test Plan
`py_compile` + `plutil -lint` clean; re-injection present/absent smoke pass; zero bare `patterns.md` remain; agents `pytest tests/` 25/25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)