### PR TITLE
feat(skills): share portable Claude skills into Codex via install symlinks

### DIFF
--- a/claude-config/install.sh
+++ b/claude-config/install.sh
@@ -488,7 +488,14 @@ CONFIG_CHANGED=$(git diff-tree -r --name-only ORIG_HEAD HEAD -- claude-config/ c
 
 if [ -n "$CONFIG_CHANGED" ]; then
     echo "[post-merge] Config files changed — re-running installer..."
-    "$REPO_DIR/claude-config/install.sh" 2>&1 | sed 's/^/[post-merge] /'
+    # Prefer the orchestrator so BOTH Claude and Codex re-sync (Codex skill
+    # symlinks are created by codex-config/install.sh). Fall back to the
+    # Claude installer alone if the orchestrator is absent.
+    if [ -x "$REPO_DIR/install-all.sh" ]; then
+        "$REPO_DIR/install-all.sh" 2>&1 | sed 's/^/[post-merge] /'
+    else
+        "$REPO_DIR/claude-config/install.sh" 2>&1 | sed 's/^/[post-merge] /'
+    fi
 else
     echo "[post-merge] No config changes — skipping install"
 fi

--- a/claude-config/scripts/check-skill-portability.sh
+++ b/claude-config/scripts/check-skill-portability.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# check-skill-portability.sh — is a Claude skill safe to symlink into Codex?
+#
+# Usage: check-skill-portability.sh <path-to-SKILL.md>
+#
+# Exit 0  → portable: the skill body/frontmatter contains no Claude-only
+#           harness constructs, so the SAME file can be symlinked into
+#           ~/.codex/skills/<name> and read by Codex unchanged.
+# Exit 1  → not portable: references a Claude-only construct that has no Codex
+#           equivalent. The dual-installer skips it for Codex (Claude-only),
+#           and prints the offending lines.
+# Exit 2  → usage / file error.
+#
+# Rationale: Claude Code and Codex read an identical SKILL.md format, so a
+# converter is unnecessary — a symlink shares one canonical file with zero
+# drift. The ONLY thing that breaks a port is a body that assumes the Claude
+# harness. We flag the unambiguous signals (tools, plan mode, MCP tool IDs,
+# restrictive frontmatter) and deliberately do NOT flag prose mentions of
+# slash commands like "/orchestrate", which are documentation, not coupling.
+#
+# Companion to codex-config/install.sh, which calls this per skill.
+
+set -euo pipefail
+
+skill="${1:-}"
+if [ -z "$skill" ] || [ ! -f "$skill" ]; then
+    echo "usage: $(basename "$0") <path-to-SKILL.md>" >&2
+    exit 2
+fi
+
+# Strong, unambiguous Claude-harness signals. Keep this list conservative:
+# a false positive needlessly denies Codex a working skill; a prose mention
+# must never trip it. Add patterns only when a construct genuinely has no
+# Codex equivalent.
+hits=$(grep -EnI -i \
+    -e '^[[:space:]]*allowed-tools:' \
+    -e '^[[:space:]]*disable-model-invocation:' \
+    -e '^[[:space:]]*context:[[:space:]]*fork' \
+    -e 'mcp__[a-z0-9_]+' \
+    -e '\bTask tool\b' -e '\bAgent tool\b' -e 'subagent_type' \
+    -e 'ScheduleWakeup|EnterPlanMode|ExitPlanMode|TaskCreate|TaskUpdate' \
+    "$skill" || true)
+
+if [ -n "$hits" ]; then
+    echo "$hits"
+    exit 1
+fi
+exit 0

--- a/codex-config/install.sh
+++ b/codex-config/install.sh
@@ -58,6 +58,54 @@ link_item "$SCRIPT_DIR/skills" "$CODEX_DIR/skills/user" "skills/user"
 
 echo ""
 
+# ─── Phase 1.5: Share Claude skills into Codex ──────────────────────────────
+# Claude Code and Codex read an identical SKILL.md format, so a portable Claude
+# skill needs no conversion — we symlink the SAME canonical file into Codex,
+# giving zero drift (edit once, both runtimes see it). Per-skill links (not a
+# whole-dir link) are required so Codex's own ~/.codex/skills/.system and
+# /user trees stay intact. A deterministic portability lint gates each skill:
+# anything referencing a Claude-only harness construct (Task/Agent tools, plan
+# mode, MCP tool IDs, restrictive frontmatter) is skipped for Codex, loudly.
+# Canonicalize (strip the `..`) so generated symlinks store clean absolute
+# paths; empty if claude-config isn't present on this machine.
+CLAUDE_CONFIG="$(cd "$SCRIPT_DIR/../claude-config" 2>/dev/null && pwd || true)"
+CLAUDE_SKILLS="${CLAUDE_CONFIG:+$CLAUDE_CONFIG/skills}"
+PORTABILITY_LINT="${CLAUDE_CONFIG:+$CLAUDE_CONFIG/scripts/check-skill-portability.sh}"
+SKILLS_PORTED=0
+SKILLS_SKIPPED=0
+
+echo "Phase 1.5: Claude skills shared into Codex"
+if [ -d "$CLAUDE_SKILLS" ] && [ -x "$PORTABILITY_LINT" ]; then
+    for skill_dir in "$CLAUDE_SKILLS"/*/; do
+        [ -d "$skill_dir" ] || continue
+        name="$(basename "$skill_dir")"
+        skill_md="$skill_dir/SKILL.md"
+        [ -f "$skill_md" ] || continue
+
+        # Never shadow Codex's reserved skill namespaces.
+        if [ "$name" = "user" ] || [ "$name" = ".system" ]; then
+            echo "  ⚠ skipping '$name' — reserved Codex skills namespace"
+            SKILLS_SKIPPED=$((SKILLS_SKIPPED + 1))
+            continue
+        fi
+
+        if "$PORTABILITY_LINT" "$skill_md" >/dev/null 2>&1; then
+            link_item "${skill_dir%/}" "$CODEX_DIR/skills/$name" "skills/$name (from claude-config)"
+            SKILLS_PORTED=$((SKILLS_PORTED + 1))
+        else
+            echo "  ⚠ skipping '$name' for Codex — Claude-only constructs:"
+            "$PORTABILITY_LINT" "$skill_md" 2>/dev/null | sed 's/^/      /'
+            SKILLS_SKIPPED=$((SKILLS_SKIPPED + 1))
+        fi
+    done
+    echo "  → $SKILLS_PORTED ported, $SKILLS_SKIPPED skipped (Claude-only)"
+else
+    echo "  ⚠ claude-config skills or portability lint not found — skipping"
+    echo "    (expected $CLAUDE_SKILLS and $PORTABILITY_LINT)"
+fi
+
+echo ""
+
 echo "Phase 2: First-time setup"
 if [ ! -f "$CODEX_DIR/config.toml" ]; then
     cp "$SCRIPT_DIR/config.toml.example" "$CODEX_DIR/config.toml"
@@ -88,6 +136,7 @@ fi
 echo ""
 echo "=== Installation Summary ==="
 echo "  Symlinks:    ✓ $LINKS_TOTAL/$LINKS_TOTAL linked"
+echo "  Claude→Codex: $SKILLS_PORTED skill(s) shared, $SKILLS_SKIPPED skipped (Claude-only)"
 echo "  Notes:       ~/.codex/skills/.system remains local and untouched"
 echo "               ~/.codex/rules/default.rules remains local (machine approvals)"
 


### PR DESCRIPTION
## Summary

Claude Code and Codex read an identical `SKILL.md` format, so portable skills need no conversion — symlink the same canonical file into both runtimes for **zero drift** (edit once, both see it).

- **`codex-config/install.sh`** — new Phase 1.5 loops `claude-config/skills/*`, lints each, and per-skill symlinks portable ones into `~/.codex/skills/<name>`, leaving Codex's reserved `.system` and `user` trees intact.
- **`claude-config/scripts/check-skill-portability.sh`** — deterministic gate: exits non-zero if a skill references a Claude-only harness construct (`Task`/`Agent` tools, plan mode, `mcp__` IDs, restrictive frontmatter), so harness-coupled skills are skipped for Codex **loudly** instead of shipped broken.
- **`claude-config/install.sh`** — post-merge hook now re-runs `install-all.sh` so a `git pull` re-syncs both runtimes.

## Why symlinks, not a converter

Both runtimes adopted the same Agent Skills spec. A converter would create a forked second copy that drifts; a symlink shares one canonical file. The only thing that breaks a port is a body assuming the Claude harness — which the lint catches.

## Test Plan

- [x] Live probe: Codex v0.134 (gpt-5.5) discovers symlinked skills and tolerates extra `version:`/`argument-hint:` frontmatter — verified on `deep-review` and `dashboard`.
- [x] Installer ports all 8 current skills, 0 skipped; `.system`/`user` intact; clean absolute symlink targets.
- [x] Lint self-tests pass both directions (portable→0, synthetic Task-tool skill→1).
- [x] `bash -n` clean on all 3 scripts + the post-merge heredoc body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)