### PR TITLE
feat(poller): auto-commit + push telemetry shard to keep agents tree clean

### DIFF
--- a/claude-config/launchd/README.md
+++ b/claude-config/launchd/README.md
@@ -1,0 +1,74 @@
+# launchd agents
+
+## `com.claude-learn-gate-poller.plist`
+
+A macOS launchd job that runs the telemetry → learn maintenance loop every
+**12 hours** (`StartInterval 43200`). It does not run at load (`RunAtLoad`
+false); the first run is one interval after it is bootstrapped.
+
+The job is a thin wrapper — all logic lives in
+[`../scripts/learn-gate-poller.sh`](../scripts/learn-gate-poller.sh) so it can
+be read, `bash -n`-checked, and edited **without re-deploying the plist**.
+
+### What each run does
+
+1. **Sync** — `git pull --ff-only` to pick up other machines' telemetry shards.
+2. **Gate + learn** — runs `telemetry_gate.py`; if the gate trips, applies
+   cross-project patterns via `claude --print "/learn --apply --cross-project
+   --validate"`.
+3. **Commit + push this machine's telemetry shard** — so the working tree
+   returns to **clean**.
+
+### Why step 3 (the structural fix)
+
+Telemetry shards (`telemetry/<host>/*.jsonl`) are tracked **by design** for
+cross-machine aggregation, but every session appends to them, so the repo tree
+is almost always dirty. A perpetually-dirty tree is what tempted autonomous
+runs to `git stash` for a clean `pull --ff-only` and then never restore —
+silently burying real WIP (four orphaned stashes, cleaned up 2026-06-02).
+
+Committing the shard here keeps the tree clean **and** shares the data, removing
+the temptation to stash. Safeguards in the script:
+
+- commits **only** `telemetry/` paths, **only** on `main` (the sanctioned
+  exception to "never commit directly to main" — machine data, never code);
+- pushes with a **rebase-retry** so a concurrent push doesn't strand the commit;
+- every step is **non-fatal** — a network/credential failure is logged and the
+  next run retries; it can never wedge the loop.
+
+Companion behavioural rule: `rules/git-workflow.md` → "Working tree hygiene in
+`~/agents`".
+
+### Requirements
+
+- `git push` needs credentials available to the launchd context. `bash -lc` is a
+  login shell, so the `osxkeychain` git credential helper (or `gh` auth) is
+  normally available. If pushes log `telemetry push failed`, check that the
+  helper is configured for the user that owns the LaunchAgent.
+
+### Deploy / reload
+
+The plist is **not** auto-installed by `install.sh`; deploy it manually. After
+editing **the plist** (not the script), redeploy and reload once:
+
+```bash
+cp claude-config/launchd/com.claude-learn-gate-poller.plist ~/Library/LaunchAgents/
+launchctl unload ~/Library/LaunchAgents/com.claude-learn-gate-poller.plist 2>/dev/null || true
+launchctl load   ~/Library/LaunchAgents/com.claude-learn-gate-poller.plist
+```
+
+Editing **only the script** (`learn-gate-poller.sh`) needs no reload — the
+plist execs it fresh each interval.
+
+### Observe
+
+```bash
+launchctl list | grep claude-learn-gate          # is it loaded?
+tail -f ~/Library/Logs/claude-learn/poller.log    # run-by-run log
+```
+
+To run once on demand (does not wait for the interval):
+
+```bash
+bash ~/agents/claude-config/scripts/learn-gate-poller.sh
+```

--- a/claude-config/launchd/com.claude-learn-gate-poller.plist
+++ b/claude-config/launchd/com.claude-learn-gate-poller.plist
@@ -6,21 +6,13 @@
     <key>Label</key>
     <string>com.claude-learn-gate-poller</string>
     <key>ProgramArguments</key>
+    <!-- Logic lives in claude-config/scripts/learn-gate-poller.sh so it is
+         readable/testable and editable without re-deploying this plist.
+         `bash -lc` = login shell so git/gh credential helpers are on PATH. -->
     <array>
         <string>/bin/bash</string>
         <string>-lc</string>
-        <string>
-          LOG="$HOME/Library/Logs/claude-learn/poller.log"
-          mkdir -p "$(dirname "$LOG")"
-          cd "$HOME/agents" \
-          &amp;&amp; git pull --ff-only --quiet 2&gt;&gt;"$LOG" \
-          &amp;&amp; python3 claude-config/scripts/telemetry_gate.py --verbose \
-               &gt;&gt;"$LOG" 2&gt;&amp;1 \
-          &amp;&amp; claude --print "/learn --apply --cross-project --validate" \
-               &gt;&gt;"$LOG" 2&gt;&amp;1 \
-          || echo "[$(date -Iseconds)] gate not tripped or pull failed — skip" \
-               &gt;&gt;"$LOG"
-        </string>
+        <string>exec "$HOME/agents/claude-config/scripts/learn-gate-poller.sh"</string>
     </array>
     <key>WorkingDirectory</key>
     <string>/Users/jasonjob/agents</string>

