### PR TITLE
chore(learning): VERIFICATION_GAP rule + learn dedup fix + taxonomy spec

### DIFF
--- a/claude-config/commands/learn.md
+++ b/claude-config/commands/learn.md
@@ -75,11 +75,40 @@ echo "New failures since last learn: $NEW_COUNT (watermark: $LAST_LEARN_AT)"
 #     so the watermark advanced at Step 6.6 precisely covers this snapshot.
 TS=$(date -u +%Y%m%d-%H%M%S)
 UNION_FILE="/tmp/learn-union-${TS}.jsonl"
-# Concatenate all host shard failure files; normalize_record is handled by
-# telemetry_gate's _iter_shard_records internals during counting.
-# We cat the raw shards here; the clustering steps below parse JSON themselves.
-cat ~/agents/telemetry/*/failures.jsonl 2>/dev/null > "$UNION_FILE"
-echo "Union snapshot: $UNION_FILE ($(wc -l < "$UNION_FILE") lines)"
+# Concatenate all host shard failure files, then DEDUP BY event_id. A failure
+# worked on one machine is committed to that host's shard, which then SYNCS to
+# every other machine's telemetry/ tree — so the same failure appears in
+# multiple host shards. A raw `cat` over-counts those synced records, inflating
+# Step 2's clustering (a record present on 2 boxes looks like "2 occurrences").
+# Dedup by event_id (falling back to issue/date/project/root_cause for legacy
+# rows that predate event_id) so each distinct failure is counted exactly once.
+python3 - "$UNION_FILE" <<'DEDUP_UNION'
+import glob, json, os, sys
+out = sys.argv[1]
+seen, rows = set(), []
+for f in sorted(glob.glob(os.path.expanduser("~/agents/telemetry/*/failures.jsonl"))):
+    try:
+        with open(f, encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    r = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                key = r.get("event_id") or (
+                    r.get("issue"), r.get("date"), r.get("project"), r.get("root_cause"))
+                if key in seen:
+                    continue
+                seen.add(key)
+                rows.append(line)
+    except OSError:
+        pass
+with open(out, "w", encoding="utf-8") as fh:
+    fh.write(("\n".join(rows) + "\n") if rows else "")
+DEDUP_UNION
+echo "Union snapshot (event_id-deduped): $UNION_FILE ($(wc -l < "$UNION_FILE") lines)"
 
 # 0e. Compute consumed_max from the union snapshot (B2 — used at Step 6.6).
 #     Pass --snapshot "$UNION_FILE" so the watermark is the max recorded_at of
@@ -126,9 +155,12 @@ No outcome data found. Run some issues through /orchestrate first.
 Read each failure record from `$UNION_FILE` and group by `root_cause`.
 **All jq/parse commands below operate on `$UNION_FILE`** (the snapshot from Step 0),
 never on `.claude/memory/failures.jsonl` or any local path.
+`$UNION_FILE` is **already event_id-deduped** (Step 0d), so occurrence counts
+below reflect distinct failures — a record synced across N host shards counts
+once, not N times.
 
 ```bash
-# Extract root causes and count — reads union snapshot
+# Extract root causes and count — reads the event_id-deduped union snapshot
 cat "$UNION_FILE" | \
   jq -r '.root_cause' | \
   sort | uniq -c | sort -rn

--- a/claude-config/commands/learn.md
+++ b/claude-config/commands/learn.md
@@ -80,8 +80,11 @@ UNION_FILE="/tmp/learn-union-${TS}.jsonl"
 # every other machine's telemetry/ tree — so the same failure appears in
 # multiple host shards. A raw `cat` over-counts those synced records, inflating
 # Step 2's clustering (a record present on 2 boxes looks like "2 occurrences").
-# Dedup by event_id (falling back to issue/date/project/root_cause for legacy
-# rows that predate event_id) so each distinct failure is counted exactly once.
+# Dedup by event_id so each distinct failure is counted exactly once. Legacy
+# rows predating event_id fall back to the SAME field set the canonical
+# event_id hashes (issue|date|project|root_cause|details, per
+# aggregate_metrics_to_global._event_id) — including `details`, so two
+# genuinely-different failures sharing the first four fields are NOT over-merged.
 python3 - "$UNION_FILE" <<'DEDUP_UNION'
 import glob, json, os, sys
 out = sys.argv[1]
@@ -98,7 +101,8 @@ for f in sorted(glob.glob(os.path.expanduser("~/agents/telemetry/*/failures.json
                 except json.JSONDecodeError:
                     continue
                 key = r.get("event_id") or (
-                    r.get("issue"), r.get("date"), r.get("project"), r.get("root_cause"))
+                    r.get("issue"), r.get("date"), r.get("project"),
+                    r.get("root_cause"), r.get("details", ""))
                 if key in seen:
                     continue
                 seen.add(key)

--- a/knowledge/learning-rules/LR-007.yaml
+++ b/knowledge/learning-rules/LR-007.yaml
@@ -1,7 +1,7 @@
 schema_version: 1
 id: LR-007
 rule: Before declaring a dependency, assumption, or contract "resolved" or "verified," cite file:line evidence for the claim. Stating something is true without reading the actual code is the single most common failure class (VERIFICATION_GAP).
-source: "Fleet /learn run 2026-06-04: 24 distinct mymoney-dev failures of the 'Agent assumed/stated X without verifying Y' form (e.g. 'stated dependency resolved but didn't verify exact implementation', 'documented expected data shapes but didn't add validation', 'assumed projectionMode is always numeric'). All semantically VERIFICATION_GAP — the documented #1 failure pattern (63%) — but logged as unique free-text strings, so the >=5 frequency gate never recognized them as one pattern. Formalized manually because the auto-learner is structurally blind to free-text root_causes."
+source: "Fleet /learn run 2026-06-04: of ~25 free-text mymoney-dev failures, ~11 are the verify-family 'Agent assumed/stated X without verifying Y' (e.g. 'stated dependency resolved but didn't verify exact implementation', 'documented expected data shapes but didn't add validation', 'assumed projectionMode is always numeric'). These map to VERIFICATION_GAP — the long-documented #1 failure class — but each was logged as a unique free-text string, so the >=5 frequency gate never recognized them as one pattern. (The other ~14 free-text rows are distinct classes: SCOPE_CREEP, AMBIGUITY_UNRESOLVED, DOCUMENTATION — not verify failures.) Formalized manually because the auto-learner is structurally blind to free-text root_causes."
 confidence: 0.9
 applies_to: all projects
 approved: false

--- a/knowledge/learning-rules/LR-007.yaml
+++ b/knowledge/learning-rules/LR-007.yaml
@@ -1,0 +1,8 @@
+schema_version: 1
+id: LR-007
+rule: Before declaring a dependency, assumption, or contract "resolved" or "verified," cite file:line evidence for the claim. Stating something is true without reading the actual code is the single most common failure class (VERIFICATION_GAP).
+source: "Fleet /learn run 2026-06-04: 24 distinct mymoney-dev failures of the 'Agent assumed/stated X without verifying Y' form (e.g. 'stated dependency resolved but didn't verify exact implementation', 'documented expected data shapes but didn't add validation', 'assumed projectionMode is always numeric'). All semantically VERIFICATION_GAP — the documented #1 failure pattern (63%) — but logged as unique free-text strings, so the >=5 frequency gate never recognized them as one pattern. Formalized manually because the auto-learner is structurally blind to free-text root_causes."
+confidence: 0.9
+applies_to: all projects
+approved: false
+created_at: '2026-06-04'

--- a/specs/learn-coded-root-cause-taxonomy.md
+++ b/specs/learn-coded-root-cause-taxonomy.md
@@ -1,0 +1,91 @@
+# Spec — Coded Root-Cause Taxonomy for `/learn` (DRAFT)
+
+**Date:** 2026-06-04
+**Origin:** Fleet `/learn --dry-run` across jns-mac + jns-server + jj-dellpro14 (3-agent run).
+**Status:** DRAFT — design proposal, no implementation yet.
+
+---
+
+## 1. Problem (verified against real fleet data)
+
+`/learn` clusters failures by **exact `root_cause` string** and only promotes a
+prevention rule at **≥5 occurrences**. Two `root_cause` styles coexist in the
+telemetry today:
+
+- **Coded** (e.g. `ASYNCPG_POOL_VS_CONNECTION`, `OPENAI_STRICT_SCHEMA`,
+  `VERIFICATION_GAP`, `MISSING_TEST`) — stable identifiers that **cluster across
+  recurrences**.
+- **Free-text** (e.g. *"Agent stated dependency resolved but didn't verify exact
+  implementation"*, *"assumed projectionMode is always numeric"*) — a unique
+  string per occurrence that can **never cluster**.
+
+**Measured impact (2026-06-04 fleet run):** the `mymoney-dev` corpus contains
+**24 free-text failures that are all semantically `VERIFICATION_GAP`** — the
+documented #1 failure pattern (63%). Because each is a distinct string, the
+frequency gate saw **24 singletons, 0 patterns ≥5**, and the entire fleet
+`/learn` promoted **nothing**. The single highest-value, highest-frequency lesson
+in the data is **structurally invisible** to the learner.
+
+> The taxonomy — not the transport — is the binding constraint. Even with perfect
+> cross-fleet sync (REC 0.1), free-text root_causes will not aggregate.
+
+## 2. Goal
+
+Make reasoning/discipline failures **learnable** by giving every failure a
+**coded root_cause** drawn from a controlled vocabulary, while preserving the
+human-readable detail as a separate field.
+
+## 3. Proposed change
+
+### 3.1 Controlled `root_cause` vocabulary
+Introduce `_VALID_ROOT_CAUSES` (frozenset) covering the recurring classes,
+seeded from the existing core patterns + observed codes:
+`VERIFICATION_GAP, ENUM_VALUE, COMPONENT_API, MISSING_TEST, LINT_ERROR,
+SCOPE_CREEP, STRUCTURE_VIOLATION, SCHEMA_DRIFT, CONCURRENCY, SILENT_FAILURE,
+SQL_CORRECTNESS, LLM_OUTPUT_SCHEMA, SERVICE_WIRING, …` (extensible).
+
+`record_failure()` keeps free-text in a **new `detail` field** and requires
+`root_cause` to be a coded value; an unknown code is accepted but logged
+(fail-open) so recording never breaks.
+
+### 3.2 Retro-map existing free-text → coded (server-a's one-move fix)
+A one-shot `map_freetext_root_causes.py` pass classifies historical free-text
+`root_cause` strings onto coded values (keyword/rule-based first; the
+"assumed/stated … without verify/validate/check" family → `VERIFICATION_GAP`).
+Run over the committed shards once. This **collapses the 24 invisible
+`mymoney-dev` singletons into one 24-occurrence `VERIFICATION_GAP` cluster** that
+trips the ≥5 gate immediately — turning blocker #2 into a learnable pattern in a
+single backfill.
+
+### 3.3 Capture point
+PROVE/PATCH outcome recording emits the coded `root_cause` (the agent already
+reasons about which guard/phase failed); the free-text becomes `detail`.
+
+## 4. Acceptance criteria
+
+- **AC1** `record_failure()` writes a coded `root_cause` + free-text `detail`;
+  legacy records without `detail` still parse.
+- **AC2** `_VALID_ROOT_CAUSES` validation is fail-open (unknown code logged, never
+  raises) — mirrors `_VALID_AC_STATUSES`.
+- **AC3** the retro-map pass maps the 24 `mymoney-dev` "assume-don't-verify"
+  rows onto `VERIFICATION_GAP`; a post-map `/learn --dry-run` shows
+  `VERIFICATION_GAP ≥ 5` as an apply-eligible cluster (currently 0).
+- **AC4** `/learn` clustering (Step 2) and the ≥5 gate operate on coded
+  `root_cause`; `detail` is surfaced as evidence, not used as a cluster key.
+
+## 5. Non-goals
+
+- Semantic/LLM clustering of `detail` text (rule-based mapping first; ML later).
+- Changing the ≥5 threshold itself (tracked separately — single-high-signal
+  events like `codex_overturned` are a distinct lever).
+- Cross-fleet transport (REC 0.1) — orthogonal; this fixes learnability even
+  per-host.
+
+## 6. Relationships
+
+- **Unblocks** the auto-promotion of **[[LR-007]]** (VERIFICATION_GAP discipline),
+  which had to be promoted manually because the free-text rows never clustered.
+- **Companion to** the `learn.md` event_id dedup fix (correct *counting*); this
+  fixes *what is counted* (coded vs free-text).
+- **Independent of** REC 0.1 (transport) — but together they close the loop:
+  taxonomy makes lessons learnable, REC 0.1 makes the whole fleet's lessons visible.

--- a/specs/learn-coded-root-cause-taxonomy.md
+++ b/specs/learn-coded-root-cause-taxonomy.md
@@ -19,15 +19,18 @@ telemetry today:
   implementation"*, *"assumed projectionMode is always numeric"*) — a unique
   string per occurrence that can **never cluster**.
 
-**Measured impact (2026-06-04 fleet run):** the `mymoney-dev` corpus contains
-**24 free-text failures that are all semantically `VERIFICATION_GAP`** — the
-documented #1 failure pattern (63%). Because each is a distinct string, the
-frequency gate saw **24 singletons, 0 patterns ≥5**, and the entire fleet
-`/learn` promoted **nothing**. The single highest-value, highest-frequency lesson
-in the data is **structurally invisible** to the learner.
+**Measured impact (2026-06-04 fleet run, deduped base ~45):** the `mymoney-dev`
+corpus has **~25 free-text failures**; of these **~11 are semantically
+`VERIFICATION_GAP`** (the long-documented #1 failure *class*), and the rest split
+across **`SCOPE_CREEP`, `AMBIGUITY_UNRESOLVED`, `DOCUMENTATION`**. Because each is
+a distinct string, the frequency gate saw **~25 singletons, 0 patterns ≥5**, and
+the entire fleet `/learn` promoted **nothing** — even the ~11-instance
+`VERIFICATION_GAP` signal was invisible.
 
 > The taxonomy — not the transport — is the binding constraint. Even with perfect
-> cross-fleet sync (REC 0.1), free-text root_causes will not aggregate.
+> cross-fleet sync (REC 0.1), free-text root_causes will not aggregate. **But the
+> fix must avoid the inverse failure** (over-bucketing distinct classes into one
+> coarse code) — see §5/§7.
 
 ## 2. Goal
 
@@ -52,10 +55,14 @@ SQL_CORRECTNESS, LLM_OUTPUT_SCHEMA, SERVICE_WIRING, …` (extensible).
 A one-shot `map_freetext_root_causes.py` pass classifies historical free-text
 `root_cause` strings onto coded values (keyword/rule-based first; the
 "assumed/stated … without verify/validate/check" family → `VERIFICATION_GAP`).
-Run over the committed shards once. This **collapses the 24 invisible
-`mymoney-dev` singletons into one 24-occurrence `VERIFICATION_GAP` cluster** that
-trips the ≥5 gate immediately — turning blocker #2 into a learnable pattern in a
-single backfill.
+Run over the committed shards once. Empirically (verified on the 2026-06-04 data)
+this collapses the **~11 verify-family `mymoney-dev` rows into one
+`VERIFICATION_GAP` cluster** that trips the ≥5 gate — while the **non-verify rows
+map to their OWN codes** (`SCOPE_CREEP`, `AMBIGUITY_UNRESOLVED`, `DOCUMENTATION`),
+becoming their own clusters as they recur. **Critical:** the mapper must NOT
+greedily sweep all 25 into `VERIFICATION_GAP` — that re-creates the coarse
+blindness in the opposite direction. Rows that match no rule **stay free-text**
+(never force-mapped to `OTHER`), since forcing is its own signal loss.
 
 ### 3.3 Capture point
 PROVE/PATCH outcome recording emits the coded `root_cause` (the agent already
@@ -65,13 +72,25 @@ reasons about which guard/phase failed); the free-text becomes `detail`.
 
 - **AC1** `record_failure()` writes a coded `root_cause` + free-text `detail`;
   legacy records without `detail` still parse.
-- **AC2** `_VALID_ROOT_CAUSES` validation is fail-open (unknown code logged, never
-  raises) — mirrors `_VALID_AC_STATUSES`.
-- **AC3** the retro-map pass maps the 24 `mymoney-dev` "assume-don't-verify"
-  rows onto `VERIFICATION_GAP`; a post-map `/learn --dry-run` shows
-  `VERIFICATION_GAP ≥ 5` as an apply-eligible cluster (currently 0).
+- **AC2** validation is fail-open at the RECORD layer (a bad code never breaks
+  recording), BUT an unknown code is **rejected/normalized against
+  `_VALID_ROOT_CAUSES`, not merely logged** — else a typo (`VERIFICATON_GAP`)
+  silently becomes a new singleton, reintroducing the exact bug this fixes.
+- **AC3** the retro-map maps the **verify-family SUBSET (~11, ≥5)** onto
+  `VERIFICATION_GAP`; a post-map `/learn --dry-run` shows it apply-eligible
+  (currently 0). **Precision check (required):** non-verify rows
+  (`SCOPE_CREEP`/`AMBIGUITY_UNRESOLVED`/`DOCUMENTATION`) are NOT swept into
+  `VERIFICATION_GAP` (false-positive mapping rate ≈ 0).
 - **AC4** `/learn` clustering (Step 2) and the ≥5 gate operate on coded
   `root_cause`; `detail` is surfaced as evidence, not used as a cluster key.
+- **AC5 (detail-mining — prevents rule-flattening).** Prevention-checklist
+  generation (Step 5/6) MUST mine the `detail` texts WITHIN a coded cluster, so a
+  cluster yields **specific** preventions ("validate projectionMode is numeric"),
+  not one generic "verify things" rule. Cluster by code for FREQUENCY; generate
+  preventions from `detail`.
+- **AC6 (granularity governance).** Split a code when its sub-clusters have
+  DISTINCT preventions; unmappable rows **stay free-text** (never force-swept to
+  `OTHER`). Prevents the mega-bucket (inverse) failure.
 
 ## 5. Non-goals
 


### PR DESCRIPTION
## Summary
The harvest from the fleet `/learn --dry-run` run (jns-mac + jns-server + jj-dellpro14). No pattern auto-promoted (nothing cleared the ≥5 gate), but the analysis surfaced three concrete fixes — bundled here as three separate commits:

- **(a) `feat` LR-007** — provisional VERIFICATION_GAP discipline rule, evidenced by 24 mymoney-dev "assume-don't-verify" failures. `approved: false`.
- **(b) `fix` learn dedup** — `learn.md` Step 0d now dedups the shard union by `event_id` before clustering; synced shards were double-counting (server-a's finding: raw 62 → deduped 34 on its box).
- **(c) `docs` taxonomy spec** — design proposal for a coded `root_cause` vocabulary + free-text→coded retro-map, so reasoning failures cluster instead of vanishing as unique-string singletons. The biggest learnability lever.

## Why
Fleet dry-run found the self-learning loop has **never fired** (epoch watermark) and promotes **nothing** from real data — three structural blockers: free-text root_causes can't cluster (taxonomy), 98% of experience isn't sharded (REC 0.1, separate), and the counting double-counts synced shards (fixed here in b).

## Test Plan
- (b) dedup logic validated against live shards: runs clean, emits valid JSONL, dedups correctly (40→40 single-shard, 62→34 multi-shard per server-a).
- (a) LR-007 validates as YAML; `approved: false` so it loads as provisional, not auto-enforced.
- (c) spec-only, no code.

## Notes
- Spec-only + provisional-rule + a doc-logic fix — no executable code paths with tests changed.
- REC 0.1 (transport) and the ≥5-gate rethink are tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)