### PR TITLE
docs(spec): REC 0 — outcome-log decision fields (per-host re-tier rate)

### DIFF
--- a/docs/rec0-outcome-log-decision-fields-spec.md
+++ b/docs/rec0-outcome-log-decision-fields-spec.md
@@ -3,7 +3,7 @@
 **Date:** 2026-06-04
 **Author:** server-a (Claude Opus 4.8, Linux server). Reviewed adversarially by scratch (Mac) + laptop-wsl.
 **Parent:** `docs/claude-workflow-improvement-plan.md` §3.8 + the cross-agent review's REC 3 ("close the feedback loop").
-**Status:** DRAFT v0.4 — Jason's cross-fleet decision = **channel hub** (data off the code repo). REC 0 core unchanged; REC 0.1 redefined to hub reporting. Ready for final sign-off.
+**Status:** DRAFT v0.5 — cross-fleet transport = a **message hub** (data off the code repo); hub named generically per policy; REC 0.1 collector homed in `~/agents`. REC 0 core unchanged. Green pending final pass.
 
 ---
 
@@ -39,7 +39,7 @@ slice — cross-fleet sync is its own infrastructure rec, not a field-add.
 
 ## CHANGELOG v0.3 → v0.4 (cross-fleet architecture decided)
 
-Jason chose the **channel hub** for cross-fleet telemetry (verified context: inbound `git pull --ff-only`
+Jason chose a **message hub** for cross-fleet telemetry (verified context: inbound `git pull --ff-only`
 already runs at session start, `sessionstart_restore_state.py:84`, purpose-built for shards; only the
 outbound path was missing). Rationale for hub over finishing the git push: **don't version append-only
 telemetry DATA in the CODE repo** — per-session commits churn history unboundedly. The hub keeps data
@@ -47,9 +47,18 @@ off git and still gives true cross-fleet aggregation.
 
 **Impact: REC 0 core is UNCHANGED** (per-host write→read on the frozen schema). Only **REC 0.1** is
 redefined — from "git `write_metrics_shard` + commit/push/pull" to **"report decision-bearing metrics
-over the ai-channels hub + hub-side aggregation."** The git-shard path is dropped for cross-fleet
+over a message hub + hub-side aggregation."** The git-shard path is dropped for cross-fleet
 metrics. (Reconciling the *existing* failure-shard git approach with the hub is itself a follow-up, not
 in REC 0.)
+
+## CHANGELOG v0.4 → v0.5 (naming policy + collector home)
+
+- **Naming policy (mandatory, all docs):** the message hub is referenced **by capability, never by
+  name.** Scrubbed every prior occurrence of the transport's proper name → generic "message hub";
+  verified zero name leaks. The spec must never name the transport.
+- **REC 0.1 collector home = `~/agents`** (Jason): the hub is an **external, unnamed dependency**;
+  REC 0.1's agent-side emit, the persistent collector participant, its store, and the cross-fleet
+  read-path all live in `~/agents` — no change to the hub's own project.
 
 ---
 
@@ -121,12 +130,16 @@ Record-building keeps the "include only if supplied" convention so PASS records 
   where `tier_corrected_to` is present and ≠ `complexity`, grouped by initial `complexity` — reading
   the **local global rollup** `~/.claude/memory/metrics.jsonl` (which already carries `tier_corrected_to`
   via field-agnostic aggregation — verified). No shard read, no cross-host dependency.
-- **Cross-fleet (REC 0.1, NOT this rec) — decided: CHANNEL HUB.** Report the decision-bearing metric
-  **projection** over the ai-channels hub (not git), with hub-side aggregation, so cross-fleet
-  comparison reads aggregated data **without versioning telemetry in the code repo.** Open sub-questions
-  for REC 0.1: report cadence (per-session vs. batched), hub persistence/durability, and the
-  aggregation read-path. The earlier git `write_metrics_shard`/commit/push/pull approach is **dropped**
-  for cross-fleet metrics (it would churn the `agents` repo history with per-session data commits).
+- **Cross-fleet (REC 0.1, NOT this rec) — decided: MESSAGE HUB.** Report the decision-bearing metric
+  **projection** over a message hub (not git), with hub-side aggregation, so cross-fleet comparison
+  reads aggregated data **without versioning telemetry in the code repo.** The hub is an **external,
+  unnamed dependency** (referenced by capability, never by name); the **collector lives in `~/agents`**
+  — agent-side emit, the persistent collector participant, its store, and the cross-fleet read-path all
+  ship in `~/agents` alongside the telemetry system (no change to the hub's own project). Open
+  sub-questions for REC 0.1: report cadence (per-session vs. batched), hub persistence/durability, and
+  the aggregation read-path. The earlier git `write_metrics_shard`/commit/push/pull approach is
+  **dropped** for cross-fleet metrics (it would churn the `agents` repo history with per-session data
+  commits).
 
 ### 3.4 Field semantics
 
@@ -222,7 +235,7 @@ This is stated, not hidden. Closing it = sibling **REC 0.2** (§8). REC 0 adds *
 | REC | Scope | Depends on |
 |---|---|---|
 | **REC 0** (this) | `tier_corrected_to` write→read **per-host** (state_manager + agent_metrics) + frozen dormant fields | — |
-| **REC 0.1** | **Cross-fleet telemetry via CHANNEL HUB** (Jason's decision): report decision-bearing metric projection over the ai-channels hub + hub-side aggregation; data stays off the code repo. Open: cadence, hub persistence, aggregation read-path | REC 0 frozen schema |
+| **REC 0.1** | **Cross-fleet telemetry via a MESSAGE HUB** (Jason's decision): report decision-bearing metric projection over an external, unnamed message hub + hub-side aggregation; **collector + store + read-path home in `~/agents`**; data stays off the code repo. Open: cadence, hub persistence, aggregation read-path | REC 0 frozen schema |
 | **REC 0.2** | Low-tier write-sites: record `/quick` + plan-mode SIMPLE outcomes | REC 0 frozen schema |
 | **REC 1 / REC 3** | Artifact producers (PLAN evidence, MAP contract-sheet, PropTypes citation) that make `guards_fired` **derived/falsifiable** | REC 0 field defn |
 

--- a/docs/rec0-outcome-log-decision-fields-spec.md
+++ b/docs/rec0-outcome-log-decision-fields-spec.md
@@ -1,9 +1,9 @@
-# REC 0 — Outcome-Log Decision Fields (Spec, v0.2 DRAFT)
+# REC 0 — Outcome-Log Decision Fields (Spec, v0.3 DRAFT)
 
 **Date:** 2026-06-04
 **Author:** server-a (Claude Opus 4.8, Linux server). Reviewed adversarially by scratch (Mac) + laptop-wsl.
 **Parent:** `docs/claude-workflow-improvement-plan.md` §3.8 + the cross-agent review's REC 3 ("close the feedback loop").
-**Status:** DRAFT v0.2 — re-scoped per the consolidated CHANGES-REQUESTED verdict. Awaiting diff re-verify.
+**Status:** DRAFT v0.3 — Blocker 3 (shard-commit gap) downscoped per re-verify; dedup hardened to field-level. Awaiting diff re-verify.
 
 ---
 
@@ -27,6 +27,16 @@ fleet-invisible fields — telemetry theater.** v0.2 delivers ONE field end-to-e
 `[]`), *dormant* (no producer), *constant* (always all three). The unified fix is task-triggered
 relevance + honest CLAIMED/VERIFIED labeling + a variance test.
 
+## CHANGELOG v0.2 → v0.3 (re-verify responses)
+
+Re-verify approved 6/7 v0.2 items; two findings remained. Both pushed REC 0 to a **honestly per-host**
+slice — cross-fleet sync is its own infrastructure rec, not a field-add.
+
+| Finding | Resolution in v0.3 |
+|---|---|
+| 🔴 **Blocker 3 — shard never committed.** Verified: `telemetry/<host>/` dirs are untracked; no hook git-adds/commits/pushes them. So write→**commit**→push→pull→read is broken at commit; "cross-host compare" reads only the local host. | **Downscoped (option b).** REC 0 DoD = **per-host re-tier rate**, read from the **local global rollup** (`~/.claude/memory/metrics.jsonl`, which already carries the field via field-agnostic aggregation — verified). `write_metrics_shard()` **and** the commit/push/pull sync move to **REC 0.1 (telemetry sync)**. Net: REC 0 shrinks to 2 files (no `aggregate` change, no shard). |
+| 🟠 **Dedup — record-level newest-wins drops a provenance fact** if a later record for the key omits the field. `tier_corrected_to` is "what happened," not mutable state. | **Field-level carry-forward** for the decision-provenance fields: newest-`recorded_at` wins for mutable/outcome fields (status, first_pass_correct, …), then **carry forward** `tier_corrected_to`/`guards_fired`/`codex_overturned` from ANY record for the key if the newest lacks them. Collision test must **FAIL on the current last-wins code** (tautology guard). |
+
 ---
 
 ## 1. Current state (VERIFIED against code at HEAD 4408d43)
@@ -46,6 +56,10 @@ relevance + honest CLAIMED/VERIFIED labeling + a variance test.
 - `metrics.status` ∈ `{PASS, BLOCKED}` (NOT `PASS|FAIL`; `FAIL` is a `prove-log` verdict). ✔
 - `evals_run` already exists as `applicable_evals` in `prove-log.jsonl`. ✔
 - **Blocker 2 CONFIRMED:** the reader ignores the three proposed fields → write-only without a consumer.
+- **Blocker 3 CONFIRMED:** `telemetry/<host>/` shard dirs are **untracked, never git-added/committed/
+  pushed** by any hook (only `worktree_manager` shells git). `jns-mac/failures.jsonl` is the sole
+  tracked shard, and it's uncommitted churn. So a write→**commit**→push→pull→read chain does not exist
+  — "cross-host comparison" would read only the local host. ⇒ cross-fleet sync is descoped to REC 0.1.
 - **Dedup:** field-blind last-wins — fragile across source files (see §3.5); the specific
   `flip_to_correction` case is *safe* because it copies fields forward and wins by append-order.
 
@@ -56,25 +70,27 @@ relevance + honest CLAIMED/VERIFIED labeling + a variance test.
 `record_metrics` captures the chosen tier (`complexity`) and outcome (`status`,
 `first_pass_correct`) but nothing about the **decisions** the cross-agent review flagged as
 highest-leverage: was the tier **re-classified** mid-flight, which **guards** were relevant, and did
-**Codex** change the output. Without a write→shard→read→compare path these are unmeasurable.
+**Codex** change the output. Without a write→read path (and a consumer that surfaces it) these are
+unmeasurable — even on a single host.
 
 ---
 
 ## 3. The change
 
-### 3.1 Definition of done (the vertical slice)
+### 3.1 Definition of done (the per-host vertical slice)
 
-REC 0 is **done** when `tier_corrected_to` flows end-to-end and is fleet-comparable:
+REC 0 is **done** when `tier_corrected_to` flows write→read **on a single host** and is reportable:
 
 ```
-record_metrics(tier_corrected_to=...)        # WRITE   (state_manager.py)
-  → aggregate + write_metrics_shard()          # SHARD   (aggregate_metrics_to_global.py)
-    → telemetry/<host>/metrics.jsonl (git)      # FLEET   (committed, cross-host visible)
-      → agent_metrics reports re-tier rate      # READ    (agent_metrics.py)
+record_metrics(tier_corrected_to=...)        # WRITE  (state_manager.py)
+  → aggregate() local rollup (field-agnostic)  # ROLLUP (~/.claude/memory/metrics.jsonl — already preserves it)
+    → agent_metrics reports per-host re-tier rate   # READ  (agent_metrics.py)
 ```
 
-`guards_fired` and `codex_overturned` are written on the **same frozen schema** but are **dormant**
-(§3.4) — defined now so producers/consumers added later require **zero reshape**.
+Cross-**fleet** comparison (committing/syncing each host's shard) is **out of scope** — it's a real
+sync-infrastructure rec (**REC 0.1**, §8), not a field-add (Blocker 3). `guards_fired` and
+`codex_overturned` are written on the **same frozen schema** but are **dormant** (§3.4) — defined now
+so producers/consumers added later require **zero reshape**.
 
 ### 3.2 Write — `record_metrics()` additions (additive, keyword-only, default None)
 
@@ -85,17 +101,17 @@ record_metrics(tier_corrected_to=...)        # WRITE   (state_manager.py)
 ```
 Record-building keeps the "include only if supplied" convention so PASS records stay compact.
 
-### 3.3 Shard + Read (promoted into DoD)
+### 3.3 Read (in DoD); Shard + Sync (descoped to REC 0.1)
 
-- **Shard:** new `write_metrics_shard()` in the Stop hook, mirroring `write_host_shard()` but
-  **field-agnostic** (carries the whole record, so dormant fields ride for free when they light up) →
-  `telemetry/<host>/metrics.jsonl`. **Volume guard:** metrics are every-task (failures are sparse), so
-  the shard writes a **decision-bearing projection** (`issue, date, recorded_at, complexity,
-  tier_corrected_to, status` + the two dormant fields) and defines **retention** (rotate per host, cap
-  rows / age) — NOT a blind mirror of the failure shard.
-- **Read:** extend `agent_metrics.py` with a **re-tier rate** (count records where
-  `tier_corrected_to` present and ≠ `complexity`, grouped by initial `complexity`), reading the
-  committed `telemetry/<host>/metrics.jsonl` shards for cross-host comparison.
+- **Read (REC 0):** extend `agent_metrics.py` with a **per-host re-tier rate** — fraction of records
+  where `tier_corrected_to` is present and ≠ `complexity`, grouped by initial `complexity` — reading
+  the **local global rollup** `~/.claude/memory/metrics.jsonl` (which already carries `tier_corrected_to`
+  via field-agnostic aggregation — verified). No shard read, no cross-host dependency.
+- **Shard + Sync (REC 0.1, NOT this rec):** `write_metrics_shard()` (field-agnostic, decision-bearing
+  **projection** with **retention** — metrics are every-task vs. sparse failures, so no blind mirror of
+  `write_host_shard`) **plus** the mechanism that actually makes shards cross-fleet: who git-adds each
+  host's shard, commit cadence, push/pull, and — the real concern — **high-frequency telemetry commits
+  churning the `agents` repo history + merge handling.** That is sync infrastructure, sized separately.
 
 ### 3.4 Field semantics
 
@@ -117,14 +133,23 @@ Record-building keeps the "include only if supplied" convention so PASS records 
   `implementation-routing.md` triggers). Validation fail-open: unknown category/guard dropped + logged,
   never raises into the orchestrator (mirrors `_VALID_AC_STATUSES`, L579).
 
-### 3.5 Dedup correctness fix
+### 3.5 Dedup correctness fix (field-level, for provenance facts)
 
-Replace field-blind last-wins for metrics with **newest-`recorded_at`-wins** (every new record carries
-microsecond-precision `recorded_at`, L327): on key collision keep the record with the greatest
-`recorded_at`; tie-break to the field-richer record. This removes the order-dependent clobber class
-(narrow today — cross-source-file same-key — but latent). **Collision test (required):** two records,
-same `(issue,date,project)`, one with `tier_corrected_to` and one without, in adverse source order →
-assert the merged global RETAINS the field. (AC4 round-trip is necessary but not sufficient.)
+The decision fields are **provenance facts** ("this issue *was* re-tiered"), not mutable state — so a
+later record for the same key that legitimately omits the field must NOT erase the fact. Record-level
+newest-wins would drop it. Therefore, on `(issue,date,project)` collision:
+
+1. take the **newest-`recorded_at`** record as the base (for mutable/outcome fields: `status`,
+   `first_pass_correct`, `corrections`, …) — `recorded_at` is microsecond-precision (L327), so this is
+   deterministic; and
+2. **carry forward** the decision-provenance fields (`tier_corrected_to`, `guards_fired`,
+   `codex_overturned`) from ANY record for the key when the base lacks them.
+
+**Collision test (required, with tautology guard):** two records, same `(issue,date,project)`, one with
+`tier_corrected_to` and one without, in adverse source order → assert the merged global RETAINS the
+field. The test MUST be authored so it **FAILS against the current last-wins implementation** (proving
+it catches the real bug, not a tautology that only passes on new code). AC4 round-trip is necessary but
+not sufficient.
 
 ---
 
@@ -146,22 +171,26 @@ This is stated, not hidden. Closing it = sibling **REC 0.2** (§8). REC 0 adds *
 - **AC3** additive only: `status` enum unchanged; no field renamed; existing `agent_metrics` + `/learn`
   jq parse pre-change records identically.
 - **AC4** `aggregate("metrics", …)` carries new fields through to the **local** global rollup unchanged.
-- **AC4b (NEW)** dedup collision: same-key records (one with / one without `tier_corrected_to`) in
-  adverse order → merged global retains the field (§3.5 merge rule).
+- **AC4b** dedup collision (field-level): same-key records (one with / one without `tier_corrected_to`)
+  in adverse order → merged global RETAINS the field (§3.5). Test MUST fail on the current last-wins
+  code (tautology guard).
 - **AC5** `evals_run` is NOT added to metrics (lives in `prove-log.applicable_evals`).
-- **AC6a** `tier_corrected_to` flows **end-to-end**: written → sharded to `telemetry/<host>/metrics.jsonl`
-  → `agent_metrics` reports a cross-host **re-tier rate**. *(This is the DoD; testable today.)*
+- **AC6a** `tier_corrected_to` flows **write→read on one host**: written → preserved in the local
+  global rollup → `agent_metrics` reports a **per-host re-tier rate**. *(This is the DoD; testable
+  today. Cross-fleet rate = REC 0.1.)*
 - **AC6b** `guards_fired` populated via explicit task-triggered self-report is testable today;
   **variance test:** an enum-touching task → non-empty incl `ENUM_VALUE`; a backend-no-enum task →
   `ENUM_VALUE` ABSENT. The artifact-**derived** path is deferred to REC 1/3 (not asserted here).
-- **AC7 (NEW)** sharded record stays within the §6 size budget under representative field population.
+- **AC7** a representative record (populated `tier_corrected_to` + dormant fields) stays within the §6
+  PIPE_BUF size budget.
 
 ## 6. Cross-env / durability notes
 
-- **PIPE_BUF atomicity is size-bounded (4096 B).** Single-line appends are atomic only ≤ PIPE_BUF; a
-  record bloated by nested `codex_overturned` + a long `guards_fired` list could exceed it and, under
-  `--parallel` concurrent appends, interleave/corrupt. **Keep records compact**; the shard writes a
-  projection (§3.3), not the full record.
+- **PIPE_BUF atomicity is size-bounded (4096 B).** `record_metrics` appends one JSON line to
+  `metrics.jsonl`; single-line appends are atomic only ≤ PIPE_BUF. A record bloated by nested
+  `codex_overturned` + a long `guards_fired` list could exceed it and, under `--parallel` concurrent
+  appends, interleave/corrupt. **Keep records compact** (and when REC 0.1 adds the shard, it writes a
+  projection, not the full record).
 - **Atomicity/fsync/perms assume native ext4** (not `/mnt/c`). Stated for the WSL machine.
 - Backward-compat is SAFE (unknown-field tolerance) — but that tolerance is precisely why a **reader**
   (§3.3) is mandatory, else the fields are silently inert.
@@ -177,12 +206,13 @@ This is stated, not hidden. Closing it = sibling **REC 0.2** (§8). REC 0 adds *
 
 | REC | Scope | Depends on |
 |---|---|---|
-| **REC 0** (this) | `tier_corrected_to` end-to-end (write+shard+read) + frozen dormant fields | — |
+| **REC 0** (this) | `tier_corrected_to` write→read **per-host** (state_manager + agent_metrics) + frozen dormant fields | — |
+| **REC 0.1** | **Telemetry sync:** `write_metrics_shard()` (projection + retention) + commit/push/pull mechanism (cadence, repo-churn, merge handling, auth) that makes shards **cross-fleet** | REC 0 frozen schema |
 | **REC 0.2** | Low-tier write-sites: record `/quick` + plan-mode SIMPLE outcomes | REC 0 frozen schema |
 | **REC 1 / REC 3** | Artifact producers (PLAN evidence, MAP contract-sheet, PropTypes citation) that make `guards_fired` **derived/falsifiable** | REC 0 field defn |
 
-Schedule REC 0.2 immediately after REC 0 — high-volume tier, high value — without bloating REC 0's
-clean landing.
+REC 0.1 + 0.2 reuse REC 0's frozen schema (zero reshape). Schedule them right after REC 0 — both
+high-value — without bloating REC 0's clean per-host landing.
 
 ## 9. Test plan
 
@@ -190,7 +220,9 @@ New `claude-config/tests/test_state_manager_decision_fields.py`:
 1. round-trip each field; present-when-supplied / absent-when-None.
 2. validation: invalid guard + unknown codex category dropped; no raise.
 3. backward-compat: field-less record survives `aggregate()` + `flip_to_correction()`.
-4. **dedup collision** (AC4b): same key, with/without field, adverse order → field retained.
-5. **shard + read** (AC6a): write → `write_metrics_shard` → `agent_metrics` re-tier rate non-zero.
+4. **dedup collision** (AC4b): same key, with/without field, adverse order → field retained; **assert
+   the test fails on the pre-change last-wins code** (tautology guard).
+5. **write → read per-host** (AC6a): `record_metrics(tier_corrected_to=…)` → local rollup →
+   `agent_metrics` per-host re-tier rate non-zero. (No shard — that's REC 0.1.)
 6. **guards_fired variance** (AC6b): enum-task non-empty incl ENUM_VALUE; backend-no-enum omits it.
 7. **size budget** (AC7): representative record ≤ PIPE_BUF.

--- a/docs/rec0-outcome-log-decision-fields-spec.md
+++ b/docs/rec0-outcome-log-decision-fields-spec.md
@@ -1,0 +1,157 @@
+# REC 0 — Outcome-Log Decision-Field Extension (Spec, v0.1 DRAFT)
+
+**Date:** 2026-06-04
+**Author:** server-a (Claude Opus 4.8, Linux server), for fleet review by scratch (Mac) + laptop-wsl.
+**Parent:** `docs/claude-workflow-improvement-plan.md` §3.8 (telemetry) + the cross-agent review's REC 3 ("close the feedback loop — the fleet is flying blind").
+**Status:** DRAFT — awaiting adversarial review by scratch + laptop-wsl before PATCH.
+
+---
+
+## 0. One-line goal
+
+Make *decision quality* measurable by adding three decision-provenance fields to the existing
+`metrics.jsonl` record — **extending** the telemetry that already exists, not rebuilding it.
+
+---
+
+## 1. Current state (VERIFIED against code at HEAD 4408d43)
+
+Read directly — not assumed (VERIFICATION_GAP guard):
+
+- **`claude-config/hooks/state_manager.py`** already has the full recorder set:
+  - `record_metrics()` (L274) → appends to `<project>/.claude/memory/metrics.jsonl`.
+  - `record_failure()` (L353) → `failures.jsonl` (carries `event_id`, `project`).
+  - `flip_to_correction()` (L424) → first-pass-correctness flip (append-only, last-wins).
+  - `record_prove_audit()` (L742) → `prove-log.jsonl`, including `applicable_evals` + `eval_results`.
+- **`claude-config/hooks/aggregate_metrics_to_global.py`** (origin #195) is the `Stop` hook:
+  merges per-project → global `~/.claude/memory/{metrics,failures}.jsonl`, **shards failures only**
+  to `~/agents/telemetry/<host>/failures.jsonl`. Fail-open, stdlib-only. Metrics dedup key =
+  `(issue, date, project)`, last-wins.
+- **Existing `metrics.jsonl` schema** (from `record_metrics`):
+  `{issue, date, recorded_at, status, complexity, stack, agents_run}` + optional
+  `{duration_seconds, root_cause, blocking_agent, agent_versions, first_pass_correct, corrections}`.
+
+### ⚠️ Two corrections to the relayed "ground truth" (both caught by reading the code)
+
+1. **`evals_run[]` already exists** — as `applicable_evals` (plus a per-eval `eval_results` map) in
+   `record_prove_audit()` → `prove-log.jsonl`. **REC 0 must NOT re-add evals to `metrics.jsonl`** —
+   that would duplicate the field and invite drift. Reference the existing `prove-log` field instead.
+2. **`metrics.status` is `PASS | BLOCKED`, not `PASS | FAIL`.** `FAIL` is a *PROVE verdict* recorded in
+   `prove-log.jsonl` (`record_prove_audit`, the AC-FORBIDS-APPROVE downgrade). The two streams are
+   distinct; the spec keeps `status` unchanged and does **not** conflate it with the PROVE verdict.
+
+Net: of the four fields originally proposed (`tier_corrected_to`, `guards_fired[]`, `evals_run[]`,
+`codex_overturned`), **only three are genuinely missing.** `evals_run` is already captured.
+
+---
+
+## 2. The gap
+
+`record_metrics` captures *what tier was chosen* (`complexity`) and *the outcome* (`status`,
+`first_pass_correct`), but nothing about the **decisions made along the way** that the cross-agent
+review identified as the highest-leverage things to measure:
+
+- Was the tier **re-classified** mid-flight? (The "SIMPLE that became FULLSTACK" leak.)
+- Which **failure-pattern guards** actually fired? (Are the guards earning their keep, or is it luck?)
+- Did **Codex review change the output**, or just confirm it? (Tail-risk value vs. latency.)
+
+Without these, we cannot answer "is the playbook improving?" — REC 3's core finding.
+
+---
+
+## 3. The change
+
+### 3.1 Schema additions to `metrics.jsonl` (all optional, omitted-when-empty)
+
+| Field | Type | Meaning | Source of truth |
+|---|---|---|---|
+| `tier_corrected_to` | `str` | Final tier if re-classified mid-flight (e.g. `"COMPLEX"` when `complexity` started `"SIMPLE"`). Omitted when no re-tier. | Orchestrator (REC #2 tripwire sets it; until then, passed when a re-tier occurred) |
+| `guards_fired` | `list[str]` | Which core guards were applied — subset of `{VERIFICATION_GAP, ENUM_VALUE, COMPONENT_API}` (extensible). Omitted when empty. | MAP/PATCH artifact frontmatter, collected by orchestrator (mirrors how `applicable_evals` comes from PROVE) |
+| `codex_overturned` | `dict` | `{"overturned": bool, "category": str}` — did a Codex review change the diff, and in which risk category (`auth\|migration\|enum_contract\|...`). Omitted when Codex didn't run. | Orchestrator (knows if `/codex:*` ran and whether BLOCKING findings were applied) |
+
+Keeps the existing "include only if supplied" convention (L333-344) so PASS records stay compact and
+`/learn`'s existing jq filters keep parsing.
+
+### 3.2 `record_metrics()` signature additions (additive, keyword-only, default None)
+
+```python
+    tier_corrected_to: str | None = None,
+    guards_fired: list[str] | None = None,
+    codex_overturned: dict | None = None,
+```
+with the matching record-building block (after L344):
+```python
+    if tier_corrected_to:
+        record["tier_corrected_to"] = tier_corrected_to
+    if guards_fired:
+        record["guards_fired"] = list(guards_fired)
+    if codex_overturned is not None:
+        record["codex_overturned"] = dict(codex_overturned)
+```
+
+### 3.3 Validation (mirror the `_VALID_AC_STATUSES` pattern, L579)
+
+- `_VALID_GUARDS = frozenset({"VERIFICATION_GAP", "ENUM_VALUE", "COMPONENT_API"})` — unknown guard
+  names are dropped + logged (fail-open, never raise into the orchestrator).
+- `codex_overturned.category` validated against a small `_VALID_CODEX_CATEGORIES` set sourced from the
+  `implementation-routing.md` escalation triggers (auth, migration, enum_contract, cross_module, ...).
+
+### 3.4 Orchestrator wiring (`claude-config/commands/orchestrate.md` Step 4)
+
+Single writer stays the orchestrator (the #104 determinism rule). It collects the three values and
+passes them to `record_metrics`. `guards_fired` is **derived from artifacts** (propose a
+`derive_guards_fired()` helper symmetric with `derive_agents_run()` L520) so it's not lost to
+stateless-between-dispatch tracking.
+
+---
+
+## 4. DECISION REQUIRED (fleet review, please weigh in)
+
+The Stop hook **shards failures per-host** (`telemetry/<host>/failures.jsonl`) but **not metrics** —
+metrics only roll up to the *local* global file. So as written, the new decision fields are
+analyzable **per-host only**, NOT across the fleet. But REC 3's entire motivation was *cross-fleet*
+comparison.
+
+**Options:**
+- **A (minimal):** fields live in `metrics.jsonl`, per-host analysis only. Smallest diff; doesn't
+  satisfy cross-fleet comparison.
+- **B (fleet-visible):** extend the Stop hook with a `write_metrics_shard()` mirroring
+  `write_host_shard()` (L281) → `telemetry/<host>/metrics.jsonl`, so the committed `telemetry/` tree
+  carries decision fields and the weekly `/learn --cross-project` can compare machines.
+
+**server-a's recommendation: B**, but as a *clearly-scoped follow-up* (REC 0.1) so the field-addition
+(REC 0) can land and start capturing data immediately while we settle the sharding shape. Flagging
+rather than silently picking — this is the one real architectural choice here.
+
+---
+
+## 5. Acceptance criteria
+
+- **AC1** `record_metrics` persists `tier_corrected_to` / `guards_fired` / `codex_overturned` when
+  supplied, and omits each when not (a plain PASS record gains zero new keys).
+- **AC2** invalid guard names and unknown codex categories are dropped + logged, never raise.
+- **AC3** additive only: `status` enum unchanged (`PASS|BLOCKED`); no field renamed; existing
+  `/learn` jq filters + `agent_metrics` parse pre-change records identically.
+- **AC4** `aggregate_metrics_to_global.aggregate("metrics", ...)` carries the new fields through to
+  the global rollup unchanged; the `(issue, date, project)` dedup key is unaffected.
+- **AC5** `evals_run` is **not** added to `metrics.jsonl` (documented: it lives in
+  `prove-log.applicable_evals`).
+- **AC6** `orchestrate.md` Step 4 populates the three fields from the documented sources; a re-tiered
+  run shows `tier_corrected_to`, a guard-applied run shows `guards_fired`.
+
+## 6. Non-goals
+
+- Re-adding `evals_run`/`eval_results` to metrics (already in `prove-log.jsonl`).
+- Changing the `status` enum or conflating it with the PROVE `verdict`.
+- Metrics sharding **in this rec** (deferred to the §4 decision / REC 0.1).
+- New agents or phases (plan §7 forbids it).
+
+## 7. Test plan
+
+New `claude-config/tests/test_state_manager_decision_fields.py` (mirrors
+`test_state_manager_prove_audit.py`):
+1. round-trip each field; assert present-when-supplied / absent-when-None.
+2. invalid guard name dropped; unknown codex category dropped; no raise.
+3. backward-compat: a record written without the fields reads back clean through
+   `aggregate()` and `flip_to_correction()`.
+4. aggregation pass-through: a sharded/global rollup preserves the three fields and the dedup key.

--- a/docs/rec0-outcome-log-decision-fields-spec.md
+++ b/docs/rec0-outcome-log-decision-fields-spec.md
@@ -1,157 +1,196 @@
-# REC 0 — Outcome-Log Decision-Field Extension (Spec, v0.1 DRAFT)
+# REC 0 — Outcome-Log Decision Fields (Spec, v0.2 DRAFT)
 
 **Date:** 2026-06-04
-**Author:** server-a (Claude Opus 4.8, Linux server), for fleet review by scratch (Mac) + laptop-wsl.
-**Parent:** `docs/claude-workflow-improvement-plan.md` §3.8 (telemetry) + the cross-agent review's REC 3 ("close the feedback loop — the fleet is flying blind").
-**Status:** DRAFT — awaiting adversarial review by scratch + laptop-wsl before PATCH.
+**Author:** server-a (Claude Opus 4.8, Linux server). Reviewed adversarially by scratch (Mac) + laptop-wsl.
+**Parent:** `docs/claude-workflow-improvement-plan.md` §3.8 + the cross-agent review's REC 3 ("close the feedback loop").
+**Status:** DRAFT v0.2 — re-scoped per the consolidated CHANGES-REQUESTED verdict. Awaiting diff re-verify.
 
 ---
 
-## 0. One-line goal
+## CHANGELOG v0.1 → v0.2 (review responses)
 
-Make *decision quality* measurable by adding three decision-provenance fields to the existing
-`metrics.jsonl` record — **extending** the telemetry that already exists, not rebuilding it.
+The fleet review returned **CHANGES REQUESTED** (write-layer approved; not measurable end-to-end as
+scoped). v0.2 addresses all seven gate items. Key reframe: **v0.1 would have shipped three write-only,
+fleet-invisible fields — telemetry theater.** v0.2 delivers ONE field end-to-end as definition-of-done.
+
+| # | Gate item | Resolution in v0.2 |
+|---|---|---|
+| 1 | Re-scope to a measurable vertical slice | §3 — `tier_corrected_to` delivered **write→shard→read→fleet-compare**; other two fields ride the frozen schema but are explicitly **DORMANT** (§3.4). |
+| 2 | Promote sharding + consumer into definition-of-done | §3.2/§3.3 — metrics shard + reader are now **in REC 0**, not deferred. (Former "REC 0.1 sharding" is absorbed.) |
+| 3 | Dedup merge + collision test [correctness] | §3.5 — deterministic **newest-`recorded_at`-wins** merge + collision test. Incl. accuracy note: the `flip_to_correction` trigger is actually safe (verified L476); the real risk is cross-source-file same-key. |
+| 4 | `guards_fired` task-triggered + AC6a/b + variance test | §3.4 + AC6a/AC6b — defined as **task-triggered relevance** (varies by surface), labeled CLAIMED not VERIFIED, with the variance test that kills constant-theater. |
+| 5 | `codex_overturned` 3-state + controlled vocab | §3.4 — `{state: not_run\|confirmed\|overturned, category}` + `_VALID_CODEX_CATEGORIES`. |
+| 6 | Named `/quick` limitation + sibling map | §4 + §8 — "orchestrated work only" stated as a NAMED limitation; sibling **REC 0.2** = low-tier write-sites. |
+| 7 | PIPE_BUF budget + ext4 assumption | §6 — documented; records kept compact. |
+
+**Three theater modes named across the three reviewers — all now defended against:** *empty* (always
+`[]`), *dormant* (no producer), *constant* (always all three). The unified fix is task-triggered
+relevance + honest CLAIMED/VERIFIED labeling + a variance test.
 
 ---
 
 ## 1. Current state (VERIFIED against code at HEAD 4408d43)
 
-Read directly — not assumed (VERIFICATION_GAP guard):
+- **`claude-config/hooks/state_manager.py`**: `record_metrics()` (L274), `record_failure()` (L353),
+  `flip_to_correction()` (L424, builds the corrected record via `dict(last_record)` — copies all
+  fields forward), `record_prove_audit()` (L742, holds `applicable_evals` + `eval_results`).
+- **`claude-config/hooks/aggregate_metrics_to_global.py`** (Stop hook): merges per-project → **local**
+  `~/.claude/memory/{metrics,failures}.jsonl`; shards **failures only** (`write_host_shard`, L281) to
+  `~/agents/telemetry/<host>/failures.jsonl`. Metrics dedup = `(issue,date,project)`, last-wins
+  (L228-229), **field-blind**. Whole-dict pass-through, **no allowlist** (verified) — so new fields
+  survive the *local* rollup.
+- **Reader = `mcp-server/tools/agent_metrics.py`** (98 lines): consumes **only** `date`, `status`,
+  `complexity`, `stack`, `root_cause` (verified L42-76). Unknown fields are silently ignored.
 
-- **`claude-config/hooks/state_manager.py`** already has the full recorder set:
-  - `record_metrics()` (L274) → appends to `<project>/.claude/memory/metrics.jsonl`.
-  - `record_failure()` (L353) → `failures.jsonl` (carries `event_id`, `project`).
-  - `flip_to_correction()` (L424) → first-pass-correctness flip (append-only, last-wins).
-  - `record_prove_audit()` (L742) → `prove-log.jsonl`, including `applicable_evals` + `eval_results`.
-- **`claude-config/hooks/aggregate_metrics_to_global.py`** (origin #195) is the `Stop` hook:
-  merges per-project → global `~/.claude/memory/{metrics,failures}.jsonl`, **shards failures only**
-  to `~/agents/telemetry/<host>/failures.jsonl`. Fail-open, stdlib-only. Metrics dedup key =
-  `(issue, date, project)`, last-wins.
-- **Existing `metrics.jsonl` schema** (from `record_metrics`):
-  `{issue, date, recorded_at, status, complexity, stack, agents_run}` + optional
-  `{duration_seconds, root_cause, blocking_agent, agent_versions, first_pass_correct, corrections}`.
-
-### ⚠️ Two corrections to the relayed "ground truth" (both caught by reading the code)
-
-1. **`evals_run[]` already exists** — as `applicable_evals` (plus a per-eval `eval_results` map) in
-   `record_prove_audit()` → `prove-log.jsonl`. **REC 0 must NOT re-add evals to `metrics.jsonl`** —
-   that would duplicate the field and invite drift. Reference the existing `prove-log` field instead.
-2. **`metrics.status` is `PASS | BLOCKED`, not `PASS | FAIL`.** `FAIL` is a *PROVE verdict* recorded in
-   `prove-log.jsonl` (`record_prove_audit`, the AC-FORBIDS-APPROVE downgrade). The two streams are
-   distinct; the spec keeps `status` unchanged and does **not** conflate it with the PROVE verdict.
-
-Net: of the four fields originally proposed (`tier_corrected_to`, `guards_fired[]`, `evals_run[]`,
-`codex_overturned`), **only three are genuinely missing.** `evals_run` is already captured.
+### Verified review premises
+- `metrics.status` ∈ `{PASS, BLOCKED}` (NOT `PASS|FAIL`; `FAIL` is a `prove-log` verdict). ✔
+- `evals_run` already exists as `applicable_evals` in `prove-log.jsonl`. ✔
+- **Blocker 2 CONFIRMED:** the reader ignores the three proposed fields → write-only without a consumer.
+- **Dedup:** field-blind last-wins — fragile across source files (see §3.5); the specific
+  `flip_to_correction` case is *safe* because it copies fields forward and wins by append-order.
 
 ---
 
 ## 2. The gap
 
-`record_metrics` captures *what tier was chosen* (`complexity`) and *the outcome* (`status`,
-`first_pass_correct`), but nothing about the **decisions made along the way** that the cross-agent
-review identified as the highest-leverage things to measure:
-
-- Was the tier **re-classified** mid-flight? (The "SIMPLE that became FULLSTACK" leak.)
-- Which **failure-pattern guards** actually fired? (Are the guards earning their keep, or is it luck?)
-- Did **Codex review change the output**, or just confirm it? (Tail-risk value vs. latency.)
-
-Without these, we cannot answer "is the playbook improving?" — REC 3's core finding.
+`record_metrics` captures the chosen tier (`complexity`) and outcome (`status`,
+`first_pass_correct`) but nothing about the **decisions** the cross-agent review flagged as
+highest-leverage: was the tier **re-classified** mid-flight, which **guards** were relevant, and did
+**Codex** change the output. Without a write→shard→read→compare path these are unmeasurable.
 
 ---
 
 ## 3. The change
 
-### 3.1 Schema additions to `metrics.jsonl` (all optional, omitted-when-empty)
+### 3.1 Definition of done (the vertical slice)
 
-| Field | Type | Meaning | Source of truth |
-|---|---|---|---|
-| `tier_corrected_to` | `str` | Final tier if re-classified mid-flight (e.g. `"COMPLEX"` when `complexity` started `"SIMPLE"`). Omitted when no re-tier. | Orchestrator (REC #2 tripwire sets it; until then, passed when a re-tier occurred) |
-| `guards_fired` | `list[str]` | Which core guards were applied — subset of `{VERIFICATION_GAP, ENUM_VALUE, COMPONENT_API}` (extensible). Omitted when empty. | MAP/PATCH artifact frontmatter, collected by orchestrator (mirrors how `applicable_evals` comes from PROVE) |
-| `codex_overturned` | `dict` | `{"overturned": bool, "category": str}` — did a Codex review change the diff, and in which risk category (`auth\|migration\|enum_contract\|...`). Omitted when Codex didn't run. | Orchestrator (knows if `/codex:*` ran and whether BLOCKING findings were applied) |
+REC 0 is **done** when `tier_corrected_to` flows end-to-end and is fleet-comparable:
 
-Keeps the existing "include only if supplied" convention (L333-344) so PASS records stay compact and
-`/learn`'s existing jq filters keep parsing.
-
-### 3.2 `record_metrics()` signature additions (additive, keyword-only, default None)
-
-```python
-    tier_corrected_to: str | None = None,
-    guards_fired: list[str] | None = None,
-    codex_overturned: dict | None = None,
 ```
-with the matching record-building block (after L344):
-```python
-    if tier_corrected_to:
-        record["tier_corrected_to"] = tier_corrected_to
-    if guards_fired:
-        record["guards_fired"] = list(guards_fired)
-    if codex_overturned is not None:
-        record["codex_overturned"] = dict(codex_overturned)
+record_metrics(tier_corrected_to=...)        # WRITE   (state_manager.py)
+  → aggregate + write_metrics_shard()          # SHARD   (aggregate_metrics_to_global.py)
+    → telemetry/<host>/metrics.jsonl (git)      # FLEET   (committed, cross-host visible)
+      → agent_metrics reports re-tier rate      # READ    (agent_metrics.py)
 ```
 
-### 3.3 Validation (mirror the `_VALID_AC_STATUSES` pattern, L579)
+`guards_fired` and `codex_overturned` are written on the **same frozen schema** but are **dormant**
+(§3.4) — defined now so producers/consumers added later require **zero reshape**.
 
-- `_VALID_GUARDS = frozenset({"VERIFICATION_GAP", "ENUM_VALUE", "COMPONENT_API"})` — unknown guard
-  names are dropped + logged (fail-open, never raise into the orchestrator).
-- `codex_overturned.category` validated against a small `_VALID_CODEX_CATEGORIES` set sourced from the
-  `implementation-routing.md` escalation triggers (auth, migration, enum_contract, cross_module, ...).
+### 3.2 Write — `record_metrics()` additions (additive, keyword-only, default None)
 
-### 3.4 Orchestrator wiring (`claude-config/commands/orchestrate.md` Step 4)
+```python
+    tier_corrected_to: str | None = None,      # ACTIVE this rec
+    guards_fired: list[str] | None = None,     # dormant (schema frozen)
+    codex_overturned: dict | None = None,      # dormant (schema frozen)
+```
+Record-building keeps the "include only if supplied" convention so PASS records stay compact.
 
-Single writer stays the orchestrator (the #104 determinism rule). It collects the three values and
-passes them to `record_metrics`. `guards_fired` is **derived from artifacts** (propose a
-`derive_guards_fired()` helper symmetric with `derive_agents_run()` L520) so it's not lost to
-stateless-between-dispatch tracking.
+### 3.3 Shard + Read (promoted into DoD)
+
+- **Shard:** new `write_metrics_shard()` in the Stop hook, mirroring `write_host_shard()` but
+  **field-agnostic** (carries the whole record, so dormant fields ride for free when they light up) →
+  `telemetry/<host>/metrics.jsonl`. **Volume guard:** metrics are every-task (failures are sparse), so
+  the shard writes a **decision-bearing projection** (`issue, date, recorded_at, complexity,
+  tier_corrected_to, status` + the two dormant fields) and defines **retention** (rotate per host, cap
+  rows / age) — NOT a blind mirror of the failure shard.
+- **Read:** extend `agent_metrics.py` with a **re-tier rate** (count records where
+  `tier_corrected_to` present and ≠ `complexity`, grouped by initial `complexity`), reading the
+  committed `telemetry/<host>/metrics.jsonl` shards for cross-host comparison.
+
+### 3.4 Field semantics
+
+- **`tier_corrected_to`** (ACTIVE): final tier when re-classified mid-flight; omitted when no re-tier.
+  Source today: orchestrator passes it when a re-tier occurs (no REC 1/3 dependency).
+- **`guards_fired`** (DORMANT until producer exists; schema frozen now): **TASK-TRIGGERED RELEVANCE**,
+  not intent. `ENUM_VALUE` only when the diff touches a role/status/type/enum surface; `COMPONENT_API`
+  only when a component/hook is reused; `VERIFICATION_GAP` when a structural assumption was made +
+  checked. So the field **varies with task surface** (kills constant-theater). Labeled
+  **CLAIMED/RELEVANT, self-reported — NOT VERIFIED-EFFECTIVE.** Two-phase: explicit-pass (orchestrator,
+  task-triggered, today) → `derive_guards_fired()` from artifact evidence (PLAN file:line, MAP
+  contract-sheet/VALUE, COMPONENT_API PropTypes citation) once **REC 1/3** produce those artifacts.
+  Until the producer lands, the orchestrator MAY pass it explicitly; analysis MUST NOT read it as
+  guard-effectiveness.
+- **`codex_overturned`** (DORMANT; schema frozen): `{"state": "not_run"|"confirmed"|"overturned",
+  "category": str}`. **3-state** because overturn-*rate* needs the denominator (how often Codex ran) —
+  a bool conflates "ran+confirmed" with "never ran". `category` ∈ `_VALID_CODEX_CATEGORIES`
+  (`auth, migration, enum_contract, cross_module, secrets, ...`, sourced from
+  `implementation-routing.md` triggers). Validation fail-open: unknown category/guard dropped + logged,
+  never raises into the orchestrator (mirrors `_VALID_AC_STATUSES`, L579).
+
+### 3.5 Dedup correctness fix
+
+Replace field-blind last-wins for metrics with **newest-`recorded_at`-wins** (every new record carries
+microsecond-precision `recorded_at`, L327): on key collision keep the record with the greatest
+`recorded_at`; tie-break to the field-richer record. This removes the order-dependent clobber class
+(narrow today — cross-source-file same-key — but latent). **Collision test (required):** two records,
+same `(issue,date,project)`, one with `tier_corrected_to` and one without, in adverse source order →
+assert the merged global RETAINS the field. (AC4 round-trip is necessary but not sufficient.)
 
 ---
 
-## 4. DECISION REQUIRED (fleet review, please weigh in)
+## 4. Named limitation (no silent cap)
 
-The Stop hook **shards failures per-host** (`telemetry/<host>/failures.jsonl`) but **not metrics** —
-metrics only roll up to the *local* global file. So as written, the new decision fields are
-analyzable **per-host only**, NOT across the fleet. But REC 3's entire motivation was *cross-fleet*
-comparison.
-
-**Options:**
-- **A (minimal):** fields live in `metrics.jsonl`, per-host analysis only. Smallest diff; doesn't
-  satisfy cross-fleet comparison.
-- **B (fleet-visible):** extend the Stop hook with a `write_metrics_shard()` mirroring
-  `write_host_shard()` (L281) → `telemetry/<host>/metrics.jsonl`, so the committed `telemetry/` tree
-  carries decision fields and the weekly `/learn --cross-project` can compare machines.
-
-**server-a's recommendation: B**, but as a *clearly-scoped follow-up* (REC 0.1) so the field-addition
-(REC 0) can land and start capturing data immediately while we settle the sharding shape. Flagging
-rather than silently picking — this is the one real architectural choice here.
+REC 0 records **orchestrated work only.** `/quick` and plan-mode SIMPLE have separate write-sites and
+emit no metric today — a known blind spot for the high-volume low tier where mis-tiering originates.
+This is stated, not hidden. Closing it = sibling **REC 0.2** (§8). REC 0 adds **no dormant unwired
+`/quick` writer** (that is the same theater trap); it only **freezes the record shape** so a future
+`/quick` row is byte-identical and 0.2 is pure wiring.
 
 ---
 
 ## 5. Acceptance criteria
 
-- **AC1** `record_metrics` persists `tier_corrected_to` / `guards_fired` / `codex_overturned` when
-  supplied, and omits each when not (a plain PASS record gains zero new keys).
-- **AC2** invalid guard names and unknown codex categories are dropped + logged, never raise.
-- **AC3** additive only: `status` enum unchanged (`PASS|BLOCKED`); no field renamed; existing
-  `/learn` jq filters + `agent_metrics` parse pre-change records identically.
-- **AC4** `aggregate_metrics_to_global.aggregate("metrics", ...)` carries the new fields through to
-  the global rollup unchanged; the `(issue, date, project)` dedup key is unaffected.
-- **AC5** `evals_run` is **not** added to `metrics.jsonl` (documented: it lives in
-  `prove-log.applicable_evals`).
-- **AC6** `orchestrate.md` Step 4 populates the three fields from the documented sources; a re-tiered
-  run shows `tier_corrected_to`, a guard-applied run shows `guards_fired`.
+- **AC1** `record_metrics` persists each field when supplied, omits each when None (plain PASS record
+  gains zero keys).
+- **AC2** invalid guard names / unknown codex categories dropped + logged, never raise.
+- **AC3** additive only: `status` enum unchanged; no field renamed; existing `agent_metrics` + `/learn`
+  jq parse pre-change records identically.
+- **AC4** `aggregate("metrics", …)` carries new fields through to the **local** global rollup unchanged.
+- **AC4b (NEW)** dedup collision: same-key records (one with / one without `tier_corrected_to`) in
+  adverse order → merged global retains the field (§3.5 merge rule).
+- **AC5** `evals_run` is NOT added to metrics (lives in `prove-log.applicable_evals`).
+- **AC6a** `tier_corrected_to` flows **end-to-end**: written → sharded to `telemetry/<host>/metrics.jsonl`
+  → `agent_metrics` reports a cross-host **re-tier rate**. *(This is the DoD; testable today.)*
+- **AC6b** `guards_fired` populated via explicit task-triggered self-report is testable today;
+  **variance test:** an enum-touching task → non-empty incl `ENUM_VALUE`; a backend-no-enum task →
+  `ENUM_VALUE` ABSENT. The artifact-**derived** path is deferred to REC 1/3 (not asserted here).
+- **AC7 (NEW)** sharded record stays within the §6 size budget under representative field population.
 
-## 6. Non-goals
+## 6. Cross-env / durability notes
 
-- Re-adding `evals_run`/`eval_results` to metrics (already in `prove-log.jsonl`).
+- **PIPE_BUF atomicity is size-bounded (4096 B).** Single-line appends are atomic only ≤ PIPE_BUF; a
+  record bloated by nested `codex_overturned` + a long `guards_fired` list could exceed it and, under
+  `--parallel` concurrent appends, interleave/corrupt. **Keep records compact**; the shard writes a
+  projection (§3.3), not the full record.
+- **Atomicity/fsync/perms assume native ext4** (not `/mnt/c`). Stated for the WSL machine.
+- Backward-compat is SAFE (unknown-field tolerance) — but that tolerance is precisely why a **reader**
+  (§3.3) is mandatory, else the fields are silently inert.
+
+## 7. Non-goals
+
+- Re-adding `evals_run`/`eval_results` to metrics (in `prove-log.jsonl`).
 - Changing the `status` enum or conflating it with the PROVE `verdict`.
-- Metrics sharding **in this rec** (deferred to the §4 decision / REC 0.1).
-- New agents or phases (plan §7 forbids it).
+- A `/quick`/freeform writer (sibling REC 0.2).
+- Artifact-derived `guards_fired` (REC 1/3) or new agents/phases (plan §7 forbids).
 
-## 7. Test plan
+## 8. Sibling RECs (reuse REC 0's FROZEN schema — no reshape)
 
-New `claude-config/tests/test_state_manager_decision_fields.py` (mirrors
-`test_state_manager_prove_audit.py`):
-1. round-trip each field; assert present-when-supplied / absent-when-None.
-2. invalid guard name dropped; unknown codex category dropped; no raise.
-3. backward-compat: a record written without the fields reads back clean through
-   `aggregate()` and `flip_to_correction()`.
-4. aggregation pass-through: a sharded/global rollup preserves the three fields and the dedup key.
+| REC | Scope | Depends on |
+|---|---|---|
+| **REC 0** (this) | `tier_corrected_to` end-to-end (write+shard+read) + frozen dormant fields | — |
+| **REC 0.2** | Low-tier write-sites: record `/quick` + plan-mode SIMPLE outcomes | REC 0 frozen schema |
+| **REC 1 / REC 3** | Artifact producers (PLAN evidence, MAP contract-sheet, PropTypes citation) that make `guards_fired` **derived/falsifiable** | REC 0 field defn |
+
+Schedule REC 0.2 immediately after REC 0 — high-volume tier, high value — without bloating REC 0's
+clean landing.
+
+## 9. Test plan
+
+New `claude-config/tests/test_state_manager_decision_fields.py`:
+1. round-trip each field; present-when-supplied / absent-when-None.
+2. validation: invalid guard + unknown codex category dropped; no raise.
+3. backward-compat: field-less record survives `aggregate()` + `flip_to_correction()`.
+4. **dedup collision** (AC4b): same key, with/without field, adverse order → field retained.
+5. **shard + read** (AC6a): write → `write_metrics_shard` → `agent_metrics` re-tier rate non-zero.
+6. **guards_fired variance** (AC6b): enum-task non-empty incl ENUM_VALUE; backend-no-enum omits it.
+7. **size budget** (AC7): representative record ≤ PIPE_BUF.

--- a/docs/rec0-outcome-log-decision-fields-spec.md
+++ b/docs/rec0-outcome-log-decision-fields-spec.md
@@ -3,7 +3,7 @@
 **Date:** 2026-06-04
 **Author:** server-a (Claude Opus 4.8, Linux server). Reviewed adversarially by scratch (Mac) + laptop-wsl.
 **Parent:** `docs/claude-workflow-improvement-plan.md` §3.8 + the cross-agent review's REC 3 ("close the feedback loop").
-**Status:** DRAFT v0.3 — Blocker 3 (shard-commit gap) downscoped per re-verify; dedup hardened to field-level. Awaiting diff re-verify.
+**Status:** DRAFT v0.4 — Jason's cross-fleet decision = **channel hub** (data off the code repo). REC 0 core unchanged; REC 0.1 redefined to hub reporting. Ready for final sign-off.
 
 ---
 
@@ -36,6 +36,20 @@ slice — cross-fleet sync is its own infrastructure rec, not a field-add.
 |---|---|
 | 🔴 **Blocker 3 — shard never committed.** Verified: `telemetry/<host>/` dirs are untracked; no hook git-adds/commits/pushes them. So write→**commit**→push→pull→read is broken at commit; "cross-host compare" reads only the local host. | **Downscoped (option b).** REC 0 DoD = **per-host re-tier rate**, read from the **local global rollup** (`~/.claude/memory/metrics.jsonl`, which already carries the field via field-agnostic aggregation — verified). `write_metrics_shard()` **and** the commit/push/pull sync move to **REC 0.1 (telemetry sync)**. Net: REC 0 shrinks to 2 files (no `aggregate` change, no shard). |
 | 🟠 **Dedup — record-level newest-wins drops a provenance fact** if a later record for the key omits the field. `tier_corrected_to` is "what happened," not mutable state. | **Field-level carry-forward** for the decision-provenance fields: newest-`recorded_at` wins for mutable/outcome fields (status, first_pass_correct, …), then **carry forward** `tier_corrected_to`/`guards_fired`/`codex_overturned` from ANY record for the key if the newest lacks them. Collision test must **FAIL on the current last-wins code** (tautology guard). |
+
+## CHANGELOG v0.3 → v0.4 (cross-fleet architecture decided)
+
+Jason chose the **channel hub** for cross-fleet telemetry (verified context: inbound `git pull --ff-only`
+already runs at session start, `sessionstart_restore_state.py:84`, purpose-built for shards; only the
+outbound path was missing). Rationale for hub over finishing the git push: **don't version append-only
+telemetry DATA in the CODE repo** — per-session commits churn history unboundedly. The hub keeps data
+off git and still gives true cross-fleet aggregation.
+
+**Impact: REC 0 core is UNCHANGED** (per-host write→read on the frozen schema). Only **REC 0.1** is
+redefined — from "git `write_metrics_shard` + commit/push/pull" to **"report decision-bearing metrics
+over the ai-channels hub + hub-side aggregation."** The git-shard path is dropped for cross-fleet
+metrics. (Reconciling the *existing* failure-shard git approach with the hub is itself a follow-up, not
+in REC 0.)
 
 ---
 
@@ -107,11 +121,12 @@ Record-building keeps the "include only if supplied" convention so PASS records 
   where `tier_corrected_to` is present and ≠ `complexity`, grouped by initial `complexity` — reading
   the **local global rollup** `~/.claude/memory/metrics.jsonl` (which already carries `tier_corrected_to`
   via field-agnostic aggregation — verified). No shard read, no cross-host dependency.
-- **Shard + Sync (REC 0.1, NOT this rec):** `write_metrics_shard()` (field-agnostic, decision-bearing
-  **projection** with **retention** — metrics are every-task vs. sparse failures, so no blind mirror of
-  `write_host_shard`) **plus** the mechanism that actually makes shards cross-fleet: who git-adds each
-  host's shard, commit cadence, push/pull, and — the real concern — **high-frequency telemetry commits
-  churning the `agents` repo history + merge handling.** That is sync infrastructure, sized separately.
+- **Cross-fleet (REC 0.1, NOT this rec) — decided: CHANNEL HUB.** Report the decision-bearing metric
+  **projection** over the ai-channels hub (not git), with hub-side aggregation, so cross-fleet
+  comparison reads aggregated data **without versioning telemetry in the code repo.** Open sub-questions
+  for REC 0.1: report cadence (per-session vs. batched), hub persistence/durability, and the
+  aggregation read-path. The earlier git `write_metrics_shard`/commit/push/pull approach is **dropped**
+  for cross-fleet metrics (it would churn the `agents` repo history with per-session data commits).
 
 ### 3.4 Field semantics
 
@@ -207,7 +222,7 @@ This is stated, not hidden. Closing it = sibling **REC 0.2** (§8). REC 0 adds *
 | REC | Scope | Depends on |
 |---|---|---|
 | **REC 0** (this) | `tier_corrected_to` write→read **per-host** (state_manager + agent_metrics) + frozen dormant fields | — |
-| **REC 0.1** | **Telemetry sync:** `write_metrics_shard()` (projection + retention) + commit/push/pull mechanism (cadence, repo-churn, merge handling, auth) that makes shards **cross-fleet** | REC 0 frozen schema |
+| **REC 0.1** | **Cross-fleet telemetry via CHANNEL HUB** (Jason's decision): report decision-bearing metric projection over the ai-channels hub + hub-side aggregation; data stays off the code repo. Open: cadence, hub persistence, aggregation read-path | REC 0 frozen schema |
 | **REC 0.2** | Low-tier write-sites: record `/quick` + plan-mode SIMPLE outcomes | REC 0 frozen schema |
 | **REC 1 / REC 3** | Artifact producers (PLAN evidence, MAP contract-sheet, PropTypes citation) that make `guards_fired` **derived/falsifiable** | REC 0 field defn |
 


### PR DESCRIPTION
## Summary

Spec for **REC 0** — extend the outcome-log (`record_metrics`) with decision-provenance so the workflow's *decision quality* becomes measurable. Parent: `docs/claude-workflow-improvement-plan.md` §3.8 + the cross-agent review's REC 3 ("close the feedback loop").

**Spec only — no code in this PR.**

### Final scope (smallest honest slice)
- **`tier_corrected_to`** (ACTIVE): written by the orchestrator; per-host **re-tier rate** surfaced by `agent_metrics.py` reading the local rollup (already field-agnostic).
- **`guards_fired` + `codex_overturned`** (DORMANT on the **frozen** schema): defined now so future producers/consumers need zero reshape.
- **Field-level carry-forward dedup** — decision fields are provenance facts, not mutable state; collision test must fail on the pre-change last-wins code (tautology guard).
- **Implementation footprint:** `state_manager.py` + `agent_metrics.py` + tests.

### Decisions baked in
- Two relayed premises corrected against code: `evals_run` already lives in `prove-log.jsonl` (not re-added); `metrics.status` is `PASS|BLOCKED`, not `PASS|FAIL`.
- **Cross-fleet telemetry → a message hub** (data stays off the code repo), homed in `~/agents`; the hub is an external, unnamed dependency referenced by capability only. → sibling **REC 0.1**.
- Sibling recs: **0.1** cross-fleet hub telemetry · **0.2** low-tier (`/quick`) write-sites · **REC 1/3** artifact producers that make `guards_fired` derived/falsifiable.

### Review
Adversarially reviewed across 5 versions by three independent agents (server-a author; scratch + laptop-wsl reviewers). Each round stripped a form of "telemetry theater" (empty / dormant / constant / write-only / uncommitted-shard). Joint approval on v0.5.

> ⚠️ **Do not merge yet** — held pending the PATCH-vs-hold-at-approved-spec decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)