### PR TITLE
feat(learn): wire read-side retro-map taxonomy into /learn clustering

### DIFF
--- a/claude-config/commands/learn.md
+++ b/claude-config/commands/learn.md
@@ -164,10 +164,18 @@ below reflect distinct failures — a record synced across N host shards counts
 once, not N times.
 
 ```bash
-# Extract root causes and count — reads the event_id-deduped union snapshot
-cat "$UNION_FILE" | \
-  jq -r '.root_cause' | \
-  sort | uniq -c | sort -rn
+# Cluster by CODED root_cause via the retro-map (READ-SIDE — raw telemetry is
+# never mutated). Free-text causes are mapped onto coded classes so semantically
+# identical failures (the "assume-without-verify" family -> VERIFICATION_GAP)
+# cluster instead of appearing as unique-string singletons. Unmatched free-text
+# stays UNMAPPED (surfaced as signal, never force-bucketed -> worst case is
+# "not learned yet", never "learned wrong").
+python3 ~/agents/claude-config/scripts/map_freetext_root_causes.py "$UNION_FILE"
+
+# AUDIT the mapping (which raw strings landed in a code) before trusting a cluster:
+#   python3 ~/agents/claude-config/scripts/map_freetext_root_causes.py "$UNION_FILE" --mine VERIFICATION_GAP
+# Raw uncoded view (compare / spot classifier gaps):
+#   cat "$UNION_FILE" | jq -r '.root_cause' | sort | uniq -c | sort -rn
 ```
 
 Expected output:
@@ -183,6 +191,19 @@ Expected output:
 ### Step 3: Analyze Each Cluster
 
 For each root cause with 3+ occurrences:
+
+#### 3a-detail. Mine `detail` for SPECIFIC preventions (anti-flattening)
+
+A coded cluster is grouped for **frequency**, but the prevention checklist must be
+**specific** — generated from the original free-text within the cluster, NOT one
+generic rule. Cluster by code for counting; generate preventions from `detail`:
+
+```bash
+# The distinct preventions inside a coded cluster (one specific item per root cause):
+python3 ~/agents/claude-config/scripts/map_freetext_root_causes.py "$UNION_FILE" --mine VERIFICATION_GAP
+# e.g. -> "validate projectionMode is numeric", "verify column dependencies",
+#         "validate label semantics match data" — 11 specific items, not one vague rule.
+```
 
 #### 3a. Extract Common Attributes
 

