### PR TITLE
feat(telemetry): precision-tiered defect tracer with calibration preflight

### DIFF
--- a/claude-config/scripts/defect_tracer.py
+++ b/claude-config/scripts/defect_tracer.py
@@ -66,6 +66,9 @@ CALIB_MIN_SAMPLE = 30  # ≥30 stratified cases per round
 CALIB_PRECISION_GATE = (
     0.9  # anchor-label emission requires precision ≥ 0.9 on the seeded set
 )
+CALIB_MAX_AGE_DAYS = (
+    90  # recalibrate quarterly (§2.2 cadence); a stale round can't authorize
+)
 
 # --- recall-estimation signals (low-precision; coverage ONLY, NEVER an individual defect label) ---
 RECALL_SIGNALS = (
@@ -86,9 +89,12 @@ RECALL_SIGNALS = (
 #       flips the meaning; `_negated_before` drops those matches (Codex F2/F3).
 #   (c) CROSS-REPO — an "owner/repo#N" qualifier that doesn't match the tracer's own repo is a
 #       reference to a DIFFERENT repo's #N, not a local target (Codex F2); `_extract_refs` drops it.
-# Requires a #N, so a commit-SHA-only revert (squash-collapsed lineage) does NOT map (§2.2).
+# Requires a #N, so a commit-SHA-only revert (squash-collapsed lineage) does NOT map (§2.2). The verb
+# must be ACCOMPLISHED tense ("reverts"/"reverted") — bare imperative "revert #42" is prospective/
+# discussed ("a tool to revert #42 if needed", "option considered: revert #42") and must NOT count as
+# a correction event (Codex re-review 3).
 _REVERT_PR_RE = re.compile(
-    r"\brevert(?:s|ed)?\b\s*(?:of\s+|pull request\s+)?(?P<repo>[-\w.]+/[-\w.]+)?#(?P<num>\d+)",
+    r"\brevert(?:s|ed)\b\s*(?:of\s+|pull request\s+)?(?P<repo>[-\w.]+/[-\w.]+)?#(?P<num>\d+)",
     re.IGNORECASE,
 )
 # "This reverts commit deadbeef" — detected but UNMAPPED (PR-level only; no usable target).
@@ -438,21 +444,31 @@ def run_calibration(
     }
 
 
+def _is_count(x) -> bool:
+    """A real non-negative integer count — excludes bool (an int subclass) and negatives."""
+    return isinstance(x, int) and not isinstance(x, bool) and x >= 0
+
+
 def calibration_authorizes_emission(calibration: dict | None) -> bool:
     """Authorize the anchor gate from the calibration round's EVIDENCE, not its summary fields. The
     decision is RE-DERIVED from the confusion-matrix counts (tp/fp) rather than trusting the reported
     `precision`/`passed` flags — so a forged `{"passed": True, "precision": 0.9}` with no real round
-    does NOT open the gate (Codex F1 + re-review). A determined caller can still author internally
-    consistent counts; true tamper-resistance needs the signed audit log (`log_calibration`), a v2 item.
+    does NOT open the gate (Codex F1 + re-review). NOTE: an in-process dict is NEVER fully tamper-proof
+    (a caller can author internally consistent counts); the PRODUCTION gate is `authorized_from_log`,
+    which ties authorization to the persisted, freshness-checked audit log. This dict check is the
+    in-process/testing path and a defense against ACCIDENTAL bypass.
 
-    Requires: an `allowed` verdict, integer tp/fp/sample_size, sample ≥ CALIB_MIN_SAMPLE, at least one
-    positive prediction (tp+fp > 0), counts not exceeding the sample, and RECOMPUTED precision ≥ gate."""
+    Requires: an `allowed` verdict, non-negative-int tp/fp/sample_size (no bools), sample ≥
+    CALIB_MIN_SAMPLE, at least one positive prediction (tp+fp > 0), counts not exceeding the sample,
+    and RECOMPUTED precision ≥ gate."""
     if not isinstance(calibration, dict):
         return False
     if calibration.get("anchor_emission") != "allowed":
         return False
     tp, fp, sample = (calibration.get(k) for k in ("tp", "fp", "sample_size"))
-    if not all(isinstance(x, int) for x in (tp, fp, sample)):
+    # Reject bools (bool IS an int subclass) and negatives — else nonsense like fp=-29 recomputes a
+    # passing precision and bypasses the matrix check (Codex re-review 3).
+    if not all(_is_count(x) for x in (tp, fp, sample)):
         return False
     if tp + fp <= 0 or sample < CALIB_MIN_SAMPLE or sample < tp + fp:
         return False
@@ -469,6 +485,47 @@ def log_calibration(result: dict, sink_path) -> dict:
     with p.open("a", encoding="utf-8") as fh:
         fh.write(json.dumps(rec, sort_keys=True) + "\n")
     return rec
+
+
+def latest_calibration(log_path) -> dict | None:
+    """The most recent `calibration_round` record in the audit log, or None if none/unreadable."""
+    from pathlib import Path
+
+    p = Path(log_path)
+    if not p.exists():
+        return None
+    last = None
+    for line in p.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            rec = json.loads(line)
+        except ValueError:
+            continue
+        if rec.get("event") == "calibration_round":
+            last = rec
+    return last
+
+
+def authorized_from_log(
+    log_path, *, now_ts: float | None = None, max_age_days: int = CALIB_MAX_AGE_DAYS
+) -> dict:
+    """PRODUCTION anchor gate: authorize from the PERSISTED audit log, not a caller-passed dict. The
+    authorization is tied to a logged round (written by `run_calibration` → `log_calibration`) AND must
+    be within the recalibration cadence (§2.2 quarterly). This raises the bar from "forge an argument"
+    to "forge a dated, passing entry in the on-disk audit log within the freshness window". (Full
+    tamper-resistance — signing the log — is a documented v2 item.)"""
+    rec = latest_calibration(log_path)
+    if rec is None:
+        return {"authorized": False, "reason": "no_calibration_logged"}
+    if not calibration_authorizes_emission(rec):
+        return {"authorized": False, "reason": "latest_round_failed"}
+    if now_ts is not None and rec.get("round_ts"):
+        ts = _parse_ts(rec["round_ts"])
+        if ts is not None and (now_ts - ts) > max_age_days * 86400:
+            return {"authorized": False, "reason": "calibration_stale", "round": rec}
+    return {"authorized": True, "reason": "ok", "round": rec}
 
 
 # --- session association (#229 dependency) -------------------------------------------------------
@@ -490,33 +547,44 @@ def associate_sessions(labeled_prs: list, session_meta: dict) -> list:
 def trace_prs(
     prs: list,
     *,
-    calibration: dict,
+    calibration: dict | None = None,
+    calibration_log_path=None,
+    now_ts: float | None = None,
     recall_threshold: float = 0.5,
     windows: tuple = WINDOWS_DAYS,
     session_meta: dict | None = None,
     repo: str | None = None,
 ) -> dict:
-    """Full tracer pass over normalized PR records. HONORS THE CALIBRATION GATE: anchor labels are
-    emitted ONLY when `calibration_authorizes_emission` independently re-verifies the round (a real
-    ≥30-case preflight at precision ≥ 0.9) — a bare `passed` flag is NOT trusted. Otherwise every PR
-    is labeled across the three windows, annotated with estimated coverage, with positive labels
-    withheld from targets below the recall threshold."""
+    """Full tracer pass over normalized PR records. HONORS THE CALIBRATION GATE. PRODUCTION callers
+    pass `calibration_log_path` (+ `now_ts`): authorization comes from the persisted, freshness-checked
+    audit log via `authorized_from_log`. The in-process/testing path passes a `calibration` dict, which
+    is re-verified from its confusion-matrix evidence. Either way a forged/absent/stale round emits NO
+    anchor labels. When authorized, every PR is labeled across the three windows, annotated with
+    estimated coverage, with positive labels withheld from targets below the recall threshold."""
     events = build_correction_index(prs, repo=repo)
     candidates = recall_candidates(prs)
     cov = estimate_coverage(
         high_precision_count=len(events), recall_candidate_count=len(candidates)
     )
     coverage = cov["coverage"]
-    if not calibration_authorizes_emission(calibration):
+    if calibration_log_path is not None:
+        auth = authorized_from_log(calibration_log_path, now_ts=now_ts)
+        authorized, reason = auth["authorized"], auth["reason"]
+    else:
+        authorized = calibration_authorizes_emission(calibration)
+        reason = (
+            calibration.get("reason", "calibration_unauthorized")
+            if isinstance(calibration, dict)
+            else "calibration_unauthorized"
+        )
+    if not authorized:
         # Gate CLOSED: withhold ALL anchor-bearing data — not just `labels`, but `correction_events`
         # too (they carry correction_or_defect classifications + target references). Returning them
         # would let a consumer read anchor signals despite the closed gate (Codex re-review F2). Only
         # non-label counts survive, for diagnostics.
         return {
             "anchor_emission": "blocked",
-            "reason": calibration.get("reason", "calibration_unauthorized")
-            if isinstance(calibration, dict)
-            else "calibration_unauthorized",
+            "reason": reason,
             "coverage": cov,
             "correction_event_count": len(events),
             "recall_candidate_count": len(candidates),

--- a/claude-config/scripts/defect_tracer.py
+++ b/claude-config/scripts/defect_tracer.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 import json
 import re
 import subprocess
+import time
 from datetime import datetime
 
 # --- precision tiers -----------------------------------------------------------------------------
@@ -68,6 +69,9 @@ CALIB_PRECISION_GATE = (
 )
 CALIB_MAX_AGE_DAYS = (
     90  # recalibrate quarterly (§2.2 cadence); a stale round can't authorize
+)
+CALIB_CLOCK_SKEW_SECONDS = (
+    300  # tolerate ≤5min clock skew; beyond that a future round_ts is rejected
 )
 
 # --- recall-estimation signals (low-precision; coverage ONLY, NEVER an individual defect label) ---
@@ -146,6 +150,11 @@ def _extract_refs(regex: re.Pattern, text: str, *, repo: str | None) -> list:
 
 def _tier_rank(tier: str) -> int:
     return _TIER_RANK.get(tier, 0)
+
+
+def _now_ts() -> float:
+    """Current wall-clock epoch — the freshness default so omitting `now_ts` fails CLOSED, not open."""
+    return time.time()
 
 
 def _parse_ts(value) -> float | None:
@@ -520,11 +529,23 @@ def authorized_from_log(
     if rec is None:
         return {"authorized": False, "reason": "no_calibration_logged"}
     if not calibration_authorizes_emission(rec):
-        return {"authorized": False, "reason": "latest_round_failed"}
-    if now_ts is not None and rec.get("round_ts"):
-        ts = _parse_ts(rec["round_ts"])
-        if ts is not None and (now_ts - ts) > max_age_days * 86400:
-            return {"authorized": False, "reason": "calibration_stale", "round": rec}
+        return {"authorized": False, "reason": "latest_round_failed", "round": rec}
+    # Freshness is MANDATORY and FAIL-CLOSED (Codex round 4): a missing/unparsable/future timestamp,
+    # or no usable clock, means we CANNOT confirm the round is within cadence → do NOT authorize.
+    ts = _parse_ts(rec.get("round_ts"))
+    if ts is None:
+        return {"authorized": False, "reason": "calibration_no_timestamp", "round": rec}
+    if now_ts is None:
+        now_ts = _now_ts()  # default to wall clock so omitting it does not fail OPEN
+    age = now_ts - ts
+    if age < -CALIB_CLOCK_SKEW_SECONDS:
+        return {
+            "authorized": False,
+            "reason": "calibration_future_timestamp",
+            "round": rec,
+        }
+    if age > max_age_days * 86400:
+        return {"authorized": False, "reason": "calibration_stale", "round": rec}
     return {"authorized": True, "reason": "ok", "round": rec}
 
 

--- a/claude-config/scripts/defect_tracer.py
+++ b/claude-config/scripts/defect_tracer.py
@@ -109,23 +109,31 @@ _NEGATION_RE = re.compile(
 )
 
 
-def _negated_before(text: str, start: int, window: int = 24) -> bool:
-    """True if an aversion word appears in the `window` chars immediately before `start` — meaning the
-    revert/regression mention is negated ("do not revert", "prevents regression") and must be dropped."""
-    return _NEGATION_RE.search(text[max(0, start - window) : start]) is not None
+_CLAUSE_BOUNDARY_RE = re.compile(r"[.;!?\n]")
+
+
+def _negated_before(text: str, start: int) -> bool:
+    """True if an aversion word appears anywhere in the CLAUSE preceding `start` (back to the nearest
+    sentence/clause boundary) — meaning the revert/regression mention is negated and must be dropped.
+    Clause-scoped (not a fixed char window) so distant negations like "do not under any circumstances
+    revert #42" are caught, while a negation in a PRIOR sentence does not bleed in (Codex re-review)."""
+    boundaries = list(_CLAUSE_BOUNDARY_RE.finditer(text, 0, start))
+    clause_start = boundaries[-1].end() if boundaries else 0
+    return _NEGATION_RE.search(text[clause_start:start]) is not None
 
 
 def _extract_refs(regex: re.Pattern, text: str, *, repo: str | None) -> list:
     """Extract local PR references from `text` for a detection regex, applying the negation and
-    cross-repo guards. A repo-qualified ref is kept only when it matches `repo` (or `repo` is unknown,
-    since GitHub auto-reverts qualify with the SAME repo)."""
+    cross-repo guards. Precision≫recall: a repo-qualified "owner/repo#N" ref is kept ONLY when the
+    local repo is KNOWN and matches — when `repo` is None we cannot confirm it is local, so we DROP it
+    (Codex re-review F2). Bare "#N" (same-repo shorthand) is always eligible."""
     refs = []
     for m in regex.finditer(text):
         if _negated_before(text, m.start()):
             continue
         ref_repo = m.group("repo")
-        if ref_repo and repo and ref_repo.lower() != repo.lower():
-            continue  # different repo's #N — not a local target
+        if ref_repo and (repo is None or ref_repo.lower() != repo.lower()):
+            continue  # unconfirmed-local or different repo's #N — not a local target
         refs.append(int(m.group("num")))
     return sorted(set(refs))
 
@@ -280,6 +288,10 @@ def label_target(
     windows = tuple(sorted(windows))
     # A PR can never label ITSELF defective; corrections must land strictly after the target (Codex F4).
     events = [e for e in correction_events if e.get("number") != num]
+    # Admissibility is global (coverage vs threshold) — apply it to EACH per-window non-observed entry
+    # too, so a window-level consumer can't read below-coverage absence as "clean" (Codex re-review F5).
+    admissible = coverage is not None and coverage >= recall_threshold
+    absent_label = LABEL_NO_DEFECT if admissible else LABEL_INDETERMINATE
     per_window: dict = {}
     observed = False
     max_tier = TIER_NOISE
@@ -306,7 +318,7 @@ def label_target(
         else:
             per_window[w] = {
                 "observed": False,
-                "label": LABEL_NO_DEFECT,
+                "label": absent_label,
                 "coverage": coverage,
             }
     if observed:
@@ -321,15 +333,14 @@ def label_target(
     # No correction observed. The label is admissible as a *quality* signal only if coverage clears the
     # recall threshold; below it (or coverage unknown) emit a DISTINCT label so "absence" can never be
     # silently consumed as "clean" (Codex F5, §0.6).
-    metric_admissible = coverage is not None and coverage >= recall_threshold
     return {
         "number": num,
-        "label": LABEL_NO_DEFECT if metric_admissible else LABEL_INDETERMINATE,
+        "label": LABEL_NO_DEFECT if admissible else LABEL_INDETERMINATE,
         "coverage": coverage,
-        "metric_admissible": metric_admissible,
+        "metric_admissible": admissible,
         "per_window": per_window,
         "note": None
-        if metric_admissible
+        if admissible
         else "coverage_below_recall_threshold__withheld_from_targets",
     }
 
@@ -428,21 +439,24 @@ def run_calibration(
 
 
 def calibration_authorizes_emission(calibration: dict | None) -> bool:
-    """Independently RE-VERIFY a calibration result before trusting it to open the anchor gate — never
-    take a bare `passed` flag on faith (Codex F1: a forged `{"passed": True}` must not emit anchors).
-    Requires an `allowed` verdict backed by a real ≥CALIB_MIN_SAMPLE round at precision ≥ CALIB_PRECISION_GATE."""
+    """Authorize the anchor gate from the calibration round's EVIDENCE, not its summary fields. The
+    decision is RE-DERIVED from the confusion-matrix counts (tp/fp) rather than trusting the reported
+    `precision`/`passed` flags — so a forged `{"passed": True, "precision": 0.9}` with no real round
+    does NOT open the gate (Codex F1 + re-review). A determined caller can still author internally
+    consistent counts; true tamper-resistance needs the signed audit log (`log_calibration`), a v2 item.
+
+    Requires: an `allowed` verdict, integer tp/fp/sample_size, sample ≥ CALIB_MIN_SAMPLE, at least one
+    positive prediction (tp+fp > 0), counts not exceeding the sample, and RECOMPUTED precision ≥ gate."""
     if not isinstance(calibration, dict):
         return False
-    sample = calibration.get("sample_size")
-    precision = calibration.get("precision")
-    return (
-        calibration.get("passed") is True
-        and calibration.get("anchor_emission") == "allowed"
-        and isinstance(sample, int)
-        and sample >= CALIB_MIN_SAMPLE
-        and isinstance(precision, (int, float))
-        and precision >= CALIB_PRECISION_GATE
-    )
+    if calibration.get("anchor_emission") != "allowed":
+        return False
+    tp, fp, sample = (calibration.get(k) for k in ("tp", "fp", "sample_size"))
+    if not all(isinstance(x, int) for x in (tp, fp, sample)):
+        return False
+    if tp + fp <= 0 or sample < CALIB_MIN_SAMPLE or sample < tp + fp:
+        return False
+    return (tp / (tp + fp)) >= CALIB_PRECISION_GATE
 
 
 def log_calibration(result: dict, sink_path) -> dict:
@@ -494,15 +508,18 @@ def trace_prs(
     )
     coverage = cov["coverage"]
     if not calibration_authorizes_emission(calibration):
+        # Gate CLOSED: withhold ALL anchor-bearing data — not just `labels`, but `correction_events`
+        # too (they carry correction_or_defect classifications + target references). Returning them
+        # would let a consumer read anchor signals despite the closed gate (Codex re-review F2). Only
+        # non-label counts survive, for diagnostics.
         return {
             "anchor_emission": "blocked",
             "reason": calibration.get("reason", "calibration_unauthorized")
             if isinstance(calibration, dict)
             else "calibration_unauthorized",
-            "calibration": calibration,
             "coverage": cov,
-            "correction_events": events,
-            "recall_candidates": candidates,
+            "correction_event_count": len(events),
+            "recall_candidate_count": len(candidates),
             "labels": [],
         }
     labels = [

--- a/claude-config/scripts/defect_tracer.py
+++ b/claude-config/scripts/defect_tracer.py
@@ -1,0 +1,550 @@
+"""Precision-tiered behavioral defect tracer (telemetry-validation §2.2, build item 4 — ⭐ long pole).
+
+The defect tracer is THE anchor of the proxy-validation loop. A contaminated anchor invalidates the
+entire loop, so the design is **precision ≫ recall**: we would rather miss real defects than
+false-accuse a clean PR. Three rules, three precision tiers:
+
+  HIGH   — explicit PR revert ("this reverts #42")            → `correction_or_defect`
+  MEDIUM — "fixes regression from #42" referencing the origin → `correction_or_defect` (medium tier)
+  NOISE  — same-file edit within a window                     → weak hint ONLY, never auto-marks defect
+
+Operates at **PR granularity via the `gh` API** — NOT commit lineage, because squash-merge collapses
+lineage so "reverts commit <sha>" cannot be mapped back to a source PR (§2.2). A revert that names only
+a commit SHA is *detected but unmapped* — it never marks any target PR defective.
+
+Because precision≫recall means many real defects go UNSEEN, "no detected correction" is **never**
+"correct" — it is `no_observed_defect` *under the tracer's stated coverage* (§0.6). A recall-estimation
+layer (§2.2) keeps coverage KNOWN rather than assumed, and positive metrics that depend on
+correctness-implied-by-absence are WITHHELD until estimated recall clears a stated threshold.
+
+Calibration is a defined PREFLIGHT control (§2.2, Codex F9) — the one precise exception to "zero
+manual": the tracer may emit anchor labels only after a ≥30-case seeded round scores precision ≥ 0.9.
+
+Host-agnostic and pure: detection/labeling logic takes injected PR records (the shape `gh pr list
+--json ...` returns, normalized by `from_gh_json`). `fetch_prs_via_gh` is the only live entrypoint.
+
+Owner lane: server-a (implementation) + agent-b (calibration as a non-same-family rater). Built
+host-agnostic by scratch against simulated PR payloads while server-a is out.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from datetime import datetime
+
+# --- precision tiers -----------------------------------------------------------------------------
+TIER_HIGH = "high"
+TIER_MEDIUM = "medium"
+TIER_NOISE = "noise"
+_TIER_RANK = {TIER_NOISE: 0, TIER_MEDIUM: 1, TIER_HIGH: 2}
+
+# --- labels --------------------------------------------------------------------------------------
+LABEL_CORRECTION = (
+    "correction_or_defect"  # a revert/regression-fix PR: undoes/corrects prior work
+)
+LABEL_OBSERVED_DEFECT = (
+    "observed_defect"  # a target PR that a later correction event references
+)
+LABEL_NO_DEFECT = (
+    "no_observed_defect"  # default — ALWAYS published with a coverage annotation
+)
+# When coverage is below the recall threshold (or unknown) the "no defect" reading is NOT trustworthy
+# as a quality signal — emit a DISTINCT label so a naive consumer cannot read absence as "clean" (§0.6).
+LABEL_INDETERMINATE = "indeterminate_coverage"
+
+# --- measurement windows (days) ------------------------------------------------------------------
+# A fixed window catches fast crashes but misses slow logic bugs; we compute all three and state the
+# per-window bias (§2.2). Windows are CUMULATIVE: a correction at lag 5d is observed in 7/14/30; a
+# correction at lag 20d is observed in 30d ONLY (absent from 7d/14d — exactly the slow-bug a short
+# window misses). `no_observed_defect_30d` (the metric, §364) is the 30d window.
+WINDOWS_DAYS = (7, 14, 30)
+
+# --- calibration preflight defaults (§2.2; v1 starting values, refined in §2.3 pre-registration) --
+CALIB_MIN_SAMPLE = 30  # ≥30 stratified cases per round
+CALIB_PRECISION_GATE = (
+    0.9  # anchor-label emission requires precision ≥ 0.9 on the seeded set
+)
+
+# --- recall-estimation signals (low-precision; coverage ONLY, NEVER an individual defect label) ---
+RECALL_SIGNALS = (
+    "ci_failed",  # CI failed on the PR
+    "reopened",  # PR/issue reopened
+    "forward_fix",  # a later PR fixes forward instead of reverting
+    "issue_ref",  # references a bug issue
+    "review_thread_negative",  # unresolved/negative review outcome
+    "same_area_rework",  # semantic same-area rework
+)
+
+# --- detection regexes (PR-level #N references only) ----------------------------------------------
+# Precision≫recall demands THREE guards beyond "verb near #N", or clean PRs get false-accused:
+#   (a) ADJACENCY — the #N must immediately follow the verb (optionally via "of"/"pull request"/an
+#       "owner/repo" prefix), so a clause-spanning "...see #42" or a quoted original title like
+#       Revert "Fix login #42" does NOT capture the inner #N.
+#   (b) NEGATION — a preceding aversion word ("do not revert", "prevents regression", "no regression")
+#       flips the meaning; `_negated_before` drops those matches (Codex F2/F3).
+#   (c) CROSS-REPO — an "owner/repo#N" qualifier that doesn't match the tracer's own repo is a
+#       reference to a DIFFERENT repo's #N, not a local target (Codex F2); `_extract_refs` drops it.
+# Requires a #N, so a commit-SHA-only revert (squash-collapsed lineage) does NOT map (§2.2).
+_REVERT_PR_RE = re.compile(
+    r"\brevert(?:s|ed)?\b\s*(?:of\s+|pull request\s+)?(?P<repo>[-\w.]+/[-\w.]+)?#(?P<num>\d+)",
+    re.IGNORECASE,
+)
+# "This reverts commit deadbeef" — detected but UNMAPPED (PR-level only; no usable target).
+_REVERT_COMMIT_RE = re.compile(
+    r"\brevert(?:s|ed|ing)?\b\s+commit\s+[0-9a-f]{7,40}", re.IGNORECASE
+)
+# "fixes regression from #42", "regression introduced in #42", "regression #42". The qualifier must
+# bridge directly to the #N — bare "regression ... #N" across a clause does not match.
+_REGRESSION_RE = re.compile(
+    r"\bregression\b\s*(?:from\s+|in\s+|introduced(?:\s+in|\s+by)?\s+)?(?P<repo>[-\w.]+/[-\w.]+)?#(?P<num>\d+)",
+    re.IGNORECASE,
+)
+# Aversion words that, when they precede the verb, invert the signal ("do NOT revert #42").
+_NEGATION_RE = re.compile(
+    r"\b(?:no|not|never|without|avoid(?:s|ing)?|prevent(?:s|ing)?|future|potential|possible|any)\b"
+    r"|n't",
+    re.IGNORECASE,
+)
+
+
+def _negated_before(text: str, start: int, window: int = 24) -> bool:
+    """True if an aversion word appears in the `window` chars immediately before `start` — meaning the
+    revert/regression mention is negated ("do not revert", "prevents regression") and must be dropped."""
+    return _NEGATION_RE.search(text[max(0, start - window) : start]) is not None
+
+
+def _extract_refs(regex: re.Pattern, text: str, *, repo: str | None) -> list:
+    """Extract local PR references from `text` for a detection regex, applying the negation and
+    cross-repo guards. A repo-qualified ref is kept only when it matches `repo` (or `repo` is unknown,
+    since GitHub auto-reverts qualify with the SAME repo)."""
+    refs = []
+    for m in regex.finditer(text):
+        if _negated_before(text, m.start()):
+            continue
+        ref_repo = m.group("repo")
+        if ref_repo and repo and ref_repo.lower() != repo.lower():
+            continue  # different repo's #N — not a local target
+        refs.append(int(m.group("num")))
+    return sorted(set(refs))
+
+
+def _tier_rank(tier: str) -> int:
+    return _TIER_RANK.get(tier, 0)
+
+
+def _parse_ts(value) -> float | None:
+    """ISO-8601 (with trailing Z) or epoch seconds → epoch float. None/unparseable → None."""
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    try:
+        return datetime.fromisoformat(str(value).replace("Z", "+00:00")).timestamp()
+    except ValueError:
+        return None
+
+
+def _within_window(
+    earlier, later, window_days: int, *, strict_after: bool = False
+) -> bool:
+    """True iff `later` is within `window_days` after `earlier` (INCLUSIVE at the upper boundary).
+    With `strict_after`, a zero lag is rejected — a correction must land STRICTLY after the target so
+    same-timestamp PRs (or a PR referencing itself) can never be read as a later correction (Codex F4)."""
+    e, lt = _parse_ts(earlier), _parse_ts(later)
+    if e is None or lt is None:
+        return False
+    lag = lt - e
+    if lag < 0 or (strict_after and lag <= 0):
+        return False
+    return lag <= window_days * 86400
+
+
+# --- normalization (gh payload → internal PR record) ---------------------------------------------
+def from_gh_json(items: list) -> list:
+    """Normalize `gh pr list --json number,title,body,mergedAt,files,labels` output into internal PR
+    records. `files` is a list of {path,...}; `labels` a list of {name}. camelCase mergedAt → merged_at.
+    Recall-signal booleans (ci_failed/reopened/...) pass through if already present (enriched upstream)."""
+    out = []
+    for it in items:
+        files = it.get("files") or []
+        labels = it.get("labels") or []
+        rec = {
+            "number": it.get("number"),
+            "title": it.get("title", "") or "",
+            "body": it.get("body", "") or "",
+            "merged_at": it.get("mergedAt") or it.get("merged_at"),
+            "files": [f.get("path") if isinstance(f, dict) else f for f in files],
+            "labels": [l_.get("name") if isinstance(l_, dict) else l_ for l_ in labels],
+        }
+        for sig in RECALL_SIGNALS:
+            if sig in it:
+                rec[sig] = it[sig]
+        out.append(rec)
+    return out
+
+
+# --- precision-tier classification of a single PR ------------------------------------------------
+def classify_pr(pr: dict, *, repo: str | None = None) -> dict | None:
+    """Classify a PR by its OWN text into a correction event, or None if it carries no correction
+    signal. A correction event references the prior PR(s) it undoes/corrects (`references`). `repo`
+    (owner/name) enables the cross-repo guard — repo-qualified refs to other repos are dropped.
+
+    Tiers: explicit PR revert → HIGH; "fixes regression from #PR" → MEDIUM. A commit-SHA-only revert
+    is returned UNMAPPED (`references=[]`, `unmapped=True`) — detected for transparency but it labels
+    no target defective, because squash-merge collapses commit lineage (§2.2)."""
+    text = f"{pr.get('title', '')}\n{pr.get('body', '')}"
+    revert_refs = _extract_refs(_REVERT_PR_RE, text, repo=repo)
+    if revert_refs:
+        return {
+            "number": pr.get("number"),
+            "label": LABEL_CORRECTION,
+            "tier": TIER_HIGH,
+            "references": revert_refs,
+            "evidence": "explicit_pr_revert",
+            "merged_at": pr.get("merged_at"),
+        }
+    _commit_revert = _REVERT_COMMIT_RE.search(text)
+    if _commit_revert and not _negated_before(text, _commit_revert.start()):
+        # Revert detected but only a commit SHA — unusable at PR granularity (§2.2).
+        return {
+            "number": pr.get("number"),
+            "label": None,
+            "tier": TIER_HIGH,
+            "references": [],
+            "evidence": "commit_revert_unmapped",
+            "unmapped": True,
+            "merged_at": pr.get("merged_at"),
+        }
+    regression_refs = _extract_refs(_REGRESSION_RE, text, repo=repo)
+    if regression_refs:
+        return {
+            "number": pr.get("number"),
+            "label": LABEL_CORRECTION,
+            "tier": TIER_MEDIUM,
+            "references": regression_refs,
+            "evidence": "regression_fix",
+            "merged_at": pr.get("merged_at"),
+        }
+    return None
+
+
+def same_file_noise_hint(pr: dict, prior_prs: list, window_days: int = 14) -> dict:
+    """NOISE tier: prior PRs sharing ≥1 file within the window. A weak corroboration hint ONLY — the
+    return carries `is_defect_label=False` and `label=None`; this NEVER auto-marks a PR defective
+    (files churn for non-defect reasons, §2.2)."""
+    target_files = set(pr.get("files") or [])
+    hits = []
+    for p in prior_prs:
+        if p.get("number") == pr.get("number"):
+            continue
+        if target_files & set(p.get("files") or []) and _within_window(
+            p.get("merged_at"), pr.get("merged_at"), window_days
+        ):
+            hits.append(p.get("number"))
+    return {
+        "tier": TIER_NOISE,
+        "label": None,
+        "is_defect_label": False,
+        "noise_refs": sorted(n for n in hits if n is not None),
+        "window_days": window_days,
+    }
+
+
+def build_correction_index(prs: list, *, repo: str | None = None) -> list:
+    """All PRs that are themselves *mapped* correction events (have ≥1 PR reference). Unmapped
+    commit-reverts are excluded from the index (they label nothing) but counted elsewhere."""
+    events = []
+    for pr in prs:
+        c = classify_pr(pr, repo=repo)
+        if c and c.get("references"):
+            events.append(c)
+    return events
+
+
+# --- target labeling across the three windows ----------------------------------------------------
+def label_target(
+    target_pr: dict,
+    correction_events: list,
+    *,
+    windows: tuple = WINDOWS_DAYS,
+    coverage: float | None = None,
+    recall_threshold: float = 0.0,
+) -> dict:
+    """Label one implementation PR. `observed_defect` if any correction event references it within a
+    window; otherwise `no_observed_defect` ANNOTATED WITH COVERAGE. The positive label is admissible
+    as a quality metric only when coverage ≥ recall_threshold (else withheld from targets, §0.5/§0.6)."""
+    num = target_pr.get("number")
+    t_ts = target_pr.get("merged_at")
+    windows = tuple(sorted(windows))
+    # A PR can never label ITSELF defective; corrections must land strictly after the target (Codex F4).
+    events = [e for e in correction_events if e.get("number") != num]
+    per_window: dict = {}
+    observed = False
+    max_tier = TIER_NOISE
+    by: set = set()
+    for w in windows:
+        hits = [
+            e
+            for e in events
+            if num in e.get("references", [])
+            and _within_window(t_ts, e.get("merged_at"), w, strict_after=True)
+        ]
+        if hits:
+            wt = max((e["tier"] for e in hits), key=_tier_rank)
+            per_window[w] = {
+                "observed": True,
+                "label": LABEL_OBSERVED_DEFECT,
+                "by": sorted(e["number"] for e in hits),
+                "tier": wt,
+            }
+            observed = True
+            if _tier_rank(wt) > _tier_rank(max_tier):
+                max_tier = wt
+            by |= {e["number"] for e in hits}
+        else:
+            per_window[w] = {
+                "observed": False,
+                "label": LABEL_NO_DEFECT,
+                "coverage": coverage,
+            }
+    if observed:
+        return {
+            "number": num,
+            "label": LABEL_OBSERVED_DEFECT,
+            "tier": max_tier,
+            "by": sorted(by),
+            "coverage": coverage,
+            "per_window": per_window,
+        }
+    # No correction observed. The label is admissible as a *quality* signal only if coverage clears the
+    # recall threshold; below it (or coverage unknown) emit a DISTINCT label so "absence" can never be
+    # silently consumed as "clean" (Codex F5, §0.6).
+    metric_admissible = coverage is not None and coverage >= recall_threshold
+    return {
+        "number": num,
+        "label": LABEL_NO_DEFECT if metric_admissible else LABEL_INDETERMINATE,
+        "coverage": coverage,
+        "metric_admissible": metric_admissible,
+        "per_window": per_window,
+        "note": None
+        if metric_admissible
+        else "coverage_below_recall_threshold__withheld_from_targets",
+    }
+
+
+# --- recall estimation (coverage only — never an individual defect label) -------------------------
+def recall_candidates(prs: list) -> list:
+    """PRs exhibiting ANY low-precision recall signal (CI failure, reopen, forward-fix, ...). These
+    feed coverage estimation ONLY — each carries `label=None`; this function NEVER marks a PR
+    defective (the §2.2 invariant: recall signals bound coverage, they do not accuse individuals)."""
+    out = []
+    for pr in prs:
+        sigs = [s for s in RECALL_SIGNALS if pr.get(s)]
+        if sigs:
+            out.append({"number": pr.get("number"), "signals": sigs, "label": None})
+    return out
+
+
+def estimate_coverage(
+    *, high_precision_count: int, recall_candidate_count: int, audit: dict | None = None
+) -> dict:
+    """Estimate the tracer's recall/coverage so positive labels can be published WITH it.
+
+    Gold method (`audit_sample`): a human re-checks a stratified slice → recall = caught/true_defects.
+    Fallback (`signal_lower_bound`): high-precision catches over (catches + low-precision candidates
+    the precise rules missed) — a conservative lower bound, never asserted as exact recall."""
+    if audit and audit.get("true_defects_found", 0) > 0:
+        cov = audit.get("tracer_caught", 0) / audit["true_defects_found"]
+        return {
+            "coverage": round(min(1.0, cov), 4),
+            "method": "audit_sample",
+            "audit": audit,
+        }
+    denom = high_precision_count + recall_candidate_count
+    cov = (high_precision_count / denom) if denom > 0 else 0.0
+    return {
+        "coverage": round(cov, 4),
+        "method": "signal_lower_bound",
+        "high_precision_count": high_precision_count,
+        "recall_candidates": recall_candidate_count,
+    }
+
+
+# --- calibration preflight -----------------------------------------------------------------------
+def _case_predicted(case: dict) -> str:
+    """A seeded case's tracer prediction: explicit `predicted`, else classify its `pr` ('defect' if it
+    classifies as a mapped correction event, else 'clean')."""
+    if "predicted" in case:
+        return case["predicted"]
+    c = classify_pr(case.get("pr", {}))
+    return "defect" if (c and c.get("references")) else "clean"
+
+
+def run_calibration(
+    seeded_cases: list,
+    *,
+    min_sample: int = CALIB_MIN_SAMPLE,
+    gate: float = CALIB_PRECISION_GATE,
+    round_ts: str | None = None,
+) -> dict:
+    """Calibration preflight (§2.2). Each case: `{truth: 'defect'|'clean', predicted|pr: ...}`.
+    Precision = TP / (TP + FP) over cases the tracer PREDICTS defective. Anchor-label emission is
+    BLOCKED if the sample is < min_sample or precision < gate; the result is logged with the round
+    timestamp, sample size, precision and pass/fail verdict (an audit record)."""
+    n = len(seeded_cases)
+    if n < min_sample:
+        return {
+            "passed": False,
+            "anchor_emission": "blocked",
+            "reason": "insufficient_sample",
+            "sample_size": n,
+            "min_sample": min_sample,
+            "precision": None,
+            "gate": gate,
+            "round_ts": round_ts,
+        }
+    tp = fp = 0
+    for c in seeded_cases:
+        if _case_predicted(c) == "defect":
+            if c.get("truth") == "defect":
+                tp += 1
+            else:
+                fp += 1
+    precision = tp / (tp + fp) if (tp + fp) > 0 else 0.0
+    passed = precision >= gate
+    return {
+        "passed": passed,
+        "anchor_emission": "allowed" if passed else "blocked",
+        "reason": "ok" if passed else "precision_below_gate",
+        "precision": round(precision, 4),
+        "sample_size": n,
+        "gate": gate,
+        "tp": tp,
+        "fp": fp,
+        "round_ts": round_ts,
+    }
+
+
+def calibration_authorizes_emission(calibration: dict | None) -> bool:
+    """Independently RE-VERIFY a calibration result before trusting it to open the anchor gate — never
+    take a bare `passed` flag on faith (Codex F1: a forged `{"passed": True}` must not emit anchors).
+    Requires an `allowed` verdict backed by a real ≥CALIB_MIN_SAMPLE round at precision ≥ CALIB_PRECISION_GATE."""
+    if not isinstance(calibration, dict):
+        return False
+    sample = calibration.get("sample_size")
+    precision = calibration.get("precision")
+    return (
+        calibration.get("passed") is True
+        and calibration.get("anchor_emission") == "allowed"
+        and isinstance(sample, int)
+        and sample >= CALIB_MIN_SAMPLE
+        and isinstance(precision, (int, float))
+        and precision >= CALIB_PRECISION_GATE
+    )
+
+
+def log_calibration(result: dict, sink_path) -> dict:
+    """Append a calibration round to an audit log (one JSON line). Returns the written record."""
+    from pathlib import Path
+
+    rec = {"event": "calibration_round", **result}
+    p = Path(sink_path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    with p.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(rec, sort_keys=True) + "\n")
+    return rec
+
+
+# --- session association (#229 dependency) -------------------------------------------------------
+def associate_sessions(labeled_prs: list, session_meta: dict) -> list:
+    """Attach the session(s) that produced each PR, via the #229 capture meta keyed by PR number — so
+    a defect signal can be associated with the session whose work it judges (the proxy-loop input)."""
+    by_pr: dict = {}
+    for sid, m in (session_meta or {}).items():
+        pr_num = m.get("pr")
+        if pr_num is not None:
+            by_pr.setdefault(pr_num, []).append(sid)
+    return [
+        {**lp, "sessions": sorted(set(by_pr.get(lp.get("number"), [])))}
+        for lp in labeled_prs
+    ]
+
+
+# --- top-level pass ------------------------------------------------------------------------------
+def trace_prs(
+    prs: list,
+    *,
+    calibration: dict,
+    recall_threshold: float = 0.5,
+    windows: tuple = WINDOWS_DAYS,
+    session_meta: dict | None = None,
+    repo: str | None = None,
+) -> dict:
+    """Full tracer pass over normalized PR records. HONORS THE CALIBRATION GATE: anchor labels are
+    emitted ONLY when `calibration_authorizes_emission` independently re-verifies the round (a real
+    ≥30-case preflight at precision ≥ 0.9) — a bare `passed` flag is NOT trusted. Otherwise every PR
+    is labeled across the three windows, annotated with estimated coverage, with positive labels
+    withheld from targets below the recall threshold."""
+    events = build_correction_index(prs, repo=repo)
+    candidates = recall_candidates(prs)
+    cov = estimate_coverage(
+        high_precision_count=len(events), recall_candidate_count=len(candidates)
+    )
+    coverage = cov["coverage"]
+    if not calibration_authorizes_emission(calibration):
+        return {
+            "anchor_emission": "blocked",
+            "reason": calibration.get("reason", "calibration_unauthorized")
+            if isinstance(calibration, dict)
+            else "calibration_unauthorized",
+            "calibration": calibration,
+            "coverage": cov,
+            "correction_events": events,
+            "recall_candidates": candidates,
+            "labels": [],
+        }
+    labels = [
+        label_target(
+            p,
+            events,
+            windows=windows,
+            coverage=coverage,
+            recall_threshold=recall_threshold,
+        )
+        for p in prs
+    ]
+    if session_meta:
+        labels = associate_sessions(labels, session_meta)
+    return {
+        "anchor_emission": "allowed",
+        "coverage": cov,
+        "calibration": calibration,
+        "correction_events": events,
+        "recall_candidates": candidates,
+        "labels": labels,
+    }
+
+
+# --- live entrypoint (not unit-tested; the thin gh adapter) --------------------------------------
+def fetch_prs_via_gh(
+    repo: str | None = None, *, state: str = "merged", limit: int = 200
+) -> list:
+    """Pull merged PRs via the `gh` CLI and normalize them. The only live/IO path; all logic above is
+    pure and tested against simulated payloads. Requires `gh` authed as the repo's account."""
+    cmd = [
+        "gh",
+        "pr",
+        "list",
+        "--state",
+        state,
+        "--limit",
+        str(limit),
+        "--json",
+        "number,title,body,mergedAt,files,labels",
+    ]
+    if repo:
+        cmd += ["--repo", repo]
+    raw = subprocess.run(cmd, capture_output=True, text=True, check=True).stdout
+    return from_gh_json(json.loads(raw))

--- a/claude-config/tests/test_defect_tracer.py
+++ b/claude-config/tests/test_defect_tracer.py
@@ -84,8 +84,8 @@ def test_clause_spanning_mentions_do_not_false_classify():
         )
         is None
     )