--- a/claude-config/scripts/learn-gate-poller.sh
+++ b/claude-config/scripts/learn-gate-poller.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# learn-gate-poller.sh — periodic maintenance for the ~/agents telemetry + learn loop.
+#
+# Invoked by launchd: com.claude-learn-gate-poller.plist (StartInterval 43200s = 12h).
+# Extracted from the plist's former inline command so the logic is readable,
+# testable (`bash -n`), and editable without re-deploying the plist.
+#
+# Responsibilities (each best-effort, none aborts the others):
+#   1. Sync the agents repo — ff-only pull of other machines' telemetry shards.
+#   2. Run the learn gate; if it trips, apply cross-project patterns via /learn.
+#   3. Commit + push THIS machine's telemetry shard so the working tree returns
+#      to CLEAN.
+#
+# Why step 3 exists — the structural fix:
+#   Telemetry shards (telemetry/<host>/*.jsonl) are tracked by design for
+#   cross-machine aggregation (feat(learn): cross-machine git-sharded telemetry),
+#   but every session appends to them, so the tree is almost always dirty. A
+#   perpetually-dirty tree is what tempted autonomous runs to `git stash` to get
+#   a clean ff-only pull — and then never restore, silently burying real WIP
+#   (four orphaned stashes, cleaned up 2026-06-02). Committing the shard here
+#   keeps the tree clean AND shares the data, removing the temptation to stash.
+#   The companion behavioural rule is rules/git-workflow.md, "Working tree
+#   hygiene in ~/agents".
+#
+# NOTE on "never commit directly to main": telemetry shard auto-commits are the
+# one sanctioned exception — machine-generated data, never code, scoped to
+# telemetry/ paths only, on main only.
+
+set -uo pipefail   # deliberately NOT `-e`: every step is independently fault-tolerant
+
+REPO="$HOME/agents"
+LOG="$HOME/Library/Logs/claude-learn/poller.log"
+mkdir -p "$(dirname "$LOG")"
+ts()  { date -Iseconds; }
+log() { echo "[$(ts)] $*" >>"$LOG"; }
+
+cd "$REPO" || { log "FATAL: $REPO missing — aborting poller run"; exit 0; }
+
+# Commit + push only the telemetry/ paths, only on main, with a rebase-retry so a
+# concurrent push from another machine/PR doesn't strand the commit. All failures
+# are logged and non-fatal; the next run retries.
+commit_and_push_telemetry() {
+    local branch
+    branch="$(git symbolic-ref --short -q HEAD || echo '')"
+    if [ "$branch" != "main" ]; then
+        log "telemetry: on '$branch' not main — skip commit (avoids cross-branch push)"
+        return
+    fi
+    if git diff --quiet -- telemetry/ && git diff --cached --quiet -- telemetry/; then
+        return  # nothing to commit
+    fi
+
+    git add telemetry/ 2>>"$LOG"            || { log "telemetry: git add failed";    return; }
+    git commit -q -m "chore(telemetry): shard update $(ts)" 2>>"$LOG" \
+                                            || { log "telemetry: git commit failed"; return; }
+
+    if git push --quiet origin main 2>>"$LOG"; then
+        log "telemetry shard committed + pushed"
+    elif git pull --rebase --quiet 2>>"$LOG" && git push --quiet origin main 2>>"$LOG"; then
+        log "telemetry shard committed + pushed (after rebase)"
+    else
+        log "telemetry push failed (non-fatal) — commit kept locally, next run retries"
+    fi
+}
+
+# 1. Sync. ff-only preserves the existing safe semantics and tolerates a dirty
+#    own-shard (incoming changes touch other hosts' paths, not ours).
+git pull --ff-only --quiet 2>>"$LOG" || log "pull --ff-only failed (non-fatal)"
+
+# 2. Gate, then learn only if the gate trips (matches the former inline behaviour).
+if python3 claude-config/scripts/telemetry_gate.py --verbose >>"$LOG" 2>&1; then
+    claude --print "/learn --apply --cross-project --validate" >>"$LOG" 2>&1 \
+        || log "/learn run failed (non-fatal)"
+else
+    log "learn gate not tripped — skip /learn"
+fi
+
+# 3. Return the tree to clean and share this machine's shard.
+commit_and_push_telemetry
+
+log "poller run complete"


### PR DESCRIPTION
## Summary

The **structural** root-cause fix for the orphaned-stash incident (companion to the behavioural guardrail in the git-workflow PR). The telemetry shard is tracked by design for cross-machine aggregation but is never committed, so the `~/agents` tree is perpetually dirty — which is what tempted autonomous runs to `git stash` for a clean `pull --ff-only` and then never restore (four orphaned stashes, one holding an in-progress feature).

## Change

- **Extract** the launchd poller's inline (XML-escaped) command into `claude-config/scripts/learn-gate-poller.sh` — readable, `bash -n`-testable, and editable without re-deploying the plist.
- **New step 3**: after the gate/learn run, commit + push this machine's `telemetry/` shard so the tree returns to **clean** and the data is shared.
- **Point the plist** at the script.
- **Document** in `claude-config/launchd/README.md`.

## Safeguards

- Commits **only** `telemetry/` paths, **only** on `main` (sanctioned exception to "never commit directly to main" — machine data, not code).
- Push uses a **rebase-retry** so a concurrent push doesn't strand the commit.
- Every step is **non-fatal** (`set -uo pipefail`, no `-e`) — a network/credential failure is logged and retried next run; it cannot wedge the gate/learn loop.

## Test Plan

- [x] `bash -n` clean on `learn-gate-poller.sh`.
- [x] `plutil -lint` OK on the plist; arg now execs the script.
- [x] Branch guard verified: on a non-`main` branch the telemetry commit is **skipped** (no cross-branch push).
- [ ] Deploy + reload per README, then confirm `~/Library/Logs/claude-learn/poller.log` shows "telemetry shard committed + pushed" on the next run.

## Residual scope

The poller runs every 12h, so the tree can still be dirty *between* runs — that window is covered by the behavioural guardrail (git-workflow PR). Requires `git push` credentials in the launchd context (`osxkeychain`/`gh`); push failures are logged non-fatally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)