--- a/claude-config/scripts/map_freetext_root_causes.py
+++ b/claude-config/scripts/map_freetext_root_causes.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Retro-map free-text root_causes onto a coded taxonomy for /learn clustering.
+
+READ-SIDE ONLY: this classifies records for clustering/counting. It never
+mutates telemetry — record_failure still writes raw free-text. A failure to
+classify is SAFE: the row stays UNMAPPED (surfaced as signal), never
+force-bucketed. Worst case is "not learned yet", never "learned wrong".
+
+Discriminator: a `root_cause` with NO spaces is treated as already-coded
+(passed through, upper-cased). A `root_cause` WITH spaces is free-text and is
+matched against conservative keyword rules; an unmatched free-text row -> UNMAPPED.
+
+Usage:
+  map_freetext_root_causes.py <union.jsonl>            # cluster counts (Step 2)
+  map_freetext_root_causes.py <union.jsonl> --mine CODE # detail texts in a cluster (Step 5)
+  map_freetext_root_causes.py <union.jsonl> --json      # structured {code: [details]}
+"""
+import json
+import re
+import sys
+from collections import defaultdict
+
+# Frozen seed vocab — conservative keyword rules. Order matters: first match wins.
+# Extend deliberately (decision 3 governance): a new code is minted only when an
+# UNMAPPED cluster recurs with a genuinely distinct prevention.
+RULES = [
+    # Conservative: clear verify/validate/check signals only. Borderline rows
+    # (e.g. "copied verbatim without understanding") deliberately fall through to
+    # UNMAPPED rather than being force-mapped here — surfacing as signal is safer
+    # than over-bucketing into VERIFICATION_GAP.
+    ("VERIFICATION_GAP", [r"assum", r"without (verif|validat|check)", r"didn'?t verif",
+                          r"didn'?t validate", r"didn'?t add validation", r"didn'?t check",
+                          r"stated .*resolved", r"defensive comment without"]),
+    ("SCOPE_CREEP", [r"only implemented", r"missed implicit", r"didn'?t consider",
+                     r"secondary (deficit|scenario|type)"]),
+    ("AMBIGUITY_UNRESOLVED", [r"both interpretations", r"identified contradiction",
+                              r"didn'?t pick", r"failed to resolve", r"didn'?t call out"]),
+    ("DOCUMENTATION", [r"didn'?t document", r"didn'?t specify"]),
+]
+
+_TOKEN_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_]+$")  # no spaces => already coded
+
+
+def classify(root_cause):
+    """Map a root_cause string to a coded value, or 'UNMAPPED' (fail-safe)."""
+    if not root_cause or not root_cause.strip() or root_cause.strip() == "?":
+        return "UNMAPPED"
+    rc = root_cause.strip()
+    if _TOKEN_RE.match(rc):          # already a code (any case) -> normalize, pass through
+        return rc.upper()
+    low = rc.lower()
+    for code, pats in RULES:
+        if any(re.search(p, low) for p in pats):
+            return code
+    return "UNMAPPED"                # conservative default: never force-bucket
+
+
+def cluster(path):
+    """Return {code: [original_root_cause, ...]} from a union JSONL file."""
+    clusters = defaultdict(list)
+    with open(path, encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                r = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            rc = r.get("root_cause", "?")
+            clusters[classify(rc)].append(rc)
+    return clusters
+
+
+def main(argv):
+    if not argv:
+        print(__doc__)
+        return 1
+    path = argv[0]
+    clusters = cluster(path)
+    if "--json" in argv:
+        print(json.dumps({k: v for k, v in clusters.items()}, indent=2))
+        return 0
+    if "--mine" in argv:
+        code = argv[argv.index("--mine") + 1]
+        # Detail-mining: the specific (deduped) preventions inside a coded cluster.
+        for detail in sorted(set(clusters.get(code.upper(), []))):
+            print(detail)
+        return 0
+    # Default: cluster counts, apply-eligibility flagged (>=5, excluding UNMAPPED).
+    for code, members in sorted(clusters.items(), key=lambda x: -len(x[1])):
+        flag = "  <== APPLY-ELIGIBLE (>=5)" if len(members) >= 5 and code != "UNMAPPED" else ""
+        print(f"{len(members):4}  {code}{flag}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/claude-config/scripts/map_freetext_root_causes.py
+++ b/claude-config/scripts/map_freetext_root_causes.py
@@ -38,16 +38,41 @@ RULES = [
     ("DOCUMENTATION", [r"didn'?t document", r"didn'?t specify"]),
 ]
 
-_TOKEN_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_]+$")  # no spaces => already coded
+# Recognized coded vocabulary (seed). A spaceless token is treated as a code
+# ONLY if it is a known member here — otherwise it falls through to UNMAPPED.
+# This enforces the spec's typo-guard (a typo'd code like "VERIFICATON_GAP" is
+# NOT in the set, so it surfaces as UNMAPPED instead of becoming a phantom code)
+# and blocks lowercase single words ("regression") from being promoted to fake
+# codes. Extend deliberately (decision-3 governance): a new code earns a slot
+# here only when an UNMAPPED cluster recurs with a genuinely distinct prevention.
+_VALID_ROOT_CAUSES = frozenset({
+    # mapped-from-free-text classes
+    "VERIFICATION_GAP", "SCOPE_CREEP", "AMBIGUITY_UNRESOLVED", "DOCUMENTATION",
+    # agent-emitted codes observed in telemetry
+    "ENUM_VALUE", "COMPONENT_API", "MISSING_TEST", "LINT_ERROR", "MULTI_MODEL",
+    "STUB_HANDLERS", "ASYNCPG_POOL_VS_CONNECTION", "PIPECAT_PIPELINE_DEADLOCK",
+    "OPENAI_STRICT_SCHEMA", "LLM_OUTPUT_SCHEMA", "SQL_RESERVED_WORD",
+    "WRONG_TABLE_NAME", "INVALID_SQL_CONSTRUCT", "MISSING_SERVICE_WIRING",
+    "WRONG_CONN_ID_SCOPE", "MISSING_INTERFACE_METHODS", "SEQUENTIAL_IO",
+    "BLOCKING_FIRE_AND_FORGET", "PATH_EXPANSION", "SERVER_DEP_MANAGEMENT",
+    "STRUCTURE_VIOLATION", "LEGACY_COMPOUND",
+})
 
 
 def classify(root_cause):
-    """Map a root_cause string to a coded value, or 'UNMAPPED' (fail-safe)."""
+    """Map a root_cause string to a coded value, NO_ROOT_CAUSE, or UNMAPPED.
+
+    - empty / missing / "?"          -> NO_ROOT_CAUSE  (recording noise, not signal)
+    - spaceless KNOWN-vocab token    -> that code      (case-normalized pass-through)
+    - free-text matching a rule      -> the matched code
+    - anything else (incl. unknown spaceless tokens / typo'd codes) -> UNMAPPED
+      (surfaced for governance; never force-bucketed)
+    """
     if not root_cause or not root_cause.strip() or root_cause.strip() == "?":
-        return "UNMAPPED"
+        return "NO_ROOT_CAUSE"
     rc = root_cause.strip()
-    if _TOKEN_RE.match(rc):          # already a code (any case) -> normalize, pass through
-        return rc.upper()
+    if " " not in rc and rc.upper() in _VALID_ROOT_CAUSES:
+        return rc.upper()            # recognized code -> normalize, pass through
     low = rc.lower()
     for code, pats in RULES:
         if any(re.search(p, low) for p in pats):


### PR DESCRIPTION
## Summary
The **cheap half** of the coded-taxonomy spec, wired live into `/learn` (decision: build now, don't shelve). Read-side retro-map that makes reasoning-failures learnable.

- `map_freetext_root_causes.py` — classifies free-text `root_cause` onto coded classes (conservative keyword rules; unmatched → UNMAPPED, never force-bucketed).
- `learn.md` Step 2 clusters on the **coded** value; Step 3a-detail **mines `detail` within a cluster** for specific preventions (anti-flattening).

## Proven on real telemetry (40 deduped failures)
```
 11  VERIFICATION_GAP  <== APPLY-ELIGIBLE (>=5)   # was 11 invisible singletons
  3  AMBIGUITY_UNRESOLVED / 2 SCOPE_CREEP / 2 DOCUMENTATION   # own codes, NOT over-bucketed
  3  UNMAPPED   # incl. borderline 'copied without understanding' — surfaced, not forced
```
Detail-mining yields 11 **specific** preventions ('validate projectionMode is numeric', 'verify column dependencies', …), not one generic rule.

## Safety (why wiring it live is low-risk)
- **Read-side only** — `record_failure` unchanged; raw telemetry never mutated.
- **Fail-safe** — unmatched → UNMAPPED; worst case 'not learned yet', never 'learned wrong'.
- **Auditable** — `--mine CODE` + the raw `jq` view stay available; `/learn` is `--dry-run` by default, prints the mapping before any `--apply`.
- Scope: read-side retro-map only. Record-time taxonomy + governance (spec §3.1/§4) deferred until REC 0.1 brings more data.

## Test Plan
- Script compiles; run on live shards reproduces the cluster table above + detail-mining.
- Conservative rules verified: borderline rows stay UNMAPPED (no over-bucketing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)