-    # but the canonical GitHub forms still classify
-    assert T.classify_pr(_pr(83, body="Reverts owner/agents#42"))["tier"] == T.TIER_HIGH
+    # but the canonical GitHub forms still classify (bare #N is same-repo shorthand)
+    assert T.classify_pr(_pr(83, body="Reverts #42"))["tier"] == T.TIER_HIGH
     assert (
         T.classify_pr(_pr(84, body="regression introduced in #42"))["tier"]
         == T.TIER_MEDIUM
@@ -104,14 +104,36 @@ def test_adjacent_negation_does_not_classify():
     assert T.classify_pr(_pr(88, title='Revert "Fix login #42"', body="")) is None
 
 
-# Precision hardening (Codex F2): a cross-repo owner/repo#N is NOT a local target --------------------
-def test_cross_repo_reference_dropped_when_repo_known():
+# Precision hardening (Codex re-review F2): repo-qualified #N only honored when local repo confirmed --
+def test_cross_repo_reference_dropped():
     pr = _pr(90, body="Reverts otherorg/otherrepo#42")
     # repo known and mismatched → reference dropped (no local target marked)
     assert T.classify_pr(pr, repo="jwj2002/agents") is None
+    # repo UNKNOWN (None) → repo-qualified ref cannot be confirmed local → also dropped
+    assert T.classify_pr(pr) is None
+    assert T.classify_pr(_pr(92, body="Reverts owner/agents#42")) is None
     # same repo → kept
     same = _pr(91, body="Reverts jwj2002/agents#42")
     assert 42 in T.classify_pr(same, repo="jwj2002/agents")["references"]
+
+
+# Precision hardening (Codex re-review F3): negation anywhere in the clause is caught, not just nearby -
+def test_long_distance_clause_negation():
+    assert (
+        T.classify_pr(_pr(93, body="Do not under any circumstances revert #42."))
+        is None
+    )
+    assert (
+        T.classify_pr(
+            _pr(94, body="This does not appear to be caused by a regression from #42.")
+        )
+        is None
+    )
+    # a negation in a PRIOR sentence must NOT bleed into a clean revert clause
+    assert (
+        T.classify_pr(_pr(95, body="We will not merge yet. This reverts #42."))["tier"]
+        == T.TIER_HIGH
+    )
 
 
 # AC5 / required-test: no revert/regression signal → no_observed_defect WITH coverage annotation ----
@@ -375,3 +397,60 @@ def test_calibration_classifies_seeded_prs():
         1.0
     )  # every predicted-defect is a true defect
     assert res["anchor_emission"] == "allowed"
