### PR TITLE
fix(telemetry): aggregation sort-key bug + ~/agents velocity rules (#187)

### DIFF
--- a/claude-config/CLAUDE.md
+++ b/claude-config/CLAUDE.md
@@ -181,3 +181,17 @@ that the M365 capability isn't configured on that machine.
 - Editing `~/.claude/` directly. Always go through `~/agents/claude-config/`.
 - Putting secrets, ephemeral state, or large code patterns in CLAUDE.md.
 - Bypassing safety with `--no-verify`, `--force`, or `bypassPermissions` without explicit user approval.
+
+---
+
+## ~/agents — personal velocity rules
+
+`~/agents` is personal tooling, not a product. Preserve fast iteration:
+
+- **TRIVIAL/SIMPLE changes**: no manifest, no spec, no adversarial review.
+- **Major refactors (4+ files, new protocol, new command)**: produce a *lightweight*
+  code-reality manifest (`specs/<name>.code-reality.md`) before drafting; aim for
+  ≤2 review rounds, not the full spec-review-workflow ceremony.
+- Route substantive ~/agents work through `/orchestrate`; ad-hoc fixes via `/quick`.
+- All telemetry routes through the same `state_manager` hooks as `~/projects/` — no
+  separate recording path needed.

--- a/claude-config/hooks/aggregate_metrics_to_global.py
+++ b/claude-config/hooks/aggregate_metrics_to_global.py
@@ -98,7 +98,7 @@ def aggregate(kind: str, source_dirs: list, global_dir: Path) -> int:
     # Sort output for deterministic, human-readable ordering.
     records = sorted(
         seen.values(),
-        key=lambda r: (r.get("date", ""), r.get("issue", 0), r.get("project", "")),
+        key=lambda r: (r.get("date", ""), str(r.get("issue", 0)), r.get("project", "")),
     )
 
     with open(global_file, "w", encoding="utf-8") as fh:


### PR DESCRIPTION
## Summary
Investigation showed #178/#179/#180 already instrument ~/agents (subscription + tracker exist). Two real gaps found:
1. **#178 was silently failing**: the aggregation sort key raised `TypeError: '<' not supported between 'str' and 'int'` on buddy's string batch-labels (`"551-573"` etc.); the bare except swallowed it, so the global metrics.jsonl was never written. Fixed via `str(r.get("issue", 0))`.
2. Added a "~/agents — personal velocity" section to CLAUDE.md (no manifest for TRIVIAL/SIMPLE; lightweight manifest only for 4+ file/architectural refactors).

Closes #187.

## Test Plan
- End-to-end against real per-project dirs: 193 metrics + 12 failures rows, exit 0, zero TypeErrors, batch-labels handled; idempotent on re-run.
- `py_compile` clean; CLAUDE.md 197 lines; agents `pytest tests/` 25/25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)