### PR TITLE
spec(rules): 4 spec-discipline rules + promotion path (from buddy R1 lessons)

### DIFF
--- a/claude-config/CLAUDE.md
+++ b/claude-config/CLAUDE.md
@@ -170,17 +170,73 @@ that the M365 capability isn't configured on that machine.
 | `rbac-pattern.md` | Auth/permissions code |
 | `orchestrate-workflow.md` | `/orchestrate` runs |
 | `spec-review-workflow.md` | Specs and `.agents/` paths |
+| `spec-self-review.md` | Auto-loads on `specs/**` — the loud pre-commit gate for §3 self-review |
+| `spec-schema-collision-check.md` | Auto-loads on `specs/**` + `db/migrations/**` — exhaustive grep for drops/extends |
+| `spec-state-machine-truth-table.md` | Auto-loads on `specs/**` — for multi-section state contracts |
+| `spec-new-substrate-domain-sweep.md` | Auto-loads on `specs/**` — 5-question domain check for NEW substrates |
 | `post-merge-verification.md` | After `/pr --merge` |
 
 ---
 
+## Promoting project memory to global rules
+
+When a project-memory file under
+`~/.claude/projects/<project>/memory/feedback-*.md` captures a lesson
+that's **generally applicable to other projects** (not specific to
+that project's domain), promote it to a global rule so every project
+inherits it.
+
+**Why this exists.** Project memory files are project-local — working
+in `safe174th` you won't see `buddy`'s feedback files. Without
+promotion, every project relearns the same lessons. The 2026-06-03
+Workspace V1 R1 incident documented this gap: 17 of 21 blockers were
+preventable by existing project-local feedback that had never been
+promoted.
+
+**Procedure:**
+
+1. **Decide it's promotable.** Cross-project relevance test: would a
+   teammate working on an unrelated project benefit from this rule
+   without seeing the originating incident? If yes, promote.
+2. **Write the new rule** in `~/agents/claude-config/rules/<name>.md`
+   with appropriate `paths:` frontmatter for auto-load.
+3. **Keep the project-memory file as back-reference.** Add a
+   `Companion: ~/.claude/rules/<name>.md` line so future readers
+   trace from incident → general rule.
+4. **Commit + PR + merge to `~/agents`** following the standard git
+   workflow (jwj2002 account per `github-accounts.md`).
+5. **Run `~/agents/claude-config/install.sh`** to refresh symlinks
+   (no-op if the rule directory was already symlinked; only catches
+   first-time symlink + missing-target cases).
+6. **For jbox06 (if applicable):** `ssh jbox06 'cd ~/agents && git
+   pull --ff-only && ./claude-config/install.sh'`. Without this step,
+   VitalAILabs app sessions won't see the new rule.
+
+**What counts as "generally applicable":**
+- Workflow discipline (review gates, self-checks, sequencing).
+- Cross-stack mistakes (enum collisions, schema drift, fence-post
+  errors in distributed systems).
+- Tool quirks that bite in any project (`codex` CLI, `gh` CLI, `git`
+  edge cases).
+
+**What stays project-local:**
+- Domain-specific patterns (e.g., a buddy-only entity-grid lesson).
+- Architectural choices recorded for context (resume docs,
+  pillar-status logs).
+- Operational incident notes specific to that project's infra.
+
 ## Anti-patterns to avoid
 
