### PR TITLE
feat(orchestrate): per-AC audit in PROVE (closes buddy#1612)

### DIFF
--- a/claude-config/agents/prove.md
+++ b/claude-config/agents/prove.md
@@ -202,15 +202,45 @@ shape.
 
 Standard Gates from Section 1 (`ruff check`, `pytest`, `npm run lint`, `npm run build`).
 
-### 3. Acceptance Criteria
+### 3. Acceptance Criteria (per-AC audit — MANDATORY)
 
-Reference PLAN/MAP-PLAN acceptance criteria:
+Issue #1612: the prose AC table is no longer load-bearing on its own. You
+MUST emit a structured ``ac_audit`` array in the artifact frontmatter so
+the orchestrator can mechanically verify AC coverage. The prose table is
+still helpful for the human-readable summary but is informational only;
+the frontmatter array is authoritative.
+
+For each AC bullet in the issue body / PLAN / MAP-PLAN:
+
+| Status | Meaning |
+|--------|---------|
+| `implemented` | Diff clearly satisfies this AC. Evidence cites `file:line` or a test path. |
+| `partial` | Diff addresses part of the AC but not all of it. Evidence names what is missing. |
+| `missing` | No code in the diff addresses this AC. |
+| `deferred` | Diff explicitly defers this AC AND `evidence` cites a follow-up issue # (e.g. `"deferred to #1620"`). |
+| `n/a` | This AC is unaffected by the change (rare; explain in evidence). |
+
+**CRITICAL: AC-FORBIDS-APPROVE rule (mirrors Codex-side #1609 / buddy
+`prompts/codex-review-clauses.md`)**:
+
+> A verdict of `PASS` is FORBIDDEN if ANY `ac_audit` entry has
+> `status="missing"` OR `status="partial"`. Those map to verdict `FAIL`.
+
+A `status="deferred"` is acceptable ONLY when `evidence` cites a specific
+follow-up issue # (e.g. `"deferred to #1620"`). A bare "deferred to
+follow-up" without a # is treated as `missing` by the orchestrator
+(`state_manager.validate_ac_audit`) and forces verdict `FAIL`.
+
+Reflect the same structure in the human-readable prose table for the
+artifact body — the table is the explanation, the frontmatter array is
+the contract:
+
 ```markdown
-| Criterion | Status |
-|-----------|--------|
-| Criterion 1 | ✅ |
-| Criterion 2 | ✅ |
-| Criterion 3 | ❌ — [reason] |
+| AC | Status | Evidence |
+|----|--------|----------|
+| {verbatim AC bullet 1} | implemented | `src/foo.py:42`, `tests/test_foo.py::test_x` |
+| {verbatim AC bullet 2} | deferred | deferred to #1620 |
+| {verbatim AC bullet 3} | partial | only the read path landed; write path missing — would need `src/bar.py` change |
 ```
 
 ---
@@ -219,10 +249,17 @@ Reference PLAN/MAP-PLAN acceptance criteria:
 
 | Condition | Status |
 |-----------|--------|
-| All commands pass, all criteria met | **PASS** ✅ |
-| Any command fails | **BLOCKED** ❌ |
-| Any criterion unmet | **BLOCKED** ❌ |
-| Pattern check fails | **BLOCKED** ❌ |
+| All gates pass, all `ac_audit` entries are `implemented` / `deferred-with-#` / `n/a` | **PASS** ✅ |
+| Any `ac_audit` entry is `missing` or `partial` (or `deferred` without #) | **FAIL** ❌ |
+| Any command fails (lint, tests, build) | **BLOCKED** ❌ |
+| Pattern check / behavioral eval fails | **BLOCKED** ❌ |
+
+`FAIL` and `BLOCKED` both prevent merge. `FAIL` specifically means "the
+implementation is incomplete relative to the agreed plan" (a planning
+gap); `BLOCKED` means "something is broken in the artifact" (a quality
+gap). Telemetry separates them so the recurring-pattern detector can
+distinguish "we keep shipping partial work" from "we keep breaking the
+build".
 
 ---
 
@@ -238,13 +275,27 @@ will record, by setting these fields in your artifact's YAML frontmatter:
 issue: {issue_number}
 agent: PROVE
 date: {YYYY-MM-DD}
-status: PASS            # or BLOCKED
+status: PASS            # PASS | FAIL | BLOCKED
 complexity: SIMPLE      # TRIVIAL | SIMPLE | COMPLEX
 stack: backend          # backend | frontend | fullstack
 root_cause: null        # MANDATORY if status=BLOCKED — use a code from _base.md §10
 blocking_agent: null    # MANDATORY if status=BLOCKED — usually "PROVE"
+# Issue #1612 — per-AC audit (mirrors buddy/prompts/codex-review-clauses.md):
+ac_audit:               # MANDATORY one entry per AC bullet
+  - ac: "verbatim AC bullet text from issue body"
+    status: implemented  # implemented | partial | missing | deferred | n/a
+    evidence: "src/foo.py:42 + tests/test_foo.py::test_x"
+applicable_evals: []    # behavioral-eval IDs run, e.g. ["E01","E03","E15"]
+eval_results: {}        # per-eval pass|fail, e.g. {"E01":"pass","E03":"fail"}
 ---
 ```
+
+`ac_audit` is parsed by the orchestrator via
+`state_manager.validate_ac_audit`. If the array is missing, empty, or
+contains any `missing` / `partial` entry (or `deferred` without an issue
+#), the orchestrator downgrades your `status: PASS` to `status: FAIL`
+and records the reason. You cannot defeat AC-FORBIDS-APPROVE by emitting
+`status: PASS` directly — the validator is the source of truth.
 
 If `status: BLOCKED`, also include a `## Failure Details` block in the
 artifact body so the orchestrator can populate `failures.jsonl`. Use simple
@@ -276,16 +327,22 @@ into the orchestrator (a deterministic Python call) closes the gap.
 issue: {issue_number}
 agent: PROVE
 date: {YYYY-MM-DD}
-status: PASS              # or BLOCKED
+status: PASS              # PASS | FAIL | BLOCKED
 complexity: SIMPLE        # required — orchestrator records this
 stack: backend            # required — orchestrator records this
 root_cause: null          # required if status=BLOCKED (use _base.md §10 codes)
 blocking_agent: null      # required if status=BLOCKED (usually "PROVE")
+ac_audit:                 # MANDATORY — issue #1612
+  - ac: "verbatim AC bullet"
+    status: implemented   # implemented | partial | missing | deferred | n/a
+    evidence: "file:line or test path or '#NNNN' for deferred"
+applicable_evals: []      # IDs of behavioral evals you ran
+eval_results: {}          # per-eval pass|fail
 ---
 
 # PROVE - Issue #{issue_number}
 
-## Status: PASS ✅ | BLOCKED ❌
+## Status: PASS ✅ | FAIL ❌ | BLOCKED ❌
 
 ## Verification Results
 
@@ -356,8 +413,11 @@ Levels:
 - [ ] Level 3: Pipeline handoff shapes verified (if sequential steps)
 
 Outcome data (orchestrator records these — you populate the frontmatter):
-- [ ] Frontmatter has `status: PASS|BLOCKED`
+- [ ] Frontmatter has `status: PASS|FAIL|BLOCKED`
 - [ ] Frontmatter has `complexity` and `stack`
+- [ ] Frontmatter has `ac_audit` with one entry per AC bullet (issue #1612)
+- [ ] Frontmatter has `applicable_evals` (list) and `eval_results` (map)
 - [ ] If BLOCKED: frontmatter has `root_cause` (from _base.md §10) and `blocking_agent`
 - [ ] If BLOCKED: artifact body has a `## Failure Details` section with `details`/`fix`/`prevention`
+- [ ] If FAIL (AC gap): the prose AC table names which AC(s) are missing/partial and why
 ```

--- a/claude-config/commands/orchestrate.md
+++ b/claude-config/commands/orchestrate.md
@@ -356,10 +356,11 @@ if [ -z "$PROVE_ART" ] || [ ! -f "$PROVE_ART" ]; then
   echo "WARNING: no PROVE artifact found for issue ${ISSUE}; skipping outcome recording"
 else
   python3 - <<PYEOF
-import sys, re
+import sys, re, subprocess
 sys.path.insert(0, '$HOME/.claude/hooks')
 from pathlib import Path
 from state_manager import (
+    count_acceptance_bullets,
     derive_agents_run,
     record_failure,
     record_metrics,
@@ -380,13 +381,17 @@ art = Path("$PROVE_ART").read_text(encoding="utf-8")
 fm_match = re.search(r"^---\n(.*?)\n---", art, re.DOTALL | re.MULTILINE)
 fm_text = fm_match.group(1) if fm_match else ""
 
+fm_data = {}
 if HAS_YAML and fm_text:
     try:
-        fm_data = yaml.safe_load(fm_text) or {}
+        parsed = yaml.safe_load(fm_text)
     except yaml.YAMLError:
-        fm_data = {}
-else:
-    fm_data = {}
+        parsed = None
+    # Codex-side concern: yaml.safe_load can return a string/list/None for
+    # syntactically valid non-map frontmatter — normalize to dict so
+    # downstream .get calls don't crash.
+    if isinstance(parsed, dict):
+        fm_data = parsed
 
 def field(name, default=None):
     """Get a scalar field. Prefers parsed yaml; falls back to regex."""
@@ -410,9 +415,26 @@ ac_audit         = fm_data.get("ac_audit")
 applicable_evals = fm_data.get("applicable_evals") or []
 eval_results     = fm_data.get("eval_results") or {}
 
+# Coverage gate: fetch the issue body and count its AC bullets so the
+# validator can detect "PROVE silently omitted an AC" (Codex R1 finding).
+# Network/gh failure → fall back to 0 (skip the count check; emit-only
+# validation still catches missing/partial/deferred-no-#).
+expected_ac_count = 0
+try:
+    body = subprocess.run(
+        ["gh", "issue", "view", str(int("$ISSUE")), "--json", "body", "--jq", ".body"],
+        check=True, capture_output=True, text=True, timeout=15,
+    ).stdout
+    expected_ac_count = count_acceptance_bullets(body)
+except (subprocess.SubprocessError, FileNotFoundError, ValueError):
+    expected_ac_count = 0
+
 downgrade_reason = None
 if status == "PASS":
-    audit = validate_ac_audit(ac_audit if isinstance(ac_audit, list) else None)
+    audit = validate_ac_audit(
+        ac_audit if isinstance(ac_audit, list) else None,
+        expected_ac_count=expected_ac_count or None,
+    )
     if audit.get("downgrade_to") == "FAIL":
         downgrade_reason = "; ".join(
             f"{m['ac']}: {m['reason']}" for m in audit.get("missing", [])

--- a/claude-config/commands/orchestrate.md
+++ b/claude-config/commands/orchestrate.md
@@ -326,10 +326,19 @@ worktree setup, resume mode), **read `templates/orchestrate-parallel.md`**.
 
 **This is the canonical outcome-recording site.** PROVE specifies the data
 via its artifact frontmatter (`status`, `complexity`, `stack`, `agents_run`,
-and — if BLOCKED — `root_cause`, `blocking_agent`, `files`, `prevention`);
-this step performs the deterministic write. PROVE does NOT write to
-`.claude/memory/` directly (see issue #104 — embedding the write in PROVE's
-prompt was unreliable).
+`ac_audit`, `applicable_evals`, `eval_results`, and — if BLOCKED —
+`root_cause`, `blocking_agent`, `files`, `prevention`); this step performs
+the deterministic write. PROVE does NOT write to `.claude/memory/` directly
+(see issue #104 — embedding the write in PROVE's prompt was unreliable).
+
+**AC-FORBIDS-APPROVE (issue #1612)**: this step also runs
+`state_manager.validate_ac_audit` on PROVE's `ac_audit` frontmatter. A
+PROVE artifact that emitted `status: PASS` is downgraded to `status: FAIL`
+when the audit finds any `missing` / `partial` entry, or any `deferred`
+entry whose evidence does not cite a follow-up issue # (`#NNNN` or
+`GH-NNNN`). The downgrade reason is persisted in `prove-log.jsonl`. PROVE
+cannot defeat the rule by emitting `PASS` directly — the validator is
+authoritative.
 
 `agents_run` is **derived from `.agents/outputs/`** by scanning for
 `<phase>-<issue>-<mmddyy>.md` artifacts and sorting by mtime — the
@@ -350,14 +359,40 @@ else
 import sys, re
 sys.path.insert(0, '$HOME/.claude/hooks')
 from pathlib import Path
-from state_manager import record_metrics, record_failure, derive_agents_run
+from state_manager import (
+    derive_agents_run,
+    record_failure,
+    record_metrics,
+    record_prove_audit,
+    validate_ac_audit,
+)
+
+# YAML is preferred (per issue #1612 the frontmatter has nested
+# ac_audit/applicable_evals/eval_results structures). Fall back to a
+# best-effort regex for scalar fields when yaml is unavailable.
+try:
+    import yaml
+    HAS_YAML = True
+except ImportError:
+    HAS_YAML = False
 
 art = Path("$PROVE_ART").read_text(encoding="utf-8")
 fm_match = re.search(r"^---\n(.*?)\n---", art, re.DOTALL | re.MULTILINE)
-fm = fm_match.group(1) if fm_match else ""
+fm_text = fm_match.group(1) if fm_match else ""
+
+if HAS_YAML and fm_text:
+    try:
+        fm_data = yaml.safe_load(fm_text) or {}
+    except yaml.YAMLError:
+        fm_data = {}
+else:
+    fm_data = {}
 
 def field(name, default=None):
-    m = re.search(rf"^{name}:\s*(.+)$", fm, re.MULTILINE)
+    """Get a scalar field. Prefers parsed yaml; falls back to regex."""
+    if name in fm_data and not isinstance(fm_data[name], (list, dict)):
+        return fm_data[name]
+    m = re.search(rf"^{name}:\s*(.+)$", fm_text, re.MULTILINE)
     return m.group(1).strip() if m else default
 
 status     = field("status", "PASS")
@@ -369,10 +404,36 @@ if not agents_run:
     agents_run = []
 root_cause = field("root_cause") if status == "BLOCKED" else None
 
+# Issue #1612 — per-AC audit. Validate before recording so the verdict
+# we persist reflects AC-FORBIDS-APPROVE.
+ac_audit         = fm_data.get("ac_audit")
+applicable_evals = fm_data.get("applicable_evals") or []
+eval_results     = fm_data.get("eval_results") or {}
+
+downgrade_reason = None
+if status == "PASS":
+    audit = validate_ac_audit(ac_audit if isinstance(ac_audit, list) else None)
+    if audit.get("downgrade_to") == "FAIL":
+        downgrade_reason = "; ".join(
+            f"{m['ac']}: {m['reason']}" for m in audit.get("missing", [])
+        )
+        status = "FAIL"
+        print(f"PROVE PASS downgraded to FAIL: {downgrade_reason}")
+
 record_metrics(
     Path("."), int("$ISSUE"), status, complexity, stack, agents_run,
     root_cause=root_cause,
-    blocking_agent=("PROVE" if status == "BLOCKED" else None),
+    blocking_agent=("PROVE" if status in ("BLOCKED", "FAIL") else None),
+)
+
+# Always log the per-AC audit row, regardless of verdict — clean PASS
+# runs are also valuable signal for the recurring-pattern detector.
+record_prove_audit(
+    Path("."), int("$ISSUE"), status,
+    ac_audit if isinstance(ac_audit, list) else [],
+    applicable_evals=applicable_evals if isinstance(applicable_evals, list) else None,
+    eval_results=eval_results if isinstance(eval_results, dict) else None,
+    downgrade_reason=downgrade_reason,
 )
 
 if status == "BLOCKED" and root_cause:

--- a/claude-config/hooks/state_manager.py
+++ b/claude-config/hooks/state_manager.py
@@ -571,3 +571,168 @@ def derive_agents_run(project_dir: Path, issue: int) -> list[str]:
     # ran when.
     matches.sort()
     return [phase for _, phase in matches]
+
+
+# ── PROVE per-AC audit (issue #1612) ──────────────────────────────────────
+
+
+_VALID_AC_STATUSES = frozenset({"implemented", "partial", "missing", "deferred", "n/a"})
+
+# Reasonable issue-reference shapes accepted as evidence for status="deferred".
+# Plain "#1234" or "issue #1234" or "GH-1234" all count; bare prose without a
+# referenced number does NOT — that's the load-bearing rule that prevents
+# "deferred to a follow-up" from becoming an APPROVE escape hatch.
+_DEFERRED_REF_RE = re.compile(r"#\d+|GH-\d+", re.IGNORECASE)
+
+
+def _ac_label(entry: dict, idx: int) -> str:
+    """Human-readable label for an AC entry in failure summaries.
+
+    Prefers ``ac`` (verbatim bullet text), trimmed. Falls back to the index.
+    """
+    text = entry.get("ac") if isinstance(entry, dict) else None
+    if isinstance(text, str) and text.strip():
+        snippet = text.strip().splitlines()[0]
+        return snippet[:80] + ("…" if len(snippet) > 80 else "")
+    return f"AC#{idx + 1}"
+
+
+def validate_ac_audit(ac_audit: list | None) -> dict:
+    """Validate a PROVE ``ac_audit`` array against the AC-FORBIDS-APPROVE rule.
+
+    Mirrors the Codex-side rule from issue #1609: a PROVE verdict of PASS
+    is FORBIDDEN if ANY ac_audit entry has ``status="missing"`` or
+    ``status="partial"``. A ``status="deferred"`` entry is acceptable ONLY
+    when ``evidence`` cites a follow-up issue # (e.g. ``"deferred to #1620"``).
+    A bare "deferred" without a # is treated as missing.
+
+    Args:
+        ac_audit: List of dicts shaped
+            ``{"ac": str, "status": str, "evidence": str}``. May be None
+            (missing array entirely → cannot validate; treat as failure).
+
+    Returns:
+        ``{"valid": bool, "downgrade_to": str|None, "missing": list[dict]}``
+        where ``missing`` enumerates the offending entries with a ``reason``
+        field. ``downgrade_to`` is ``"FAIL"`` when the audit forbids APPROVE,
+        else ``None``. ``valid`` is False iff ``ac_audit`` is missing,
+        empty, or contains an entry with an invalid status string.
+
+    The function is pure (no I/O). Callers persist the result via
+    ``record_prove_audit``.
+    """
+    missing: list[dict] = []
+    if not isinstance(ac_audit, list) or not ac_audit:
+        return {
+            "valid": False,
+            "downgrade_to": "FAIL",
+            "missing": [{
+                "ac": "(no ac_audit array)",
+                "status": "missing",
+                "reason": "PROVE artifact has no ac_audit entries; cannot verify AC coverage",
+            }],
+        }
+
+    valid = True
+    for idx, entry in enumerate(ac_audit):
+        if not isinstance(entry, dict):
+            valid = False
+            missing.append({
+                "ac": _ac_label({}, idx),
+                "status": "invalid",
+                "reason": f"ac_audit[{idx}] is not an object",
+            })
+            continue
+        status = entry.get("status")
+        if status not in _VALID_AC_STATUSES:
+            valid = False
+            missing.append({
+                "ac": _ac_label(entry, idx),
+                "status": str(status),
+                "reason": f"unknown status {status!r}; expected one of {sorted(_VALID_AC_STATUSES)}",
+            })
+            continue
+        if status in ("missing", "partial"):
+            missing.append({
+                "ac": _ac_label(entry, idx),
+                "status": status,
+                "reason": f"AC #{idx + 1} marked {status}",
+            })
+        elif status == "deferred":
+            evidence = entry.get("evidence")
+            if not isinstance(evidence, str) or not _DEFERRED_REF_RE.search(evidence):
+                missing.append({
+                    "ac": _ac_label(entry, idx),
+                    "status": "missing",
+                    "reason": "deferred without follow-up issue # — treated as missing",
+                })
+        # implemented + n/a are clean; nothing to record.
+
+    downgrade = "FAIL" if missing else None
+    return {"valid": valid, "downgrade_to": downgrade, "missing": missing}
+
+
+def record_prove_audit(
+    project_dir: Path,
+    issue: int,
+    verdict: str,
+    ac_audit: list | None,
+    applicable_evals: list[str] | None = None,
+    eval_results: dict[str, str] | None = None,
+    downgrade_reason: str | None = None,
+) -> None:
+    """Append one PROVE per-AC audit row to ``.claude/memory/prove-log.jsonl``.
+
+    Companion to ``record_metrics`` — keeps the AC discipline trail separate
+    so /learn and the recurring-pattern detector can analyze AC coverage
+    independently of the overall PASS/BLOCKED metric stream.
+
+    Schema (per issue #1612):
+
+        {
+          "ts": "...UTC iso...",
+          "issue": N,
+          "phase": "PROVE",
+          "verdict": "PASS|FAIL|BLOCKED",
+          "ac_audit": [...],
+          "applicable_evals": [...],
+          "eval_results": {...},
+          "downgrade_reason": "..." (optional)
+        }
+
+    Args:
+        project_dir: Project root. File lives at
+            ``<project_dir>/.claude/memory/prove-log.jsonl``.
+        issue: GitHub issue number.
+        verdict: ``"PASS"``, ``"FAIL"``, or ``"BLOCKED"``. ``FAIL`` is the
+            new verdict that AC-FORBIDS-APPROVE downgrades a PASS to.
+        ac_audit: The verbatim ac_audit array PROVE emitted (or ``[]`` if
+            absent).
+        applicable_evals: The behavioral-eval IDs PROVE ran (e.g.
+            ``["E01", "E03", "E15"]``).
+        eval_results: Per-eval pass/fail map (e.g.
+            ``{"E01": "pass", "E03": "fail"}``).
+        downgrade_reason: When ``verdict="FAIL"`` because ``validate_ac_audit``
+            forced the downgrade, the human-readable reason.
+
+    Returns: None. Errors are logged; the function never raises.
+    """
+    record: dict = {
+        "ts": _utc_now_iso(),
+        "issue": int(issue),
+        "phase": "PROVE",
+        "verdict": verdict,
+        "ac_audit": list(ac_audit) if ac_audit else [],
+    }
+    if applicable_evals:
+        record["applicable_evals"] = list(applicable_evals)
+    if eval_results:
+        record["eval_results"] = dict(eval_results)
+    if downgrade_reason:
+        record["downgrade_reason"] = downgrade_reason
+
+    target = _memory_dir(project_dir) / "prove-log.jsonl"
+    try:
+        _append_jsonl(target, record)
+    except OSError as e:
+        logging.warning(f"record_prove_audit: could not append to {target}: {e}")

--- a/claude-config/hooks/state_manager.py
+++ b/claude-config/hooks/state_manager.py
@@ -597,7 +597,50 @@ def _ac_label(entry: dict, idx: int) -> str:
     return f"AC#{idx + 1}"
 
 
-def validate_ac_audit(ac_audit: list | None) -> dict:
+def count_acceptance_bullets(issue_body: str) -> int:
+    """Count markdown task items under an "Acceptance" heading.
+
+    Scans ``issue_body`` for the first heading containing the word
+    ``acceptance`` (case-insensitive) and counts ``- [ ]`` / ``- [x]``
+    bullets until the next ``## ``/``### `` heading or end-of-body.
+
+    Returns 0 when no Acceptance section can be located — the caller
+    should treat that as "cannot enforce one-row-per-AC" and fall back
+    to the emit-only validator.
+
+    Args:
+        issue_body: The full GitHub issue body markdown.
+
+    Returns:
+        Number of AC bullets found, or 0 when the section is absent.
+    """
+    if not isinstance(issue_body, str) or not issue_body:
+        return 0
+    lines = issue_body.splitlines()
+    in_ac = False
+    count = 0
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            # New heading. Decide whether we're entering or leaving the AC block.
+            if in_ac:
+                break
+            heading = stripped.lstrip("# ").lower()
+            if "acceptance" in heading:
+                in_ac = True
+            continue
+        if not in_ac:
+            continue
+        # Match markdown task items: "- [ ] ..." or "- [x] ..." (case
+        # insensitive). Allow indented variants but reject deeply nested
+        # sub-items (4+ spaces) — those are typically clarifications, not
+        # top-level ACs.
+        if re.match(r"^(\s{0,3}- \[[ xX]\] )", line):
+            count += 1
+    return count
+
+
+def validate_ac_audit(ac_audit: list | None, expected_ac_count: int | None = None) -> dict:
     """Validate a PROVE ``ac_audit`` array against the AC-FORBIDS-APPROVE rule.
 
     Mirrors the Codex-side rule from issue #1609: a PROVE verdict of PASS
@@ -606,10 +649,19 @@ def validate_ac_audit(ac_audit: list | None) -> dict:
     when ``evidence`` cites a follow-up issue # (e.g. ``"deferred to #1620"``).
     A bare "deferred" without a # is treated as missing.
 
+    When ``expected_ac_count`` is provided (the orchestrator passes the
+    count derived from the issue body's Acceptance section), the
+    validator also FAILS if ``len(ac_audit) < expected_ac_count``. This
+    closes the "PROVE silently omits an AC" bypass that an emit-only
+    validator misses.
+
     Args:
         ac_audit: List of dicts shaped
             ``{"ac": str, "status": str, "evidence": str}``. May be None
             (missing array entirely → cannot validate; treat as failure).
+        expected_ac_count: Number of AC bullets the issue body declares.
+            ``None`` means "skip the count check" (used by unit tests +
+            issues where the AC section can't be parsed).
 
     Returns:
         ``{"valid": bool, "downgrade_to": str|None, "missing": list[dict]}``
@@ -634,6 +686,21 @@ def validate_ac_audit(ac_audit: list | None) -> dict:
         }
 
     valid = True
+    # Coverage gate: if the issue declares N ACs and PROVE only emits M < N,
+    # the audit silently misses (N - M) ACs. Force missing entries for the
+    # uncovered slots so the verdict downgrades.
+    if isinstance(expected_ac_count, int) and expected_ac_count > len(ac_audit):
+        for slot in range(len(ac_audit), expected_ac_count):
+            missing.append({
+                "ac": f"AC#{slot + 1}",
+                "status": "missing",
+                "reason": (
+                    f"issue declares {expected_ac_count} AC bullets but "
+                    f"ac_audit has only {len(ac_audit)} entries; "
+                    f"AC #{slot + 1} omitted"
+                ),
+            })
+
     for idx, entry in enumerate(ac_audit):
         if not isinstance(entry, dict):
             valid = False

--- a/claude-config/tests/conftest.py
+++ b/claude-config/tests/conftest.py
@@ -1,0 +1,13 @@
+"""Pytest config — make `hooks/` importable as a top-level module."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Put hooks/ on sys.path so `from state_manager import ...` works the same
+# way `python3 -c 'import state_manager'` does from the orchestrator
+# command (which prepends `$HOME/.claude/hooks`).
+_HOOKS = Path(__file__).resolve().parent.parent / "hooks"
+if str(_HOOKS) not in sys.path:
+    sys.path.insert(0, str(_HOOKS))

--- a/claude-config/tests/test_state_manager_prove_audit.py
+++ b/claude-config/tests/test_state_manager_prove_audit.py
@@ -1,0 +1,235 @@
+"""Tests for state_manager — per-AC audit + prove-log.jsonl writer (#1612).
+
+Run from the repo root:
+
+    python3 -m pytest claude-config/tests/ -v
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from state_manager import (  # type: ignore[import-not-found]
+    record_prove_audit,
+    validate_ac_audit,
+)
+
+
+# ── validate_ac_audit ────────────────────────────────────────────────────────
+
+
+def test_all_implemented_passes():
+    """All ACs implemented → no downgrade."""
+    audit = validate_ac_audit(
+        [
+            {"ac": "AC 1", "status": "implemented", "evidence": "src/a.py:10"},
+            {"ac": "AC 2", "status": "implemented", "evidence": "src/b.py:20"},
+        ]
+    )
+    assert audit["valid"] is True
+    assert audit["downgrade_to"] is None
+    assert audit["missing"] == []
+
+
+def test_five_acs_four_implemented_one_missing_fails():
+    """AC test from issue #1612: 5 ACs, PR implements 4 → FAIL with the
+    missing AC named."""
+    audit = validate_ac_audit(
+        [
+            {"ac": "AC 1: foo", "status": "implemented", "evidence": "src/a.py:1"},
+            {"ac": "AC 2: bar", "status": "implemented", "evidence": "src/b.py:2"},
+            {"ac": "AC 3: baz", "status": "implemented", "evidence": "src/c.py:3"},
+            {"ac": "AC 4: qux", "status": "implemented", "evidence": "src/d.py:4"},
+            {"ac": "AC 5: quux", "status": "missing", "evidence": ""},
+        ]
+    )
+    assert audit["downgrade_to"] == "FAIL"
+    assert len(audit["missing"]) == 1
+    entry = audit["missing"][0]
+    assert "AC 5: quux" in entry["ac"]
+    assert entry["status"] == "missing"
+
+
+def test_partial_status_forbids_pass():
+    """AC marked `partial` → FAIL."""
+    audit = validate_ac_audit(
+        [
+            {"ac": "AC 1", "status": "implemented", "evidence": "tests/test_a.py"},
+            {"ac": "AC 2", "status": "partial", "evidence": "only read path; write path missing"},
+        ]
+    )
+    assert audit["downgrade_to"] == "FAIL"
+    assert len(audit["missing"]) == 1
+    assert audit["missing"][0]["status"] == "partial"
+
+
+def test_deferred_with_issue_number_is_accepted():
+    """AC test from issue #1612: 'deferred' AC with follow-up # → accepted."""
+    audit = validate_ac_audit(
+        [
+            {"ac": "AC 1", "status": "implemented", "evidence": "src/a.py:1"},
+            {"ac": "AC 2", "status": "deferred", "evidence": "deferred to #1620"},
+            {"ac": "AC 3", "status": "deferred", "evidence": "Deferred to GH-1621 per Discuss"},
+        ]
+    )
+    assert audit["downgrade_to"] is None
+    assert audit["missing"] == []
+
+
+def test_deferred_without_issue_number_is_treated_as_missing():
+    """AC test from issue #1612: 'deferred' AC without # → treated as missing."""
+    audit = validate_ac_audit(
+        [
+            {"ac": "AC 1", "status": "implemented", "evidence": "src/a.py:1"},
+            {"ac": "AC 2", "status": "deferred", "evidence": "deferred to a follow-up"},
+        ]
+    )
+    assert audit["downgrade_to"] == "FAIL"
+    assert len(audit["missing"]) == 1
+    assert "deferred without follow-up" in audit["missing"][0]["reason"]
+
+
+def test_deferred_with_empty_evidence_is_missing():
+    """Empty evidence on `deferred` is the same as no follow-up — FAIL."""
+    audit = validate_ac_audit(
+        [
+            {"ac": "AC 1", "status": "deferred", "evidence": ""},
+        ]
+    )
+    assert audit["downgrade_to"] == "FAIL"
+
+
+def test_na_status_is_accepted():
+    """`n/a` is acceptable (rare but valid)."""
+    audit = validate_ac_audit(
+        [
+            {"ac": "AC 1", "status": "implemented", "evidence": "src/a.py:1"},
+            {"ac": "AC 2", "status": "n/a", "evidence": "test infra only — no runtime path"},
+        ]
+    )
+    assert audit["downgrade_to"] is None
+
+
+def test_missing_ac_audit_array_is_failure():
+    """No ac_audit → cannot verify → FAIL."""
+    audit = validate_ac_audit(None)
+    assert audit["valid"] is False
+    assert audit["downgrade_to"] == "FAIL"
+
+
+def test_empty_ac_audit_array_is_failure():
+    """Empty array → no ACs verified → FAIL."""
+    audit = validate_ac_audit([])
+    assert audit["valid"] is False
+    assert audit["downgrade_to"] == "FAIL"
+
+
+def test_unknown_status_string_is_failure():
+    """Garbage status (e.g. typo) → flagged as invalid."""
+    audit = validate_ac_audit(
+        [
+            {"ac": "AC 1", "status": "implmented", "evidence": "src/a.py:1"},
+        ]
+    )
+    assert audit["valid"] is False
+    assert audit["downgrade_to"] == "FAIL"
+
+
+def test_non_dict_entry_is_failure():
+    """ac_audit[i] must be a dict; anything else → FAIL."""
+    audit = validate_ac_audit(
+        [
+            {"ac": "AC 1", "status": "implemented", "evidence": "src/a.py:1"},
+            "this is a string, not a dict",
+        ]
+    )
+    assert audit["valid"] is False
+    assert audit["downgrade_to"] == "FAIL"
+
+
+# ── record_prove_audit ───────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def project_dir(tmp_path: Path) -> Path:
+    """Isolated project root for each test."""
+    return tmp_path
+
+
+def _read_log(project_dir: Path) -> list[dict]:
+    path = project_dir / ".claude" / "memory" / "prove-log.jsonl"
+    if not path.exists():
+        return []
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+def test_record_prove_audit_writes_pass_row(project_dir):
+    record_prove_audit(
+        project_dir,
+        issue=1610,
+        verdict="PASS",
+        ac_audit=[{"ac": "AC 1", "status": "implemented", "evidence": "src/a.py:1"}],
+        applicable_evals=["E15"],
+        eval_results={"E15": "pass"},
+    )
+    rows = _read_log(project_dir)
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["issue"] == 1610
+    assert row["phase"] == "PROVE"
+    assert row["verdict"] == "PASS"
+    assert row["ac_audit"] == [
+        {"ac": "AC 1", "status": "implemented", "evidence": "src/a.py:1"}
+    ]
+    assert row["applicable_evals"] == ["E15"]
+    assert row["eval_results"] == {"E15": "pass"}
+    assert "downgrade_reason" not in row
+
+
+def test_record_prove_audit_writes_fail_row_with_reason(project_dir):
+    record_prove_audit(
+        project_dir,
+        issue=1610,
+        verdict="FAIL",
+        ac_audit=[{"ac": "AC 5", "status": "missing", "evidence": ""}],
+        downgrade_reason="AC 5: AC #5 marked missing",
+    )
+    rows = _read_log(project_dir)
+    assert len(rows) == 1
+    assert rows[0]["verdict"] == "FAIL"
+    assert "AC 5" in rows[0]["downgrade_reason"]
+
+
+def test_record_prove_audit_appends_not_overwrites(project_dir):
+    record_prove_audit(project_dir, 1, "PASS", [])
+    record_prove_audit(project_dir, 2, "PASS", [])
+    record_prove_audit(project_dir, 3, "FAIL", [{"ac": "x", "status": "missing"}])
+    rows = _read_log(project_dir)
+    assert len(rows) == 3
+    assert [r["issue"] for r in rows] == [1, 2, 3]
+
+
+def test_record_prove_audit_creates_memory_dir(project_dir):
+    """First call creates .claude/memory/ if absent."""
+    assert not (project_dir / ".claude" / "memory").exists()
+    record_prove_audit(project_dir, 1, "PASS", [])
+    assert (project_dir / ".claude" / "memory" / "prove-log.jsonl").exists()
+
+
+def test_record_prove_audit_handles_none_ac_audit(project_dir):
+    """ac_audit=None → recorded as []."""
+    record_prove_audit(project_dir, 1, "FAIL", None, downgrade_reason="no ac_audit array")
+    rows = _read_log(project_dir)
+    assert rows[0]["ac_audit"] == []
+
+
+def test_record_prove_audit_omits_optional_fields_when_absent(project_dir):
+    """applicable_evals / eval_results / downgrade_reason are optional."""
+    record_prove_audit(project_dir, 1, "PASS", [{"ac": "x", "status": "implemented"}])
+    rows = _read_log(project_dir)
+    assert "applicable_evals" not in rows[0]
+    assert "eval_results" not in rows[0]
+    assert "downgrade_reason" not in rows[0]

--- a/claude-config/tests/test_state_manager_prove_audit.py
+++ b/claude-config/tests/test_state_manager_prove_audit.py
@@ -13,6 +13,7 @@ from pathlib import Path
 import pytest
 
 from state_manager import (  # type: ignore[import-not-found]
+    count_acceptance_bullets,
     record_prove_audit,
     validate_ac_audit,
 )
@@ -233,3 +234,106 @@ def test_record_prove_audit_omits_optional_fields_when_absent(project_dir):
     assert "applicable_evals" not in rows[0]
     assert "eval_results" not in rows[0]
     assert "downgrade_reason" not in rows[0]
+
+
+# ── count_acceptance_bullets ────────────────────────────────────────────────
+
+
+def test_count_acceptance_bullets_under_h2():
+    body = """\
+## What
+
+Some prose.
+
+## Acceptance
+
+- [ ] First AC
+- [ ] Second AC
+- [x] Third AC (already checked)
+
+## Out of scope
+
+- [ ] Not an AC bullet
+"""
+    assert count_acceptance_bullets(body) == 3
+
+
+def test_count_acceptance_bullets_under_h3():
+    body = "### Acceptance criteria\n\n- [ ] One\n- [ ] Two\n"
+    assert count_acceptance_bullets(body) == 2
+
+
+def test_count_acceptance_bullets_zero_when_no_section():
+    body = "## Background\n\nNo acceptance criteria here."
+    assert count_acceptance_bullets(body) == 0
+
+
+def test_count_acceptance_bullets_zero_on_empty_input():
+    assert count_acceptance_bullets("") == 0
+    assert count_acceptance_bullets(None) == 0  # type: ignore[arg-type]
+
+
+def test_count_acceptance_bullets_stops_at_next_heading():
+    """Bullets after a subsequent heading should not be counted."""
+    body = """\
+## Acceptance
+- [ ] AC 1
+- [ ] AC 2
+## Out of scope
+- [ ] Not an AC
+"""
+    assert count_acceptance_bullets(body) == 2
+
+
+# ── coverage gate (expected_ac_count) ───────────────────────────────────────
+
+
+def test_emit_fewer_than_expected_is_failure():
+    """Codex R1 bypass fix: 5 expected ACs, only 4 emitted (all
+    implemented) → FAIL because AC #5 is silently omitted."""
+    audit = validate_ac_audit(
+        [
+            {"ac": "AC 1", "status": "implemented", "evidence": "src/a.py"},
+            {"ac": "AC 2", "status": "implemented", "evidence": "src/b.py"},
+            {"ac": "AC 3", "status": "implemented", "evidence": "src/c.py"},
+            {"ac": "AC 4", "status": "implemented", "evidence": "src/d.py"},
+        ],
+        expected_ac_count=5,
+    )
+    assert audit["downgrade_to"] == "FAIL"
+    assert any("AC #5" in m["reason"] for m in audit["missing"])
+
+
+def test_emit_equal_to_expected_is_pass():
+    audit = validate_ac_audit(
+        [
+            {"ac": "AC 1", "status": "implemented", "evidence": "src/a.py"},
+            {"ac": "AC 2", "status": "implemented", "evidence": "src/b.py"},
+        ],
+        expected_ac_count=2,
+    )
+    assert audit["downgrade_to"] is None
+
+
+def test_emit_more_than_expected_is_pass():
+    """Tolerate over-counting; under-counting is the load-bearing case."""
+    audit = validate_ac_audit(
+        [
+            {"ac": "AC 1", "status": "implemented", "evidence": "src/a.py"},
+            {"ac": "AC 2", "status": "implemented", "evidence": "src/b.py"},
+            {"ac": "AC 3 (bonus)", "status": "implemented", "evidence": "src/c.py"},
+        ],
+        expected_ac_count=2,
+    )
+    assert audit["downgrade_to"] is None
+
+
+def test_expected_ac_count_none_skips_coverage_check():
+    """Backward compat: callers that don't pass the count keep the
+    emit-only validation behavior (unit tests, issues with no parseable
+    AC section)."""
+    audit = validate_ac_audit(
+        [{"ac": "AC 1", "status": "implemented", "evidence": "src/a.py"}],
+        expected_ac_count=None,
+    )
+    assert audit["downgrade_to"] is None


### PR DESCRIPTION
## Summary

Closes jwj2002/meeting-buddy#1612 (Harold-borrowed loop-closer 3 of 5).

PROVE now emits a structured `ac_audit` array in its frontmatter, and the orchestrator runs `validate_ac_audit` on PASS verdicts — downgrading to a new `FAIL` state when any AC is `missing` / `partial` (or `deferred` without a follow-up issue #). Companion to the Codex-side fragment that landed in #1609 (`buddy/prompts/codex-review-clauses.md`).

## What changed

- **`claude-config/agents/prove.md`** — added §3 \"Acceptance Criteria (per-AC audit — MANDATORY)\" with the 5-status table + CRITICAL: AC-FORBIDS-APPROVE rule. Frontmatter now requires `ac_audit`, `applicable_evals`, `eval_results`. Status table extended to include `FAIL` (AC gap) alongside `BLOCKED` (gate failure).
- **`claude-config/hooks/state_manager.py`** — `validate_ac_audit(ac_audit)` pure validator + `record_prove_audit(...)` JSONL appender writing to `<project>/.claude/memory/prove-log.jsonl`.
- **`claude-config/commands/orchestrate.md`** — Step 4 parses frontmatter via YAML, runs `validate_ac_audit` on PASS verdicts, downgrades to `FAIL` on AC gaps, records via `record_prove_audit`. Falls back to regex on scalars when yaml unavailable.
- **`claude-config/tests/`** (new) — 17 tests covering all AC test bullets from #1612.

## Acceptance criteria audit

- [x] **PROVE subagent prompt updated to require `ac_audit` in output** — `agents/prove.md` §3 + frontmatter schema + Quick Checklist.
- [x] **PROVE caller parses + validates the array; missing/partial AC → verdict downgraded** — `commands/orchestrate.md` Step 4 (PYEOF block).
- [x] **Test: synthetic issue with 5 ACs, PR implements 4 → PROVE returns FAIL with the missing AC named** — `test_five_acs_four_implemented_one_missing_fails`.
- [x] **Test: 'deferred' AC with follow-up # → accepted** — `test_deferred_with_issue_number_is_accepted`.
- [x] **Test: 'deferred' AC without # → treated as missing** — `test_deferred_without_issue_number_is_treated_as_missing`.
- [x] **Each orchestrate run appends one row to `~/.claude/projects/.../prove-log.jsonl`** — `record_prove_audit` writes to `<project_dir>/.claude/memory/prove-log.jsonl` (consistent with `metrics.jsonl`).
- [x] **Cross-link: recurring-pattern detector can consume this log to surface ACs that fail repeatedly** — schema includes `verdict`, `downgrade_reason`, and the full `ac_audit` array; pattern detector is future work, no shape change needed.

## Test plan

- [x] `python3 -m pytest claude-config/tests/ -v` — 17/17 green
- [x] Manual review of YAML parsing fallback path (regex parses scalar fields when yaml unavailable)
- [ ] Live verification: deferred to first real `/orchestrate` run that includes `ac_audit` (#1611 or one of the Phase B issues)

## Schema (one row per orchestrate run)

```json
{
  \"ts\": \"2026-06-02T...\",
  \"issue\": 1611,
  \"phase\": \"PROVE\",
  \"verdict\": \"PASS | FAIL | BLOCKED\",
  \"ac_audit\": [
    {\"ac\": \"verbatim AC bullet\", \"status\": \"implemented|partial|missing|deferred|n/a\", \"evidence\": \"file:line or #NNNN\"}
  ],
  \"applicable_evals\": [\"E01\", \"E15\"],
  \"eval_results\": {\"E01\": \"pass\", \"E15\": \"pass\"},
  \"downgrade_reason\": \"AC 5: AC #5 marked missing\"
}
```

## Why FAIL not BLOCKED for AC gaps

- `FAIL`: implementation is incomplete relative to the agreed plan (a planning gap)
- `BLOCKED`: something is broken in the artifact (a quality gap — lint, tests, build)

Separating them lets the recurring-pattern detector distinguish \"we keep shipping partial work\" from \"we keep breaking the build\".

🤖 Generated with [Claude Code](https://claude.com/claude-code)