### PR TITLE
feat(team-knowledge): taxonomy + pattern schema + confidence function (#239)

### DIFF
--- a/team-knowledge/scripts/patterns.py
+++ b/team-knowledge/scripts/patterns.py
@@ -1,0 +1,171 @@
+"""Pattern taxonomy, confidence, and schema logic for the Team Knowledge Hub (§1.3, §1.5).
+
+Pure-logic module. Backs issue #239. Two principles are load-bearing (Codex F6 + laptop-wsl):
+  1. Confidence is COMPUTED, never authored — and OCCURRENCE confidence (how often seen) is kept
+     separate from EFFICACY confidence (does telemetry show it helps; null until powered).
+  2. Bootstrap seeds the TAXONOMY only — `observation_count` starts at 0 per dev; the seed corpus's
+     `validated`/`validated_count` is NEVER mapped to observations (the fake-consensus guard, §7).
+"""
+from __future__ import annotations
+
+import math
+import re
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover
+    yaml = None
+
+UNMAPPED = "UNMAPPED"  # sentinel: "no pattern_key fits" — never force-bucket to the closest match
+
+DEFAULT_N_CAP = 50
+DEFAULT_CONSENSUS_FLOOR = 0.4
+_DECLARED_PENALTY = 0.5      # declared-only confidence is halved vs the same observed count
+_CORROBORATION_BONUS = 0.2   # only for GENUINELY independent telemetry agreement
+
+REQUIRED_PATTERN_FIELDS = ("id", "dev", "area", "pattern_key", "practice", "source")
+_COMPUTED_FIELDS = ("occurrence_confidence", "efficacy_confidence")
+_VALID_SOURCES = {"observed", "declared", "observed+declared"}
+
+
+# --- confidence (§1.3, Codex F6) ------------------------------------------------------------
+def compute_occurrence_confidence(
+    observation_count: int,
+    *,
+    source: str = "observed",
+    independent_corroboration: bool = False,
+    n_cap: int = DEFAULT_N_CAP,
+) -> float:
+    """A simple, inspectable capped-log of how OFTEN a practice was observed. Never a learned score.
+
+    base = log2(1+obs) / log2(1+n_cap); declared-only is penalized; independent telemetry adds a
+    fixed bonus. Clamped to [0, 1]. `observation_count=0 -> 0.0`; `=n_cap -> 1.0`.
+    """
+    if observation_count <= 0:
+        base = 0.0
+    else:
+        base = math.log2(1 + observation_count) / math.log2(1 + max(1, n_cap))
+        base = min(1.0, base)
+    conf = base
+    if "observed" not in (source or ""):
+        conf *= _DECLARED_PENALTY  # declared-only: weaker than the same observed count
+    if independent_corroboration:
+        conf = min(1.0, conf + _CORROBORATION_BONUS)
+    return round(conf, 4)
+
+
+def compute_efficacy_confidence(*_args, **_kwargs):
+    """Efficacy is NOT auto-computed — it stays None until powered outcome evidence exists
+    (§1.3, §1.6 step 6). This function exists to make that explicit and is intentionally inert."""
+    return None
+
+
+# --- gating (§1.3) --------------------------------------------------------------------------
+def is_consensus_eligible(occurrence_confidence: float, source: str, floor: float = DEFAULT_CONSENSUS_FLOOR) -> bool:
+    """CONSENSUS requires occurrence_confidence >= floor AND `source` includes 'observed'.
+    The two conditions are checked SEPARATELY so a purely-declared pattern that clears the floor
+    (e.g. via bonus) is still excluded (the purely-declared quorum guard)."""
+    return occurrence_confidence >= floor and "observed" in (source or "")
+
+
+def consensus_candidates(patterns: list, floor: float = DEFAULT_CONSENSUS_FLOOR) -> list:
+    return [p for p in patterns
+            if is_consensus_eligible(p.get("occurrence_confidence", 0.0), p.get("source", ""), floor)]
+
+
+def conflict_gap_candidates(patterns: list) -> list:
+    """CONFLICT/GAP analysis keeps EVERY pattern, including low-confidence ones — a low-confidence
+    *contradictory* signal may be the only evidence a consensus is unsafe, so it stays visible
+    (§1.3, Codex F6: don't let the floor mute contradiction)."""
+    return list(patterns)
+
+
+# --- pattern_key resolution / UNMAPPED ------------------------------------------------------
+def resolve_pattern_key(candidate_key: str, taxonomy_keys) -> str:
+    """Return the candidate key if it is in the controlled taxonomy, else UNMAPPED.
+    NEVER returns a 'closest match' — an unmapped observation is surfaced as a taxonomy gap."""
+    if candidate_key and candidate_key in set(taxonomy_keys):
+        return candidate_key
+    return UNMAPPED
+
+
+def is_taxonomy_gap(pattern_key: str) -> bool:
+    return pattern_key == UNMAPPED
+
+
+# --- schema validation (§1.3) ---------------------------------------------------------------
+def validate_authored_pattern(pattern: dict, taxonomy: dict | None = None) -> list:
+    """Validate a pattern as AUTHORED by a dev (not yet system-computed). Returns errors; empty=valid.
+
+    Rejects any authored `occurrence_confidence`/`efficacy_confidence` — those are COMPUTED by the
+    system, never hand-written (authoring one would bypass the gate). Checks required fields,
+    a valid `source`, and (if a taxonomy is given) that area + pattern_key are controlled.
+    """
+    errors: list = []
+    if not isinstance(pattern, dict):
+        return ["pattern is not a mapping"]
+    for f in _COMPUTED_FIELDS:
+        if f in pattern:
+            errors.append(f"{f!r} is COMPUTED — must not be authored")
+    for f in REQUIRED_PATTERN_FIELDS:
+        if not pattern.get(f):
+            errors.append(f"missing required field {f!r}")
+    src = pattern.get("source")
+    if src and src not in _VALID_SOURCES:
+        errors.append(f"invalid source {src!r} (expected one of {sorted(_VALID_SOURCES)})")
+    if taxonomy:
+        areas = taxonomy.get("areas", {})
+        area = pattern.get("area")
+        key = pattern.get("pattern_key")
+        if area and area not in areas:
+            errors.append(f"area {area!r} not in controlled taxonomy")
+        elif area and key and key != UNMAPPED and key not in set(areas.get(area, [])):
+            errors.append(f"pattern_key {key!r} not in taxonomy for area {area!r} (use {UNMAPPED} if none fits)")
+    return errors
+
+
+# --- bootstrap (§1.5) -----------------------------------------------------------------------
+def _key_from_pattern_file(data: dict) -> str:
+    """Derive a canonical pattern_key from a knowledge/patterns/ file (vocabulary only)."""
+    raw = data.get("name") or data.get("legacy_id") or data.get("id") or ""
+    key = re.sub(r"[^A-Za-z0-9]+", "_", str(raw)).strip("_").upper()
+    return key or UNMAPPED
+
+
+def bootstrap_vocabulary(patterns_dir) -> dict:
+    """Extract area -> [pattern_key] VOCABULARY from knowledge/patterns/*.yaml.
+
+    VOCABULARY ONLY. `observation_count` is NOT set here (it starts at 0 per dev elsewhere), and the
+    seed corpus's `status: validated` / `validated_count` / `consecutive_successes` are IGNORED —
+    mapping them to observations would manufacture consensus from the seed (laptop-wsl, §7).
+    """
+    if yaml is None:
+        raise RuntimeError("PyYAML required to bootstrap vocabulary")
+    vocab: dict = {}
+    for path in sorted(Path(patterns_dir).glob("*.yaml")):
+        try:
+            data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        except Exception:
+            continue
+        if not isinstance(data, dict):
+            continue
+        area = data.get("category")
+        if not area:
+            continue
+        key = _key_from_pattern_file(data)
+        vocab.setdefault(area, [])
+        if key not in vocab[area]:
+            vocab[area].append(key)
+    return vocab
+
+
+def seed_observation_counts(vocab: dict, devs: list) -> dict:
+    """Return {(dev, area, pattern_key): 0} for every bootstrapped key — the zero-start guarantee.
+    observation_count accrues only on REAL observation of a dev using a key, never from the seed."""
+    return {
+        (dev, area, key): 0
+        for area, keys in vocab.items()
+        for key in keys
+        for dev in devs
+    }

--- a/team-knowledge/taxonomy/GOVERNANCE.md
+++ b/team-knowledge/taxonomy/GOVERNANCE.md
@@ -1,0 +1,29 @@
+# Taxonomy governance — minting new areas / pattern_keys (§1.5)
+
+The taxonomy is the comparability layer (#223): patterns only align when keyed to a *shared*
+vocabulary. So it must be **controlled** — but also **extensible**, or it ossifies and everything
+real falls into `UNMAPPED`.
+
+## The signal to extend
+`UNMAPPED` is not noise — it's the **taxonomy-gap signal**. When observations repeatedly resolve to
+`UNMAPPED` (see `scripts/patterns.py:resolve_pattern_key`), that recurrence is the trigger to
+consider a new key/area. An `ALL_CAPS` token recurring in `UNMAPPED` clusters = "add a key" (#223).
+
+## The rule (conservative by design)
+Mint a new `area` or `pattern_key` only when **all** hold:
+1. **Recurrence:** the same unmapped concern shows up ≥ N times (start N=3) across observations,
+   not a one-off.
+2. **Distinct concern:** it isn't a rename of an existing key — it captures a genuinely different
+   practice (else you fragment the vocabulary and break matching).
+3. **Cross-checked:** at least one other roster member agrees it's distinct (avoids one dev's
+   idiosyncratic split). Conflicts go to the §arbiter (Jason).
+
+## What NOT to do
+- **Never force-bucket** an unmapped observation to the closest existing key — that manufactures
+  false matches. `UNMAPPED` is correct until a key is deliberately minted.
+- **Never** back-fill `observation_count` from a seed/import — vocabulary is seeded, observations
+  are earned (`scripts/patterns.py:bootstrap_vocabulary`).
+
+## Mechanics
+Edit `areas.yaml` (add the area/key), reference the recurring `UNMAPPED` evidence in the PR, and
+get one other roster member's review. The change is vocabulary-only; it never carries counts.

--- a/team-knowledge/taxonomy/areas.yaml
+++ b/team-knowledge/taxonomy/areas.yaml
@@ -1,0 +1,35 @@
+# Controlled practice-area + pattern_key vocabulary (§1.5). The comparability layer: patterns only
+# align when keyed to a SHARED taxonomy (#223). Seeded from the team's discovered common stack +
+# the existing knowledge/patterns/ categories (VOCABULARY ONLY — never observation_count/validated,
+# see scripts/patterns.py:bootstrap_vocabulary and the §7 fake-consensus guard).
+#
+# Extend via governance (taxonomy/GOVERNANCE.md): a new area/key is minted only when UNMAPPED
+# patterns recur with a genuinely distinct concern. UNMAPPED is the sentinel for "no key fits" —
+# never force-bucket to the closest match.
+schema_version: 1
+config:
+  n_cap: 50                 # occurrence_confidence saturation point (>=50 keeps 1-obs sub-floor)
+  consensus_floor: 0.4      # occurrence_confidence threshold to be CONSENSUS-eligible
+areas:
+  auth: [JWT_WITH_REFRESH, SESSION_REDIS, OAUTH2_FLOW, AUTH_CONTEXT_DEP, PASSWORD_HASH_BCRYPT]
+  rbac: [ROLE_PERMISSION_DICT, REQUIRE_PERMISSION_DEP, OWNER_SCOPED_DEP]
+  fastapi-layering: [ROUTER_SERVICE_REPO, BASE_MODEL_MIXIN, DEPENDS_INJECTION, ALEMBIC_SETUP]
+  db-orm: [ASYNCPG_POOL, SQLALCHEMY_ASYNC, REPO_PATTERN, NO_RAW_DB_EXECUTE]
+  data-migrations: [ADDITIVE_ONLY, ALEMBIC_AUTOGEN, FK_WITH_INDEX]
+  caching: [REDIS_TTL, CACHE_ASIDE]
+  multi-tenancy: [TENANT_SCOPED_QUERY, ROW_LEVEL_ISOLATION]
+  api-design: [REST_RESOURCE, PYDANTIC_SCHEMA_IO, PAGINATION_CURSOR]
+  typing-schemas: [PYDANTIC_STRICT, OPTIONAL_MATCHES_NULLABLE, SCHEMA_MODEL_PARITY]
+  error-handling: [CUSTOM_EXC_PER_MODULE, NO_BARE_EXCEPT, STRUCTURED_ERROR_RESPONSE]
+  testing: [SQLITE_COMPAT_TESTS, FIXTURE_FACTORIES, ADVERSARIAL_INPUT_TESTS, NO_SECRET_IN_FIXTURES]
+  git-workflow: [BRANCH_FROM_MAIN, CONVENTIONAL_COMMITS, SQUASH_MERGE, REBASE_AUTOSTASH]
+  code-review: [CODEX_ADVERSARIAL_PASS, PER_AC_AUDIT, SCOPE_FREEZE]
+  dependency-mgmt: [PINNED_DEPS, ANNOTATED_DEPS, PRE_PROVISION_BASE_ENV]
+  security: [NO_SECRETS_IN_CODE, SANITIZE_BEFORE_SHARE, QUARANTINE_UNTRUSTED, DOCKER_NONROOT_USER]
+  concurrency: [ASYNC_FIRE_AND_FORGET_GUARD, NO_BLOCKING_IN_ASYNC, CONN_ID_SCOPE]
+  observability-logging: [STRUCTURED_LOGGING, HEARTBEAT_DEADMAN, OTEL_EXPORT]
+  documentation: [DOCSTRING_INVARIANTS, README_BOUNDARY, SPEC_CODE_REALITY_MANIFEST]
+  naming-style: [SNAKE_CASE_PY, CONVENTIONAL_FILE_LAYOUT]
+  ai-agent-workflow: [MAP_PLAN_PATCH_PROVE, RIGHT_SIZE_MODEL_TIER, ESCALATE_ON_RISK, ADVISORY_NOT_ENFORCED]
+  performance: [CACHE_AWARE_COST, AVOID_SEQUENTIAL_IO, MEASURE_BEFORE_OPTIMIZE]
+  refactoring: [EXTRACT_PURE_FUNCTION, DELETE_DEAD_CODE]

--- a/team-knowledge/tests/test_patterns.py
+++ b/team-knowledge/tests/test_patterns.py
@@ -1,0 +1,106 @@
+"""Acceptance tests for issue #239 — taxonomy + pattern schema + confidence (§1.3, §1.5)."""
+import sys
+from pathlib import Path
+
+import pytest
+
+_TK = Path(__file__).resolve().parents[1]
+_AGENTS = _TK.parent
+sys.path.insert(0, str(_TK / "scripts"))
+
+import patterns as P  # noqa: E402
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover
+    yaml = None
+
+AREAS_PATH = _TK / "taxonomy" / "areas.yaml"
+KNOWLEDGE_PATTERNS = _AGENTS / "knowledge" / "patterns"
+
+
+@pytest.fixture(scope="module")
+def taxonomy() -> dict:
+    return yaml.safe_load(AREAS_PATH.read_text(encoding="utf-8"))
+
+
+# 1. occurrence confidence arithmetic --------------------------------------------------------
+def test_occurrence_confidence_arithmetic():
+    assert P.compute_occurrence_confidence(0, source="observed") == 0.0
+    # 1 observation, no bonus, N_cap=50 -> well below the 0.4 floor (conservative cap)
+    one = P.compute_occurrence_confidence(1, source="observed", n_cap=50)
+    assert 0.0 < one < 0.4, one
+    # saturates at N_cap
+    assert P.compute_occurrence_confidence(50, source="observed", n_cap=50) == 1.0
+
+
+# 2. declared-only penalty -------------------------------------------------------------------
+def test_declared_only_is_penalized():
+    obs = P.compute_occurrence_confidence(20, source="observed")
+    dec = P.compute_occurrence_confidence(20, source="declared")
+    assert dec < obs, (dec, obs)
+
+
+# 3. purely-declared quorum guard ------------------------------------------------------------
+def test_declared_only_excluded_from_consensus_even_above_floor():
+    # declared-only at a high observation count clears the numeric floor...
+    conf = P.compute_occurrence_confidence(50, source="declared")
+    assert conf >= P.DEFAULT_CONSENSUS_FLOOR, conf  # 1.0 * 0.5 = 0.5 >= 0.4
+    # ...yet it is STILL excluded from CONSENSUS because `source` lacks 'observed'
+    assert P.is_consensus_eligible(conf, "declared") is False
+    # an observed pattern at the same confidence IS eligible
+    assert P.is_consensus_eligible(conf, "observed") is True
+
+
+# 4. bootstrap zero-start (the fake-consensus guard) -----------------------------------------
+def test_bootstrap_is_vocabulary_only_zero_observations():
+    vocab = P.bootstrap_vocabulary(KNOWLEDGE_PATTERNS)
+    assert vocab, "expected some bootstrapped areas"
+    assert "auth" in vocab  # auth-*.yaml carry category: auth
+    seeded = P.seed_observation_counts(vocab, devs=["jason", "server-a", "laptop-wsl", "agent-b"])
+    # EVERY (dev, area, key) starts at 0 — validated_count from the corpus is NOT mapped in
+    assert seeded, "expected seeded counts"
+    assert set(seeded.values()) == {0}, "observation_count must start at 0 for all seeds"
+    # the bootstrap output carries no validation/status field that could leak into a count
+    assert all(isinstance(k, tuple) and v == 0 for k, v in seeded.items())
+
+
+# 5. low-confidence contradiction stays visible in CONFLICT/GAP ------------------------------
+def test_low_confidence_contradiction_visible_but_not_in_consensus():
+    patterns = [
+        {"pattern_key": "A", "occurrence_confidence": 0.8, "source": "observed"},
+        {"pattern_key": "A", "occurrence_confidence": 0.7, "source": "observed"},
+        {"pattern_key": "A", "occurrence_confidence": 0.6, "source": "observed"},
+        {"pattern_key": "B", "occurrence_confidence": 0.2, "source": "observed"},  # low-conf, contradicts A
+    ]
+    consensus = P.consensus_candidates(patterns)
+    conflict = P.conflict_gap_candidates(patterns)
+    low = patterns[-1]
+    assert low not in consensus, "low-confidence pattern must be excluded from CONSENSUS"
+    assert low in conflict, "low-confidence contradiction must stay visible in CONFLICT/GAP"
+
+
+# 6. UNMAPPED surfacing ----------------------------------------------------------------------
+def test_unmapped_never_force_bucketed(taxonomy):
+    keys = [k for area in taxonomy["areas"].values() for k in area]
+    assert P.resolve_pattern_key("JWT_WITH_REFRESH", keys) == "JWT_WITH_REFRESH"
+    # a key that matches nothing -> UNMAPPED, never the closest existing key
+    assert P.resolve_pattern_key("SOMETHING_TOTALLY_NEW", keys) == P.UNMAPPED
+    assert P.is_taxonomy_gap(P.UNMAPPED) is True
+    assert P.is_taxonomy_gap("JWT_WITH_REFRESH") is False
+
+
+# 7. schema rejects authored confidence ------------------------------------------------------
+def test_schema_rejects_authored_confidence(taxonomy):
+    base = {
+        "id": "PRAC-jason-error-handling-001", "dev": "jason", "area": "error-handling",
+        "pattern_key": "CUSTOM_EXC_PER_MODULE", "practice": "custom exc per module",
+        "source": "observed",
+    }
+    assert P.validate_authored_pattern(base, taxonomy) == []  # clean authored pattern is valid
+    bad = dict(base, occurrence_confidence=0.99)              # hand-authored confidence
+    errs = P.validate_authored_pattern(bad, taxonomy)
+    assert any("occurrence_confidence" in e for e in errs), errs
+    # an uncontrolled pattern_key for the area is rejected (use UNMAPPED instead)
+    bad_key = dict(base, pattern_key="NOT_A_REAL_KEY")
+    assert any("not in taxonomy" in e for e in P.validate_authored_pattern(bad_key, taxonomy))


### PR DESCRIPTION
## Summary
The comparability layer (§1.3, §1.5) — laptop-wsl's expertise lane, **built by scratch** (hub down → solo take-over). Blocked-by #238 (merged).

- `taxonomy/areas.yaml` — 22 controlled areas, each with seed `pattern_key`s + config (`n_cap`, `consensus_floor`)
- `scripts/patterns.py`:
  - **occurrence_confidence** (capped-log, `N_cap=50`, declared-only penalty, independent-corroboration bonus) kept **separate from efficacy_confidence** (null until powered — §1.6, Codex F6)
  - CONSENSUS gating: `>= floor` **AND** `source` includes `observed` (purely-declared never trips quorum — checked separately)
  - CONFLICT/GAP keeps **low-confidence contradictions visible** (don't let the floor mute dissent — Codex F6)
  - `UNMAPPED` sentinel — never force-bucket to a closest match
  - `bootstrap_vocabulary` — **vocabulary only; `observation_count` starts 0; the corpus's `validated`/`validated_count` is NEVER mapped** (laptop-wsl's fake-consensus guard, §7)
- `taxonomy/GOVERNANCE.md` — conservative new-area minting (UNMAPPED recurrence = the signal)

## Tests
`tests/test_patterns.py` — the 7 required cases (confidence arithmetic, declared penalty, purely-declared quorum guard, **bootstrap zero-start**, low-conf contradiction visibility, UNMAPPED surfacing, authored-confidence rejection). **7 pass, ruff clean.**

## Review note
Built + self-reviewed by scratch (no independent gate — hub down, Codex hung twice). Tests are the gate. The confidence constants (`n_cap`/`floor`/`penalty`/`bonus`) are **config** — laptop-wsl to tune on its review; any change is a knob, not a redo.

Closes #239

🤖 Generated with [Claude Code](https://claude.com/claude-code)