### PR TITLE
feat(telemetry): OTEL readable-sink reader + cache-aware cost + freshness (#230)

### DIFF
--- a/claude-config/scripts/otel_sink.py
+++ b/claude-config/scripts/otel_sink.py
@@ -1,0 +1,136 @@
+"""OTEL → readable token-usage sink: reader, cache-aware cost, freshness check (§1.1, §1.2).
+
+The "sleeper" prerequisite (telemetry-validation §5 build item 1.5): Claude Code PUSHES
+`claude_code.token.usage` via OTEL — it is not sitting in a file. A collector/file-exporter lands
+it in a readable JSONL sink; THIS module reads that sink, computes cache-aware COST (not raw
+tokens — §1.2), and provides the exporter-freshness alarm that feeds the watchdog (§0.1).
+
+Scope note: the live collector wiring (Claude Code OTLP -> file exporter) is a per-host DEPLOY
+documented in OTEL_SINK_SETUP.md and deferred to jns-server. This module + its tests run against
+simulated pushes (the AC's "simulated OTEL push") and are host-agnostic.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+TOKEN_FIELDS = ("input", "output", "cache_creation", "cache_read")
+
+# Per-token USD prices. Ratios are the load-bearing part (§1.2): cache_read = 0.10x fresh input,
+# output dearest, cache_creation ~1.25x input. Absolute numbers track Anthropic's published rates
+# (per-MTok / 1e6) and are config — refine as pricing changes.
+PRICES = {
+    "claude-opus-4":   {"input": 15e-6, "output": 75e-6, "cache_creation": 18.75e-6, "cache_read": 1.5e-6},
+    "claude-sonnet-4": {"input": 3e-6,  "output": 15e-6, "cache_creation": 3.75e-6,  "cache_read": 0.30e-6},
+    "claude-haiku-4":  {"input": 0.80e-6, "output": 4e-6, "cache_creation": 1.0e-6,  "cache_read": 0.08e-6},
+}
+DEFAULT_PRICE = PRICES["claude-sonnet-4"]  # conservative fallback for unrecognized models
+
+EXPORTER_FRESHNESS_SLA_DEFAULT = 24 * 3600  # 24h: sink must be written within SLA or alarm (§0.1)
+
+
+def _price_for(model: str) -> dict:
+    """Pick a price row by model-family prefix; fall back to DEFAULT_PRICE for unknown models."""
+    if not model:
+        return DEFAULT_PRICE
+    m = str(model).lower()
+    for family, row in PRICES.items():
+        if m.startswith(family) or family.split("-")[1] in m:  # 'opus'/'sonnet'/'haiku' substring
+            return row
+    return DEFAULT_PRICE
+
+
+def compute_cost(record: dict, prices: dict | None = None) -> float:
+    """Cache-aware USD cost of a usage record `{input, output, cache_creation, cache_read, model}`.
+    Raw token COUNT is not a valid cost measure (§1.2) — this price-weights each token type."""
+    row = (prices or {}).get(record.get("model")) if prices else None
+    row = row or _price_for(record.get("model", ""))
+    return round(sum(int(record.get(f, 0) or 0) * row[f] for f in TOKEN_FIELDS), 10)
+
+
+def normalize_from_datapoints(datapoints: list) -> dict:
+    """Aggregate raw OTEL `claude_code.token.usage` datapoints into a normalized usage record.
+
+    Each datapoint looks like `{"value": N, "attributes": {"type": "input"|"output"|
+    "cache_creation"|"cache_read"|"cacheRead"..., "model": "..."}}`. Type names are normalized
+    (camelCase/aliases accepted). This is the OTLP -> readable mapping the file-exporter performs;
+    kept here so the mapping is tested even before the live collector lands.
+    """
+    out = {f: 0 for f in TOKEN_FIELDS}
+    model = ""
+    alias = {
+        "input": "input", "output": "output",
+        "cache_creation": "cache_creation", "cachecreation": "cache_creation",
+        "cache_creation_input_tokens": "cache_creation", "ephemeral_5m_input_tokens": "cache_creation",
+        "cache_read": "cache_read", "cacheread": "cache_read", "cache_read_input_tokens": "cache_read",
+    }
+    for dp in datapoints or []:
+        attrs = dp.get("attributes", {}) or {}
+        ttype = str(attrs.get("type", "")).replace("-", "_").lower()
+        field = alias.get(ttype)
+        if field:
+            out[field] += int(dp.get("value", 0) or 0)
+        if attrs.get("model"):
+            model = attrs["model"]
+    out["model"] = model
+    return out
+
+
+def append_sink_record(path, record: dict) -> None:
+    """Append-safe write of one normalized record as a JSONL line (back-to-back sessions safe)."""
+    p = Path(path).expanduser()
+    p.parent.mkdir(parents=True, exist_ok=True)
+    line = json.dumps(record, separators=(",", ":"), ensure_ascii=False) + "\n"
+    with open(p, "a", encoding="utf-8") as fh:
+        fh.write(line)
+
+
+def read_sink(path) -> list:
+    """Read all normalized usage records from the sink JSONL.
+
+    A MISSING sink path is an actionable error, never a silent empty read (§0.3 / AC edge case):
+    raises FileNotFoundError with a message pointing at OTEL_SINK_SETUP.md. Malformed lines are
+    skipped (the exporter may write partial lines under crash), not fatal.
+    """
+    p = Path(path).expanduser()
+    if not p.exists():
+        raise FileNotFoundError(
+            f"OTEL sink not found at {p}. The exporter is not running or misconfigured — "
+            f"see claude-config/telemetry/OTEL_SINK_SETUP.md to set up the OTLP file exporter."
+        )
+    records = []
+    with open(p, encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                records.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue  # skip a partial/corrupt line; never abort the whole read
+    return records
+
+
+def sink_last_write_ts(path):
+    """mtime of the sink (epoch seconds), or None if missing."""
+    p = Path(path).expanduser()
+    return p.stat().st_mtime if p.exists() else None
+
+
+def is_stale(last_write_ts, now_ts: float, sla_seconds: float = EXPORTER_FRESHNESS_SLA_DEFAULT) -> bool:
+    """Pure freshness predicate: stale if never written or last write older than the SLA."""
+    if last_write_ts is None:
+        return True
+    return (now_ts - last_write_ts) > sla_seconds
+
+
+def check_exporter_freshness(path, now_ts: float, sla_seconds: float = EXPORTER_FRESHNESS_SLA_DEFAULT) -> dict:
+    """Exporter-freshness alarm (§0.1 stale-exporter state). Returns
+    `{"alarm": bool, "reason": str, "age_seconds": float|None}` — feeds the #231/#232 watchdog."""
+    last = sink_last_write_ts(path)
+    if last is None:
+        return {"alarm": True, "reason": "sink_missing", "age_seconds": None}
+    age = now_ts - last
+    if age > sla_seconds:
+        return {"alarm": True, "reason": "stale_exporter", "age_seconds": round(age, 3)}
+    return {"alarm": False, "reason": "fresh", "age_seconds": round(age, 3)}

--- a/claude-config/telemetry/OTEL_SINK_SETUP.md
+++ b/claude-config/telemetry/OTEL_SINK_SETUP.md
@@ -1,0 +1,51 @@
+# OTEL → readable token-usage sink (issue #230, telemetry-validation §1.1/§1.5)
+
+Claude Code **pushes** `claude_code.token.usage` over OTEL; it is not in a file by default. This is
+the "sleeper" prerequisite: stand up a local **OTLP file sink** so the token collector (#231) can
+read cache-aware cost. The *code* that reads the sink + computes cost + alarms on staleness lives in
+`claude-config/scripts/otel_sink.py` (host-agnostic, tested against simulated pushes). This doc is
+the *deploy recipe* — the live wiring is per-host.
+
+## 1. Enable Claude Code OTEL export (env, per host)
+```bash
+export CLAUDE_CODE_ENABLE_TELEMETRY=1
+export OTEL_METRICS_EXPORTER=otlp
+export OTEL_EXPORTER_OTLP_PROTOCOL=grpc          # or http/protobuf
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
+```
+
+## 2. Run a collector with a file exporter (the sink producer)
+Claude Code emits OTLP → a local **otel-collector** maps it to the readable JSONL sink. Minimal
+`otelcol` config:
+```yaml
+receivers:
+  otlp: { protocols: { grpc: { endpoint: localhost:4317 } } }
+exporters:
+  file: { path: ${HOME}/.claude/telemetry/otel.jsonl }   # the sink read by otel_sink.py
+service:
+  pipelines:
+    metrics: { receivers: [otlp], exporters: [file] }
+```
+The sink is normalized JSONL of usage records `{ts, session_id, model, input, output,
+cache_creation, cache_read}`. If the collector emits raw OTLP datapoints instead, map them with
+`otel_sink.normalize_from_datapoints(...)` (a thin shim or a collector transform) before the file
+exporter — that mapping is implemented + tested in `otel_sink.py`.
+
+## 3. Sink location
+Default: `~/.claude/telemetry/otel.jsonl`. Append-only; the collector (single writer per host) keeps
+it append-safe. `otel_sink.read_sink()` skips partial/corrupt lines and **errors loudly on a missing
+sink** (never a silent empty read).
+
+## 4. Freshness alarm
+`otel_sink.check_exporter_freshness(path, now_ts, sla_seconds=24h)` returns the stale-exporter alarm
+state (§0.1) — wired into the watchdog (#232). `sink_missing` and `stale_exporter` are distinct
+alarm reasons.
+
+## Host notes / deferred (no server-a)
+- **macOS (scratch):** run the collector via `launchd`; paths as above. This host can be validated
+  end-to-end locally.
+- **Linux (jns-server):** run the collector via `systemd`; same env + config. **DEPLOY + LIVE
+  VALIDATION ON jns-server IS DEFERRED** until server-a is reachable — the code + simulated-push
+  tests are complete and host-agnostic, but a real Claude-Code-session → sink confirmation on Linux
+  has not been run. This is a deploy task, not a code gap. (And per §0.1, a host whose sink goes
+  stale/missing is *itself* the fleet alarm — exactly the current server-a situation.)

--- a/claude-config/tests/test_otel_sink.py
+++ b/claude-config/tests/test_otel_sink.py
@@ -1,0 +1,92 @@
+"""Acceptance tests for issue #230 — OTEL → readable-sink export (§1.1, §1.2).
+
+Runs against SIMULATED OTEL pushes (per the ACs) — host-agnostic, no live exporter needed.
+"""
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+import otel_sink as S  # noqa: E402
+
+
+# 1. sink written after a simulated OTEL push, all required fields present --------------------
+def test_simulated_push_writes_all_fields(tmp_path):
+    sink = tmp_path / "otel.jsonl"
+    # simulate raw OTEL claude_code.token.usage datapoints (one per type)
+    datapoints = [
+        {"value": 1000, "attributes": {"type": "input", "model": "claude-sonnet-4"}},
+        {"value": 200, "attributes": {"type": "output", "model": "claude-sonnet-4"}},
+        {"value": 5000, "attributes": {"type": "cache_read", "model": "claude-sonnet-4"}},
+        {"value": 800, "attributes": {"type": "cache_creation", "model": "claude-sonnet-4"}},
+    ]
+    rec = S.normalize_from_datapoints(datapoints)
+    S.append_sink_record(sink, rec)
+    got = S.read_sink(sink)
+    assert len(got) == 1
+    r = got[0]
+    for f in (*S.TOKEN_FIELDS, "model"):
+        assert f in r, f
+    assert r["input"] == 1000 and r["cache_read"] == 5000 and r["model"] == "claude-sonnet-4"
+
+
+# 2. cache-aware cost: cache_read ≈ 10% of same-token fresh input -----------------------------
+def test_cache_read_is_ten_percent_of_fresh_input():
+    n = 100_000
+    for model in ("claude-opus-4", "claude-sonnet-4", "claude-haiku-4"):
+        fresh = S.compute_cost({"input": n, "model": model})
+        cached = S.compute_cost({"cache_read": n, "model": model})
+        assert fresh > 0
+        assert cached == pytest.approx(0.10 * fresh, rel=1e-6), model
+    # output is the dearest token type (§1.2)
+    out = S.compute_cost({"output": n, "model": "claude-sonnet-4"})
+    assert out > S.compute_cost({"input": n, "model": "claude-sonnet-4"})
+
+
+# 3 & 4. exporter-freshness alarm fires when stale, not when fresh ----------------------------
+def test_freshness_alarm_fires_when_stale(tmp_path):
+    sink = tmp_path / "otel.jsonl"
+    S.append_sink_record(sink, {"input": 1, "model": "claude-sonnet-4"})
+    now = S.sink_last_write_ts(sink)
+    # pure predicate
+    assert S.is_stale(now - 100 * 3600, now, sla_seconds=24 * 3600) is True
+    # via the file: backdate the sink's mtime 48h and check
+    old = now - 48 * 3600
+    os.utime(sink, (old, old))
+    res = S.check_exporter_freshness(sink, now_ts=now, sla_seconds=24 * 3600)
+    assert res["alarm"] is True and res["reason"] == "stale_exporter"
+
+
+def test_freshness_alarm_quiet_when_fresh(tmp_path):
+    sink = tmp_path / "otel.jsonl"
+    S.append_sink_record(sink, {"input": 1, "model": "claude-sonnet-4"})
+    now = S.sink_last_write_ts(sink) + 60  # one minute later
+    res = S.check_exporter_freshness(sink, now_ts=now, sla_seconds=24 * 3600)
+    assert res["alarm"] is False and res["reason"] == "fresh"
+    assert S.is_stale(S.sink_last_write_ts(sink), now, sla_seconds=24 * 3600) is False
+
+
+# 5. back-to-back sessions append without truncation/corruption -------------------------------
+def test_back_to_back_appends_intact(tmp_path):
+    sink = tmp_path / "otel.jsonl"
+    S.append_sink_record(sink, {"input": 10, "output": 1, "model": "claude-opus-4", "session_id": "s1"})
+    S.append_sink_record(sink, {"input": 20, "output": 2, "model": "claude-sonnet-4", "session_id": "s2"})
+    got = S.read_sink(sink)
+    assert len(got) == 2
+    assert {r["session_id"] for r in got} == {"s1", "s2"}
+    assert got[0]["input"] == 10 and got[1]["input"] == 20  # order + values preserved
+
+
+# 6. missing sink path → graceful, actionable error (not silent) -----------------------------
+def test_missing_sink_raises_actionable_error(tmp_path):
+    missing = tmp_path / "does_not_exist.jsonl"
+    with pytest.raises(FileNotFoundError) as ei:
+        S.read_sink(missing)
+    msg = str(ei.value)
+    assert "OTEL_SINK_SETUP.md" in msg and "not found" in msg.lower()
+    # freshness on a missing sink alarms as sink_missing (not a silent pass)
+    res = S.check_exporter_freshness(missing, now_ts=1_000_000.0)
+    assert res["alarm"] is True and res["reason"] == "sink_missing"


### PR DESCRIPTION
## Summary
The "sleeper" prerequisite (telemetry-validation §1.1/§1.5) — unblocks the token collector (#231). server-a's lane, **built by scratch on the Mac** (server-a out of commission; built host-agnostic).

- `scripts/otel_sink.py` — `read_sink` (loud on missing path, skips partial lines), `normalize_from_datapoints` (OTLP `claude_code.token.usage` → normalized record), `compute_cost` (**cache-aware**: `cache_read = 0.1× input`, output dearest — §1.2), `append_sink_record` (back-to-back safe), `check_exporter_freshness` (stale/missing alarm states → #232 watchdog, §0.1)
- `telemetry/OTEL_SINK_SETUP.md` — deploy recipe (env + otel-collector file exporter), macOS/Linux notes
- `tests/test_otel_sink.py` — 6 required cases (simulated-push fields, **cache_read = 10% of fresh input**, freshness fires/quiet, back-to-back append, missing-path actionable error). **6 pass, ruff clean.**

## What's deferred (needs server-a) — tracked separately
Live OTEL **collector deploy + real-session→sink validation on Linux/jns-server**. The code is host-agnostic + simulated-push-tested (the AC's "simulated OTEL push"); **standing up the live exporter is a deploy task, not a code gap** — filed as a follow-up issue. Per §0.1, a host whose sink goes stale/missing is itself the fleet alarm (the current server-a situation).

## Review note
Built + self-reviewed by scratch (server-a down, Codex hung twice). Additive new module, no existing code touched. Tests are the gate.

Closes #230

🤖 Generated with [Claude Code](https://claude.com/claude-code)