+    # and that real round authorizes emission via the evidence-based gate
+    assert T.calibration_authorizes_emission(res) is True
+
+
+# Gate integrity (Codex re-review F2): the BLOCKED output carries NO anchor-bearing data --------------
+def test_blocked_output_withholds_correction_events():
+    prs = T.from_gh_json(
+        [
+            {
+                "number": 42,
+                "title": "feat",
+                "body": "",
+                "mergedAt": "2026-06-01T00:00:00Z",
+            },
+            {
+                "number": 43,
+                "title": 'Revert "feat"',
+                "body": "This reverts #42.",
+                "mergedAt": "2026-06-03T00:00:00Z",
+            },
+        ]
+    )
+    out = T.trace_prs(prs, calibration={"passed": True})  # forged → blocked
+    assert out["anchor_emission"] == "blocked"
+    assert out["labels"] == []
+    # the anchor-bearing lists must be ABSENT — only non-label counts survive
+    assert "correction_events" not in out
+    assert "recall_candidates" not in out
+    assert out["correction_event_count"] == 1
+
+
+# Gate integrity (Codex re-review F1): forged evidence cannot fake the confusion matrix ---------------
+def test_evidence_based_gate_rejects_inconsistent_counts():
+    # claims precision 1.0 but supplies counts that recompute below the gate
+    sneaky = {
+        "anchor_emission": "allowed",
+        "passed": True,
+        "precision": 1.0,
+        "sample_size": 30,
+        "tp": 17,
+        "fp": 5,
+    }  # 17/22 = 0.77 < 0.9
+    assert T.calibration_authorizes_emission(sneaky) is False
+    # counts exceeding the sample are rejected
+    impossible = {"anchor_emission": "allowed", "tp": 40, "fp": 0, "sample_size": 30}
+    assert T.calibration_authorizes_emission(impossible) is False
+
+
+# Consistency (Codex re-review F5): below-threshold per-window entries are NOT labeled clean -----------
+def test_below_threshold_per_window_not_clean():
+    lab = T.label_target(
+        _pr(42), correction_events=[], coverage=0.2, recall_threshold=0.5
+    )
+    assert lab["label"] == T.LABEL_INDETERMINATE
+    for w in T.WINDOWS_DAYS:
+        assert lab["per_window"][w]["label"] == T.LABEL_INDETERMINATE
+        assert lab["per_window"][w]["label"] != T.LABEL_NO_DEFECT

