### PR TITLE
feat(rules): promote 2 lessons from buddy #1758 smoke sweep

### DIFF
--- a/claude-config/rules/no-app-layer-ddl.md
+++ b/claude-config/rules/no-app-layer-ddl.md
@@ -1,0 +1,118 @@
+---
+paths: ["**/src/**", "**/app/**", "**/server/**"]
+---
+
+# No Application-Layer DDL — Migrations Are the Sole Source of Truth
+
+**When application code runs `CREATE TABLE IF NOT EXISTS`, `ALTER TABLE ADD COLUMN IF NOT EXISTS`, `CREATE INDEX IF NOT EXISTS`, or `DROP TABLE/COLUMN/INDEX` outside of a migration file, REMOVE IT.**
+
+The migration system is the canonical source of schema truth. Application code that performs idempotent DDL at startup or on connection acquire competes with migrations and produces an undetectable failure class: migrations drop something, application code immediately resurrects it. The next operator audit thinks the migration didn't apply when in fact it did — and was immediately undone.
+
+---
+
+## When this rule fires
+
+Auto-loaded on any session touching `src/`, `app/`, or `server/` code. Triggers whenever you see one of these patterns in application code:
+
+```python
+# anti-pattern A — table bootstrap
+await conn.execute("CREATE TABLE IF NOT EXISTS my_table (...)")
+
+# anti-pattern B — column addition guard
+await conn.execute("""
+    DO $$ BEGIN
+        ALTER TABLE my_table ADD COLUMN new_col TEXT;
+    EXCEPTION WHEN duplicate_column THEN NULL;
+    END $$
+""")
+
+# anti-pattern C — index assertion
+await conn.execute("CREATE INDEX IF NOT EXISTS idx_my_table_x ON my_table(x)")
+
+# anti-pattern D — application-side DROP
+await conn.execute("DROP TABLE IF EXISTS deprecated_thing")
+```
+
+Even if the pattern looks defensive and idempotent, **remove it**. The migration system handles all three responsibilities.
+
+---
+
+## Why this is a distinct failure class
+
+This rule generalizes a 2026-06-05 buddy incident (#1766). Person Consolidation V1 (5-PR migration wave 2026-05-22 → 2026-05-25) correctly dropped `contact_notes.relationship_id` via migration `20260524180200_pr8_drop_relationship_id_columns.sql`. But `src/buddy/knowledge/postgres_store.py:_ensure_schema()` ran:
+
+```python
+# (in application code, on every pool acquire)
+CREATE TABLE IF NOT EXISTS contact_notes (... relationship_id TEXT ...)
+DO $$ BEGIN ALTER TABLE contact_notes ADD COLUMN relationship_id TEXT;
+     EXCEPTION WHEN duplicate_column THEN NULL; END $$
+CREATE INDEX IF NOT EXISTS idx_contact_notes_rel ON contact_notes(relationship_id)
+```
+
+Result: migration dropped the column at 2026-05-24; every subsequent server boot (every pool acquire, really) immediately re-created it as TEXT, no FK. A schema audit on 2026-06-05 found the column "still there" — leading initially to a (wrong) hypothesis that the migration audit missed the table. Closer investigation showed the migration WAS complete; the in-code DDL was the resurrection vector.
+
+This failure class is **invisible to schema-audit tooling**:
+- `grep` for the dropped column in migration files — finds the DROP migration. Pattern looks complete.
+- `\d <table>` in psql — column is there. Audit assumes the DROP migration didn't apply.
+- `schema_migrations` table — DROP migration shows applied. Now you're confused.
+- Only by reading application source code do you discover the resurrection.
+
+The existing `~/.claude/rules/spec-schema-collision-check.md` Part 1 (SQL-site grep) catches in-code SQL **queries** against dropped tables. It does NOT catch in-code DDL **bootstrap blocks** that re-create dropped objects.
+
+---
+
+## The procedure
+
+1. **Find every instance** in the codebase. Run:
+   ```bash
+   grep -rn --include='*.py' --include='*.ts' --include='*.go' \
+       -E 'CREATE TABLE IF NOT EXISTS|ALTER TABLE.*ADD COLUMN|CREATE INDEX IF NOT EXISTS|DO \$\$' \
+       src/ app/ server/ 2>/dev/null
+   ```
+2. **For each hit**, classify:
+   - **Schema bootstrap** (creating tables/columns/indexes the app needs) → DELETE. Migrations already create these.
+   - **Idempotent column add** (defensive add-if-missing) → DELETE. If the column exists in production, the migration that added it is authoritative.
+   - **Defensive `DROP IF EXISTS`** in cleanup code → File as follow-up; needs explicit migration to drop.
+   - **Test fixture setup** (only runs in test mode) → KEEP but isolate to test code, not production startup paths.
+3. **Verify the schema lives in migrations.** For every table/index your application reads or writes, confirm `db/migrations/` (or equivalent) has a `CREATE TABLE` migration. If not, write the migration — don't restore the in-code DDL.
+4. **Document the removal.** Comment at the deletion site referencing this rule and the migration that owns the schema:
+   ```python
+   # contact_notes is created + maintained by db/migrations/.
+   # Per ~/.claude/rules/no-app-layer-ddl.md — never add CREATE TABLE
+   # IF NOT EXISTS or ALTER TABLE ADD COLUMN here.
+   ```
+
+---
+
+## What this rule allows
+
+- **Migration files** under `db/migrations/`, `migrations/`, `alembic/versions/`, etc. — these ARE the source of truth.
+- **Test fixtures** that set up + tear down ephemeral schemas (clearly isolated from production startup paths).
+- **`SELECT to_regclass(...)` health checks** that verify expected schema is present without modifying it.
+- **`pg_dump`/migration-tool calls** that operate on the schema as a whole, never on individual objects from application code.
+
+---
+
+## What this rule forbids
+
+- `CREATE TABLE IF NOT EXISTS` in any production startup or connection-acquire path
+- `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` or `DO $$ BEGIN ALTER ... EXCEPTION ... END $$`
+- `CREATE INDEX IF NOT EXISTS` outside migrations
+- `DROP TABLE/COLUMN/INDEX` from application code
+- "Idempotent migration shims" embedded in service code (e.g., `_ensure_schema()` methods)
+
+---
+
+## When the rule was born
+
+**2026-06-05 buddy #1766 (smoke sweep #1758).** Person Consolidation V1 migration correctly dropped `contact_notes.relationship_id` on 2026-05-24. `src/buddy/knowledge/postgres_store.py:_ensure_schema()` resurrected it on every pool acquire. Discovered during a smoke audit that looked like the migration had failed but actually the application was undoing it.
+
+The fix (PR #1774) removed the in-code DDL block and added a comment pointing future developers at the migration as the source of truth. This rule was promoted to global because the failure pattern is generic — any project with both a migration system and "defensive" application-layer DDL will eventually hit it.
+
+---
+
+## Companion rules
+
+- `~/.claude/rules/spec-schema-collision-check.md` — Part 1 (SQL-site grep for queries against dropped tables) — complementary to this rule. That rule catches queries that reference dropped objects; THIS rule catches code that re-creates them.
+- `~/.claude/rules/spec-self-review.md` — Check 2 cross-refs spec ↔ migration. Extend with: also check application-layer DDL.
+- Companion to buddy-local feedback: `~/.claude/projects/-Users-jasonjob-projects-buddy/memory/feedback_spec_grep_every_sql_site.md` (original 2026-05-24 incident — Part 1 SQL-site grep).

--- a/claude-config/rules/spec-schema-collision-check.md
+++ b/claude-config/rules/spec-schema-collision-check.md
@@ -41,14 +41,27 @@ migration failure on Supabase.
 For every table / type the spec drops, renames, or consolidates:
 
 ```bash
+# 1a — queries against the target
 grep -rn --include='*.py' --include='*.ts' --include='*.tsx' \
     "FROM <table>\b\|JOIN <table>\b\|UPDATE <table>\b\|INSERT INTO <table>\b\|DELETE FROM <table>\b" \
     src/ > /tmp/sql-audit-<table>.txt
+
+# 1b — application-layer DDL that resurrects the target
+# (added 2026-06-05 after buddy #1766 — migration dropped a column
+# but `_ensure_schema()` in app code recreated it on every pool acquire)
+grep -rn --include='*.py' --include='*.ts' --include='*.go' \
+    -E "CREATE TABLE IF NOT EXISTS <table>|ALTER TABLE <table>.*ADD COLUMN.*<column>|CREATE INDEX IF NOT EXISTS.*ON <table>|DO \$\$.*<table>" \
+    src/ app/ server/ > /tmp/ddl-audit-<table>.txt
 ```
 
 Categorize each hit:
 - **IN-SCOPE** — already covered by some spec phase / PR.
 - **OUT-OF-SCOPE** — needs spec expansion OR a follow-up issue.
+- **DDL RESURRECTION** (from 1b) — **immediately blocking**. The migration's
+  DROP will be silently undone on every server boot. Either delete the
+  in-code DDL block AND coordinate the migration drop, OR keep the
+  application-layer DDL and skip the migration. NEVER both. See companion
+  rule `~/.claude/rules/no-app-layer-ddl.md`.
 
 If OUT-OF-SCOPE > 0, **expand the spec OR file follow-up issues before
 locking**. Don't assume "the audits got it all" — implicit topic


### PR DESCRIPTION
## Summary
Two promotions from the buddy autonomous smoke sweep #1758 root-cause analyses:

1. NEW `claude-config/rules/no-app-layer-ddl.md` — application-layer DDL (CREATE TABLE IF NOT EXISTS / ALTER TABLE ADD COLUMN / DO \$\$ ... \$\$) is a distinct failure class that defeats migration cleanups. Migration drops a column → app recreates it on next boot. Invisible to schema-audit tooling. buddy #1766 was the canonical case.

2. EXTEND `spec-schema-collision-check.md` Part 1 with grep 1b for application-layer DDL targeting dropped objects + new "DDL RESURRECTION" blocker.

Promotion per `~/.claude/CLAUDE.md` rule-promotion procedure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)