-- Long CLAUDE.md (target <200 lines; this file is the target).
+- Long CLAUDE.md (target <200 lines; this file is the target — the
+  promotion-path section above adds ~30 lines, balanced by keeping
+  rules in their own files).
 - Reaching for a subagent before exhausting CLAUDE.md and skills (Anthropic's recommended order).
 - Editing `~/.claude/` directly. Always go through `~/agents/claude-config/`.
 - Putting secrets, ephemeral state, or large code patterns in CLAUDE.md.
 - Bypassing safety with `--no-verify`, `--force`, or `bypassPermissions` without explicit user approval.
+- **Letting project-local lessons stay project-local indefinitely.**
+  If a `feedback-*.md` file would help another project, promote it
+  per the procedure above.
 
 ---
 

--- a/claude-config/rules/spec-new-substrate-domain-sweep.md
+++ b/claude-config/rules/spec-new-substrate-domain-sweep.md
@@ -1,0 +1,222 @@
+---
+paths: ["**/specs/**", "**/.agents/**"]
+---
+
+# Spec New-Substrate Domain Sweep — 5 Questions Before R1
+
+**When a spec proposes a NEW persistence substrate (sync, indexing,
+queueing, cache, write-through layer), answer 5 domain-expertise
+questions in the spec body BEFORE submitting V1.0 for adversarial
+review.**
+
+The code-reality manifest checks what EXISTS. This rule checks what a
+domain expert would say about your NEW substrate — gaps that the
+manifest can't catch because the substrate didn't exist to manifest
+against.
+
+---
+
+## When this rule fires
+
+Your spec introduces ANY of:
+
+| Substrate kind | Examples |
+|---|---|
+| **Sync** | Polling a remote system, delta tokens, history APIs, change-data-capture, eventual-consistency mirror |
+| **Indexing** | Search index, embedding store, header-only mirror of remote content, cached projection |
+| **Queueing** | Job queue, deferred task store, retry buffer, dead-letter queue |
+| **Cache** | Read-through cache, write-through cache, TTL-bounded store |
+| **Write-through** | Local write that must also write to a remote system, with rollback semantics |
+
+If your spec's net-new schema is doing one of those things,
+**answer the 5 questions in the spec body** before R1 review.
+
+---
+
+## The 5 questions
+
+### Q1 — Deletion / move / rename model
+
+For every upstream entity your substrate mirrors or projects: **what
+happens when the upstream side deletes, moves, archives, renames, or
+marks the entity?**
+
+Your spec must answer:
+- Do you propagate the delete (cascade tombstone)?
+- Do you keep the local copy until next full sync?
+- Do you mark `deleted_at` and continue showing in some views?
+- What WS frame fires?
+- What is the user experience — do search hits include or exclude
+  recently-deleted entities?
+
+**R1 finding this would have prevented:** W5 (Workspace V1 email_index
+did not specify delete handling).
+
+### Q2 — Cursor / state shape (row-level vs entity-level)
+
+Where does sync cursor state live?
+
+- **Row-level** (e.g., a column on each mirror row) — almost always
+  wrong. Fails for empty entities, duplicates across rows, races on
+  multi-row updates.
+- **Entity-level** (e.g., one row per provider+account in a separate
+  state table) — almost always right. Single writer per entity.
+- **Process-level** (in-memory) — only valid for ephemeral
+  substrates; bad on restart.
+
+Your spec must:
+1. State which level (row / entity / process).
+2. If row-level: explain why this case is the exception (almost
+   certainly you can't).
+3. If entity-level: name the separate state table and its columns.
+
+**R1 finding this would have prevented:** W4 (Workspace V1 put
+`sync_state` on `email_index` row, should have been on a separate
+`email_sync_state` table keyed by (provider, account)).
+
+### Q3 — Identifier uniqueness scope
+
+For every upstream identifier your substrate stores: **is the
+identifier globally unique, or only locally unique within an
+account/tenant/provider?**
+
+Most provider IDs (Gmail message_id, Slack message_ts, Microsoft
+Graph thread_id) are **per-account only**, not globally unique. If
+your substrate has multiple accounts, the natural primary key MUST
+include the account.
+
+Your spec must declare:
+- For each upstream ID, the uniqueness scope.
+- The local primary key shape (composite vs surrogate).
+- How the REST endpoint resolves identity (e.g.,
+  `(provider, account, message_id)` not just `message_id`).
+
+**R1 finding this would have prevented:** W6 (Workspace V1 email
+thread endpoint took only `provider_thread_id`, would leak
+cross-account data).
+
+### Q4 — Derived-data classification (privacy / sensitivity)
+
+For any data your substrate derives from upstream content (snippets,
+embeddings, summaries, fingerprints, hashes): **what classification
+applies?**
+
+Default-to-public is unsafe. Default-to-sender-based is unsafe (misses
+sensitive content from ordinary senders). Default-to-private with
+escalation pathways is usually right.
+
+Your spec must:
+1. Name the classification levels (e.g., L0/L1/L2/L3 from privacy_class).
+2. State the default for derived data.
+3. State the escalation pathway (sender, keyword, manual override).
+4. State whether derived data (snippets, embeddings) inherits the
+   upstream entity's classification or is classified separately.
+5. State retention semantics — does the substrate retain after the
+   upstream deletes?
+
+**R1 finding this would have prevented:** W8 (Workspace V1 email_index
+classified only by sender; missed sensitive content from ordinary
+senders + embeddings classified as derived without explicit policy).
+
+### Q5 — Migration portability prerequisites
+
+For every schema your substrate adds: **what extensions, types, and
+operational prerequisites does it need across all deployment
+environments?**
+
+Your spec must declare:
+- Required Postgres extensions (e.g., `vector`, `pgcrypto`,
+  `pg_trgm`) and the migration's `CREATE EXTENSION IF NOT EXISTS`.
+- Vector / type dimensions (e.g., 768d nomic, 1536d openai) and where
+  the value comes from.
+- Index creation constraints (e.g., `ivfflat` requires populated
+  tables for sensible `lists` parameter — empty-table creation may
+  warn or fail).
+- Down-migration completeness (every UP statement has a corresponding
+  DOWN statement OR an explicit "down-migration drops the column;
+  data loss accepted" with rationale).
+- Compatibility across deployment targets (local Docker pg vs
+  Supabase pooler vs Supabase direct vs jbox06 pg).
+
+**R1 finding this would have prevented:** W9 (Workspace V1 email_index
+migration didn't specify `vector` extension, didn't address ivfflat
+empty-table behavior, didn't define down-migration).
+
+---
+
+## How to apply
+
+Add a `## §N — Domain Sweep` section to the spec, with subsections
+for each of the 5 questions. ~200-400 words per question for a
+typical substrate. Insert this section **between the substrate's
+schema/design section and its Acceptance Criteria section.**
+
+Example layout for an email-index spec:
+
+```
+## §9 Email Index (E3) — Backend Substrate
+   §9.1 Goals
+   §9.2 Schema
+   §9.3 Sync Services
+   §9.4 REST Endpoints
+   §9.5 Frontend consumption
+   §9.6 Privacy Gating
+
+## §9a Domain Sweep — substrate completeness check  ← NEW
+   §9a.1 Q1 Deletion / move / rename model
+   §9a.2 Q2 Cursor / state shape
+   §9a.3 Q3 Identifier uniqueness
+   §9a.4 Q4 Derived-data classification
+   §9a.5 Q5 Migration portability
+
+## §10 Acceptance Criteria
+```
+
+For specs that propose MULTIPLE substrates, write one Domain Sweep
+section per substrate.
+
+---
+
+## When to skip
+
+- Your spec proposes no new persistence substrate (e.g., it only adds
+  voice tools or UI components against existing tables). Skip the
+  rule.
+- Your spec extends an existing substrate that already has a Domain
+  Sweep section in its V1 spec. Cross-reference instead of duplicating.
+- Your spec is a project-private prototype with no deployment story.
+  Skip with explicit one-line rationale.
+
+A general "small change" is NOT a valid skip. The 2026-06-03 R1 email
+substrate was framed as "just an index" — the 5 missed answers turned
+a "small change" into 4 blockers.
+
+---
+
+## How this rule was born
+
+**2026-06-03 Mavis Workspace V1 R1.** Four of 12 blocking findings on
+Workspace V1 (W4, W5, W6, W8, W9) were all email-substrate domain
+gaps. The spec proposed `email_index` + sync services without an
+expert-domain sweep; each missed answer became a blocker.
+
+Classified in
+`~/projects/buddy/.agents/outputs/r1-root-cause-analysis.md` as
+"Group D — process-absent." No existing global rule covered NEW
+substrate domain sweeps; the code-reality manifest only checks what
+EXISTS, not what a domain expert would have asked about a NEW thing.
+
+This rule fills the gap. New global rule per Proposal 4 of
+`r1-corrective-proposals.md`.
+
+## Companion rules
+
+- `~/.claude/rules/spec-self-review.md` — calls this rule out in Check 4
+  (when the spec is UI/Fullstack; this rule generalizes the check to
+  all NEW substrates regardless of UI involvement).
+- `~/.claude/rules/spec-review-workflow.md` — overall spec workflow.
+- `~/.claude/rules/spec-schema-collision-check.md` — Q5's migration
+  portability check overlaps; that rule covers EXISTING-schema
+  collisions, this one covers NEW-schema completeness.
+- `~/.claude/templates/code-reality-manifest.md` — Q1 cross-refs the
+  manifest's §7 Negative Manifest for "what's new vs what exists."

--- a/claude-config/rules/spec-review-workflow.md
+++ b/claude-config/rules/spec-review-workflow.md
@@ -548,3 +548,32 @@ And ensures:
 - ✅ Immutable references (git commits)
 - ✅ Clear version history
 - ✅ Efficient workflow
+
+---
+
+## Companion rules — the §3 self-review enforcement layer
+
+`§3` of this document is the self-review checklist that catches the
+majority of spec defects. The 2026-06-03 Workspace V1 + AggregateKanban
+V1 R1 review proved §3 can be skipped silently — 17 of 21 blockers
+were preventable by §3 if invoked.
+
+To make §3 impossible to skip silently, these companion rules
+auto-load on `specs/**`:
+
+| Rule | Catches |
+|---|---|
+| `spec-self-review.md` | Loud pre-commit gate; restates §3 with "not optional" + when-to-bypass |
+| `spec-schema-collision-check.md` | Schema drops / renames / consolidations / **extensions** — exhaustive grep + shipped-state collision check |
+| `spec-state-machine-truth-table.md` | Multi-section state contracts where each section reads correct but the cross-section state machine contradicts itself |
+| `spec-new-substrate-domain-sweep.md` | 5-question domain expertise check for any spec proposing a NEW persistence substrate (sync/index/queue/cache) |
+
+These rules were born from the same R1 incident (root-cause
+analysis: `~/projects/buddy/.agents/outputs/r1-root-cause-analysis.md`,
+proposals: `r1-corrective-proposals.md`). They take the §3 discipline
+and make it loud + file-pattern-triggered.
+
+When a R1/R2/R3 finding surfaces a lesson likely to recur in other
+projects, promote it to a global rule per the **"Promoting project
+memory to global rules"** procedure in `~/.claude/CLAUDE.md`. Don't
+let it stay project-local indefinitely.

--- a/claude-config/rules/spec-schema-collision-check.md
+++ b/claude-config/rules/spec-schema-collision-check.md
@@ -1,0 +1,165 @@
+---
+paths: ["**/specs/**", "**/db/migrations/**", "**/.agents/**"]
+---
+
+# Spec Schema Collision Check — Exhaustive Grep Before Locking
+
+**When a spec drops, renames, consolidates, OR EXTENDS a database
+table, enum, or CHECK constraint:** run an exhaustive grep for every
+SQL site against the target BEFORE submitting V1.0 for review. Then
+cross-reference every shipped column / enum value the spec is
+extending to prevent silent collisions.
+
+This rule generalizes the buddy-local lesson
+`feedback_spec_grep_every_sql_site.md` and adds the
+"extension collision" half learned during the 2026-06-03 R1 review.
+
+---
+
+## When this rule fires
+
+Your spec is doing any of:
+
+- **Drop / Rename / Consolidate** — removing or renaming an existing
+  table, column, type, or CHECK value.
+- **Extend** — adding a new column to an existing table, adding a new
+  value to a CHECK constraint or enum, or adding an index that names a
+  field a sibling spec might already index.
+
+The 2026-05-24 Person Consolidation V1 incident covered the first
+class. The 2026-06-03 Workspace V1 + AggregateKanban V1 R1 review
+proved the second class (extension) is just as failure-prone:
+collisions and missed-shipped-values would have caused immediate
+migration failure on Supabase.
+
+---
+
+## The two-part procedure
+
+### Part 1 — SQL-site grep (for drops / renames / consolidations)
+
+For every table / type the spec drops, renames, or consolidates:
+
+```bash
+grep -rn --include='*.py' --include='*.ts' --include='*.tsx' \
+    "FROM <table>\b\|JOIN <table>\b\|UPDATE <table>\b\|INSERT INTO <table>\b\|DELETE FROM <table>\b" \
+    src/ > /tmp/sql-audit-<table>.txt
+```
+
+Categorize each hit:
+- **IN-SCOPE** — already covered by some spec phase / PR.
+- **OUT-OF-SCOPE** — needs spec expansion OR a follow-up issue.
+
+If OUT-OF-SCOPE > 0, **expand the spec OR file follow-up issues before
+locking**. Don't assume "the audits got it all" — implicit topic
+scoping is the failure mode that birthed this rule.
+
+### Part 2 — Shipped-state collision check (for extensions)
+
+For every column / enum value / CHECK constraint the spec extends:
+
+```bash
+# Find the owning migration for every table you're modifying.
+grep -rn "CREATE TABLE <table>\|ALTER TABLE <table>" db/migrations/ \
+    | sort -u
+
+# Open each owning migration and read the FULL column list + CHECK constraints.
+# Note: also check for the SAME CHECK constraint being rewritten by later
+# migrations (the canonical shipped state is the LAST migration that
+# touched the constraint, not the FIRST).
+```
+
+For each column / enum value / CHECK clause your spec proposes adding:
+
+| Check | If yes |
+|---|---|
+| Does an existing column already exist with the same role? | Reuse it (e.g., `tasks.kanban_blocker` exists; don't add `blocked_on`). Document the reuse decision. |
+| Does an existing enum value cover the case? | Reuse it; don't add a duplicate-by-meaning value. |
+| If you're REWRITING a CHECK constraint (DROP + ADD), does your replacement preserve ALL currently-allowed values? | If not, the migration WILL fail on existing rows with the dropped value. Either keep the dropped value OR add a data-migration step. |
+| Does the FK column you're adding already have an index via a multi-column composite? | If yes, your new single-column index is redundant. |
+
+---
+
+## What this rule would have prevented
+
+**2026-05-24 Person Consolidation V1 (Part 1 incident):** 8 PRs +
+26 migrations shipped consolidating `relationships` → `entity`. After
+"complete," found 6 subsystems still querying the dropped table
+across 8 source files, ~20 live SQL sites. Recovery cost: 7 follow-up
+PRs + 5 expert audits. Would-have-been-prevented cost: 1 day of grep
++ 1 day of spec expansion.
+
+**2026-06-03 AggregateKanban V1 R1 (Part 2 incidents):**
+
+- **K1** — Spec rewrote `tasks_kind_check` as
+  `('todo', 'mission', 'agent_job')` from memory. Missions V1 actually
+  shipped `('todo', 'mission', 'agent_job', 'initiative')`. Migration
+  would have failed on any `initiative` row.
+- **K2** — Spec added `tasks.blocked_on` for waiting-column reason.
+  PM V1 already shipped `tasks.kanban_blocker` for exactly this role.
+  Two columns would coexist with overlapping meaning.
+- **K4** — Spec declared `WorkerState =
+  'queued' | 'running' | 'paused' | 'completed' | 'failed' |
+  'cancelled'`. Orchestration V1 actually ships 7 values including
+  `reaped`. Spec's TypeScript type would reject valid responses.
+- **K6** — Spec used `project_slug` filter without resolving how mission
+  rows join to projects (PM V1 uses `tasks.project_id`; Missions V1
+  carries project association through `mission_meta`). The filter
+  would return wrong rows OR no rows for missions.
+
+All four were preventable by running Part 2 against PM V1, Missions
+V1, and Orchestration V1 schemas.
+
+---
+
+## How to apply during the four spec-authoring phases
+
+| Phase | Action |
+|---|---|
+| Drafting (before §3 self-review) | Run Part 1 + Part 2 for every table/enum the spec touches. Cite results in the spec's Migration Risk section. |
+| §3 self-review (this rule's parent) | This rule's Check 2 in `spec-self-review.md` re-invokes the procedure. |
+| R1 / R2 / R3 adversarial review | Treat "Coverage gap — SQL sites against `<table>` not addressed" OR "Shipped-state collision against `<existing>`" as BLOCKING findings. |
+| Pre-merge (after PR ships) | Re-run Part 1 against the current state of `src/`. Any hit is a blocker — either fix in the PR or file a follow-up + add a regression test. |
+
+---
+
+## Anti-patterns
+
+- ❌ "The expert audits covered the schema" — implicit scoping leaves
+  gaps. Audits cover what they're asked to cover.
+- ❌ "I remembered the column list" — schema drifts; memory doesn't.
+  The 2026-06-03 R1 K1/K4 collisions both came from drafting from memory.
+- ❌ "We'll find issues when PRs reach PROVE" — PROVE runs against the
+  current schema, not the migrated schema. Schema drift is invisible
+  until migrations apply.
+- ❌ "The constraint dropped a deprecated value" — every shipped value
+  is in use somewhere until proven otherwise via Part 1 grep.
+
+---
+
+## Companion files
+
+- `~/.claude/rules/spec-self-review.md` — invokes this rule as Check 2.
+- `~/.claude/rules/spec-review-workflow.md` — overall spec workflow (R1-R3).
+- `~/.claude/projects/.../memory/feedback_spec_grep_every_sql_site.md`
+  — buddy-local back-reference to the 2026-05-24 incident.
+- `~/projects/buddy/.agents/outputs/r1-root-cause-analysis.md` —
+  2026-06-03 R1 root-cause analysis covering K1/K2/K4/K6.
+
+## How this rule was born
+
+This rule has TWO origin incidents:
+
+1. **2026-05-24 Person Consolidation V1.** Project-local lesson
+   captured as `feedback_spec_grep_every_sql_site.md` (buddy memory).
+   Covered drops/renames/consolidations.
+2. **2026-06-03 Workspace V1 + AggregateKanban V1 R1.** Extension
+   collisions surfaced. Project-local lesson would have been
+   `feedback-spec-schema-extension-collision-check.md` — instead, both
+   lessons promoted to a single global rule here.
+
+The promotion happened because the buddy-local memory was invisible
+to other projects, so the lesson was at risk of being relearned
+elsewhere. Documented promotion path lives in
+`~/agents/claude-config/CLAUDE.md` (the global orientation) per
+Proposal 5 of the 2026-06-03 corrective-proposals doc.

--- a/claude-config/rules/spec-schema-collision-check.md
+++ b/claude-config/rules/spec-schema-collision-check.md
@@ -56,17 +56,35 @@ scoping is the failure mode that birthed this rule.
 
 ### Part 2 — Shipped-state collision check (for extensions)
 
-For every column / enum value / CHECK constraint the spec extends:
+**EXHAUSTIVENESS REQUIREMENT** (post-2026-06-03 lesson — repeat
+incidents proved load-bearing). For every table the spec touches,
+inventory the **FULL** shipped column list BEFORE proposing any
+addition. Do not grep only the columns you think you're adding —
+grep every column the spec mentions ANYWHERE (including comments,
+type declarations, voice tool schemas, frontend types).
 
 ```bash
-# Find the owning migration for every table you're modifying.
-grep -rn "CREATE TABLE <table>\|ALTER TABLE <table>" db/migrations/ \
-    | sort -u
+# Step 1: list EVERY column shipped on each table the spec mentions.
+table_name=tasks  # repeat for every table cited in the spec
+psql "$DATABASE_URL" -c "\d $table_name"
 
-# Open each owning migration and read the FULL column list + CHECK constraints.
-# Note: also check for the SAME CHECK constraint being rewritten by later
-# migrations (the canonical shipped state is the LAST migration that
-# touched the constraint, not the FIRST).
+# Or read from migration history (offline):
+grep -rn "$table_name" db/migrations/ scripts/init-db.sql | grep -E "ADD COLUMN|CREATE TABLE|priority|kind|status" | sort -u
+```
+
+Then grep the spec for EVERY column name it touches:
+
+```bash
+spec_file=specs/<feature>.md
+grep -oE '\`[a-z_][a-z0-9_]*\`' "$spec_file" \
+    | sort -u \
+    | grep -v '^\`\(specs\|src\|db\|frontend\|backend\|tests\|docs\)' \
+    > /tmp/spec-tokens.txt
+
+# Cross-check every token in /tmp/spec-tokens.txt against the
+# shipped column list. Any token that matches a shipped column =
+# potential collision; verify the shape (type, enum values, CHECK,
+# default) before approving the spec's usage.
 ```
 
 For each column / enum value / CHECK clause your spec proposes adding:
@@ -75,8 +93,18 @@ For each column / enum value / CHECK clause your spec proposes adding:
 |---|---|
 | Does an existing column already exist with the same role? | Reuse it (e.g., `tasks.kanban_blocker` exists; don't add `blocked_on`). Document the reuse decision. |
 | Does an existing enum value cover the case? | Reuse it; don't add a duplicate-by-meaning value. |
+| Does an existing column have a CONFLICTING shape? (e.g., your spec proposes `priority: low/medium/high/urgent` but shipped is `low/normal/high/urgent`) | Either translate at the boundary OR change the spec to match shipped. **Don't write the shipped column with the new shape — the CHECK will reject it at insert time.** |
 | If you're REWRITING a CHECK constraint (DROP + ADD), does your replacement preserve ALL currently-allowed values? | If not, the migration WILL fail on existing rows with the dropped value. Either keep the dropped value OR add a data-migration step. |
 | Does the FK column you're adding already have an index via a multi-column composite? | If yes, your new single-column index is redundant. |
+| Does a sibling spec (in the same V1 wave) ALSO touch this table? | Coordinate: enumerate columns added by ALL sibling specs before adding yours. (2026-05-24 PersonConsolidation V1 added `tasks.assignee_entity_id`; an unrelated spec drafted before that migration landed would have missed it.) |
+
+**The 2026-06-03 R3 lesson: the grep is exhaustive ONLY if it covers
+EVERY column the spec mentions, not just the columns the spec is
+proposing to add.** A `priority` enum collision is a CHECK collision
+even when the spec doesn't propose adding a `priority` column —
+because the spec INSERTS into that column from another source. Same
+for `assignee`-shaped fields, `status`-shaped fields, any column the
+spec writes-through from another table.
 
 ---
 

--- a/claude-config/rules/spec-self-review.md
+++ b/claude-config/rules/spec-self-review.md
@@ -1,0 +1,186 @@
+---
+paths: ["**/specs/**", "**/.agents/**"]
+---
+
+# Spec Self-Review Checklist — Mandatory Pre-Submission Gate
+
+**This rule is the loud, file-pattern-triggered companion to
+`spec-review-workflow.md` §3.** It exists because §3 of that workflow
+is the discipline that catches the majority of spec defects, but the
+2026-06-03 Workspace V1 + AggregateKanban V1 R1 review proved it can
+be skipped without anyone noticing — 17 of 21 R1 blockers (81%) would
+have been prevented by §3 if it had been invoked.
+
+This rule auto-loads on any session touching `specs/**` (or
+`.agents/**`). The discipline below is **not optional** before
+committing any spec PR you authored in this session.
+
+---
+
+## When this rule fires
+
+You are authoring or substantially modifying a spec under `specs/`.
+That means BOTH of:
+
+- You're about to commit a `feat(spec)`, `spec(...)`, or `docs(spec)`
+  PR, OR
+- You're about to invoke `/codex:adversarial-review` (R1+) on a draft.
+
+If either is true: **stop and run the checks below before committing.**
+
+---
+
+## The four mandatory checks
+
+Adapted from `~/.claude/rules/spec-review-workflow.md` §3.1–§3.4.
+Re-stated here because the spec-review-workflow rule is workflow-stage
+guidance; this rule is the per-PR gate.
+
+### Check 1 — Spec ↔ manifest cross-check (every backtick symbol)
+
+```bash
+# From the repo root:
+grep -oE '\`[A-Za-z_][A-Za-z0-9_./:-]*\`' specs/<feature>.md | sort -u > /tmp/spec-symbols.txt
+
+# Cross-check each symbol against the manifest:
+grep -oE '\`[A-Za-z_][A-Za-z0-9_./:-]*\`' specs/<feature>.code-reality.md | sort -u > /tmp/manifest-symbols.txt
+
+# Any symbol in the spec but NOT in the manifest:
+comm -23 /tmp/spec-symbols.txt /tmp/manifest-symbols.txt
+```
+
+Every result is one of:
+- **A load-bearing claim that wasn't verified** → add to manifest by
+  reading actual code, then proceed.
+- **Prose that doesn't need to be in the spec** → remove or
+  un-backtick it.
+
+If you can't fit a symbol into one of those two buckets, the spec is
+making an unverified claim.
+
+### Check 2 — Spec ↔ upstream-spec cross-check (schema/enum collisions)
+
+**This was a 2026-06-03 R1 finding** — the Workspace V1 + AggregateKanban
+spec proposed columns and enum values that collided with already-shipped
+substrates. See companion rule `spec-schema-collision-check.md`.
+
+For every table, enum, or CHECK constraint your spec touches:
+
+```bash
+# Find the migration that owns each cited table/enum/CHECK:
+grep -rn "CREATE TABLE <table>\|CREATE TYPE <enum>\|ADD CONSTRAINT.*CHECK" \
+    db/migrations/ specs/ | head
+
+# Read those migrations end-to-end. Confirm:
+# 1. Every column your spec proposes adding has NO collision with shipped names.
+# 2. Every enum value your spec proposes extending PRESERVES all shipped values.
+# 3. Every constraint your spec proposes rewriting is rewritten ADDITIVELY.
+```
+
+If you find a collision: rename, reuse, or document the collision
+explicitly in the spec's migration section.
+
+### Check 3 — Internal-consistency pass (pick 4-6 pairs)
+
+The §3.3 owner_onboarding lesson: spec sections drift apart silently.
+Pick the 4-6 pairs most likely to contradict each other and read them
+in sequence.
+
+Typical drift pairs (every spec has them):
+
+| Pair | Why they drift |
+|---|---|
+| §Goals / §Principles ↔ §Schema / §Implementation | Marketing statement contradicted by what the spec actually proposes |
+| §Schema migration ↔ §Rollback / §Versioning | "No data loss" claims contradicted by `DROP COLUMN` in down-migrations |
+| §State machine ↔ §AC | AC names a behavior the state machine doesn't produce |
+| §AC ↔ §Body | AC count or name mismatches §Body's enumeration (e.g., "5 panels" vs body lists 7) |
+| §Tool/endpoint signature ↔ §Frontend consumer | Frontend dispatch needs fields the tool/endpoint doesn't expose |
+| §Phase ordering ↔ §Rollback procedure | Phase N's rollback depends on Phase M still being in place |
+
+**Read each pair in sequence (top-to-bottom of one section, then
+top-to-bottom of the next). Do NOT just spot-check.** Drift is
+detected by reading, not by grep.
+
+### Check 4 — Frontend component-API verification (UI/Fullstack specs only)
+
+Skip for backend-only specs. For specs that touch frontend code:
+
+- Every component cited has a verified prop contract in the manifest §1.
+- Every hook cited has a verified return shape in the manifest §2.
+- Every design token matches the project's design-tokens (or manifest §3).
+- Manifest §5 maps spec requirements to real components.
+- Manifest §6 lists components considered-but-absent.
+
+If any box is unchecked and the spec is UI/Fullstack, **V1.0 is not
+ready.**
+
+---
+
+## Output gate
+
+If any of Checks 1–4 surfaces a discrepancy:
+
+1. **STOP committing.**
+2. Fix the spec OR fix the manifest (whichever is wrong).
+3. Re-run the check that surfaced the discrepancy.
+4. Only proceed to commit after a clean pass.
+
+**Cost:** 15-30 minutes for a moderate-sized spec.
+**Savings:** documented from 2026-06-03 R1 — 17 blocker fix-ups, each
+~10-20 min in adversarial-review cycles. Catches one of those: 5×
+ROI minimum.
+
+---
+
+## When to bypass (rare)
+
+You may skip this checklist ONLY when:
+
+- The change is a typo / wording polish on a section without claims.
+- The change is purely additive to a section already locked (e.g.,
+  adding an Open-Items entry).
+- You are working under an explicit operator directive that names this
+  rule by file path and says "skip for this PR" with a reason.
+
+A general "I'm in a hurry" is NOT a valid bypass. The 2026-06-03 R1
+incident was specifically a "hurry to ship" case — 6 PRs in one
+session, no §3 invocation, 17 preventable blockers.
+
+---
+
+## How this rule was born
+
+**2026-06-03 Mavis Workspace V1 + AggregateKanban V1 R1 review.**
+Codex (R1 single-reviewer) returned BLOCK on both specs with 12 + 9
+blocking findings, risk 9/10 on both. Investigation
+(`~/projects/buddy/.agents/outputs/r1-root-cause-analysis.md` +
+`r1-corrective-proposals.md`) classified:
+
+- 12 of 21 blockers were "process-not-applied" — `spec-review-workflow.md`
+  §3 would have caught them but was skipped.
+- 4 were "process-too-weak" — covered by `spec-state-machine-truth-table.md`
+  (new rule, same PR).
+- 4 were "process-absent" — covered by
+  `spec-new-substrate-domain-sweep.md` (new rule, same PR).
+
+The fix wasn't to add a new discipline. The fix was to make the
+existing §3 discipline **impossible to skip silently** by:
+
+1. Promoting §3 to a standalone rule (this file).
+2. Frontmatter-loading on every spec touch (`paths: ["**/specs/**"]`).
+3. Stating bluntly at the top: "not optional."
+
+This is the **enforcement layer** for `spec-review-workflow.md` §3.
+
+## Related
+
+- `~/.claude/rules/spec-review-workflow.md` — the authoritative §3
+  definition + R1-R3 convergence rules + stop conditions.
+- `~/.claude/rules/spec-schema-collision-check.md` — Check 2's deep
+  procedure for schema-touching specs.
+- `~/.claude/rules/spec-state-machine-truth-table.md` — when Check 3
+  finds a multi-section state contract.
+- `~/.claude/rules/spec-new-substrate-domain-sweep.md` — when the spec
+  proposes a NEW persistence substrate.
+- `~/.claude/templates/code-reality-manifest.md` — template for the
+  Step 4 manifest these checks cross-reference.

--- a/claude-config/rules/spec-state-machine-truth-table.md
+++ b/claude-config/rules/spec-state-machine-truth-table.md
@@ -1,0 +1,175 @@
+---
+paths: ["**/specs/**", "**/.agents/**"]
+---
+
+# Spec State-Machine Truth Table — Mandatory For Multi-Section Contracts
+
+**When a spec defines a state contract that spans 2 or more sections,
+write the truth table explicitly in the spec.** Every cell must be
+filled or marked N/A with reason.
+
+This rule covers a class of spec defects that
+`spec-review-workflow.md` §3.2 ("execution-order trace") doesn't catch
+because §3.2 is single-call-path-focused. Multi-section state
+contracts contradict each other not via execution flow but via
+implicit assumptions about what each section means by "state."
+
+---
+
+## When this rule fires
+
+Your spec has 2 or more sections that interact via state. Common shapes:
+
+| Shape | Sections that need to agree |
+|---|---|
+| Voice tool payload → frontend dispatcher → WS frame | Tool schema §, frontend action handler §, WS frame contract § |
+| Backend insert → supervisor transition → external state mapping | Schema §, supervisor hook §, view-type endpoint § |
+| Phase enum → derived display state → user mutation | Domain phase enum §, view derivation §, mutation API § |
+| Initial state → conflict-resolution algorithm → fallback | Default state §, conflict resolution §, fallback handling § |
+
+If you can describe your spec with the phrase "and then it
+transitions to..." across 2 or more `##` headings, **write the truth
+table.**
+
+---
+
+## The truth table format
+
+A truth table is a markdown table whose **rows are states** (or
+transitions) and whose **columns are perspectives** (each `##`
+section that touches the state).
+
+Required columns:
+1. **State / Transition** — the row name (e.g., `queued`, or
+   `voice → frontend → WS`).
+2. **One column per section the state touches** — what THIS section
+   says happens / what value this state has.
+3. **Notes** — any cell that's load-bearing or non-obvious.
+
+Every cell must be:
+- Filled with the verbatim section's stated value, OR
+- Marked **N/A** with a one-line reason why the section doesn't apply.
+
+Empty / "TBD" / "see §X" cells fail the check.
+
+---
+
+## Worked example — agent-job kanban column (would have prevented R1 K3)
+
+The AggregateKanban V1 spec said in §5.1: "When `start_job` spawns
+with `project_slug`, insert a `tasks` row at `kanban_column='doing'`."
+It also said in §5.2: "worker_state→column mapping: `queued → inbox`,
+`running → doing`." `start_job` actually creates `worker_jobs` rows in
+state `queued`. The spec contradicted itself.
+
+The truth table that would have surfaced this BEFORE R1:
+
+| worker_state | §5.1 says column is | §5.2 says column is | §7.1 KanbanCard kind | §AC1 says | Resolved value |
+|---|---|---|---|---|---|
+| queued | `doing` (hardcoded insert) | `inbox` (mapping) | `agent_job` | `doing` | **CONFLICT** — pick one |
+| running | n/a | `doing` | `agent_job` | n/a | `doing` |
+| paused | n/a | `waiting` | `agent_job` | n/a | `waiting` |
+| completed | n/a | `done` | `agent_job` | n/a | `done` |
+| failed | n/a | `done` (badge: failed) | `agent_job` | n/a | `done` |
+| cancelled | n/a | `done` (badge: cancelled) | `agent_job` | n/a | `done` |
+| reaped | n/a | **MISSING** | **MISSING** in WorkerState type | n/a | **CONFLICT** — type rejects valid response |
+
+Two `CONFLICT` rows visible in 5 minutes of table-writing. Without the
+table, the spec author (me) read §5.1 + §5.2 + §7.1 + §AC1 in separate
+passes and never noticed the queued-row contradiction.
+
+---
+
+## Worked example — nav-conflict resolution (would have prevented R1 W3)
+
+Workspace V1 §8.3 said "frontend consumes `workspace_navigate` and
+calls `setActiveTab` immediately." §8.5 said "user navigation within
+500ms wins because Mavis navigate is briefly enqueued." The truth
+table:
+
+| Event sequence | §8.3 algorithm | §8.5 algorithm | Resolved |
+|---|---|---|---|
+| Mavis nav at t=0, no user action | setActiveTab(target) immediately | enqueue; apply at t=500ms | **CONFLICT** |
+| Mavis nav at t=0, user nav at t=100ms | switched at t=0, then user wins → switched back at t=100ms | enqueue at t=0; user-nav cancels enqueue at t=100ms; only user-nav applies | **CONFLICT** — UX is double-switch vs single-switch |
+| Mavis nav at t=0, user nav at t=600ms | switched at t=0, switched again at t=600ms | applied at t=500ms, switched again at t=600ms | Same end state, different intermediate UX |
+| Two Mavis navs at t=0 and t=300ms | both apply (no debounce) | first enqueued, second... what? | **UNDEFINED for §8.5** |
+
+Three rows produce contradictions or undefined behavior. The truth
+table makes them visible.
+
+---
+
+## How to write the truth table efficiently
+
+1. **List the sections** that touch the contract. 2-4 is typical.
+2. **List the states / transitions / inputs** as rows. Be exhaustive
+   — every value the upstream type can produce.
+3. **For each row × column cell**, copy the verbatim language from
+   that section.
+4. **Look for contradictions** — same cell, two different values is
+   a blocker.
+5. **Look for empty cells** — section doesn't address this state.
+   Either add a clause to the section OR mark N/A with reason.
+6. **Resolve the conflicts in-spec.** The table doesn't have to live
+   in the spec body (it can live in a `__truth-tables.md` companion
+   file), but the resolved values DO.
+
+---
+
+## When to skip
+
+Single-section state machines (one `##` heading defines and uses the
+state internally) do not need a truth table. Examples:
+- A repository class with `_pending`/`_running`/`_done` private state.
+- A frontend reducer that doesn't expose its internal state to
+  another section.
+
+If two readers can disagree about what state X means, write the
+table.
+
+---
+
+## What this rule would prevent — beyond R1 W3 + K3
+
+Across the 2026-06-03 R1 review:
+
+- **W2** — `workspace_navigate` payload table (one row per tab x mode,
+  columns: required selection fields, optional fields, default values).
+- **W7** — Email mutation table (one row per endpoint, columns:
+  optimistic update?, provider write-through?, rollback shape?, audit
+  required?).
+- **K5** — Mission proposal kanban card table (one row per proposal
+  state, columns: has task_id?, KanbanCard.kind value?, can be
+  rendered?, can be moved?).
+- **K8** — Linked-ref mutation table (one row per linked-ref
+  operation, columns: WS frame fired?, re-render trigger?, AC
+  reference?).
+
+All four were spec gaps that 5 minutes of truth-table writing would
+have surfaced.
+
+---
+
+## How this rule was born
+
+**2026-06-03 Mavis Workspace V1 + AggregateKanban V1 R1.** Five of 21
+blocking findings (W2, W3, W7, K3, K5) were multi-section state
+contradictions where each section read in isolation seemed correct
+but the cross-section state machine contradicted itself.
+
+Classified in
+`~/projects/buddy/.agents/outputs/r1-root-cause-analysis.md` as
+"Group C — process-too-weak." `spec-review-workflow.md` §3.2
+("execution-order trace") wasn't strong enough because it focused on
+single-call-path tracing, not on multi-section state shapes.
+
+This rule fills the gap. Promoted to global from project-local lesson
+per Proposal 3 of `r1-corrective-proposals.md`.
+
+## Companion rules
+
+- `~/.claude/rules/spec-self-review.md` — calls this rule out in Check 3.
+- `~/.claude/rules/spec-review-workflow.md` §3.2 — single-call-path
+  execution trace (the discipline this rule complements).
+- `~/.claude/rules/spec-schema-collision-check.md` — for schema-level
+  collisions (a different failure mode).


### PR DESCRIPTION
## Summary

Born from the 2026-06-03 Mavis Workspace V1 + AggregateKanban V1 R1 adversarial review on the buddy repo. Codex returned BLOCK on both specs with 12 + 9 blocking findings (21 total, risk 9/10 each). Root-cause analysis ([buddy/.agents/outputs/r1-root-cause-analysis.md](https://github.com/jwj2002/meeting-buddy/blob/main/.agents/outputs/r1-root-cause-analysis.md)) classified:

- 12 of 21 blockers — **process-not-applied**. `spec-review-workflow.md` §3 self-review would have caught them; this session skipped §3.
- 5 — **process-too-weak**. §3.2 execution-order trace doesn't cover multi-section state contracts.
- 4 — **process-absent**. No global rule covered new-substrate domain expertise.

This PR lands the five corrective additions (Proposals 1-5 in [r1-corrective-proposals.md](https://github.com/jwj2002/meeting-buddy/blob/main/.agents/outputs/r1-corrective-proposals.md)).

## What changes

### 4 NEW rules (all auto-load on `specs/**`)

| Rule | Catches |
|---|---|
| `spec-self-review.md` | LOUD enforcement of `spec-review-workflow.md` §3. "Not optional before committing a spec PR." Four checks: spec↔manifest, spec↔upstream collisions, internal-consistency, frontend component-API. |
| `spec-schema-collision-check.md` | Generalizes buddy-local `feedback_spec_grep_every_sql_site.md` to cover EXTENSIONS (CHECK / enum / column adds) in addition to drops/renames. Would have caught R1 K1/K2/K4/K6 (4 of 21). |
| `spec-state-machine-truth-table.md` | Mandates explicit truth tables for state contracts spanning 2+ sections. Would have caught R1 W2/W3/W7/K3/K5 (5 of 21). |
| `spec-new-substrate-domain-sweep.md` | 5-question domain expertise check for NEW persistence substrates. Would have caught R1 W4/W5/W6/W8/W9 (4 of 21 — entire email-substrate cluster). |

### 2 MODIFIED files

| File | What |
|---|---|
| `CLAUDE.md` | Adds 4 new rules to the reference table + **NEW "Promoting project memory to global rules"** section. This section documents the previously-undocumented promotion path — the structural gap that allowed 0 of 15 buddy-local feedback files to proliferate despite cross-project relevance. |
| `rules/spec-review-workflow.md` | Adds companion-rules cross-reference table + reminder to promote R1/R2/R3 lessons to global when broadly applicable. |

## Verified before commit

- All 4 new files appear at `~/.claude/rules/` via the existing `install.sh` symlink (no `install.sh` changes needed — `rules/` is symlinked as a directory).
- Frontmatter `paths:` verified — auto-load triggers fire on `specs/**` / `db/migrations/**` / `.agents/**` as appropriate.
- Total addition: 4 new files (30K) + 2 minor edits in 6 files changed.

## Proliferation status

- **This laptop**: instant on next session start.
- **jbox06 (VitalAILabs)**: pending `git pull` + `install.sh` re-run. Step documented in the new `CLAUDE.md` promotion-path section.

## Test plan

Docs-only / rule additions. Will be tested LIVE by applying them to the R2 fix-up commits on buddy PRs [#1660](https://github.com/jwj2002/meeting-buddy/pull/1660) (Workspace V1 spec) and [#1661](https://github.com/jwj2002/meeting-buddy/pull/1661) (AggregateKanban V1 spec) — see the buddy work tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)