--- a/claude-config/tests/test_defect_tracer.py
+++ b/claude-config/tests/test_defect_tracer.py
@@ -454,3 +454,89 @@ def test_below_threshold_per_window_not_clean():
     for w in T.WINDOWS_DAYS:
         assert lab["per_window"][w]["label"] == T.LABEL_INDETERMINATE
         assert lab["per_window"][w]["label"] != T.LABEL_NO_DEFECT
+
+
+# Gate integrity (Codex round 3): bool/negative counts cannot forge a passing matrix -----------------
+def test_gate_rejects_bool_and_negative_counts():
+    # bool is an int subclass — must be rejected
+    assert (
+        T.calibration_authorizes_emission(
+            {"anchor_emission": "allowed", "tp": True, "fp": False, "sample_size": 30}
+        )
+        is False
+    )
+    # negative fp recomputes a passing precision — must be rejected
+    assert (
+        T.calibration_authorizes_emission(
+            {"anchor_emission": "allowed", "tp": 30, "fp": -29, "sample_size": 30}
+        )
+        is False
+    )
+
+
+# Precision (Codex round 3): prospective/discussed reverts are NOT correction events -----------------
+def test_prospective_revert_not_classified():
+    assert T.classify_pr(_pr(96, body="Adds a tool to revert #42 if needed.")) is None
+    assert T.classify_pr(_pr(97, body="Option considered: revert #42.")) is None
+    assert T.classify_pr(_pr(98, body="Please revert #42 when ready.")) is None
+    # accomplished tense still classifies
+    assert T.classify_pr(_pr(99, body="This reverts #42."))["tier"] == T.TIER_HIGH
+    assert T.classify_pr(_pr(100, body="Reverted #42."))["tier"] == T.TIER_HIGH
+
+
+# Production gate (Codex round 3): authorization comes from the persisted, fresh audit log -----------
+def test_authorized_from_log(tmp_path):
+    log = tmp_path / "calib.jsonl"
+    # no log yet → not authorized
+    assert T.authorized_from_log(log)["authorized"] is False
+    assert T.authorized_from_log(log)["reason"] == "no_calibration_logged"
+    # log a real passing round
+    T.log_calibration(
+        T.run_calibration(_seeded(tp=27, fp=2, tn=5), round_ts="2026-06-01T00:00:00Z"),
+        log,
+    )
+    fresh = T.authorized_from_log(log, now_ts=T._parse_ts("2026-06-15T00:00:00Z"))
+    assert fresh["authorized"] is True
+    # the same round 200 days later is STALE (quarterly cadence) → not authorized
+    stale = T.authorized_from_log(log, now_ts=T._parse_ts("2026-12-20T00:00:00Z"))
+    assert stale["authorized"] is False
+    assert stale["reason"] == "calibration_stale"
+
+
+def test_trace_prs_uses_calibration_log(tmp_path):
+    log = tmp_path / "calib.jsonl"
+    prs = T.from_gh_json(
+        [
+            {
+                "number": 42,
+                "title": "feat",
+                "body": "",
+                "mergedAt": "2026-06-01T00:00:00Z",
+            },
+            {
+                "number": 43,
+                "title": 'Revert "feat"',
+                "body": "This reverts #42.",
+                "mergedAt": "2026-06-03T00:00:00Z",
+            },
+        ]
+    )
+    # no logged calibration → blocked even though no dict was forged
+    out_blocked = T.trace_prs(prs, calibration_log_path=log)
+    assert out_blocked["anchor_emission"] == "blocked"
+    assert out_blocked["reason"] == "no_calibration_logged"
+    # after a real logged round → allowed
+    T.log_calibration(
+        T.run_calibration(_seeded(tp=27, fp=2, tn=5), round_ts="2026-06-01T00:00:00Z"),
+        log,
+    )
+    out_ok = T.trace_prs(
+        prs,
+        calibration_log_path=log,
+        now_ts=T._parse_ts("2026-06-10T00:00:00Z"),
+        recall_threshold=0.0,
+    )
+    assert out_ok["anchor_emission"] == "allowed"
+    assert {lbl["number"]: lbl["label"] for lbl in out_ok["labels"]}[
+        42
+    ] == T.LABEL_OBSERVED_DEFECT

