### PR TITLE
docs(git-workflow): forbid stash-and-forget; commit telemetry, branch WIP

### DIFF
--- a/claude-config/rules/git-workflow.md
+++ b/claude-config/rules/git-workflow.md
@@ -111,3 +111,26 @@ Split into phased PRs, each leaving main in a working state:
 - Force push to shared branches
 - Skip CI with `--no-verify`
 - Merge without rebasing on latest main
+- `git stash` someone else's uncommitted work to clear the tree and walk away
+  (stash-and-forget). If a dirty tree blocks a pull, see "Working tree hygiene"
+  below — never bury WIP you did not create in an anonymous stash.
+
+## Working tree hygiene in `~/agents` (autonomous runs)
+
+`~/agents` accumulates two kinds of dirtiness that an unattended run must handle
+**without stashing-and-forgetting** (which has silently buried real WIP — see
+the four orphaned stashes cleaned up 2026-06-02):
+
+- **Telemetry shard churn** (`telemetry/<host>/*.jsonl`) is tracked *by design*
+  for cross-machine aggregation (`feat(learn): cross-machine git-sharded
+  telemetry`). It is meant to be **committed**, not stashed and not gitignored.
+  An autonomous run that finds only telemetry dirty should commit the shard
+  (`chore(telemetry): shard update`), not stash it.
+- **Unrelated WIP** (anything else uncommitted): if you must reset the tree,
+  **commit it to a throwaway branch first** (`wip/<date>-<context>`) so it is
+  recoverable, then return to your task. Never `git stash` it anonymously.
+
+Rationale: the SessionStart hook and the learn-gate poller both `git pull
+--ff-only` and assume a clean-enough tree; the failure mode is runs that stash
+to get there and never restore. Committing (telemetry) or branching (other WIP)
+keeps every change recoverable.


### PR DESCRIPTION
## Summary

Root-causes the orphaned-stash incident of 2026-06-02. Investigation showed the stashes were **not** created by any cron/launchd script — the launchd poller and SessionStart hook both `git pull --ff-only` with no stash. They came from **autonomous Claude Code sessions** running ad-hoc `git stash push -m "…"` to clear a dirty tree before pulling, then never restoring. Four stashes had accumulated, one containing an in-progress feature.

The recurring **trigger** is the telemetry shard (`telemetry/<host>/*.jsonl`), which is tracked *by design* for cross-machine aggregation but is never committed, so the tree is perpetually dirty.

## Change

`claude-config/rules/git-workflow.md`:
- Adds **stash-and-forget** to "Never Do These".
- New **"Working tree hygiene in ~/agents"** section: telemetry shards must be **committed** (not stashed, not gitignored); other WIP must be committed to a `wip/` branch before any tree reset.

## Follow-up (not in this PR — needs a decision)

The structural fix is to **auto-commit + push the telemetry shard** (from the learn-gate poller or SessionStart hook) so the tree stays clean and no run is tempted to stash. That introduces background auto-push, so it's left for an explicit decision rather than bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)