### PR TITLE
chore(agents): salvage stash-hygiene rule + poller refactor (#220 Wins A+B)

### DIFF
--- a/claude-config/launchd/README.md
+++ b/claude-config/launchd/README.md
@@ -1,0 +1,56 @@
+# launchd agents
+
+## `com.claude-learn-gate-poller.plist`
+
+A macOS launchd job that runs the telemetry → learn maintenance loop every
+**12 hours** (`StartInterval 43200`). It does not run at load (`RunAtLoad`
+false); the first run is one interval after it is bootstrapped.
+
+The job is a thin wrapper — all logic lives in
+[`../scripts/learn-gate-poller.sh`](../scripts/learn-gate-poller.sh) so it can
+be read, `bash -n`-checked, and edited **without re-deploying the plist**.
+
+### What each run does
+
+1. **Sync** — `git pull --ff-only` to pick up other machines' telemetry shards.
+2. **Gate + learn** — runs `telemetry_gate.py`; if the gate trips, applies
+   cross-project patterns via `claude --print "/learn --apply --cross-project
+   --validate"`.
+
+> **Win C (deferred)**: fixing the perpetually-dirty working tree caused by
+> `telemetry/<host>/*.jsonl` shards is tracked under issue #220 / REC 0.1 and
+> will be resolved in lockstep with that coordination effort. This script does
+> not stash or commit shards.
+
+### Why the script is separate
+
+Keeping the logic in `learn-gate-poller.sh` rather than inline in the plist
+means it is readable, syntax-checkable (`bash -n`), and editable without
+re-deploying the plist. Editing only the script requires no `launchctl` reload.
+
+### Deploy / reload
+
+The plist is **not** auto-installed by `install.sh`; deploy it manually. After
+editing **the plist** (not the script), redeploy and reload once:
+
+```bash
+cp claude-config/launchd/com.claude-learn-gate-poller.plist ~/Library/LaunchAgents/
+launchctl unload ~/Library/LaunchAgents/com.claude-learn-gate-poller.plist 2>/dev/null || true
+launchctl load   ~/Library/LaunchAgents/com.claude-learn-gate-poller.plist
+```
+
+Editing **only the script** (`learn-gate-poller.sh`) needs no reload — the
+plist execs it fresh each interval.
+
+### Observe
+
+```bash
+launchctl list | grep claude-learn-gate          # is it loaded?
+tail -f ~/Library/Logs/claude-learn/poller.log    # run-by-run log
+```
+
+To run once on demand (does not wait for the interval):
+
+```bash
+bash ~/agents/claude-config/scripts/learn-gate-poller.sh
+```

--- a/claude-config/launchd/com.claude-learn-gate-poller.plist
+++ b/claude-config/launchd/com.claude-learn-gate-poller.plist
@@ -6,21 +6,13 @@
     <key>Label</key>
     <string>com.claude-learn-gate-poller</string>
     <key>ProgramArguments</key>
+    <!-- Logic lives in claude-config/scripts/learn-gate-poller.sh so it is
+         readable/testable and editable without re-deploying this plist.
+         `bash -lc` = login shell so git/gh credential helpers are on PATH. -->
     <array>
         <string>/bin/bash</string>
         <string>-lc</string>
-        <string>
-          LOG="$HOME/Library/Logs/claude-learn/poller.log"
-          mkdir -p "$(dirname "$LOG")"
-          cd "$HOME/agents" \
-          &amp;&amp; git pull --ff-only --quiet 2&gt;&gt;"$LOG" \
-          &amp;&amp; python3 claude-config/scripts/telemetry_gate.py --verbose \
-               &gt;&gt;"$LOG" 2&gt;&amp;1 \
-          &amp;&amp; claude --print "/learn --apply --cross-project --validate" \
-               &gt;&gt;"$LOG" 2&gt;&amp;1 \
-          || echo "[$(date -Iseconds)] gate not tripped or pull failed — skip" \
-               &gt;&gt;"$LOG"
-        </string>
+        <string>exec "$HOME/agents/claude-config/scripts/learn-gate-poller.sh"</string>
     </array>
     <key>WorkingDirectory</key>
     <string>/Users/jasonjob/agents</string>

--- a/claude-config/rules/git-workflow.md
+++ b/claude-config/rules/git-workflow.md
@@ -111,3 +111,24 @@ Split into phased PRs, each leaving main in a working state:
 - Force push to shared branches
 - Skip CI with `--no-verify`
 - Merge without rebasing on latest main
+- `git stash` to clear the working tree and not restore it later (stash-and-forget).
+  If a dirty tree blocks a pull, see "Working tree hygiene" below.
+
+## Working tree hygiene in `~/agents` (autonomous runs)
+
+If uncommitted changes block a `git pull --ff-only`, never stash anonymously.
+Instead, **commit the WIP to a throwaway branch first** so it is recoverable:
+
+```bash
+git checkout -b wip/$(date +%Y%m%d)-<context>
+git add -A && git commit -m "wip: save state before reset"
+git checkout -        # return to the original branch
+```
+
+Rationale: anonymous stashes silently bury real work. Four orphaned stashes were
+found and cleaned up 2026-06-02 because unattended runs stashed to get a clean
+`pull --ff-only` and never restored. A named branch keeps every change recoverable.
+
+> Note: the perpetually-dirty-tree problem caused by telemetry shards
+> (`telemetry/<host>/*.jsonl`) is tracked as Win C under issue #220 and will be
+> resolved in lockstep with REC 0.1. Do not stash or commit shards unilaterally.

--- a/claude-config/scripts/learn-gate-poller.sh
+++ b/claude-config/scripts/learn-gate-poller.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# learn-gate-poller.sh — periodic maintenance for the ~/agents telemetry + learn loop.
+#
+# Invoked by launchd: com.claude-learn-gate-poller.plist (StartInterval 43200s = 12h).
+# Extracted from the plist's former inline command so the logic is readable,
+# testable (`bash -n`), and editable without re-deploying the plist.
+#
+# Responsibilities (each best-effort, none aborts the others):
+#   1. Sync the agents repo — ff-only pull of other machines' telemetry shards.
+#   2. Run the learn gate; if it trips, apply cross-project patterns via /learn.
+#
+# Win C (fixing the perpetually-dirty tree caused by telemetry/<host>/*.jsonl shards)
+# is tracked under issue #220 / REC 0.1 and is intentionally NOT handled here.
+# Do not stash or commit shards unilaterally — see rules/git-workflow.md,
+# "Working tree hygiene in ~/agents".
+
+set -uo pipefail   # deliberately NOT `-e`: every step is independently fault-tolerant
+
+REPO="$HOME/agents"
+LOG="$HOME/Library/Logs/claude-learn/poller.log"
+mkdir -p "$(dirname "$LOG")"
+ts()  { date -Iseconds; }
+log() { echo "[$(ts)] $*" >>"$LOG"; }
+
+cd "$REPO" || { log "FATAL: $REPO missing — aborting poller run"; exit 0; }
+
+# 1. Sync. ff-only preserves the existing safe semantics and tolerates a dirty
+#    own-shard (incoming changes touch other hosts' paths, not ours).
+git pull --ff-only --quiet 2>>"$LOG" || log "pull --ff-only failed (non-fatal)"
+
+# 2. Gate, then learn only if the gate trips (matches the former inline behaviour).
+if python3 claude-config/scripts/telemetry_gate.py --verbose >>"$LOG" 2>&1; then
+    claude --print "/learn --apply --cross-project --validate" >>"$LOG" 2>&1 \
+        || log "/learn run failed (non-fatal)"
+else
+    log "learn gate not tripped — skip /learn"
+fi
+
+log "poller run complete"


### PR DESCRIPTION
Implements **Wins A + B of #220** — the architecture-neutral salvage from closed PRs #210/#211, minus the git-push telemetry approach the message-hub decision (REC 0.1) superseded.

## Changes
- **`git-workflow.md`** (Win A) — ban *stash-and-forget*; document *commit WIP to a `wip/<date>-<context>` branch before any tree reset*. No "commit telemetry shards" guidance (that conflicted with the hub decision).
- **`scripts/learn-gate-poller.sh`** (new, Win B) — extract the launchd poller's inline XML into a readable, `bash -n`-testable script. **Steps 1–2 only** (ff-only pull, gate+learn); the rejected step 3 (commit+push shard) is omitted.
- **`com.claude-learn-gate-poller.plist`** — execs the script instead of an inline command.
- **`launchd/README.md`** (new) — documents steps 1–2; notes Win C deferred to REC 0.1.

## Built via
`/orchestrate` SIMPLE: MAP-PLAN → PATCH → PROVE (PASS). 33/33 tests green; `bash -n` clean; plist well-formed; verified no commit/push-telemetry logic leaked in.

## Scope
**Win C is NOT in this PR** — keeping the `~/agents` tree clean without committing telemetry data is a REC 0.1 coordination point (the existing `#195` git-sharded failures + tracked `jns-mac` shard must be retired in lockstep with the hub). #220 stays open for it.

> ⚠️ **Merge held** for the maintainer's call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)