--- a/claude-config/tests/test_defect_tracer.py
+++ b/claude-config/tests/test_defect_tracer.py
@@ -1,0 +1,377 @@
+"""Acceptance tests for issue #233 — precision-tiered defect tracer (telemetry-validation §2.2).
+
+Runs against SIMULATED PR payloads (the shape `gh pr list --json ...` returns) — host-agnostic, no
+live `gh` calls. Precision≫recall: the tracer must NEVER false-accuse a clean PR.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+import defect_tracer as T  # noqa: E402
+
+
+def _pr(
+    number, *, title="", body="", merged_at="2026-06-01T00:00:00Z", files=None, **extra
+):
+    return {
+        "number": number,
+        "title": title,
+        "body": body,
+        "merged_at": merged_at,
+        "files": files or [],
+        **extra,
+    }
+
+
+# AC1 / required-test: explicit revert → correction_or_defect (NOT a bare 'defect'), HIGH tier ------
+def test_revert_pr_is_correction_or_defect_high():
+    pr = _pr(99, title='Revert "feat: add widget"', body="This reverts #42.")
+    c = T.classify_pr(pr)
+    assert c is not None
+    assert c["label"] == T.LABEL_CORRECTION
+    assert c["label"] != "defect"  # never the bare/standalone defect label
+    assert c["tier"] == T.TIER_HIGH
+    assert 42 in c["references"]
+
+
+# AC3 / required-test: same-file edit within window → NOISE hint only, never a defect label ---------
+def test_same_file_within_window_is_noise_only():
+    original = _pr(42, files=["a.py", "b.py"], merged_at="2026-06-01T00:00:00Z")
+    churn = _pr(
+        50, files=["a.py"], merged_at="2026-06-10T00:00:00Z"
+    )  # 9 days later, shared file
+    hint = T.same_file_noise_hint(churn, [original], window_days=14)
+    assert hint["tier"] == T.TIER_NOISE
+    assert hint["is_defect_label"] is False
+    assert hint["label"] is None
+    assert 42 in hint["noise_refs"]
+    # and the churn PR, classified by its own text, is NOT a correction event
+    assert T.classify_pr(churn) is None
+
+
+# AC2 / required-test: "fixes regression from #PR" → MEDIUM tier correction --------------------------
+def test_regression_fix_is_medium():
+    pr = _pr(
+        60,
+        title="fix: nav crash",
+        body="Fixes regression from #42 introduced last week.",
+    )
+    c = T.classify_pr(pr)
+    assert c is not None
+    assert c["label"] == T.LABEL_CORRECTION
+    assert c["tier"] == T.TIER_MEDIUM
+    assert 42 in c["references"]
+    # revert takes precedence over regression when both appear
+    both = _pr(61, body="This reverts #7. Fixes regression from #8.")
+    assert T.classify_pr(both)["tier"] == T.TIER_HIGH
+
+
+# Precision hardening: prose mentioning the verb + a distant #N must NOT classify (no false accuse) -
+def test_clause_spanning_mentions_do_not_false_classify():
+    # the #N belongs to a different clause — a loose regex would contaminate the anchor here
+    assert (
+        T.classify_pr(_pr(80, body="Do not revert anything; see #42 for context."))
+        is None
+    )
+    assert T.classify_pr(_pr(81, body="No regression here, closes #42.")) is None
+    assert (
+        T.classify_pr(
+            _pr(82, body="This avoids a future revert of the parser. Ref #42.")
+        )
+        is None
+    )
+    # but the canonical GitHub forms still classify
+    assert T.classify_pr(_pr(83, body="Reverts owner/agents#42"))["tier"] == T.TIER_HIGH
+    assert (
+        T.classify_pr(_pr(84, body="regression introduced in #42"))["tier"]
+        == T.TIER_MEDIUM
+    )
+
+
+# Precision hardening (Codex F2/F3): ADJACENT negation inverts the signal — must not classify --------
+def test_adjacent_negation_does_not_classify():
+    assert (
+        T.classify_pr(_pr(85, body="Do not revert #42 under any circumstances."))
+        is None
+    )
+    assert T.classify_pr(_pr(86, body="Prevents regression from #42.")) is None
+    assert T.classify_pr(_pr(87, body="No regression in #42.")) is None
+    # a quoted ORIGINAL title carrying an issue number must not be mined as the revert target
+    assert T.classify_pr(_pr(88, title='Revert "Fix login #42"', body="")) is None
+
+
+# Precision hardening (Codex F2): a cross-repo owner/repo#N is NOT a local target --------------------
+def test_cross_repo_reference_dropped_when_repo_known():
+    pr = _pr(90, body="Reverts otherorg/otherrepo#42")
+    # repo known and mismatched → reference dropped (no local target marked)
+    assert T.classify_pr(pr, repo="jwj2002/agents") is None
+    # same repo → kept
+    same = _pr(91, body="Reverts jwj2002/agents#42")
+    assert 42 in T.classify_pr(same, repo="jwj2002/agents")["references"]
+
+
+# AC5 / required-test: no revert/regression signal → no_observed_defect WITH coverage annotation ----
+def test_no_signal_is_no_observed_defect_with_coverage():
+    target = _pr(42)
+    lab = T.label_target(
+        target, correction_events=[], coverage=0.6, recall_threshold=0.5
+    )
+    assert lab["label"] == T.LABEL_NO_DEFECT
+    assert lab["coverage"] == 0.6
+    assert lab["metric_admissible"] is True  # 0.6 >= 0.5 threshold
+    # below threshold → positive label withheld from targets AND a DISTINCT label (Codex F5) so a
+    # naive consumer cannot read absence-of-defect as "clean"
+    withheld = T.label_target(
+        target, correction_events=[], coverage=0.2, recall_threshold=0.5
+    )
+    assert withheld["metric_admissible"] is False
+    assert withheld["label"] == T.LABEL_INDETERMINATE
+    assert withheld["label"] != T.LABEL_NO_DEFECT
+    assert "withheld" in withheld["note"]
+
+
+# AC4 / required-test: three windows; fast vs slow bug; boundary edge -------------------------------
+def test_three_window_cumulative_and_boundary():
+    target = _pr(42, merged_at="2026-06-01T00:00:00Z")
+    # a FAST correction at lag 5d → observed in all three windows (7/14/30)
+    fast = T.classify_pr(
+        _pr(43, body="This reverts #42.", merged_at="2026-06-06T00:00:00Z")
+    )
+    lab_fast = T.label_target(target, [fast])
+    assert lab_fast["label"] == T.LABEL_OBSERVED_DEFECT
+    assert lab_fast["per_window"][7]["observed"] is True
+    assert lab_fast["per_window"][30]["observed"] is True
+
+    # a SLOW correction at lag 20d → observed in 30d ONLY, absent from 7d and 14d
+    slow = T.classify_pr(
+        _pr(44, body="This reverts #42.", merged_at="2026-06-21T00:00:00Z")
+    )
+    lab_slow = T.label_target(target, [slow])
+    assert lab_slow["per_window"][7]["observed"] is False
+    assert lab_slow["per_window"][14]["observed"] is False
+    assert lab_slow["per_window"][30]["observed"] is True
+    assert lab_slow["label"] == T.LABEL_OBSERVED_DEFECT  # observed in ≥1 window
+
+    # BOUNDARY: a correction at exactly lag 7d is INCLUSIVE in the 7d window
+    edge = T.classify_pr(
+        _pr(45, body="This reverts #42.", merged_at="2026-06-08T00:00:00Z")
+    )
+    assert T.label_target(target, [edge])["per_window"][7]["observed"] is True
+
+
+# AC6 / required-test: calibration precision 0.85 → emission BLOCKED --------------------------------
+def _seeded(tp, fp, tn):
+    """tp predicted-defect&true-defect, fp predicted-defect&true-clean, tn predicted-clean&true-clean."""
+    cases = []
+    cases += [{"predicted": "defect", "truth": "defect"} for _ in range(tp)]
+    cases += [{"predicted": "defect", "truth": "clean"} for _ in range(fp)]
+    cases += [{"predicted": "clean", "truth": "clean"} for _ in range(tn)]
+    return cases
+
+
+def test_calibration_below_gate_blocks_emission():
+    res = T.run_calibration(
+        _seeded(tp=17, fp=3, tn=10), round_ts="2026-06-06T00:00:00Z"
+    )  # 0.85
+    assert res["precision"] == pytest.approx(0.85)
+    assert res["passed"] is False
+    assert res["anchor_emission"] == "blocked"
+    assert res["reason"] == "precision_below_gate"
+
+
+# AC7 / required-test: calibration precision 0.92 → emission ALLOWED --------------------------------
+def test_calibration_at_or_above_gate_allows_emission():
+    res = T.run_calibration(
+        _seeded(tp=23, fp=2, tn=5), round_ts="2026-06-06T00:00:00Z"
+    )  # 0.92
+    assert res["precision"] == pytest.approx(0.92)
+    assert res["passed"] is True
+    assert res["anchor_emission"] == "allowed"
+
+
+# AC8 / required-test: sample < 30 → calibration rejected (insufficient sample) ---------------------
+def test_calibration_insufficient_sample_rejected():
+    res = T.run_calibration(
+        _seeded(tp=15, fp=0, tn=5)
+    )  # 20 cases, perfect precision but too few
+    assert res["passed"] is False
+    assert res["reason"] == "insufficient_sample"
+    assert res["sample_size"] == 20
+    assert res["anchor_emission"] == "blocked"
+
+
+# AC6 (recall): CI-failure signal updates coverage, does NOT mark the PR individually defective ------
+def test_recall_signal_estimates_coverage_not_individual_defect():
+    prs = [
+        _pr(42, ci_failed=True),
+        _pr(43),
+    ]  # 42 had a CI failure, no revert references it
+    cands = T.recall_candidates(prs)
+    assert [c["number"] for c in cands] == [42]
+    assert cands[0]["label"] is None  # NOT an observed_defect label
+    # the CI-failed PR, with no correction event referencing it, stays no_observed_defect
+    lab = T.label_target(_pr(42, ci_failed=True), correction_events=[], coverage=0.5)
+    assert lab["label"] == T.LABEL_NO_DEFECT
+    # coverage estimate reflects the candidate as a missed-defect denominator
+    cov = T.estimate_coverage(high_precision_count=1, recall_candidate_count=1)
+    assert cov["coverage"] == pytest.approx(0.5)
+    assert cov["method"] == "signal_lower_bound"
+    # audit sample is the gold estimate when present
+    audit_cov = T.estimate_coverage(
+        high_precision_count=1,
+        recall_candidate_count=99,
+        audit={"true_defects_found": 10, "tracer_caught": 7},
+    )
+    assert audit_cov["coverage"] == pytest.approx(0.7)
+    assert audit_cov["method"] == "audit_sample"
+
+
+# AC integration: end-to-end gh pull → labeled output with coverage; calibration gate honored --------
+def test_end_to_end_from_gh_json_with_calibration_gate():
+    gh_payload = [
+        {
+            "number": 42,
+            "title": "feat: nav",
+            "body": "",
+            "mergedAt": "2026-06-01T00:00:00Z",
+            "files": [{"path": "nav.py"}],
+            "labels": [{"name": "feature"}],
+        },
+        {
+            "number": 43,
+            "title": 'Revert "feat: nav"',
+            "body": "This reverts #42.",
+            "mergedAt": "2026-06-03T00:00:00Z",
+            "files": [{"path": "nav.py"}],
+            "labels": [],
+        },
+        {
+            "number": 44,
+            "title": "chore: docs",
+            "body": "",
+            "mergedAt": "2026-06-04T00:00:00Z",
+            "files": [{"path": "README.md"}],
+            "labels": [],
+        },
+    ]
+    prs = T.from_gh_json(gh_payload)
+    assert prs[0]["merged_at"] == "2026-06-01T00:00:00Z"  # camelCase normalized
+    assert prs[0]["files"] == ["nav.py"]
+
+    # gate OPEN: a REAL calibration result that authorizes emission
+    passed = T.run_calibration(_seeded(tp=23, fp=2, tn=5))  # precision 0.92, n=30
+    assert T.calibration_authorizes_emission(passed) is True
+    out = T.trace_prs(prs, calibration=passed, recall_threshold=0.0)
+    assert out["anchor_emission"] == "allowed"
+    by_num = {l_["number"]: l_ for l_ in out["labels"]}
+    assert (
+        by_num[42]["label"] == T.LABEL_OBSERVED_DEFECT
+    )  # reverted by #43 within window
+    assert by_num[42]["by"] == [43]
+    assert by_num[44]["label"] == T.LABEL_NO_DEFECT
+    assert "coverage" in out and out["coverage"]["coverage"] >= 0
+
+    # gate CLOSED: calibration failed → NO anchor labels emitted
+    blocked = T.run_calibration(_seeded(tp=17, fp=3, tn=10))  # precision 0.85
+    out2 = T.trace_prs(prs, calibration=blocked)
+    assert out2["anchor_emission"] == "blocked"
+    assert out2["labels"] == []
+
+
+# Calibration-gate bypass (Codex F1): a FORGED calibration object must NOT open the anchor gate -------
+def test_forged_calibration_cannot_emit_anchors():
+    prs = T.from_gh_json(
+        [{"number": 1, "title": "x", "body": "", "mergedAt": "2026-06-01T00:00:00Z"}]
+    )
+    forged = {
+        "passed": True,
+        "anchor_emission": "allowed",
+    }  # no real seeded round behind it
+    assert T.calibration_authorizes_emission(forged) is False
+    out = T.trace_prs(prs, calibration=forged)
+    assert out["anchor_emission"] == "blocked"
+    assert out["labels"] == []
+    # also reject a passed-but-undersized round, and a non-dict
+    undersized = {
+        "passed": True,
+        "anchor_emission": "allowed",
+        "sample_size": 5,
+        "precision": 1.0,
+    }
+    assert T.calibration_authorizes_emission(undersized) is False
+    assert T.calibration_authorizes_emission(None) is False
+
+
+# Anchor safety (Codex F4): a PR cannot label ITSELF and same-timestamp corrections don't count -------
+def test_self_reference_and_same_timestamp_do_not_label():
+    # a PR whose body references its OWN number must not mark itself defective
+    self_ref = T.classify_pr(
+        _pr(42, body="This reverts #42.", merged_at="2026-06-01T00:00:00Z")
+    )
+    assert (
+        T.label_target(_pr(42, merged_at="2026-06-01T00:00:00Z"), [self_ref])["label"]
+        != T.LABEL_OBSERVED_DEFECT
+    )
+    # a correction merged at the SAME timestamp as the target is not "strictly after" → not counted
+    target = _pr(50, merged_at="2026-06-01T00:00:00Z")
+    same_ts = T.classify_pr(
+        _pr(51, body="This reverts #50.", merged_at="2026-06-01T00:00:00Z")
+    )
+    assert T.label_target(target, [same_ts])["label"] != T.LABEL_OBSERVED_DEFECT
+    # one second later DOES count
+    later = T.classify_pr(
+        _pr(52, body="This reverts #50.", merged_at="2026-06-01T00:00:01Z")
+    )
+    assert T.label_target(target, [later])["label"] == T.LABEL_OBSERVED_DEFECT
+
+
+# Edge: squash-merge PR — commit lineage NOT used; only PR-level #N signals matter ------------------
+def test_squash_merge_commit_revert_is_unmapped():
+    # GitHub's squash revert body references a commit SHA, not a PR number.
+    pr = _pr(70, title='Revert "feat: x"', body="This reverts commit deadbeefcafe1234.")
+    c = T.classify_pr(pr)
+    assert c is not None
+    assert c["evidence"] == "commit_revert_unmapped"
+    assert c["references"] == []  # no PR-level target → labels nothing
+    assert c["label"] is None
+    # it is excluded from the correction index (cannot mark any target defective)
+    assert T.build_correction_index([pr]) == []
+    # so a target PR is NOT falsely accused by a commit-only revert
+    target = _pr(42)
+    assert (
+        T.label_target(target, T.build_correction_index([pr]))["label"]
+        != T.LABEL_OBSERVED_DEFECT
+    )
+
+
+# Calibration logging: round is persisted as an audit record ---------------------------------------
+def test_calibration_round_is_logged(tmp_path):
+    res = T.run_calibration(_seeded(tp=23, fp=2, tn=5), round_ts="2026-06-06T00:00:00Z")
+    sink = tmp_path / "calib.jsonl"
+    rec = T.log_calibration(res, sink)
+    assert rec["event"] == "calibration_round"
+    assert rec["precision"] == pytest.approx(0.92)
+    lines = sink.read_text().strip().splitlines()
+    assert len(lines) == 1
+
+
+# Calibration end-to-end via classify (seeded PRs, not pre-labeled predictions) --------------------
+def test_calibration_classifies_seeded_prs():
+    # 30 cases: 25 seeded reverts (true defects the tracer should catch) + 5 clean PRs
+    cases = [
+        {"pr": _pr(i, body=f"This reverts #{i - 1}."), "truth": "defect"}
+        for i in range(100, 125)
+    ]
+    cases += [
+        {"pr": _pr(i, title="feat: clean"), "truth": "clean"} for i in range(200, 205)
+    ]
+    res = T.run_calibration(cases)
+    assert res["sample_size"] == 30
+    assert res["precision"] == pytest.approx(
+        1.0
+    )  # every predicted-defect is a true defect
+    assert res["anchor_emission"] == "allowed"

--- a/claude-config/tests/test_defect_tracer.py
+++ b/claude-config/tests/test_defect_tracer.py
@@ -540,3 +540,37 @@ def test_trace_prs_uses_calibration_log(tmp_path):
     assert {lbl["number"]: lbl["label"] for lbl in out_ok["labels"]}[
         42
     ] == T.LABEL_OBSERVED_DEFECT
+
+
+# Gate integrity (Codex round 4): freshness is FAIL-CLOSED, not fail-open ----------------------------
+def test_freshness_fails_closed(tmp_path):
+    log = tmp_path / "calib.jsonl"
+    # a passing round WITHOUT a timestamp cannot be confirmed fresh → not authorized
+    rnd = T.run_calibration(_seeded(tp=27, fp=2, tn=5))  # round_ts defaults to None
+    T.log_calibration(rnd, log)
+    res = T.authorized_from_log(log, now_ts=T._parse_ts("2026-06-10T00:00:00Z"))
+    assert res["authorized"] is False
+    assert res["reason"] == "calibration_no_timestamp"
+
+
+def test_freshness_omitted_now_does_not_fail_open(tmp_path):
+    # an ancient round must be rejected even when now_ts is omitted (defaults to wall clock, not skip)
+    log = tmp_path / "calib.jsonl"
+    T.log_calibration(
+        T.run_calibration(_seeded(tp=27, fp=2, tn=5), round_ts="2000-01-01T00:00:00Z"),
+        log,
+    )
+    res = T.authorized_from_log(log)  # no now_ts → uses wall clock → ancient → stale
+    assert res["authorized"] is False
+    assert res["reason"] == "calibration_stale"
+
+
+def test_future_timestamp_rejected(tmp_path):
+    log = tmp_path / "calib.jsonl"
+    T.log_calibration(
+        T.run_calibration(_seeded(tp=27, fp=2, tn=5), round_ts="2099-01-01T00:00:00Z"),
+        log,
+    )
+    res = T.authorized_from_log(log, now_ts=T._parse_ts("2026-06-10T00:00:00Z"))
+    assert res["authorized"] is False
+    assert res["reason"] == "calibration_future_timestamp"


### PR DESCRIPTION
## Summary
Implements the behavioral defect tracer — telemetry-validation **§2.2**, build item 4, the ⭐ **critical-path anchor** of the proxy-validation loop. A contaminated anchor invalidates the entire downstream loop, so the design is **precision ≫ recall**.

- **Three precision tiers**: HIGH (explicit PR revert `this reverts #N`) → `correction_or_defect`; MEDIUM (`fixes regression from #N`); NOISE (same-file-within-window — weak hint, **never** auto-marks defective).
- **PR granularity via the `gh` API** — *not* commit lineage (squash-merge collapses it); a commit-SHA-only revert is detected-but-unmapped.
- **Three cumulative windows** (7d/14d/30d) with documented fast-vs-slow-bug bias.
- **"No detected correction" is never "correct"** (§0.6): `no_observed_defect` published *with* estimated coverage; a distinct `indeterminate_coverage` label below the recall threshold so absence can't be silently read as clean.
- **Recall-estimation layer** (CI-fail / reopen / forward-fix / issue-ref / review-thread / same-area-rework) bounds **coverage only** — never labels an individual PR defective.
- **Calibration preflight**: ≥30 stratified seeded cases, precision ≥ 0.9 gates anchor-label emission; `trace_prs` **independently re-verifies** the round (no forged-`passed` bypass).

## Codex adversarial review — 5 blocking findings, all folded
1. **Calibration-gate bypass** — `trace_prs` trusted a bare `passed` flag → now re-verifies sample≥30 + precision≥0.9 + `allowed` via `calibration_authorizes_emission`.
2. **Revert regex precision leak** — negated/cross-repo/quoted-title → adjacency + `_negated_before` + cross-repo guards.
3. **Regression regex leak** — "no/prevents regression" → same negation guard.
4. **Same-timestamp / self-reference** — a PR could label itself → strict-after + self-exclude.
5. **Below-threshold still emitted `no_observed_defect`** → distinct `indeterminate_coverage` label.

## Test Plan
- 18 acceptance tests covering every AC + required test + each Codex finding as a regression test.
- `python3 -m pytest claude-config/tests/` → 74 passed. `ruff check` / `ruff format --check` clean.

Closes #233.

🤖 Generated with [Claude Code](https://claude.com/claude-code)