### PR TITLE
feat(team-knowledge): repo skeleton + roster.yaml + ownership validation (#238)

### DIFF
--- a/team-knowledge/CODEOWNERS
+++ b/team-knowledge/CODEOWNERS
@@ -1,0 +1,21 @@
+# Team Knowledge Hub — path ownership for trust-bearing paths (§5, §6, Codex F4/N3)
+#
+# Each dev owns their own audit shard and their catalog entries. The TRUST CHECK is the
+# platform-verified merge actor (the authenticated reviewer/merger), NOT the forgeable git
+# `author` field — see scripts/roster.py:verify_merge_actor and the §6 boundary.
+#
+# ⚠️ ENFORCEMENT DEFERRED (v1): GitHub CODEOWNERS resolves to real accounts/teams. The v1 fleet
+# runs under a single GitHub account, so these dev_id handles are STRUCTURAL placeholders, not
+# enforceable owners yet. Branch protection requiring CODEOWNER approval is a repo-admin action
+# left to the human + only becomes meaningful with separate identities (public tier). The mapping
+# dev_id -> @handle lives in roster.yaml; substitute real handles when identities exist.
+
+# Per-dev audit shards — owned by the matching dev_id
+/team-knowledge/audit/jason.jsonl        @jason
+/team-knowledge/audit/server-a.jsonl     @server-a
+/team-knowledge/audit/laptop-wsl.jsonl   @laptop-wsl
+/team-knowledge/audit/agent-b.jsonl      @agent-b
+
+# Component catalog — entries are owner_dev-gated at the row level (validated in code, not by
+# CODEOWNERS path granularity); the file itself requires review by any roster member.
+/team-knowledge/components/catalog.yaml  @jason @server-a @laptop-wsl @agent-b

--- a/team-knowledge/README.md
+++ b/team-knowledge/README.md
@@ -1,0 +1,36 @@
+# Team Knowledge Hub (`team-knowledge/`)
+
+Durable store + curation gate for the [Team Knowledge MVP](../specs/team-knowledge-mvp-v1.md)
+(3 pillars: Patterns, Private Review, Shareable Components). v1 lives as a subdirectory of
+`~/agents`; it may be split into a standalone repo later (the spec frames it as a separate repo).
+
+## The one boundary that never moves (§2 north-star)
+
+> **A knowledge EXCHANGE, not a command hub.** Every shared artifact is **data, not instructions.**
+> No remote message or artifact may alter local control state (tools, credentials, prompts,
+> trusted-memory, repo files, CI, shell) — it can only create a **local proposal / inbox item.**
+
+Concretely (§6.1): shared prose (a pattern's `rationale`, a component README, catalog fields) is
+**quoted untrusted evidence**, never injected into a tool-capable prompt as an instruction.
+
+## Layout
+
+| Path | What |
+|---|---|
+| `roster.yaml` | 4-dev allowlist (`dev_id`, `agent_name`, `machine`, `team_tag`) — §5 attribution-not-auth |
+| `CODEOWNERS` | per-dev path ownership for trust-bearing paths (enforcement deferred — see file header) |
+| `taxonomy/areas.yaml` | controlled `area` + `pattern_key` vocab *(issue #239 — laptop-wsl)* |
+| `patterns/<area>/<dev>.yaml` | each dev's per-area patterns *(issue #243)* |
+| `patterns/adopted/BKM-NNN.yaml` | adopted team patterns (BKMs) |
+| `components/catalog.yaml` | shareable-component index + git refs |
+| `scripts/roster.py` | roster/ownership validation + sender quarantine (this issue) |
+| `scripts/map_patterns.py` | within-dev + team divergence map *(issue #244 — server-a)* |
+| `audit/<dev>.jsonl` | per-dev append-only audit shards, union-on-read *(issue #240)* |
+
+## Trust model (§5/§6)
+
+Attribution is required (whose pattern/component is whose); authentication is not (4 known
+teammates). But **attribution alone is forgeable in a shared repo**, so trust-bearing writes
+(`audit/<dev>.jsonl`, catalog entries) are CODEOWNER/path-owned and — when real identities exist —
+gated by **branch protection + a CI check on the platform-verified merge actor (never the git
+`author`)**. v1 ships the structure + validation logic; the repo-admin enforcement is deferred.

--- a/team-knowledge/audit/.gitkeep
+++ b/team-knowledge/audit/.gitkeep
@@ -1,0 +1,1 @@
+# placeholder — populated by a later build issue (see README.md)

--- a/team-knowledge/components/catalog.yaml
+++ b/team-knowledge/components/catalog.yaml
@@ -1,0 +1,5 @@
+# Shareable-component catalog (§Pillar 3). Each entry is owner_dev-gated; `secrets_scan_clean`
+# means "outbound secret scan passed" — NOT "safe to run". Importers MUST run the ComponentReview
+# intake gate (quarantine-clone pinned SHA, manifest, review_token) before adapting — issue #242.
+schema_version: 1
+components: []   # populated when the first component is published (e.g. the voice pipeline)

--- a/team-knowledge/patterns/.gitkeep
+++ b/team-knowledge/patterns/.gitkeep
@@ -1,0 +1,1 @@
+# placeholder — populated by a later build issue (see README.md)

--- a/team-knowledge/patterns/adopted/.gitkeep
+++ b/team-knowledge/patterns/adopted/.gitkeep
@@ -1,0 +1,1 @@
+# placeholder — populated by a later build issue (see README.md)

--- a/team-knowledge/roster.yaml
+++ b/team-knowledge/roster.yaml
@@ -1,0 +1,25 @@
+# Team Knowledge Hub — developer allowlist (§5 Identity = attribution, NOT authentication)
+# MVP v1: a static roster of the 4 collaborating nodes. Agents self-declare dev_id;
+# unknown senders are quarantined (see scripts/roster.py:classify_sender).
+# NOTE: real cross-account CODEOWNER enforcement + branch protection is DEFERRED — it requires
+# separate GitHub identities, which the v1 fleet (all under one account) does not have. The
+# roster + CODEOWNERS here are the STRUCTURAL contract; enforcement lands at the public tier.
+schema_version: 1
+team_tag: team-v1
+devs:
+  - dev_id: jason
+    agent_name: claude-code
+    machine: jns-mac
+    team_tag: team-v1
+  - dev_id: server-a
+    agent_name: claude-code
+    machine: jns-server
+    team_tag: team-v1
+  - dev_id: laptop-wsl
+    agent_name: claude-code
+    machine: jj-dellpro14
+    team_tag: team-v1
+  - dev_id: agent-b
+    agent_name: codex
+    machine: jns-server          # co-located bridge (codex-bridge-agent-b); own clone in serial mode
+    team_tag: team-v1

--- a/team-knowledge/scripts/roster.py
+++ b/team-knowledge/scripts/roster.py
@@ -1,0 +1,102 @@
+"""Roster + path-ownership validation for the Team Knowledge Hub (§5, §6).
+
+Pure-logic module — no network, no side effects. Backs issue #238's acceptance tests.
+
+The load-bearing rule (Codex F4/N3): the trust check for a change to a trust-bearing path keys on
+the **platform-verified merge actor**, NEVER the forgeable git `author` field. This module makes
+that explicit so the CI/branch-protection wiring (deferred to repo-admin) has a tested contract.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover - PyYAML is a soft dep for file loading only
+    yaml = None
+
+REQUIRED_DEV_FIELDS = ("dev_id", "agent_name", "machine", "team_tag")
+
+# audit/<dev>.jsonl  ->  <dev>  (dev_id chars: alnum, dash, underscore)
+_AUDIT_PATH_RE = re.compile(r"(?:^|/)audit/(?P<dev>[A-Za-z0-9_-]+)\.jsonl$")
+
+
+def load_roster(path) -> dict:
+    """Load roster.yaml into a dict. Raises if PyYAML is unavailable."""
+    if yaml is None:
+        raise RuntimeError("PyYAML is required to load roster.yaml")
+    return yaml.safe_load(Path(path).read_text(encoding="utf-8")) or {}
+
+
+def validate_roster(roster: dict) -> list:
+    """Return a list of human-readable errors; an empty list means the roster is valid."""
+    errors: list = []
+    if roster.get("schema_version") != 1:
+        errors.append(f"schema_version must be 1, got {roster.get('schema_version')!r}")
+    devs = roster.get("devs")
+    if not isinstance(devs, list) or not devs:
+        errors.append("roster.devs must be a non-empty list")
+        return errors
+    seen: set = set()
+    for i, dev in enumerate(devs):
+        if not isinstance(dev, dict):
+            errors.append(f"devs[{i}] is not a mapping")
+            continue
+        for field in REQUIRED_DEV_FIELDS:
+            if not dev.get(field):
+                errors.append(
+                    f"devs[{i}] ({dev.get('dev_id', '?')}) missing required field {field!r}"
+                )
+        did = dev.get("dev_id")
+        if did in seen:
+            errors.append(f"duplicate dev_id {did!r}")
+        seen.add(did)
+    return errors
+
+
+def roster_dev_ids(roster: dict) -> set:
+    return {d.get("dev_id") for d in roster.get("devs", []) if isinstance(d, dict)}
+
+
+def is_known_dev(roster: dict, dev_id: str) -> bool:
+    return dev_id in roster_dev_ids(roster)
+
+
+def classify_sender(roster: dict, dev_id: str) -> str:
+    """'known' if dev_id is in the roster, else 'quarantine' (§5: unknown senders quarantined)."""
+    return "known" if is_known_dev(roster, dev_id) else "quarantine"
+
+
+def audit_path_owner(path: str):
+    """dev_id that owns an audit shard: audit/<dev>.jsonl -> <dev>; None if not an audit path."""
+    m = _AUDIT_PATH_RE.search(str(path).replace("\\", "/"))
+    return m.group("dev") if m else None
+
+
+def is_path_owned_by(path: str, dev_id: str) -> bool:
+    return audit_path_owner(path) == dev_id
+
+
+def verify_merge_actor(owner_dev: str, *, pr_actor: str, git_author=None) -> bool:
+    """Trust check for a change to an owned path (Codex F4/N3).
+
+    Returns True ONLY if the platform-verified merge actor equals ``owner_dev``. ``git_author`` is
+    accepted but DELIBERATELY IGNORED for the decision — it is user-controlled text and exists in
+    this signature only to document that ``pr_actor`` and ``git_author`` can differ (the
+    forgeable-attribution trap). Never substitute ``git_author`` into the comparison.
+    """
+    return pr_actor == owner_dev
+
+
+def catalog_entry_valid(entry: dict, approvals: dict) -> bool:
+    """A catalog entry is importable only if its ``scan_audit`` row carries a protected-approval
+    record (§6 / Codex F4). ``approvals`` maps a scan_audit ref -> approval record; a falsy/absent
+    record means un-gated provenance, which is refused.
+    """
+    if not isinstance(entry, dict):
+        return False
+    ref = entry.get("scan_audit")
+    if not ref:
+        return False
+    return bool(approvals.get(ref))

--- a/team-knowledge/taxonomy/.gitkeep
+++ b/team-knowledge/taxonomy/.gitkeep
@@ -1,0 +1,1 @@
+# placeholder — populated by a later build issue (see README.md)

--- a/team-knowledge/tests/test_roster.py
+++ b/team-knowledge/tests/test_roster.py
@@ -1,0 +1,89 @@
+"""Acceptance tests for issue #238 — team-knowledge skeleton + roster (§5, §6).
+
+Covers the five required cases: roster schema, CODEOWNERS path match, the forgeable-attribution
+guard, importer rejection of un-gated provenance, and unknown-sender quarantine.
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+_TK = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_TK / "scripts"))
+
+import roster as R  # noqa: E402
+
+ROSTER_PATH = _TK / "roster.yaml"
+
+
+@pytest.fixture(scope="module")
+def real_roster() -> dict:
+    return R.load_roster(ROSTER_PATH)
+
+
+# 1. roster.yaml schema validation -----------------------------------------------------------
+def test_real_roster_is_valid(real_roster):
+    assert R.validate_roster(real_roster) == []
+    ids = R.roster_dev_ids(real_roster)
+    assert {"jason", "server-a", "laptop-wsl", "agent-b"} <= ids
+    for dev in real_roster["devs"]:
+        for field in R.REQUIRED_DEV_FIELDS:
+            assert dev.get(field), f"{dev.get('dev_id')} missing {field}"
+
+
+def test_missing_required_field_is_an_error():
+    bad = {"schema_version": 1, "devs": [{"dev_id": "x", "agent_name": "a", "machine": "m"}]}
+    errs = R.validate_roster(bad)
+    assert any("team_tag" in e for e in errs)
+
+
+def test_duplicate_dev_id_is_an_error():
+    dup = {
+        "schema_version": 1,
+        "devs": [
+            {"dev_id": "x", "agent_name": "a", "machine": "m", "team_tag": "t"},
+            {"dev_id": "x", "agent_name": "a", "machine": "m", "team_tag": "t"},
+        ],
+    }
+    assert any("duplicate" in e for e in R.validate_roster(dup))
+
+
+# 2. CODEOWNERS path match -------------------------------------------------------------------
+def test_audit_path_ownership():
+    assert R.audit_path_owner("team-knowledge/audit/jason.jsonl") == "jason"
+    assert R.is_path_owned_by("team-knowledge/audit/jason.jsonl", "jason") is True
+    # server-a's shard is NOT owned by jason
+    assert R.is_path_owned_by("team-knowledge/audit/server-a.jsonl", "jason") is False
+    assert R.audit_path_owner("team-knowledge/audit/server-a.jsonl") == "server-a"
+    # a non-audit path has no audit owner
+    assert R.audit_path_owner("team-knowledge/components/catalog.yaml") is None
+
+
+# 3. forgeable-attribution guard -------------------------------------------------------------
+def test_trust_check_uses_pr_actor_not_git_author():
+    # The platform-verified merge actor matches the owner -> trusted, even though the (forgeable)
+    # git author claims to be the owner in BOTH cases. The decision must follow pr_actor only.
+    assert R.verify_merge_actor("jason", pr_actor="jason", git_author="jason") is True
+    # Attacker forges git author = 'jason' but the real merge actor is someone else -> REFUSED.
+    assert R.verify_merge_actor("jason", pr_actor="mallory", git_author="jason") is False
+    # pr_actor and git_author can legitimately differ (commit by A, merged by owner) -> still trusted.
+    assert R.verify_merge_actor("jason", pr_actor="jason", git_author="contributor") is True
+
+
+# 4. importer rejection of un-gated provenance ----------------------------------------------
+def test_catalog_entry_rejected_without_approval_record():
+    entry = {"id": "voice-pipeline-v1", "owner_dev": "jason",
+             "scan_audit": "audit/jason.jsonl#evt-1"}
+    # No approval record for that scan_audit ref -> refused.
+    assert R.catalog_entry_valid(entry, approvals={}) is False
+    # With a protected-approval record present -> accepted.
+    assert R.catalog_entry_valid(entry, approvals={"audit/jason.jsonl#evt-1": {"approved_by": "jason"}}) is True
+    # Missing scan_audit pointer -> refused.
+    assert R.catalog_entry_valid({"id": "x", "owner_dev": "jason"}, approvals={"x": True}) is False
+
+
+# 5. unknown-sender quarantine ---------------------------------------------------------------
+def test_unknown_sender_is_quarantined(real_roster):
+    assert R.classify_sender(real_roster, "jason") == "known"
+    assert R.classify_sender(real_roster, "agent-d") == "quarantine"
+    assert R.is_known_dev(real_roster, "agent-d") is False


### PR DESCRIPTION
## Summary
Foundation for the team-knowledge build slice (#238) — the root that #239–#245 depend on. **Built by scratch** (taking over development while the hub is down / server-a unreachable).

Adds the `team-knowledge/` scaffold + `roster.yaml` (4-dev allowlist) + CODEOWNERS + a pure-logic ownership/validation module + tests.

## Two decisions I made (flagging — easy to change)
1. **`team-knowledge/` as a subdir of `~/agents`** for v1, not a separate repo (spec frames it as separate). Reversible; avoids new-repo admin; keeps the build in one place. Propagates to #239–245, so say if you want it split.
2. **Branch protection + CI merge-actor check = DEFERRED to you (repo-admin).** Enabling branch protection on this repo could lock the autonomous merge loop, and real CODEOWNER enforcement needs **separate GitHub identities the v1 fleet doesn't have** (all under one account) — it only becomes meaningful at the public tier. I built the CODEOWNERS *file* + the trust-check *logic* + tests; I did **not** flip repo settings.

## What's in
- `roster.yaml` — 4 devs (jason/server-a/laptop-wsl/agent-b), §5 attribution-not-auth
- `CODEOWNERS` — per-dev `audit/<dev>.jsonl` ownership (structural; enforcement deferred per above)
- `scripts/roster.py` — schema validation, audit-path ownership, **`verify_merge_actor` (keys on the platform-verified merge actor, NOT the forgeable git author — Codex F4/N3)**, catalog importer-rejection, unknown-sender quarantine
- `README.md` — layout + the §2 north-star boundary (data, not instructions)
- scaffold dirs with placeholders (taxonomy/patterns/components/audit) for the downstream issues

## Tests
`tests/test_roster.py` — the 5 required cases: roster schema, CODEOWNERS path-match, **forged-author refusal** (mallory forges git author=jason but merge actor differs → refused), importer rejection of un-gated provenance, unknown-sender quarantine. **7 tests pass, ruff clean.**

## Review note
Built + self-reviewed by scratch (no independent gate: hub down → server-a unreachable; Codex hung twice today). Tests are the gate. Low-risk mechanical scaffold. Branch-protection decision is yours.

Closes #238

🤖 Generated with [Claude Code](https://claude.com/claude-code)