### PR TITLE
chore(claude-config): enable security-guidance plugin fleet-wide

### DIFF
--- a/claude-config/settings.json
+++ b/claude-config/settings.json
@@ -125,7 +125,7 @@
   "enabledPlugins": {
     "frontend-design@claude-plugins-official": true,
     "codex@openai-codex": true,
-    "security-guidance@claude-plugins-official": false,
+    "security-guidance@claude-plugins-official": true,
     "typescript-lsp@claude-plugins-official": true,
     "pyright-lsp@claude-plugins-official": true,
     "pr-review-toolkit@claude-plugins-official": true,


### PR DESCRIPTION
## Summary
Enable `security-guidance@claude-plugins-official` across all machines (flip `false`→`true` in `claude-config/settings.json`).

During a cross-agent `~/agents` config-parity review, server-a was found to have this plugin enabled locally while scratch and laptop-wsl had it off. Rather than leave it as per-machine drift, Jason authorized standardizing it **fleet-wide** so all three agents get it via a normal pull.

## Test Plan
- One-line config change; no code paths affected.
- After merge, each machine's post-merge hook re-runs `install.sh` on pull, deploying the updated `settings.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)