### PR TITLE
chore(settings): enable telegram plugin

### DIFF
--- a/claude-config/settings.json
+++ b/claude-config/settings.json
@@ -141,7 +141,8 @@
     "typescript-lsp@claude-plugins-official": true,
     "pyright-lsp@claude-plugins-official": true,
     "pr-review-toolkit@claude-plugins-official": true,
-    "playwright@claude-plugins-official": true
+    "playwright@claude-plugins-official": true,
+    "telegram@claude-plugins-official": true
   },
   "extraKnownMarketplaces": {
     "openai-codex": {


### PR DESCRIPTION
Enables the marketplace-installed `external_plugins/telegram` plugin so the telegram MCP server spawns and its tools are available for status pings. Takes effect on next Claude Code restart. TRIVIAL per `~/agents` velocity rule — single-line settings change.