### PR TITLE
feat(telemetry): REC 0 — outcome-log decision fields + per-host re-tier rate

### DIFF
--- a/claude-config/hooks/aggregate_metrics_to_global.py
+++ b/claude-config/hooks/aggregate_metrics_to_global.py
@@ -162,6 +162,24 @@ def normalize_record(record: dict, project: str = "") -> list:
     return expanded
 
 
+_DECISION_FIELDS = ("tier_corrected_to", "guards_fired", "codex_overturned")
+
+
+def _merge_decision_fields(base: dict, candidates: list) -> None:
+    """Carry forward decision-provenance fields to *base* from *candidates*.
+
+    For each field in _DECISION_FIELDS: if *base* lacks the field and any
+    candidate has it, copy the value from the first candidate that has it.
+    Mutates *base* in-place.
+    """
+    for field in _DECISION_FIELDS:
+        if field not in base:
+            for cand in candidates:
+                if field in cand:
+                    base[field] = cand[field]
+                    break
+
+
 def _derive_project(source_dir: Path) -> str:
     """Return the repo-root name for a given memory directory.
 
@@ -178,6 +196,7 @@ def _load_source(
     file: Path,
     project_name: str,
     seen: dict,
+    all_metrics: dict,
 ) -> None:
     """Read one JSONL file and merge records into *seen* (last record wins).
 
