### PR TITLE
docs(metrics): clarify per_host_re_tier_rate is single-host / by-original-tier

### DIFF
--- a/mcp-server/tools/agent_metrics.py
+++ b/mcp-server/tools/agent_metrics.py
@@ -76,7 +76,10 @@ def agent_metrics(period: str | None = None, project: str | None = None) -> dict
 
     top_failures = sorted(cause_counts.items(), key=lambda x: -x[1])[:5]
 
-    # Per-host re-tier rate
+    # Per-host re-tier rate. NOTE: "per-host" = THIS host only — the source is the
+    # local rollup (~/.claude/memory/metrics.jsonl), not a cross-machine view. The
+    # breakdown is grouped by ORIGINAL complexity tier (how often a tier got
+    # re-classified mid-flight), NOT by machine. Cross-fleet segmentation is REC 0.1.
     by_complexity_retier: dict = defaultdict(lambda: {"retier_count": 0, "total": 0})
     for r in records:
         c = r.get("complexity", "UNKNOWN")


### PR DESCRIPTION
1-line **comment-only** follow-up to #218 (REC 0).

Addresses Codex review finding #12 + the fleet's editorial ask: make explicit that `per_host_re_tier_rate` reads **this host's** local rollup and groups by **original complexity tier**, so it isn't misread as cross-machine segmentation (cross-fleet is REC 0.1).

No logic/test change — diff is comments only. 33/33 tests green, ruff clean.

Per the "merged SHA == validated SHA" discipline (Option A), this was deliberately kept off #218 so the merged implementation matched exactly what the fleet validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)