### PR TITLE
feat(google): central OAuth credential helper for all agents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,9 @@ claude-config/skills/email-digest/recipients.json
 # M365 credentials (defense in depth — should never be in repo anyway)
 m365/*.json
 m365/*-cache.bin
+
+# Google / Gmail OAuth credentials (central set for all agents; never commit)
+# Ignore secrets (client + token, incl. legacy subdir) but keep helper code tracked.
+google/*.json
+google/**/*.json
+google/*.bin

--- a/google/README.md
+++ b/google/README.md
@@ -1,0 +1,95 @@
+# Central Google credentials (`~/agents/google`)
+
+**One Google authorization for every agent on a machine.** Re-auth once, send/read
+from anywhere, no per-tool credential sprawl.
+
+## Layout
+
+| File | Tracked in git? | What it is |
+|---|---|---|
+| `auth.py` | ✅ | Shared loader — `load_credentials()` returns valid creds, auto-refreshing. |
+| `reauth.py` | ✅ | One browser consent → writes `token.json`. **Your "reauth google" command.** |
+| `send_mail.py` | ✅ | Sender used by all agents (mirrors `m365/send_mail.py`). |
+| `requirements.txt` | ✅ | `google-auth`, `google-auth-oauthlib`, `google-api-python-client`. |
+| `oauth_client.json` | ❌ (git-ignored) | Installed-app OAuth client (client_id/secret). Same on every machine. |
+| `token.json` | ❌ (git-ignored) | Your user authorization (refresh token). **Secret. Per-user.** |
+| `legacy-gmail-mcp/` | ❌ (git-ignored) | Old `@gongrzhe` gmail-send MCP creds, kept only so the deprecated MCP still resolves. Safe to delete once the MCP is removed (`claude mcp remove gmail-send`). |
+
+Scopes (superset, so one token covers all agents): `gmail.send`, `gmail.modify`,
+`calendar`, `tasks`, `contacts.readonly`.
+
+## Everyday use
+
+```bash
+PY=~/agents/.venv/bin/python
+
+# Re-authorize (opens a browser; pick the right Google account):
+$PY ~/agents/google/reauth.py
+
+# Send mail (from the authorized account):
+$PY ~/agents/google/send_mail.py --to a@b.com --subject "Hi" --body "Hello" --attach file.md
+```
+
+In Python (any agent):
+
+```python
+import sys; sys.path.insert(0, "/Users/jasonjob/agents/google")
+from auth import load_credentials
+from googleapiclient.discovery import build
+svc = build("gmail", "v1", credentials=load_credentials())
+```
+
+## How buddy uses it
+
+buddy reads `~/.buddy/google_token.json` and `~/.buddy/google_credentials.json`.
+Those are **symlinked** to this directory's `token.json` and `oauth_client.json`,
+so buddy and every other agent share one token. buddy's auto-refresh writes back
+through the symlink, keeping everyone in sync. No buddy code change required.
+
+## Enabling email on another machine
+
+The **code** arrives via git (the `.py` files are tracked). The **secrets** do not
+(git-ignored) — you provide them on the new box. Two files must exist in
+`~/agents/google/`:
+
+1. **`oauth_client.json`** — the app identity (not your mailbox). Copy it from an
+   existing machine, or re-download the *installed-app* OAuth client from Google
+   Cloud Console. Identical on every machine.
+2. **`token.json`** — your authorization. Choose by machine type:
+
+   - **Laptop / has a browser →** run `reauth.py` on that machine:
+     ```bash
+     ~/agents/.venv/bin/python ~/agents/google/reauth.py
+     ```
+   - **Headless server / jbox06 (no browser) →** authorize on your laptop once,
+     then copy the token over:
+     ```bash
+     scp ~/agents/google/token.json  jbox06:~/agents/google/token.json
+     scp ~/agents/google/oauth_client.json jbox06:~/agents/google/oauth_client.json
+     ```
+     The refresh token is **portable across machines** for the same OAuth client.
+
+Then (for buddy) symlink its paths at the central files:
+```bash
+ln -sf ~/agents/google/token.json        ~/.buddy/google_token.json
+ln -sf ~/agents/google/oauth_client.json ~/.buddy/google_credentials.json
+```
+Don't forget deps on the new box: `~/agents/.venv/bin/pip install -r requirements.txt`.
+
+## Make it durable — publish the OAuth app
+
+While the OAuth consent screen is in **"Testing"**, Google **expires refresh tokens
+after 7 days** (that's the recurring `invalid_grant`). One-time fix:
+
+> Google Cloud Console → APIs & Services → OAuth consent screen →
+> **Publishing status → "In production"**
+
+After that the token only dies if you revoke it — so the headless "copy token once"
+flow above keeps working indefinitely.
+
+## Most robust option for the Workspace domain (future)
+
+For sending **as `@vital-enterprises.com`** (Google Workspace), the headless-friendly
+pattern is a **service account with domain-wide delegation** — no browser, no per-user
+token, works on every machine. (Not applicable to the personal `gmail.com` account,
+which still needs the user-consent flow above.)

--- a/google/auth.py
+++ b/google/auth.py
@@ -1,0 +1,61 @@
+"""Shared Google OAuth credentials for all agents — single source of truth.
+
+Files (this directory, git-ignored):
+    oauth_client.json  installed-app OAuth client (client_id/secret; same on every machine)
+    token.json         user authorization (standard google.oauth2 format; auto-refreshed)
+
+Every agent should obtain credentials through ``load_credentials()`` rather than
+re-implementing OAuth. buddy points at ``token.json`` via a symlink (see README).
+
+Requires the libs in requirements.txt (installed in ~/agents/.venv).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+BASE = Path(__file__).resolve().parent
+CLIENT_PATH = BASE / "oauth_client.json"
+TOKEN_PATH = BASE / "token.json"
+
+# Superset of scopes so one token serves every agent (gmail send/modify, calendar,
+# tasks, contacts). gmail.modify supersedes gmail.readonly.
+SCOPES = [
+    "https://www.googleapis.com/auth/gmail.send",
+    "https://www.googleapis.com/auth/gmail.modify",
+    "https://www.googleapis.com/auth/calendar",
+    "https://www.googleapis.com/auth/tasks",
+    "https://www.googleapis.com/auth/contacts.readonly",
+]
+
+
+def load_credentials(token_path: Path | str = TOKEN_PATH):
+    """Return valid Google ``Credentials``, refreshing + persisting if expired.
+
+    Raises FileNotFoundError if no token exists (run reauth.py) or RuntimeError
+    if the token is unusable (refresh token revoked/expired — run reauth.py).
+    """
+    from google.auth.transport.requests import Request
+    from google.oauth2.credentials import Credentials
+
+    p = Path(token_path).expanduser()
+    if not p.exists():
+        raise FileNotFoundError(
+            f"No Google token at {p}.\nRun:  ~/agents/.venv/bin/python {BASE / 'reauth.py'}"
+        )
+
+    data = json.loads(p.read_text())
+    creds = Credentials.from_authorized_user_info(data, data.get("scopes", SCOPES))
+
+    if creds.expired and creds.refresh_token:
+        creds.refresh(Request())
+        p.write_text(creds.to_json())  # persist the refreshed access token
+        p.chmod(0o600)
+
+    if not creds.valid:
+        raise RuntimeError(
+            f"Google token at {p} is invalid (likely revoked/expired refresh token).\n"
+            f"Re-run:  ~/agents/.venv/bin/python {BASE / 'reauth.py'}"
+        )
+    return creds

--- a/google/reauth.py
+++ b/google/reauth.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Re-authorize Google for every agent — one browser consent → token.json.
+
+Usage:
+    ~/agents/.venv/bin/python ~/agents/google/reauth.py
+
+Writes ~/agents/google/token.json, which all agents (and buddy, via symlink) share.
+
+On a NEW machine you can skip the browser entirely and instead COPY token.json
+from a machine that is already authorized — the refresh token is portable for the
+same OAuth client. See README.md ("Enabling email on another machine").
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from auth import CLIENT_PATH, SCOPES, TOKEN_PATH  # noqa: E402
+
+# Installed-app clients use a loopback redirect; Google accepts any localhost port.
+REDIRECT_PORT = 8098
+
+
+def main() -> None:
+    from google_auth_oauthlib.flow import InstalledAppFlow
+
+    if not CLIENT_PATH.exists():
+        raise SystemExit(
+            f"Missing OAuth client at {CLIENT_PATH}.\n"
+            "Copy it from an authorized machine, or download the *installed-app* "
+            "OAuth client JSON from Google Cloud Console and save it there."
+        )
+
+    flow = InstalledAppFlow.from_client_secrets_file(str(CLIENT_PATH), SCOPES)
+    creds = flow.run_local_server(port=REDIRECT_PORT, prompt="consent")
+
+    TOKEN_PATH.write_text(creds.to_json())
+    TOKEN_PATH.chmod(0o600)
+    print(f"Authorized. Token written to {TOKEN_PATH}")
+    print("Account:", getattr(creds, "account", "") or "(authorized Google account)")
+    print("Scopes :", ", ".join(s.split("/")[-1] for s in SCOPES))
+
+
+if __name__ == "__main__":
+    main()

--- a/google/requirements.txt
+++ b/google/requirements.txt
@@ -1,0 +1,3 @@
+google-auth>=2.0
+google-auth-oauthlib>=1.0
+google-api-python-client>=2.0

--- a/google/send_mail.py
+++ b/google/send_mail.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Send email as the authorized Google account — shared helper for all agents.
+
+Mirrors ~/agents/m365/send_mail.py, but sends from the Google identity in
+token.json (auto-refreshes). Used by any agent that needs to send Gmail.
+
+Examples:
+    ~/agents/.venv/bin/python ~/agents/google/send_mail.py \\
+        --to someone@example.com --subject "Hi" --body "Hello there"
+
+    # body from stdin, with attachments:
+    cat note.md | ~/agents/.venv/bin/python ~/agents/google/send_mail.py \\
+        --to a@b.com --subject "Notes" --body - --attach note.md --attach chart.png
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import mimetypes
+import sys
+from email.message import EmailMessage
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from auth import load_credentials  # noqa: E402
+
+
+def send_mail(to, subject, body, attach=None, cc=None, bcc=None):
+    """Send one email; returns (sender_address, message_id)."""
+    from googleapiclient.discovery import build
+
+    creds = load_credentials()
+    svc = build("gmail", "v1", credentials=creds)
+
+    msg = EmailMessage()
+    msg["To"] = ", ".join(to)
+    if cc:
+        msg["Cc"] = ", ".join(cc)
+    if bcc:
+        msg["Bcc"] = ", ".join(bcc)
+    msg["Subject"] = subject
+    msg.set_content(body)
+
+    for f in attach or []:
+        p = Path(f).expanduser()
+        if not p.exists():
+            raise SystemExit(f"Attachment not found: {p}")
+        ctype, _ = mimetypes.guess_type(p.name)
+        maintype, subtype = (
+            ctype.split("/", 1) if ctype else ("application", "octet-stream")
+        )
+        msg.add_attachment(
+            p.read_bytes(), maintype=maintype, subtype=subtype, filename=p.name
+        )
+
+    raw = base64.urlsafe_b64encode(msg.as_bytes()).decode()
+    sent = svc.users().messages().send(userId="me", body={"raw": raw}).execute()
+    sender = svc.users().getProfile(userId="me").execute().get("emailAddress")
+    return sender, sent.get("id")
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(
+        description="Send email from the shared Google identity."
+    )
+    ap.add_argument(
+        "--to", required=True, action="append", help="recipient (repeatable)"
+    )
+    ap.add_argument("--cc", action="append", help="cc (repeatable)")
+    ap.add_argument("--bcc", action="append", help="bcc (repeatable)")
+    ap.add_argument("--subject", required=True)
+    ap.add_argument("--body", required=True, help="body text, or '-' to read stdin")
+    ap.add_argument(
+        "--attach", action="append", default=[], help="file path (repeatable)"
+    )
+    a = ap.parse_args()
+
+    body = sys.stdin.read() if a.body == "-" else a.body
+    sender, mid = send_mail(a.to, a.subject, body, a.attach, a.cc, a.bcc)
+    print(f"SENT from {sender} -> {', '.join(a.to)} (id {mid})")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
One Google authorization shared by every agent, replacing per-tool credential sprawl (buddy's `~/.buddy` token + the @gongrzhe gmail-send MCP token were two separate Google auths).

- `~/agents/google/reauth.py` — single browser-consent re-auth → `token.json`
- `~/agents/google/send_mail.py` — shared sender (mirrors `m365/send_mail.py`)
- `~/agents/google/auth.py` — `load_credentials()` with auto-refresh
- `README.md` — multi-machine setup (laptop reauth vs headless token-copy), publish-to-production guidance
- buddy symlinked to the central token; secrets git-ignored (`google/*.json`)

## Test Plan
- `ruff check` / `ruff format --check` pass on new code
- `load_credentials()` returns a valid token for jasonwadejob@gmail.com (gmail.send present)
- `send_mail.py` used to deliver a real email with attachment (verified)
- `git check-ignore` confirms client/token never tracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)