### PR TITLE
feat(telemetry): cache-aware token cost collector (#231)

### DIFF
--- a/claude-config/scripts/token_collector.py
+++ b/claude-config/scripts/token_collector.py
@@ -1,0 +1,139 @@
+"""Cache-aware token COST collector (telemetry-validation §1.1-§1.5, build item 2).
+
+Reads the OTEL sink (#230, `otel_sink`) and produces price-weighted USD cost per session, then per
+task where sessions share an attribution link. Raw token counts are diagnostics; cost is the valid
+efficiency sensor (§1.2). Cost-per-outcome / waste-share stay TARGET-GATED (§0.5) — emitted here
+only as `diagnostic_only`.
+
+server-a's lane; built host-agnostic by scratch against simulated sink data (live data lands once
+the #252 collector deploy runs on jns-server). Pure logic, no side effects.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import otel_sink as O  # noqa: E402
+
+# Work types with no valid code-quality measurement — cost-tracked but EXCLUDED from targets (§2.5).
+EXCLUDED_WORK_TYPES = frozenset({"deliberative", "ops"})
+RECONCILE_TOLERANCE_DEFAULT = 0.01  # 1% — per-task sum must reconcile vs global OTEL (§2.5 watchdog)
+
+
+def is_known_model(model: str) -> bool:
+    """True if the model maps to a real price row (family prefix or opus/sonnet/haiku substring)."""
+    if not model:
+        return False
+    m = str(model).lower()
+    return any(m.startswith(fam) or fam.split("-")[1] in m for fam in O.PRICES)
+
+
+def session_cost(record: dict, *, strict: bool = True) -> float:
+    """USD cost of one usage record. STRICT (default): an unknown model is an ERROR with the model
+    name — never a silent zero-cost (that would hide spend, the #231 edge case). otel_sink.compute_cost
+    alone would fall back to a default price; the collector refuses to guess silently."""
+    model = record.get("model", "")
+    if strict and not is_known_model(model):
+        raise ValueError(
+            f"unknown model {model!r} not in price table — refusing silent zero/guessed cost; "
+            f"add it to otel_sink.PRICES"
+        )
+    return O.compute_cost(record)
+
+
+def _task_link(meta: dict) -> str | None:
+    """A task link ties sessions into one logical task: prefer issue, then branch, then task_id.
+    None => unattributed (the session IS the unit, but its cost can't roll into a task)."""
+    for k in ("issue", "branch", "task_id"):
+        v = meta.get(k)
+        if v:
+            return f"{k}:{v}"
+    return None
+
+
+def collect_sessions(sink_records: list, session_meta: dict | None = None, *, strict: bool = True) -> list:
+    """Per-session cost records (the primary unit, §1.3). `session_meta` joins capture metadata
+    (work_type / issue / branch from #229) onto the OTEL token records by session_id."""
+    session_meta = session_meta or {}
+    out = []
+    for r in sink_records:
+        sid = r.get("session_id")
+        meta = session_meta.get(sid, {})
+        work_type = meta.get("work_type") or r.get("work_type")
+        out.append({
+            "session_id": sid,
+            "model": r.get("model"),
+            "work_type": work_type,
+            "tokens": {f: int(r.get(f, 0) or 0) for f in O.TOKEN_FIELDS},
+            "cost_usd": session_cost(r, strict=strict),
+            "task_link": _task_link({**meta, **r}),
+            "excluded": work_type in EXCLUDED_WORK_TYPES,
+        })
+    return out
+
+
+def aggregate(session_costs: list) -> dict:
+    """Roll per-session costs into per-task records + the separate excluded/unattributed buckets
+    (§0.5 attribution-coverage inputs). Excluded sessions never enter task rollups or targets."""
+    tasks: dict = {}
+    excluded = 0.0
+    unattributed = 0.0
+    attributed = 0.0
+    for s in session_costs:
+        cost = s["cost_usd"]
+        if s.get("excluded"):
+            excluded += cost
+            continue
+        link = s.get("task_link")
+        if link is None:
+            unattributed += cost
+            continue
+        attributed += cost
+        t = tasks.setdefault(link, {"task_link": link, "cost_usd": 0.0, "sessions": []})
+        t["cost_usd"] = round(t["cost_usd"] + cost, 10)
+        t["sessions"].append(s["session_id"])
+    total = attributed + unattributed + excluded
+    coverage = (attributed / total) if total > 0 else 0.0
+    return {
+        "tasks": list(tasks.values()),
+        "attributed_cost_usd": round(attributed, 10),
+        "unattributed_cost_usd": round(unattributed, 10),
+        "excluded_cost_usd": round(excluded, 10),
+        "attribution_coverage": round(coverage, 4),  # feeds the §0.5 target-promotion gate
+    }
+
+
+def reconcile(attributed_total: float, otel_global_total: float, tolerance: float = RECONCILE_TOLERANCE_DEFAULT) -> dict:
+    """Token-coverage reconciliation (§2.5 watchdog): per-task attributed cost must track the global
+    OTEL total within tolerance, else attribution gaps are hiding spend → alarm."""
+    if otel_global_total <= 0:
+        return {"alarm": attributed_total > 0, "reason": "no_global_total", "deviation": None}
+    deviation = abs(attributed_total - otel_global_total) / otel_global_total
+    return {
+        "alarm": deviation > tolerance,
+        "deviation": round(deviation, 6),
+        "reason": "reconciliation_drift" if deviation > tolerance else "ok",
+    }
+
+
+def build_report(sink_records: list, session_meta: dict | None = None, *,
+                 otel_global_total: float | None = None, strict: bool = True) -> dict:
+    """The collector's emitted record. Per-session cost + per-task rollup are diagnostics. Cost-per-
+    outcome / waste-share are TARGET-GATED (§0.5) so they are explicitly labeled diagnostic_only."""
+    sessions = collect_sessions(sink_records, session_meta, strict=strict)
+    agg = aggregate(sessions)
+    report = {
+        "schema_version": 1,
+        "sessions": sessions,            # diagnostic: raw per-session cost
+        **agg,
+        "diagnostic_only": {
+            # not targets until the §0.5 gate clears (source+coverage+proxy-validated+companions)
+            "waste_token_share": None,
+            "cost_per_no_observed_defect": None,
+            "_note": "TARGET-GATED (§0.5) — diagnostics only until the promotion gate clears",
+        },
+    }
+    if otel_global_total is not None:
+        report["reconciliation"] = reconcile(agg["attributed_cost_usd"], otel_global_total)
+    return report

--- a/claude-config/tests/test_token_collector.py
+++ b/claude-config/tests/test_token_collector.py
@@ -1,0 +1,99 @@
+"""Acceptance tests for issue #231 — cache-aware token cost collector (§1.1-§1.5)."""
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+import token_collector as C  # noqa: E402
+import otel_sink as O  # noqa: E402
+
+SONNET = "claude-sonnet-4"
+
+
+# 1. cost computation at known prices --------------------------------------------------------
+def test_cost_computation_known_prices():
+    rec = {"input": 1000, "output": 500, "cache_read": 200, "cache_creation": 100, "model": SONNET}
+    p = O.PRICES[SONNET]
+    expected = (1000 * p["input"] + 500 * p["output"] + 200 * p["cache_read"] + 100 * p["cache_creation"])
+    assert C.session_cost(rec) == pytest.approx(expected, rel=1e-9)
+
+
+# 2. cache-read ≈ 10% of fresh input ---------------------------------------------------------
+def test_cache_read_ten_percent_of_input():
+    n = 50_000
+    fresh = C.session_cost({"input": n, "model": SONNET})
+    cached = C.session_cost({"cache_read": n, "model": SONNET})
+    assert cached == pytest.approx(0.10 * fresh, rel=1e-6)
+
+
+# 3. output is dearest -----------------------------------------------------------------------
+def test_output_dearest():
+    n = 10_000
+    assert C.session_cost({"output": n, "model": SONNET}) > C.session_cost({"input": n, "model": SONNET})
+
+
+# 4. multi-session task sum ------------------------------------------------------------------
+def test_multi_session_task_sum():
+    sink = [
+        {"session_id": "s1", "input": 1000, "model": SONNET},
+        {"session_id": "s2", "input": 2000, "model": SONNET},
+    ]
+    meta = {"s1": {"issue": 42}, "s2": {"issue": 42}}  # same logical task
+    agg = C.aggregate(C.collect_sessions(sink, meta))
+    assert len(agg["tasks"]) == 1
+    task = agg["tasks"][0]
+    assert task["task_link"] == "issue:42"
+    assert set(task["sessions"]) == {"s1", "s2"}
+    assert task["cost_usd"] == pytest.approx(
+        C.session_cost(sink[0]) + C.session_cost(sink[1]), rel=1e-9)
+
+
+# 5. unattributed cost -----------------------------------------------------------------------
+def test_unattributed_cost():
+    sink = [{"session_id": "lonely", "input": 1000, "model": SONNET}]
+    agg = C.aggregate(C.collect_sessions(sink, session_meta={}))  # no task link
+    assert agg["tasks"] == []
+    assert agg["unattributed_cost_usd"] == pytest.approx(C.session_cost(sink[0]), rel=1e-9)
+    assert agg["attribution_coverage"] == 0.0
+
+
+# 6. reconciliation alarm --------------------------------------------------------------------
+def test_reconciliation_alarm():
+    drift = C.reconcile(attributed_total=10.0, otel_global_total=12.0, tolerance=0.01)
+    assert drift["alarm"] is True and drift["reason"] == "reconciliation_drift"
+    ok = C.reconcile(attributed_total=11.99, otel_global_total=12.0, tolerance=0.01)
+    assert ok["alarm"] is False and ok["reason"] == "ok"
+
+
+# 7. model not in price table → error, not silent zero ---------------------------------------
+def test_unknown_model_errors():
+    with pytest.raises(ValueError) as ei:
+        C.session_cost({"input": 1000, "model": "gpt-4-turbo"})
+    assert "gpt-4-turbo" in str(ei.value)
+    assert C.is_known_model("claude-opus-4") is True
+    assert C.is_known_model("gpt-4-turbo") is False
+
+
+# (+) excluded work-type cost is bucketed separately -----------------------------------------
+def test_excluded_work_type_cost_separated():
+    sink = [
+        {"session_id": "impl", "input": 1000, "model": SONNET},
+        {"session_id": "spec", "input": 5000, "model": SONNET},
+    ]
+    meta = {"impl": {"issue": 7, "work_type": "implementation"},
+            "spec": {"work_type": "deliberative"}}  # spec/design = excluded (§2.5)
+    agg = C.aggregate(C.collect_sessions(sink, meta))
+    assert agg["excluded_cost_usd"] == pytest.approx(C.session_cost(sink[1]), rel=1e-9)
+    # the excluded deliberative session is NOT in tasks or unattributed
+    assert agg["attributed_cost_usd"] == pytest.approx(C.session_cost(sink[0]), rel=1e-9)
+    assert agg["unattributed_cost_usd"] == 0.0
+
+
+# (+) report labels gated metrics diagnostic_only --------------------------------------------
+def test_report_marks_targets_diagnostic_only():
+    rep = C.build_report([{"session_id": "s", "input": 1000, "model": SONNET}],
+                         session_meta={"s": {"issue": 1}}, otel_global_total=None)
+    assert "waste_token_share" in rep["diagnostic_only"]
+    assert rep["diagnostic_only"]["cost_per_no_observed_defect"] is None


### PR DESCRIPTION
## Summary
The **#1 gap closed (in code): token capture.** Reads the #230 OTEL sink → price-weighted USD cost. server-a's lane, **built host-agnostic by scratch** (server-a out of commission; tested against simulated sink data).

- `scripts/token_collector.py`:
  - `session_cost` — cache-aware (via `otel_sink`), **STRICT unknown-model error** (no silent zero-cost — resolves #230's lenient fallback for the collector)
  - `collect_sessions` — per-session primary unit (§1.3); joins #229 capture metadata (work_type/issue/branch)
  - `aggregate` — per-task sum by issue/branch link; **separate `excluded_cost_usd`** (deliberative/ops, §2.5) **+ `unattributed_cost_usd` + `attribution_coverage`** (feeds the §0.5 gate)
  - `reconcile` — per-task vs global OTEL within tolerance (§2.5 watchdog)
  - `build_report` — per-session/task = diagnostics; **waste-share + cost-per-outcome `diagnostic_only`** (TARGET-GATED, §0.5)
- `tests/test_token_collector.py` — 7 required (known-price cost, cache_read=10%, output-dearest, multi-session task sum, unattributed, reconciliation alarm, unknown-model error) + excluded-cost + diagnostic-label. **9 pass, ruff clean.**

## Deferred (needs server-a)
Live cost data depends on the #252 sink deploy on jns-server. The collector logic is complete + simulated-data-tested. With #229→#230→#231, the token-cost pipeline is **code-complete** — it produces real numbers the moment the sink has live data.

Closes #231

🤖 Generated with [Claude Code](https://claude.com/claude-code)