### PR TITLE
fix(learn): harden retro-map classifier + dedup (Codex adversarial findings)

### DIFF
--- a/claude-config/commands/learn.md
+++ b/claude-config/commands/learn.md
@@ -75,20 +75,30 @@ echo "New failures since last learn: $NEW_COUNT (watermark: $LAST_LEARN_AT)"
 #     so the watermark advanced at Step 6.6 precisely covers this snapshot.
 TS=$(date -u +%Y%m%d-%H%M%S)
 UNION_FILE="/tmp/learn-union-${TS}.jsonl"
-# Concatenate all host shard failure files, then DEDUP BY event_id. A failure
-# worked on one machine is committed to that host's shard, which then SYNCS to
-# every other machine's telemetry/ tree — so the same failure appears in
-# multiple host shards. A raw `cat` over-counts those synced records, inflating
-# Step 2's clustering (a record present on 2 boxes looks like "2 occurrences").
-# Dedup by event_id so each distinct failure is counted exactly once. Legacy
-# rows predating event_id fall back to the SAME field set the canonical
-# event_id hashes (issue|date|project|root_cause|details, per
-# aggregate_metrics_to_global._event_id) — including `details`, so two
-# genuinely-different failures sharing the first four fields are NOT over-merged.
+# Concatenate all host shard failure files, then DEDUP by a RECOMPUTED canonical
+# key + apply the 90-day window. A failure worked on one machine syncs to every
+# other machine's telemetry/ tree, so the same failure appears in multiple shards;
+# a raw `cat` over-counts. We dedup by recomputing the canonical content hash
+# (issue|date|project|root_cause|details, matching aggregate_metrics_to_global
+# ._event_id) for EVERY row — we do NOT trust a provided event_id, because (a) a
+# row carrying event_id and the same row lacking it must still collapse, and (b) a
+# forged/stale/corrupt event_id must not merge two genuinely-different failures.
+# Rows older than 90 days are dropped here so the window actually applies downstream.
 python3 - "$UNION_FILE" <<'DEDUP_UNION'
-import glob, json, os, sys
+import datetime, glob, hashlib, json, os, sys
 out = sys.argv[1]
+cutoff = (datetime.datetime.now(datetime.timezone.utc)
+          - datetime.timedelta(days=90)).strftime("%Y-%m-%d")
+
+def canon_key(r):
+    # Mirror aggregate_metrics_to_global._event_id exactly (issue default 0).
+    payload = "{}|{}|{}|{}|{}".format(
+        r.get("issue", 0), r.get("date", ""), r.get("project", ""),
+        r.get("root_cause", ""), r.get("details", ""))
+    return hashlib.sha1(payload.encode("utf-8")).hexdigest()
+
 seen, rows = set(), []
+skipped_json = skipped_window = 0
 for f in sorted(glob.glob(os.path.expanduser("~/agents/telemetry/*/failures.jsonl"))):
     try:
         with open(f, encoding="utf-8") as fh:
@@ -99,10 +109,16 @@ for f in sorted(glob.glob(os.path.expanduser("~/agents/telemetry/*/failures.json
                 try:
                     r = json.loads(line)
                 except json.JSONDecodeError:
+                    skipped_json += 1
                     continue
-                key = r.get("event_id") or (
-                    r.get("issue"), r.get("date"), r.get("project"),
-                    r.get("root_cause"), r.get("details", ""))
+                if not isinstance(r, dict):
+                    skipped_json += 1
+                    continue
+                ts = (r.get("recorded_at") or r.get("date") or "")
+                if isinstance(ts, str) and ts[:10] and ts[:10] < cutoff:
+                    skipped_window += 1          # outside the 90-day window
+                    continue
+                key = canon_key(r)               # recompute; never trust event_id
                 if key in seen:
                     continue
                 seen.add(key)
@@ -111,6 +127,9 @@ for f in sorted(glob.glob(os.path.expanduser("~/agents/telemetry/*/failures.json
         pass
 with open(out, "w", encoding="utf-8") as fh:
     fh.write(("\n".join(rows) + "\n") if rows else "")
+if skipped_json or skipped_window:
+    sys.stderr.write("learn: skipped {} malformed + {} out-of-window row(s)\n"
+                     .format(skipped_json, skipped_window))
 DEDUP_UNION
 echo "Union snapshot (event_id-deduped): $UNION_FILE ($(wc -l < "$UNION_FILE") lines)"
 
@@ -159,9 +178,10 @@ No outcome data found. Run some issues through /orchestrate first.
 Read each failure record from `$UNION_FILE` and group by `root_cause`.
 **All jq/parse commands below operate on `$UNION_FILE`** (the snapshot from Step 0),
 never on `.claude/memory/failures.jsonl` or any local path.
-`$UNION_FILE` is **already event_id-deduped** (Step 0d), so occurrence counts
-below reflect distinct failures — a record synced across N host shards counts
-once, not N times.
+`$UNION_FILE` is **already deduped by a recomputed canonical content key and
+filtered to the 90-day window** (Step 0d), so occurrence counts below reflect
+distinct, in-window failures — a record synced across N host shards counts once,
+and a forged/missing `event_id` neither double-counts nor merges distinct failures.
 
 ```bash
 # Cluster by CODED root_cause via the retro-map (READ-SIDE — raw telemetry is

--- a/claude-config/commands/learn.md
+++ b/claude-config/commands/learn.md
@@ -85,17 +85,22 @@ UNION_FILE="/tmp/learn-union-${TS}.jsonl"
 # forged/stale/corrupt event_id must not merge two genuinely-different failures.
 # Rows older than 90 days are dropped here so the window actually applies downstream.
 python3 - "$UNION_FILE" <<'DEDUP_UNION'
-import datetime, glob, hashlib, json, os, sys
+import datetime, glob, json, os, sys
+# Reuse the AUTHORITATIVE normalization + hashing so legacy compound rows
+# ({"issues":[...],"root_causes":[...]}) are expanded the SAME way the aggregate
+# Stop hook does — otherwise distinct compound rows collide on an empty key and
+# the survivor loses its root_cause. _event_id recomputes from content (we never
+# trust a provided event_id), fixing both double-count (#3) and forged-id-merge (#4).
+sys.path.insert(0, os.path.expanduser("~/agents/claude-config/hooks"))
+from aggregate_metrics_to_global import normalize_record, _event_id
 out = sys.argv[1]
 cutoff = (datetime.datetime.now(datetime.timezone.utc)
           - datetime.timedelta(days=90)).strftime("%Y-%m-%d")
 
 def canon_key(r):
-    # Mirror aggregate_metrics_to_global._event_id exactly (issue default 0).
-    payload = "{}|{}|{}|{}|{}".format(
-        r.get("issue", 0), r.get("date", ""), r.get("project", ""),
-        r.get("root_cause", ""), r.get("details", ""))
-    return hashlib.sha1(payload.encode("utf-8")).hexdigest()
+    return _event_id(issue=r.get("issue", 0), date=r.get("date", ""),
+                     project=r.get("project", ""), root_cause=r.get("root_cause", ""),
+                     details=r.get("details", ""))
 
 seen, rows = set(), []
 skipped_json = skipped_window = 0
@@ -114,15 +119,16 @@ for f in sorted(glob.glob(os.path.expanduser("~/agents/telemetry/*/failures.json
                 if not isinstance(r, dict):
                     skipped_json += 1
                     continue
-                ts = (r.get("recorded_at") or r.get("date") or "")
-                if isinstance(ts, str) and ts[:10] and ts[:10] < cutoff:
-                    skipped_window += 1          # outside the 90-day window
-                    continue
-                key = canon_key(r)               # recompute; never trust event_id
-                if key in seen:
-                    continue
-                seen.add(key)
-                rows.append(line)
+                for rec in normalize_record(r):  # expand legacy compound rows (M5)
+                    ts = (rec.get("recorded_at") or rec.get("date") or "")
+                    if isinstance(ts, str) and ts[:10] and ts[:10] < cutoff:
+                        skipped_window += 1       # outside the 90-day window
+                        continue
+                    key = canon_key(rec)          # recompute; never trust event_id
+                    if key in seen:
+                        continue
+                    seen.add(key)
+                    rows.append(json.dumps(rec, separators=(",", ":")))  # write NORMALIZED record
     except OSError:
         pass
 with open(out, "w", encoding="utf-8") as fh:

--- a/claude-config/scripts/map_freetext_root_causes.py
+++ b/claude-config/scripts/map_freetext_root_causes.py
@@ -50,7 +50,7 @@ _VALID_ROOT_CAUSES = frozenset({
 _NON_PATTERN = frozenset({"UNMAPPED", "NO_ROOT_CAUSE", "MALFORMED"})
 
 # Negation/no-verify variants, on normalized (lowercased, straight-apostrophe) text.
-_DIDNT = r"(?:didn'?t|did not|doesn'?t|don'?t|without)"
+_DIDNT = r"(?:didn'?t|did not|doesn'?t|does not|don'?t|without)"
 
 # Conservative keyword rules on NORMALIZED text. Order matters (first match wins):
 # AMBIGUITY before SCOPE so "didn't consider both interpretations" -> ambiguity, not
@@ -67,7 +67,7 @@ RULES = [
                      r"secondary (deficit|scenario|type)"]),
     ("DOCUMENTATION", [rf"{_DIDNT} document", rf"{_DIDNT} specify",
                        r"missing docs?\b", r"forgot to document"]),
-    ("VERIFICATION_GAP", [r"\bassum(?:e|ed|es|ing|ption)\b",
+    ("VERIFICATION_GAP", [r"\bassum(?:e|ed|es|ing|ption|ptions)\b",
                           rf"{_DIDNT}\b.{{0,30}}(verif|validat|check)",
                           rf"{_DIDNT} add validation",
                           r"stated\b.{0,40}resolved", r"defensive comment without"]),

--- a/claude-config/scripts/map_freetext_root_causes.py
+++ b/claude-config/scripts/map_freetext_root_causes.py
@@ -1,88 +1,115 @@
 #!/usr/bin/env python3
 """Retro-map free-text root_causes onto a coded taxonomy for /learn clustering.
 
-READ-SIDE ONLY: this classifies records for clustering/counting. It never
-mutates telemetry — record_failure still writes raw free-text. A failure to
-classify is SAFE: the row stays UNMAPPED (surfaced as signal), never
-force-bucketed. Worst case is "not learned yet", never "learned wrong".
+READ-SIDE ONLY: classifies records for clustering/counting. It never mutates
+telemetry — record_failure still writes raw free-text. A failure to classify is
+SAFE: the row stays UNMAPPED (surfaced as signal), never force-bucketed. Worst
+case is "not learned yet", never "learned wrong".
 
-Discriminator: a `root_cause` with NO spaces is treated as already-coded
-(passed through, upper-cased). A `root_cause` WITH spaces is free-text and is
-matched against conservative keyword rules; an unmatched free-text row -> UNMAPPED.
+Discriminator: a `root_cause` with NO spaces is a code ONLY if it is in
+`_VALID_ROOT_CAUSES` (so a typo'd code is surfaced as UNMAPPED, not a phantom
+code). Free-text (has spaces, or unrecognized) goes through conservative keyword
+rules; unmatched -> UNMAPPED. Non-string root_cause -> MALFORMED (surfaced, never
+crashes). Empty/missing -> NO_ROOT_CAUSE.
 
 Usage:
   map_freetext_root_causes.py <union.jsonl>            # cluster counts (Step 2)
-  map_freetext_root_causes.py <union.jsonl> --mine CODE # detail texts in a cluster (Step 5)
-  map_freetext_root_causes.py <union.jsonl> --json      # structured {code: [details]}
+  map_freetext_root_causes.py <union.jsonl> --mine CODE # detail/evidence in a cluster (Step 5)
+  map_freetext_root_causes.py <union.jsonl> --json      # structured {code: [records]}
 """
 import json
+import os
 import re
 import sys
+import unicodedata
 from collections import defaultdict
 
-# Frozen seed vocab — conservative keyword rules. Order matters: first match wins.
-# Extend deliberately (decision 3 governance): a new code is minted only when an
+# Recognized coded vocabulary. The canonical enum (claude-config/agents/_base.md
+# §10) is authoritative; observed agent-emitted codes extend it. A spaceless token
+# is treated as a code ONLY if it is a member here — so a typo ("VERIFICATON_GAP")
+# or a lowercase word ("regression") falls through to UNMAPPED instead of becoming
+# a phantom code. Extend deliberately (governance): a new code earns a slot when an
 # UNMAPPED cluster recurs with a genuinely distinct prevention.
+_VALID_ROOT_CAUSES = frozenset({
+    # canonical (_base.md §10) — these MUST all be present or real clusters vanish
+    "ENUM_VALUE", "COMPONENT_API", "MULTI_MODEL", "API_MISMATCH", "ACCESS_CONTROL",
+    "MISSING_TEST", "SQLITE_COMPAT", "STRUCTURE_VIOLATION", "SCOPE_CREEP",
+    "VERIFICATION_GAP", "OTHER",
+    # mapped-from-free-text classes
+    "AMBIGUITY_UNRESOLVED", "DOCUMENTATION",
+    # observed agent-emitted extensions
+    "LINT_ERROR", "STUB_HANDLERS", "ASYNCPG_POOL_VS_CONNECTION",
+    "PIPECAT_PIPELINE_DEADLOCK", "OPENAI_STRICT_SCHEMA", "LLM_OUTPUT_SCHEMA",
+    "SQL_RESERVED_WORD", "WRONG_TABLE_NAME", "INVALID_SQL_CONSTRUCT",
+    "MISSING_SERVICE_WIRING", "WRONG_CONN_ID_SCOPE", "MISSING_INTERFACE_METHODS",
+    "SEQUENTIAL_IO", "BLOCKING_FIRE_AND_FORGET", "PATH_EXPANSION",
+    "SERVER_DEP_MANAGEMENT", "LEGACY_COMPOUND",
+})
+
+# Buckets that are signal/noise, never an apply-eligible learnable pattern.
+_NON_PATTERN = frozenset({"UNMAPPED", "NO_ROOT_CAUSE", "MALFORMED"})
+
+# Negation/no-verify variants, on normalized (lowercased, straight-apostrophe) text.
+_DIDNT = r"(?:didn'?t|did not|doesn'?t|don'?t|without)"
+
+# Conservative keyword rules on NORMALIZED text. Order matters (first match wins):
+# AMBIGUITY before SCOPE so "didn't consider both interpretations" -> ambiguity, not
+# scope. Known limitation: pure negation ("no assumption; explicit API mismatch") and
+# compound failures ("only implemented X and didn't verify Y") are inherently
+# multi-label — the conservative UNMAPPED default + the consensus-validation gate
+# (see specs) bound the damage; semantic clustering is the deferred upgrade.
 RULES = [
-    # Conservative: clear verify/validate/check signals only. Borderline rows
-    # (e.g. "copied verbatim without understanding") deliberately fall through to
-    # UNMAPPED rather than being force-mapped here — surfacing as signal is safer
-    # than over-bucketing into VERIFICATION_GAP.
-    ("VERIFICATION_GAP", [r"assum", r"without (verif|validat|check)", r"didn'?t verif",
-                          r"didn'?t validate", r"didn'?t add validation", r"didn'?t check",
-                          r"stated .*resolved", r"defensive comment without"]),
-    ("SCOPE_CREEP", [r"only implemented", r"missed implicit", r"didn'?t consider",
-                     r"secondary (deficit|scenario|type)"]),
     ("AMBIGUITY_UNRESOLVED", [r"both interpretations", r"identified contradiction",
-                              r"didn'?t pick", r"failed to resolve", r"didn'?t call out"]),
-    ("DOCUMENTATION", [r"didn'?t document", r"didn'?t specify"]),
+                              rf"{_DIDNT} pick", r"failed to resolve",
+                              rf"{_DIDNT} call out"]),
+    ("SCOPE_CREEP", [r"only implemented", r"missed implicit",
+                     rf"{_DIDNT} consider\b.{{0,40}}(scenario|case|edge|deficit|type|path)",
+                     r"secondary (deficit|scenario|type)"]),
+    ("DOCUMENTATION", [rf"{_DIDNT} document", rf"{_DIDNT} specify",
+                       r"missing docs?\b", r"forgot to document"]),
+    ("VERIFICATION_GAP", [r"\bassum(?:e|ed|es|ing|ption)\b",
+                          rf"{_DIDNT}\b.{{0,30}}(verif|validat|check)",
+                          rf"{_DIDNT} add validation",
+                          r"stated\b.{0,40}resolved", r"defensive comment without"]),
 ]
 
-# Recognized coded vocabulary (seed). A spaceless token is treated as a code
-# ONLY if it is a known member here — otherwise it falls through to UNMAPPED.
-# This enforces the spec's typo-guard (a typo'd code like "VERIFICATON_GAP" is
-# NOT in the set, so it surfaces as UNMAPPED instead of becoming a phantom code)
-# and blocks lowercase single words ("regression") from being promoted to fake
-# codes. Extend deliberately (decision-3 governance): a new code earns a slot
-# here only when an UNMAPPED cluster recurs with a genuinely distinct prevention.
-_VALID_ROOT_CAUSES = frozenset({
-    # mapped-from-free-text classes
-    "VERIFICATION_GAP", "SCOPE_CREEP", "AMBIGUITY_UNRESOLVED", "DOCUMENTATION",
-    # agent-emitted codes observed in telemetry
-    "ENUM_VALUE", "COMPONENT_API", "MISSING_TEST", "LINT_ERROR", "MULTI_MODEL",
-    "STUB_HANDLERS", "ASYNCPG_POOL_VS_CONNECTION", "PIPECAT_PIPELINE_DEADLOCK",
-    "OPENAI_STRICT_SCHEMA", "LLM_OUTPUT_SCHEMA", "SQL_RESERVED_WORD",
-    "WRONG_TABLE_NAME", "INVALID_SQL_CONSTRUCT", "MISSING_SERVICE_WIRING",
-    "WRONG_CONN_ID_SCOPE", "MISSING_INTERFACE_METHODS", "SEQUENTIAL_IO",
-    "BLOCKING_FIRE_AND_FORGET", "PATH_EXPANSION", "SERVER_DEP_MANAGEMENT",
-    "STRUCTURE_VIOLATION", "LEGACY_COMPOUND",
-})
+
+def _normalize(text):
+    """NFKC + curly->straight apostrophe + lowercase, for robust regex matching."""
+    t = unicodedata.normalize("NFKC", text)
+    t = t.replace("’", "'").replace("‘", "'").replace("ʼ", "'")
+    return t.lower()
 
 
 def classify(root_cause):
-    """Map a root_cause string to a coded value, NO_ROOT_CAUSE, or UNMAPPED.
+    """Map a root_cause to a coded value, or a surfaced non-pattern bucket.
 
-    - empty / missing / "?"          -> NO_ROOT_CAUSE  (recording noise, not signal)
-    - spaceless KNOWN-vocab token    -> that code      (case-normalized pass-through)
-    - free-text matching a rule      -> the matched code
-    - anything else (incl. unknown spaceless tokens / typo'd codes) -> UNMAPPED
-      (surfaced for governance; never force-bucketed)
+    None/missing/empty/"?" -> NO_ROOT_CAUSE; non-string -> MALFORMED (surfaced,
+    never crashes); recognized spaceless token -> that code; free-text matching a
+    rule -> the code; anything else -> UNMAPPED.
     """
-    if not root_cause or not root_cause.strip() or root_cause.strip() == "?":
+    if root_cause is None:
         return "NO_ROOT_CAUSE"
-    rc = root_cause.strip()
-    if " " not in rc and rc.upper() in _VALID_ROOT_CAUSES:
-        return rc.upper()            # recognized code -> normalize, pass through
-    low = rc.lower()
+    if not isinstance(root_cause, str):
+        return "MALFORMED"          # non-string -> surfaced, never .strip()-crashes
+    raw = root_cause.strip()
+    if not raw or raw == "?":
+        return "NO_ROOT_CAUSE"
+    if " " not in raw and raw.upper() in _VALID_ROOT_CAUSES:
+        return raw.upper()          # recognized code -> normalize, pass through
+    low = _normalize(raw)
     for code, pats in RULES:
         if any(re.search(p, low) for p in pats):
             return code
-    return "UNMAPPED"                # conservative default: never force-bucket
+    return "UNMAPPED"               # conservative default: never force-bucket
 
 
 def cluster(path):
-    """Return {code: [original_root_cause, ...]} from a union JSONL file."""
+    """Return ({code: [record, ...]}, skipped_line_count). Records (not just the
+    root_cause string) are retained so --mine/--json can surface `details` — the
+    prevention evidence Step 5 needs."""
     clusters = defaultdict(list)
+    skipped = 0
     with open(path, encoding="utf-8") as fh:
         for line in fh:
             line = line.strip()
@@ -91,31 +118,63 @@ def cluster(path):
             try:
                 r = json.loads(line)
             except json.JSONDecodeError:
+                skipped += 1
                 continue
-            rc = r.get("root_cause", "?")
-            clusters[classify(rc)].append(rc)
-    return clusters
+            if not isinstance(r, dict):
+                skipped += 1
+                continue
+            clusters[classify(r.get("root_cause"))].append(r)
+    return clusters, skipped
+
+
+def _evidence(record):
+    """The specific prevention evidence for detail-mining: prefer `details`,
+    fall back to the root_cause text."""
+    detail = record.get("details")
+    if isinstance(detail, str) and detail.strip():
+        return detail.strip()
+    rc = record.get("root_cause")
+    return rc.strip() if isinstance(rc, str) else ""
 
 
 def main(argv):
-    if not argv:
+    if not argv or argv[0] in ("-h", "--help"):
         print(__doc__)
-        return 1
+        return 0
     path = argv[0]
-    clusters = cluster(path)
-    if "--json" in argv:
-        print(json.dumps({k: v for k, v in clusters.items()}, indent=2))
-        return 0
+    if not os.path.exists(path):
+        print(f"error: union file not found: {path}", file=sys.stderr)
+        return 2
+    clusters, skipped = cluster(path)
+    if skipped:
+        print(f"warning: skipped {skipped} malformed JSON line(s)", file=sys.stderr)
+
+    # --mine takes precedence over --json (more specific).
     if "--mine" in argv:
-        code = argv[argv.index("--mine") + 1]
-        # Detail-mining: the specific (deduped) preventions inside a coded cluster.
-        for detail in sorted(set(clusters.get(code.upper(), []))):
-            print(detail)
+        idx = argv.index("--mine")
+        if idx + 1 >= len(argv):
+            print("error: --mine requires a CODE argument", file=sys.stderr)
+            return 2
+        code = argv[idx + 1].upper()
+        seen = set()
+        for record in clusters.get(code, []):
+            ev = _evidence(record)
+            if ev and ev not in seen:
+                seen.add(ev)
+                print(ev)
         return 0
-    # Default: cluster counts, apply-eligibility flagged (>=5, excluding UNMAPPED).
-    for code, members in sorted(clusters.items(), key=lambda x: -len(x[1])):
-        flag = "  <== APPLY-ELIGIBLE (>=5)" if len(members) >= 5 and code != "UNMAPPED" else ""
-        print(f"{len(members):4}  {code}{flag}")
+
+    if "--json" in argv:
+        print(json.dumps({k: v for k, v in clusters.items()}, indent=2, default=str))
+        return 0
+
+    # Default: cluster counts; apply-eligibility flagged (>=5, excluding non-patterns).
+    for code, recs in sorted(clusters.items(), key=lambda x: -len(x[1])):
+        flag = "  <== APPLY-ELIGIBLE (>=5)" if len(recs) >= 5 and code not in _NON_PATTERN else ""
+        print(f"{len(recs):4}  {code}{flag}")
+    if clusters.get("MALFORMED"):
+        print(f"warning: {len(clusters['MALFORMED'])} record(s) had a non-string "
+              f"root_cause (MALFORMED) — telemetry corruption", file=sys.stderr)
     return 0
 
 


### PR DESCRIPTION
## Summary
An independent **GPT-5/Codex adversarial review** of the live `/learn` classifier (reviewed only by Claude before) found **7 BLOCKING + 2 non-blocking** bugs. This fixes all of them.

The diversity dividend, on code: same-model (Claude) review + I blessed this classifier; a different model still found real correctness/robustness holes.

## BLOCKING fixes
| # | Bug | Fix |
|---|---|---|
| 1 | Canonical codes (`API_MISMATCH`, `ACCESS_CONTROL`, `SQLITE_COMPAT`, `OTHER`) → UNMAPPED, suppressing real clusters | added the full `_base.md §10` enum to `_VALID_ROOT_CAUSES` |
| 2 | `--mine`/`--json` lost `details` (prevention evidence) | retain full records; `--mine` surfaces `details` |
| 3 | string-key vs tuple-key → double-count same event | recompute canonical content key for every row |
| 4 | blind `event_id` trust → merges *different* failures (data loss) | recompute, never trust provided `event_id` |
| 5 | non-string `root_cause` crashed `/learn` | → `MALFORMED` (surfaced, never aborts) |
| 6 | regex: negation-blind `assum`, `did not`/curly-apostrophe misses, mis-ordering | NFKC + apostrophe normalization, word-boundary assume, AMBIGUITY-before-SCOPE |
| 7 | 90-day window computed but never applied | Step 0d now drops out-of-window rows |

## Non-blocking
- #8 surface skip counts (malformed + out-of-window) — aligns with the watchdog principle.
- #9 CLI robustness (`--help`, missing path, `--mine` without arg, `--json`/`--mine` precedence).

## Test Plan
- 33/33 tests pass.
- Every Codex break-case verified fixed (canonical codes recognized; non-string → MALFORMED no crash; `--mine` surfaces details; `did not`/curly-apostrophe → VERIFICATION_GAP; `reassumption` no longer false-matches; dedup A/B collapse + forged-event_id-not-merged + 90d-window-drop).
- **No regression:** live VERIFICATION_GAP cluster unchanged at 11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)