@@ -190,6 +209,10 @@ def _load_source(
     in the local ``~/.claude/memory/`` view.  Metrics records (which have a
     ``status`` field) retain the legacy ``(issue, date, project)`` key because
     they don't have meaningful event_ids.
+
+    *all_metrics* accumulates every metrics record seen for each key so that
+    _merge_decision_fields() can carry forward provenance fields from older
+    records if the newest-recorded_at winner lacks them (issue #217, AC4b).
     """
     try:
         with open(file, encoding="utf-8") as fh:
@@ -226,7 +249,16 @@ def _load_source(
                     else:
                         # Metrics records: legacy (issue, date, project) key is fine.
                         key = (record.get("issue"), record.get("date"), record.get("project"))
-                    seen[key] = record  # last wins
+                        # Pick newest by recorded_at (ISO strings sort lexicographically).
+                        existing = seen.get(key)
+                        if existing is None:
+                            seen[key] = record
+                        elif record.get("recorded_at", "") >= existing.get("recorded_at", ""):
+                            seen[key] = record
+                        # Accumulate all metrics records for field-level carry-forward.
+                        all_metrics.setdefault(key, []).append(record)
+                        continue
+                    seen[key] = record  # last wins (failures)
     except OSError:
         pass  # file vanished between glob and open — harmless
 
@@ -237,13 +269,20 @@ def aggregate(kind: str, source_dirs: list, global_dir: Path) -> int:
     Returns the number of records written.
     """
     seen: dict = {}  # key=event_id (failures) or (issue,date,project) (metrics) -> record
+    all_metrics: dict = {}  # (issue,date,project) -> list of all metrics records for that key
 
     for source_dir in sorted(source_dirs):
         file = source_dir / f"{kind}.jsonl"
         if not file.exists():
             continue
         project_name = _derive_project(source_dir)
-        _load_source(file, project_name, seen)
+        _load_source(file, project_name, seen, all_metrics)
+
+    # Field-level carry-forward: if the newest-recorded_at winner for a key
+    # lacks a decision-provenance field, recover it from any older record.
+    for key, base in seen.items():
+        if key in all_metrics:
+            _merge_decision_fields(base, all_metrics[key])
 
     global_dir.mkdir(parents=True, exist_ok=True)
     global_file = global_dir / f"{kind}.jsonl"

--- a/claude-config/hooks/aggregate_metrics_to_global.py
+++ b/claude-config/hooks/aggregate_metrics_to_global.py
@@ -168,16 +168,30 @@ _DECISION_FIELDS = ("tier_corrected_to", "guards_fired", "codex_overturned")
 def _merge_decision_fields(base: dict, candidates: list) -> None:
     """Carry forward decision-provenance fields to *base* from *candidates*.
 
-    For each field in _DECISION_FIELDS: if *base* lacks the field and any
-    candidate has it, copy the value from the first candidate that has it.
-    Mutates *base* in-place.
+    For each field in _DECISION_FIELDS: if *base* lacks the field, copy the
+    value from the newest-recorded_at candidate that has it. Mutable values
+    (lists/dicts) are copied, not aliased. Mutates *base* in-place.
     """
     for field in _DECISION_FIELDS:
         if field not in base:
-            for cand in candidates:
-                if field in cand:
-                    base[field] = cand[field]
-                    break
+            # Newest donor wins: a provenance fact should be carried from the
+            # most recent record that actually has it, not the first one we
+            # happen to encounter in source/line order (Codex review #4).
+            donors = sorted(
+                (c for c in candidates if field in c),
+                key=lambda c: c.get("recorded_at", ""),
+                reverse=True,
+            )
+            if donors:
+                val = donors[0][field]
+                # Copy mutable containers so carry-forward never aliases the
+                # source record still held in all_metrics (Codex review #2).
+                if isinstance(val, list):
+                    base[field] = list(val)
+                elif isinstance(val, dict):
+                    base[field] = dict(val)
+                else:
+                    base[field] = val
 
 
 def _derive_project(source_dir: Path) -> str:
@@ -250,10 +264,13 @@ def _load_source(
                         # Metrics records: legacy (issue, date, project) key is fine.
                         key = (record.get("issue"), record.get("date"), record.get("project"))
                         # Pick newest by recorded_at (ISO strings sort lexicographically).
+                        # Strict `>` so a true tie keeps the first-seen record
+                        # (deterministic) rather than silently letting the
+                        # last-processed source win (Codex review #1).
                         existing = seen.get(key)
                         if existing is None:
                             seen[key] = record
-                        elif record.get("recorded_at", "") >= existing.get("recorded_at", ""):
+                        elif record.get("recorded_at", "") > existing.get("recorded_at", ""):
                             seen[key] = record
                         # Accumulate all metrics records for field-level carry-forward.
                         all_metrics.setdefault(key, []).append(record)

--- a/claude-config/hooks/state_manager.py
+++ b/claude-config/hooks/state_manager.py
@@ -284,6 +284,10 @@ def record_metrics(
     agent_versions: dict[str, str] | None = None,
     first_pass_correct: bool | None = None,
     corrections: list | None = None,
+    *,
+    tier_corrected_to: str | None = None,
+    guards_fired: list[str] | None = None,
+    codex_overturned: dict | None = None,
 ) -> None:
     """Append a single record to ``.claude/memory/metrics.jsonl``.
 
@@ -317,6 +321,20 @@ def record_metrics(
             added retroactively by flip_to_correction).
         corrections: List of correction reason strings. Only present
             after /correction has been run at least once.
+        tier_corrected_to: Final complexity tier when the issue was
+            re-classified mid-flight (e.g. "COMPLEX" when it started
+            as "SIMPLE"). Omitted when no re-tier occurred.
+        guards_fired: Names of pattern-guards that fired during the
+            run (e.g. ["ENUM_VALUE", "VERIFICATION_GAP"]). Only names
+            in ``_VALID_GUARDS`` are written; unknown names are dropped
+            with a WARNING log. Omitted entirely when empty after
+            filtering. DORMANT — schema only; no producer yet.
+        codex_overturned: Dict with shape
+            ``{"state": "not_run"|"confirmed"|"overturned",
+            "category": str}`` recording whether Codex review changed
+            the PROVE verdict. Both ``state`` and ``category`` must
+            pass validation; the whole dict is dropped (with a WARNING)
+            if either is invalid. DORMANT — schema only; no producer yet.
 
     Returns: None. Errors are logged to ``~/.claude/hooks.log``; the
     function never raises into the orchestrator.
@@ -342,6 +360,35 @@ def record_metrics(
         record["first_pass_correct"] = first_pass_correct
     if corrections is not None:
         record["corrections"] = list(corrections)
+
+    if tier_corrected_to:
+        record["tier_corrected_to"] = str(tier_corrected_to)
+
+    if guards_fired is not None:
+        valid = [g for g in guards_fired if g in _VALID_GUARDS]
+        dropped = set(guards_fired) - set(valid)
+        if dropped:
+            logging.warning(
+                "record_metrics: dropped unknown guards %r", dropped
+            )
+        if valid:
+            record["guards_fired"] = valid
+
+    if codex_overturned is not None:
+        _state = codex_overturned.get("state", "")
+        _cat = codex_overturned.get("category", "")
+        if _state not in _VALID_CODEX_STATES:
+            logging.warning(
+                "record_metrics: dropped codex_overturned with invalid "
+                "state %r", _state
+            )
+        elif _cat not in _VALID_CODEX_CATEGORIES:
+            logging.warning(
+                "record_metrics: dropped codex_overturned with invalid "
+                "category %r", _cat
+            )
+        else:
+            record["codex_overturned"] = dict(codex_overturned)
 
     target = _memory_dir(project_dir) / "metrics.jsonl"
     try:
@@ -583,6 +630,14 @@ _VALID_AC_STATUSES = frozenset({"implemented", "partial", "missing", "deferred",
 # referenced number does NOT — that's the load-bearing rule that prevents
 # "deferred to a follow-up" from becoming an APPROVE escape hatch.
 _DEFERRED_REF_RE = re.compile(r"#\d+|GH-\d+", re.IGNORECASE)
+
+_VALID_GUARDS = frozenset({
+    "VERIFICATION_GAP", "ENUM_VALUE", "COMPONENT_API",
+})
+_VALID_CODEX_STATES = frozenset({"not_run", "confirmed", "overturned"})
+_VALID_CODEX_CATEGORIES = frozenset({
+    "auth", "migration", "enum_contract", "cross_module", "secrets",
+})
 
 
 def _ac_label(entry: dict, idx: int) -> str:

--- a/claude-config/hooks/state_manager.py
+++ b/claude-config/hooks/state_manager.py
@@ -361,7 +361,7 @@ def record_metrics(
     if corrections is not None:
         record["corrections"] = list(corrections)
 
-    if tier_corrected_to:
+    if tier_corrected_to is not None:
         record["tier_corrected_to"] = str(tier_corrected_to)
 
     if guards_fired is not None:

--- a/claude-config/tests/test_state_manager_decision_fields.py
+++ b/claude-config/tests/test_state_manager_decision_fields.py
@@ -1,0 +1,384 @@
+"""Tests for decision-provenance fields added in issue #217.
+
+Covers spec §9 ACs 1-7:
+  AC1  Round-trip: fields present/absent as expected (test_roundtrip_present_absent)
+  AC2  Validation: invalid guards/categories dropped, no raise (test_validation_drop_invalid)
+  AC3  Backward-compat: old records survive unchanged (test_backward_compatibility)
+  AC4b Collision dedup: field retained when base (newest) lacks it (test_dedup_collision)
+  AC6a Write→read per-host re-tier rate via agent_metrics() (test_retier_rate_write_read)
+  AC6b guards_fired variance: enum task vs no-enum task (test_guards_fired_variance)
+  AC7  Size budget: representative record ≤ 4096 bytes (test_size_budget)
+
+Run from the repo root:
+
+    python3 -m pytest claude-config/tests/test_state_manager_decision_fields.py -v
+
+The conftest.py in this directory adds hooks/ to sys.path automatically.
+mcp-server/tools/ is added here so the agent_metrics import does not pollute
+other test modules.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+# Add mcp-server/ to sys.path so `tools.agent_metrics` can be imported with its
+# relative `from .vault_common import ...` intact. Scoped to this module only;
+# conftest.py already adds hooks/.
+_MCP_SERVER = Path(__file__).resolve().parent.parent.parent / "mcp-server"
+if str(_MCP_SERVER) not in sys.path:
+    sys.path.insert(0, str(_MCP_SERVER))
+
+from state_manager import record_metrics  # type: ignore[import-not-found]  # noqa: E402
+from aggregate_metrics_to_global import aggregate  # type: ignore[import-not-found]  # noqa: E402
+from tools.agent_metrics import agent_metrics  # type: ignore[import-not-found]  # noqa: E402
+
+
+# ── Fixtures & helpers ───────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def project_dir(tmp_path: Path) -> Path:
+    """Isolated project root for each test."""
+    return tmp_path
+
+
+def _read_metrics(project_dir: Path) -> list[dict]:
+    """Read all records from metrics.jsonl in *project_dir*."""
+    path = project_dir / ".claude" / "memory" / "metrics.jsonl"
+    if not path.exists():
+        return []
+    return [
+        json.loads(line)
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+def _read_global_metrics(global_dir: Path) -> list[dict]:
+    """Read all records from the global metrics.jsonl."""
+    path = global_dir / "metrics.jsonl"
+    if not path.exists():
+        return []
+    return [
+        json.loads(line)
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+def _write_raw_metrics(project_dir: Path, records: list[dict]) -> None:
+    """Write records directly to metrics.jsonl (bypasses record_metrics validation)."""
+    target = project_dir / ".claude" / "memory" / "metrics.jsonl"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    with open(target, "a", encoding="utf-8") as fh:
+        for rec in records:
+            fh.write(json.dumps(rec, separators=(",", ":")) + "\n")
+
+
+# ── Test 1: Round-trip present/absent (AC1) ──────────────────────────────────
+
+
+def test_roundtrip_present_absent(project_dir):
+    """Fields are written when supplied and absent when not supplied (AC1)."""
+    # Call with all three decision fields.
+    record_metrics(
+        project_dir,
+        issue=1,
+        status="PASS",
+        complexity="SIMPLE",
+        stack="backend",
+        agents_run=["MAP", "PATCH", "PROVE"],
+        tier_corrected_to="COMPLEX",
+        guards_fired=["VERIFICATION_GAP"],
+        codex_overturned={"state": "overturned", "category": "auth"},
+    )
+    rows = _read_metrics(project_dir)
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["tier_corrected_to"] == "COMPLEX"
+    assert row["guards_fired"] == ["VERIFICATION_GAP"]
+    assert row["codex_overturned"] == {"state": "overturned", "category": "auth"}
+
+    # Call without decision fields — none of the three keys should appear.
+    record_metrics(
+        project_dir,
+        issue=2,
+        status="PASS",
+        complexity="TRIVIAL",
+        stack="backend",
+        agents_run=["PATCH", "PROVE"],
+    )
+    rows = _read_metrics(project_dir)
+    second = rows[1]
+    assert "tier_corrected_to" not in second
+    assert "guards_fired" not in second
+    assert "codex_overturned" not in second
+
+
+# ── Test 2: Validation — drop invalid, no raise (AC2) ───────────────────────
+
+
+def test_validation_drop_invalid(project_dir):
+    """Invalid guard names are dropped; invalid codex dicts are omitted; no raise (AC2)."""
+    # Mixed valid + invalid guard name: only valid name should survive.
+    record_metrics(
+        project_dir,
+        issue=10,
+        status="PASS",
+        complexity="SIMPLE",
+        stack="backend",
+        agents_run=["PATCH"],
+        guards_fired=["ENUM_VALUE", "NOT_A_GUARD"],
+    )
+    rows = _read_metrics(project_dir)
+    row = rows[-1]
+    assert row["guards_fired"] == ["ENUM_VALUE"]
+
+    # Invalid category: whole dict dropped.
+    record_metrics(
+        project_dir,
+        issue=11,
+        status="PASS",
+        complexity="SIMPLE",
+        stack="backend",
+        agents_run=["PATCH"],
+        codex_overturned={"state": "overturned", "category": "BADCAT"},
+    )
+    rows = _read_metrics(project_dir)
+    row = rows[-1]
+    assert "codex_overturned" not in row
+
+    # Invalid state: whole dict dropped.
+    record_metrics(
+        project_dir,
+        issue=12,
+        status="PASS",
+        complexity="SIMPLE",
+        stack="backend",
+        agents_run=["PATCH"],
+        codex_overturned={"state": "BADSTATE", "category": "auth"},
+    )
+    rows = _read_metrics(project_dir)
+    row = rows[-1]
+    assert "codex_overturned" not in row
+
+    # Ensure none of the three calls raised.
+    # (Reaching this line proves no exception was raised above.)
+
+
+# ── Test 3: Backward-compatibility (AC3) ────────────────────────────────────
+
+
+def test_backward_compatibility(project_dir, tmp_path):
+    """Pre-change records survive unchanged; new records carry decision fields (AC3)."""
+    source_dir = project_dir / ".claude" / "memory"
+    global_dir = tmp_path / "global"
+
+    # Write a legacy record (no decision fields) via raw write to simulate a
+    # pre-change record that would have been written before issue #217.
+    _write_raw_metrics(project_dir, [
+        {
+            "issue": 100,
+            "date": "2026-01-01",
+            "recorded_at": "2026-01-01T10:00:00.000000Z",
+            "status": "PASS",
+            "complexity": "TRIVIAL",
+            "stack": "backend",
+            "agents_run": ["PATCH"],
+            "project": "agents",
+        }
+    ])
+
+    # Write a record with decision fields for a different issue.
+    record_metrics(
+        project_dir,
+        issue=200,
+        status="PASS",
+        complexity="SIMPLE",
+        stack="backend",
+        agents_run=["MAP", "PATCH", "PROVE"],
+        tier_corrected_to="COMPLEX",
+        guards_fired=["ENUM_VALUE"],
+        codex_overturned={"state": "confirmed", "category": "migration"},
+    )
+
+    aggregate("metrics", [source_dir], global_dir)
+    global_rows = _read_global_metrics(global_dir)
+
+    issue100 = next(r for r in global_rows if r["issue"] == 100)
+    issue200 = next(r for r in global_rows if r["issue"] == 200)
+
+    # Old record must not gain spurious new keys.
+    assert "tier_corrected_to" not in issue100
+    assert "guards_fired" not in issue100
+    assert "codex_overturned" not in issue100
+
+    # New record's decision fields must survive the rollup.
+    assert issue200["tier_corrected_to"] == "COMPLEX"
+    assert issue200["guards_fired"] == ["ENUM_VALUE"]
+    assert issue200["codex_overturned"] == {"state": "confirmed", "category": "migration"}
+
+
+# ── Test 4: Field-level dedup collision (AC4b, TAUTOLOGY GUARD) ─────────────
+
+
+def test_dedup_collision(project_dir, tmp_path):
+    """Field retained when newest-recorded_at winner for a key lacks it (AC4b).
+
+    This test is intentionally written to FAIL against the pre-fix
+    `seen[key] = record` last-wins code in aggregate_metrics_to_global.py.
+    It verifies the field-level carry-forward added in issue #217.
+    """
+    source_dir = project_dir / ".claude" / "memory"
+    global_dir = tmp_path / "global"
+
+    # Record A: older timestamp, HAS tier_corrected_to.
+    _write_raw_metrics(project_dir, [
+        {
+            "issue": 5,
+            "date": "2026-01-01",
+            "recorded_at": "2026-01-01T10:00:00.000000Z",
+            "status": "PASS",
+            "complexity": "SIMPLE",
+            "stack": "backend",
+            "agents_run": ["PATCH"],
+            "project": "agents",
+            "tier_corrected_to": "COMPLEX",
+        },
+        # Record B: newer timestamp (higher recorded_at), SAME key, NO tier_corrected_to.
+        # Under old last-wins code, B overwrites A entirely, losing tier_corrected_to.
+        {
+            "issue": 5,
+            "date": "2026-01-01",
+            "recorded_at": "2026-01-01T11:00:00.000000Z",
+            "status": "PASS",
+            "complexity": "SIMPLE",
+            "stack": "backend",
+            "agents_run": ["PATCH", "PROVE"],
+            "project": "agents",
+        },
+    ])
+
+    aggregate("metrics", [source_dir], global_dir)
+    global_rows = _read_global_metrics(global_dir)
+
+    # Only one record should exist for (issue=5, date=2026-01-01, project=agents).
+    issue5_rows = [r for r in global_rows if r["issue"] == 5]
+    assert len(issue5_rows) == 1
+
+    # The aggregated record MUST carry tier_corrected_to recovered from record A.
+    assert "tier_corrected_to" in issue5_rows[0], (
+        "tier_corrected_to was lost — field-level carry-forward not working. "
+        "This test is designed to FAIL against the pre-fix last-wins code."
+    )
+    assert issue5_rows[0]["tier_corrected_to"] == "COMPLEX"
+
+
+# ── Test 5: Write→read per-host re-tier rate (AC6a) ─────────────────────────
+
+
+def test_retier_rate_write_read(project_dir, tmp_path):
+    """tier_corrected_to flows from write through aggregate to agent_metrics() (AC6a)."""
+    source_dir = project_dir / ".claude" / "memory"
+    # Global dir is what agent_metrics reads — we point project= at tmp_path/global.
+    global_dir = tmp_path / "global_mem" / ".claude" / "memory"
+
+    # Two SIMPLE records: one re-tiered, one not.
+    record_metrics(
+        project_dir,
+        issue=301,
+        status="PASS",
+        complexity="SIMPLE",
+        stack="backend",
+        agents_run=["PATCH"],
+        tier_corrected_to="COMPLEX",  # re-tiered
+    )
+    record_metrics(
+        project_dir,
+        issue=302,
+        status="PASS",
+        complexity="SIMPLE",
+        stack="backend",
+        agents_run=["PATCH"],
+        # no re-tier
+    )
+    # One TRIVIAL record, no re-tier.
+    record_metrics(
+        project_dir,
+        issue=303,
+        status="PASS",
+        complexity="TRIVIAL",
+        stack="backend",
+        agents_run=["PATCH"],
+    )
+
+    aggregate("metrics", [source_dir], global_dir)
+
+    result = agent_metrics(period="all", project=str(tmp_path / "global_mem"))
+
+    rtr = result["per_host_re_tier_rate"]
+    assert rtr["SIMPLE"]["retier_count"] == 1
+    assert rtr["SIMPLE"]["total"] == 2
+    assert rtr["SIMPLE"]["rate"] == 0.5
+    assert rtr["TRIVIAL"]["retier_count"] == 0
+
+
+# ── Test 6: guards_fired variance (AC6b) ────────────────────────────────────
+
+
+def test_guards_fired_variance(project_dir):
+    """Enum task includes ENUM_VALUE guard; non-enum backend task omits guards (AC6b)."""
+    # Enum-touching issue: guards should include ENUM_VALUE.
+    record_metrics(
+        project_dir,
+        issue=401,
+        status="PASS",
+        complexity="FULLSTACK",
+        stack="fullstack",
+        agents_run=["MAP", "PATCH", "PROVE"],
+        guards_fired=["ENUM_VALUE", "VERIFICATION_GAP"],
+    )
+    rows = _read_metrics(project_dir)
+    enum_row = rows[-1]
+    assert "guards_fired" in enum_row
+    assert "ENUM_VALUE" in enum_row["guards_fired"]
+
+    # Non-enum backend issue: no guards_fired argument at all.
+    record_metrics(
+        project_dir,
+        issue=402,
+        status="PASS",
+        complexity="SIMPLE",
+        stack="backend",
+        agents_run=["PATCH"],
+    )
+    rows = _read_metrics(project_dir)
+    no_enum_row = rows[-1]
+    assert "guards_fired" not in no_enum_row
+
+
+# ── Test 7: Size budget (AC7) ────────────────────────────────────────────────
+
+
+def test_size_budget():
+    """Representative record with all three fields fits within 4096 bytes (AC7)."""
+    rec = {
+        "issue": 9999,
+        "date": "2026-06-04",
+        "recorded_at": "2026-06-04T12:00:00.000000Z",
+        "status": "PASS",
+        "complexity": "COMPLEX",
+        "stack": "fullstack",
+        "agents_run": ["MAP", "PLAN", "CONTRACT", "PATCH", "PROVE"],
+        "duration_seconds": 3600,
+        "tier_corrected_to": "FULLSTACK",
+        "guards_fired": ["VERIFICATION_GAP", "ENUM_VALUE", "COMPONENT_API"],
+        "codex_overturned": {"state": "overturned", "category": "enum_contract"},
+    }
+    size = len(json.dumps(rec).encode("utf-8"))
+    assert size <= 4096, f"Record size {size} exceeds 4096-byte PIPE_BUF budget"

--- a/mcp-server/tools/agent_metrics.py
+++ b/mcp-server/tools/agent_metrics.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import json
 from collections import defaultdict
 from datetime import datetime, timedelta
-from pathlib import Path
 
 from .vault_common import get_project_memory_dir
 

--- a/mcp-server/tools/agent_metrics.py
+++ b/mcp-server/tools/agent_metrics.py
@@ -77,6 +77,15 @@ def agent_metrics(period: str | None = None, project: str | None = None) -> dict
 
     top_failures = sorted(cause_counts.items(), key=lambda x: -x[1])[:5]
 
+    # Per-host re-tier rate
+    by_complexity_retier: dict = defaultdict(lambda: {"retier_count": 0, "total": 0})
+    for r in records:
+        c = r.get("complexity", "UNKNOWN")
+        by_complexity_retier[c]["total"] += 1
+        corrected = r.get("tier_corrected_to")
+        if corrected and corrected != c:
+            by_complexity_retier[c]["retier_count"] += 1
+
     return {
         "period": period,
         "total_records": total,
@@ -95,4 +104,11 @@ def agent_metrics(period: str | None = None, project: str | None = None) -> dict
             for k, v in sorted(by_stack.items())
         },
         "top_failures": [{"cause": c, "count": n} for c, n in top_failures],
+        "per_host_re_tier_rate": {
+            k: {
+                **v,
+                "rate": round(v["retier_count"] / v["total"], 3) if v["total"] else 0,
+            }
+            for k, v in sorted(by_complexity_retier.items())
+        },
     }


### PR DESCRIPTION
Implements **#217** (spec: PR #216, `docs/rec0-outcome-log-decision-fields-spec.md` v0.5).

## What
- **`state_manager.record_metrics()`** — 3 optional keyword-only fields: `tier_corrected_to` (ACTIVE), `guards_fired[]` + `codex_overturned` (DORMANT on a frozen schema). Include-only-if-supplied; fail-open validation (`_VALID_GUARDS` / `_VALID_CODEX_STATES` / `_VALID_CODEX_CATEGORIES`).
- **`aggregate_metrics_to_global.py`** — field-level carry-forward dedup for the decision-provenance fields (newest-`recorded_at` base + carry-forward from the newest donor; mutable values copied, not aliased).
- **`agent_metrics.py`** — per-host re-tier-rate reader from the local rollup `~/.claude/memory/metrics.jsonl`.
- **`test_state_manager_decision_fields.py`** — 7 tests (spec §9).

## Verification
- **33/33 tests green**, ruff clean.
- **Tautology guard (AC4b) empirically proven** — PROVE stashed the dedup fix → `test_dedup_collision` *failed* on old last-wins code (`tier_corrected_to was lost`) → restored → passed.
- **9/9 ACs** implemented (no AC-FORBIDS-APPROVE downgrade).

## Review trail
- Built via `/orchestrate` COMPLEX: MAP → PLAN → PLAN-CHECK (PASS) → PATCH → PROVE (PASS).
- **Codex adversarial pass** on the dedup logic found 3 BLOCKING (tie-break `>=`→`>`, carry-forward aliasing, `tier_corrected_to` truthiness) + 1 NON-BLOCKING (newest-donor) — all fixed in `eaa40b4`.
- Spec itself reviewed across 5 versions by 3 independent agents.

## Scope
In: per-host slice only. Out (sibling recs): cross-fleet message-hub sync (REC 0.1), low-tier `/quick` (REC 0.2), artifact-derived `guards_fired` (REC 1/3). `guards_fired`/`codex_overturned` ship DORMANT.

> ⚠️ **Merge held** — awaiting fleet cross-env re-validation of `eaa40b4` (Mac + WSL2) and the maintainer's merge call. Open as the review surface.

Closes #217.

🤖 Generated with [Claude Code](https://claude.com/claude-code)