### PR TITLE
feat(telemetry): no_observed_defect_30d positive-signal sensor with exposure evidence

### DIFF
--- a/claude-config/scripts/positive_signal_sensor.py
+++ b/claude-config/scripts/positive_signal_sensor.py
@@ -1,0 +1,212 @@
+"""`no_observed_defect_30d` positive-signal sensor (telemetry-validation §3 / §0.6, build item 7).
+
+The honest positive metric. It breaks the failure-ONLY dependency (we otherwise only ever learn from
+things that broke) WITHOUT manufacturing a false "correct" label. Naming discipline is the whole point
+(Codex F3): the metric is **`no_observed_defect_30d`** — NEVER the legacy first-pass-correct naming.
+"No defect observed" is NOT "correct"; the tracer is precision≫recall (§2.2), so absence of a signal means
+the work *escaped detection*, not that it was right.
+
+A unit (session/task) earns the positive `no_observed_defect` label ONLY when ALL of these hold:
+  1. no correction signal within the 30d window (the defect tracer found no observed_defect), AND
+  2. deployed/used code path (the change was actually exercised), AND
+  3. meaningful test EXECUTION — tests actually ran AND covered the changed paths (not "tests exist"), AND
+  4. reviewer coverage (human or qualified automated review occurred), AND
+  5. CI scope (CI covered the change's surface), AND
+  6. tracer coverage ≥ the stated recall threshold (§2.2) — coverage is KNOWN and adequate.
+Miss ANY of 2-6 → `unverified` (NOT "good", never silently dropped). A correction within the window →
+`correction_detected` regardless of exposure. Window not yet closed → `pending` (no label emitted yet).
+
+The 30d window is measured from the task-freeze timestamp (frozen at the first implementation artifact,
+#229) — never re-anchored after the outcome is known.
+
+Cross-spec gate: a confirmed `no_observed_defect` is the ONLY state the team-knowledge auto-observe
+pipeline (team-knowledge-mvp-v1 §1.2) may consume as a positive example — `unverified`/`pending`/
+`correction_detected` are not auto-observable. `auto_observe_event` enforces that.
+
+Host-agnostic and pure: takes injected tracer results + exposure evidence. Owner lane: server-a.
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import defect_tracer as DT  # noqa: E402
+
+WINDOW_DAYS = 30
+
+# Terminal labels + the non-terminal "window still open" state.
+LABEL_GOOD = "no_observed_defect"
+LABEL_UNVERIFIED = "unverified"
+LABEL_CORRECTION = "correction_detected"
+LABEL_PENDING = (
+    "pending"  # window not yet closed — NOT one of the three terminal labels
+)
+
+# Exposure-evidence booleans that ALL must be true for a positive label (conditions 2-5; condition 3
+# is split into ran AND covered, per "tests actually ran and covered the changed paths").
+REQUIRED_EXPOSURE = (
+    "deployed",  # the change was actually exercised / used
+    "tests_ran",  # tests EXECUTED (not merely present)
+    "tests_covered_changed",  # and covered the changed paths
+    "reviewer_coverage",  # human or qualified automated review occurred
+    "ci_scope",  # CI covered the change's surface
+)
+
+
+def _parse_ts(value) -> float | None:
+    """ISO-8601 (trailing Z ok) or epoch seconds → epoch float; None/unparseable → None."""
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    try:
+        return datetime.fromisoformat(str(value).replace("Z", "+00:00")).timestamp()
+    except ValueError:
+        return None
+
+
+def window_closed(freeze_ts, now_ts, window_days: int = WINDOW_DAYS) -> bool:
+    """True iff ≥ `window_days` have elapsed since the task-freeze timestamp. An unparsable/missing
+    timestamp is NOT closed (fail-safe: a unit we can't time stays `pending`, never a premature label)."""
+    f, n = _parse_ts(freeze_ts), _parse_ts(now_ts)
+    if f is None or n is None:
+        return False
+    return (n - f) >= window_days * 86400
+
+
+def missing_exposure(evidence: dict) -> list:
+    """The exposure conditions NOT satisfied (empty list ⇒ complete). `evidence` defaults missing keys
+    to falsey, so an absent field is a MISSING condition, never an assumed-present one."""
+    evidence = evidence or {}
+    return [k for k in REQUIRED_EXPOSURE if not evidence.get(k)]
+
+
+def exposure_complete(evidence: dict) -> bool:
+    """All exposure conditions (2-5, with tests split into ran+covered) present and true."""
+    return not missing_exposure(evidence)
+
+
+def classify_unit(
+    unit_id,
+    *,
+    tracer_result: dict,
+    exposure: dict,
+    recall_threshold: float,
+    freeze_ts,
+    now_ts,
+    window_days: int = WINDOW_DAYS,
+    tracer_coverage_pct: float | None = None,
+) -> dict:
+    """Label one unit. `tracer_result` is the defect tracer's per-PR label dict (`label_target` /
+    `trace_prs` output); `exposure` is the evidence dict. Order matters: window gate → correction →
+    exposure+coverage. A correction is terminal regardless of exposure; below-threshold tracer coverage
+    forces `unverified` even when every other condition is met (Codex F2/§2.2)."""
+    coverage = (
+        tracer_coverage_pct
+        if tracer_coverage_pct is not None
+        else (tracer_result or {}).get("coverage")
+    )
+    base = {
+        "unit_id": unit_id,
+        "window_days": window_days,
+        "tracer_coverage_pct": coverage,
+    }
+    # 0. window must be closed before ANY terminal label is emitted
+    if not window_closed(freeze_ts, now_ts, window_days):
+        return {**base, "label": LABEL_PENDING, "reason": "window_open"}
+    # 1. a correction observed within the window is terminal — exposure is irrelevant
+    if (tracer_result or {}).get("label") == DT.LABEL_OBSERVED_DEFECT:
+        return {
+            **base,
+            "label": LABEL_CORRECTION,
+            "correction_by": tracer_result.get("by"),
+        }
+    # 2-6. no correction → require complete exposure AND adequate tracer coverage
+    miss = missing_exposure(exposure)
+    coverage_ok = coverage is not None and coverage >= recall_threshold
+    exposure_ok = not miss
+    if exposure_ok and coverage_ok:
+        label = LABEL_GOOD
+    else:
+        label = LABEL_UNVERIFIED
+    return {
+        **base,
+        "label": label,
+        "exposure_evidence": {
+            k: bool((exposure or {}).get(k)) for k in REQUIRED_EXPOSURE
+        },
+        "missing_exposure": miss,
+        "coverage_ok": coverage_ok,
+    }
+
+
+def auto_observe_event(classification: dict) -> dict | None:
+    """The team-knowledge auto-observe hookpoint (tk-mvp-v1 §1.2). Emits a positive-example event ONLY
+    for a CONFIRMED `no_observed_defect` — `unverified` / `pending` / `correction_detected` are NOT
+    auto-observable (the cross-spec gate). Returns None for anything but the confirmed positive."""
+    if classification.get("label") != LABEL_GOOD:
+        return None
+    return {
+        "event": "positive_example",
+        "source": "no_observed_defect_30d",
+        "unit_id": classification.get("unit_id"),
+        "tracer_coverage_pct": classification.get("tracer_coverage_pct"),
+        "window_days": classification.get("window_days"),
+    }
+
+
+def run_sensor(
+    prs: list,
+    units: list,
+    *,
+    exposure_by_unit: dict,
+    recall_threshold: float,
+    now_ts,
+    calibration: dict | None = None,
+    calibration_log_path=None,
+    window_days: int = WINDOW_DAYS,
+    repo: str | None = None,
+) -> dict:
+    """Full pipeline: defect tracer → per-unit exposure check → labels (+ auto-observe events).
+
+    `units` are `{unit_id, pr, freeze_ts}` records; `exposure_by_unit` maps unit_id → evidence dict.
+    Honors the tracer's calibration gate: if anchor emission is BLOCKED, no correction signals are
+    trustworthy, so every unit is `unverified` (we cannot confirm a positive without a calibrated tracer)."""
+    traced = DT.trace_prs(
+        prs,
+        calibration=calibration,
+        calibration_log_path=calibration_log_path,
+        now_ts=_parse_ts(now_ts),
+        recall_threshold=recall_threshold,
+        windows=(window_days,)
+        if window_days not in DT.WINDOWS_DAYS
+        else DT.WINDOWS_DAYS,
+        repo=repo,
+    )
+    gate_open = traced.get("anchor_emission") == "allowed"
+    by_pr = {lbl["number"]: lbl for lbl in traced.get("labels", [])}
+    classifications = []
+    for u in units:
+        tracer_result = by_pr.get(u.get("pr"), {}) if gate_open else {}
+        classifications.append(
+            classify_unit(
+                u.get("unit_id"),
+                tracer_result=tracer_result,
+                exposure=exposure_by_unit.get(u.get("unit_id"), {}),
+                recall_threshold=recall_threshold,
+                freeze_ts=u.get("freeze_ts"),
+                now_ts=now_ts,
+                window_days=window_days,
+            )
+        )
+    events = [
+        e for e in (auto_observe_event(c) for c in classifications) if e is not None
+    ]
+    return {
+        "anchor_emission": traced.get("anchor_emission"),
+        "classifications": classifications,
+        "auto_observe_events": events,
+    }

--- a/claude-config/scripts/positive_signal_sensor.py
+++ b/claude-config/scripts/positive_signal_sensor.py
@@ -124,17 +124,21 @@ def classify_unit(
             "label": LABEL_CORRECTION,
             "correction_by": tracer_result.get("by"),
         }
-    # 2-6. no correction → require complete exposure AND adequate tracer coverage
+    # 2-6. A positive requires an EXPLICIT confirmed no-defect tracer result — "not observed_defect"
+    # is NOT enough (Codex): a missing/unknown/`indeterminate_coverage` label means the tracer could
+    # not confirm, which is `unverified`, never good (§0.6). Then full exposure AND adequate coverage.
+    no_correction_confirmed = (tracer_result or {}).get("label") == DT.LABEL_NO_DEFECT
     miss = missing_exposure(exposure)
     coverage_ok = coverage is not None and coverage >= recall_threshold
     exposure_ok = not miss
-    if exposure_ok and coverage_ok:
+    if no_correction_confirmed and exposure_ok and coverage_ok:
         label = LABEL_GOOD
     else:
         label = LABEL_UNVERIFIED
     return {
         **base,
         "label": label,
+        "no_correction_confirmed": no_correction_confirmed,
         "exposure_evidence": {
             k: bool((exposure or {}).get(k)) for k in REQUIRED_EXPOSURE
         },
@@ -146,8 +150,16 @@ def classify_unit(
 def auto_observe_event(classification: dict) -> dict | None:
     """The team-knowledge auto-observe hookpoint (tk-mvp-v1 §1.2). Emits a positive-example event ONLY
     for a CONFIRMED `no_observed_defect` — `unverified` / `pending` / `correction_detected` are NOT
-    auto-observable (the cross-spec gate). Returns None for anything but the confirmed positive."""
+    auto-observable (the cross-spec gate). Defense-in-depth (Codex): the label alone is not trusted —
+    the classification must ALSO show a confirmed no-correction tracer result, complete exposure, and
+    adequate coverage, so an externally-constructed/forged label cannot enter the pipeline."""
     if classification.get("label") != LABEL_GOOD:
+        return None
+    if (
+        classification.get("no_correction_confirmed") is not True
+        or classification.get("coverage_ok") is not True
+        or classification.get("missing_exposure")
+    ):
         return None
     return {
         "event": "positive_example",

--- a/claude-config/scripts/positive_signal_sensor.py
+++ b/claude-config/scripts/positive_signal_sensor.py
@@ -159,6 +159,7 @@ def auto_observe_event(classification: dict) -> dict | None:
         classification.get("no_correction_confirmed") is not True
         or classification.get("coverage_ok") is not True
         or classification.get("missing_exposure")
+        != []  # explicit empty list, not merely absent
     ):
         return None
     return {

--- a/claude-config/tests/test_positive_signal_sensor.py
+++ b/claude-config/tests/test_positive_signal_sensor.py
@@ -249,3 +249,36 @@ def test_auto_observe_event_only_for_confirmed_positive():
         )
         is None
     )
+
+
+# Strictness (Codex review): a positive requires an EXPLICIT confirmed no-defect tracer label ---------
+def test_positive_requires_explicit_no_defect_tracer_label():
+    # missing tracer label + externally supplied high coverage + full exposure → NOT good
+    res = _classify(tracer_result={}, tracer_coverage_pct=0.9)
+    assert res["label"] == S.LABEL_UNVERIFIED
+    assert res["no_correction_confirmed"] is False
+    # an indeterminate-coverage tracer label is also not a confirmation
+    indet = {"label": DT.LABEL_INDETERMINATE, "coverage": 0.9}
+    assert (
+        _classify(tracer_result=indet, tracer_coverage_pct=0.9)["label"]
+        == S.LABEL_UNVERIFIED
+    )
+    # an unknown label likewise
+    assert _classify(tracer_result={"label": "weird"}, tracer_coverage_pct=0.9)[
+        "label"
+    ] == (S.LABEL_UNVERIFIED)
+
+
+# Defense-in-depth (Codex review): auto-observe rejects a forged label lacking confirmation evidence --
+def test_auto_observe_rejects_forged_label():
+    forged = {
+        "unit_id": "x",
+        "label": S.LABEL_GOOD,  # claims good...
+        "coverage_ok": False,  # ...but evidence absent
+        "no_correction_confirmed": False,
+        "missing_exposure": ["deployed"],
+        "window_days": 30,
+    }
+    assert S.auto_observe_event(forged) is None
+    # a label claiming good but with no confirmation fields at all is also rejected
+    assert S.auto_observe_event({"label": S.LABEL_GOOD}) is None

--- a/claude-config/tests/test_positive_signal_sensor.py
+++ b/claude-config/tests/test_positive_signal_sensor.py
@@ -1,0 +1,251 @@
+"""Acceptance tests for issue #236 — `no_observed_defect_30d` positive-signal sensor (§3 / §0.6).
+
+Host-agnostic: injected tracer results + exposure evidence, no live gh. The cardinal rule: a unit is
+`no_observed_defect` ONLY with full exposure evidence + adequate tracer coverage — absence is never
+silently "good".
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+import positive_signal_sensor as S  # noqa: E402
+import defect_tracer as DT  # noqa: E402
+
+FULL_EXPOSURE = {
+    "deployed": True,
+    "tests_ran": True,
+    "tests_covered_changed": True,
+    "reviewer_coverage": True,
+    "ci_scope": True,
+}
+NO_CORRECTION = {"label": DT.LABEL_NO_DEFECT, "coverage": 0.8}
+FREEZE = "2026-05-01T00:00:00Z"
+NOW_CLOSED = "2026-06-10T00:00:00Z"  # 40d after freeze → window closed
+NOW_OPEN = "2026-05-25T00:00:00Z"  # 24d after freeze → window open
+
+
+def _classify(
+    tracer_result=NO_CORRECTION,
+    exposure=None,
+    *,
+    recall_threshold=0.5,
+    freeze_ts=FREEZE,
+    now_ts=NOW_CLOSED,
+    **kw,
+):
+    return S.classify_unit(
+        "u1",
+        tracer_result=tracer_result,
+        exposure=FULL_EXPOSURE if exposure is None else exposure,
+        recall_threshold=recall_threshold,
+        freeze_ts=freeze_ts,
+        now_ts=now_ts,
+        **kw,
+    )
+
+
+# Required: 30d elapsed, no correction, test execution missing → unverified (not no_observed_defect) --
+def test_missing_test_execution_is_unverified():
+    exposure = {**FULL_EXPOSURE, "tests_ran": False}
+    res = _classify(exposure=exposure)
+    assert res["label"] == S.LABEL_UNVERIFIED
+    assert "tests_ran" in res["missing_exposure"]
+
+
+# Required: 30d elapsed, no correction, ALL six met → no_observed_defect -----------------------------
+def test_all_conditions_met_is_no_observed_defect():
+    res = _classify()
+    assert res["label"] == S.LABEL_GOOD
+    assert res["missing_exposure"] == []
+    assert res["coverage_ok"] is True
+    assert res["label"] == "no_observed_defect"  # exact name discipline
+
+
+# Required: correction within 30d → correction_detected regardless of exposure ------------------------
+def test_correction_is_terminal_regardless_of_exposure():
+    corrected = {"label": DT.LABEL_OBSERVED_DEFECT, "by": [43], "coverage": 0.9}
+    # even with FULL exposure, a correction wins
+    res = _classify(tracer_result=corrected)
+    assert res["label"] == S.LABEL_CORRECTION
+    assert res["correction_by"] == [43]
+    # and with NO exposure too
+    res2 = _classify(tracer_result=corrected, exposure={})
+    assert res2["label"] == S.LABEL_CORRECTION
+
+
+# Required: tracer coverage below threshold → forces unverified even with all else --------------------
+def test_low_tracer_coverage_forces_unverified():
+    low = {"label": DT.LABEL_NO_DEFECT, "coverage": 0.2}
+    res = _classify(
+        tracer_result=low, recall_threshold=0.5
+    )  # full exposure, but coverage 0.2 < 0.5
+    assert res["label"] == S.LABEL_UNVERIFIED
+    assert res["coverage_ok"] is False
+    # threshold is configurable: lower it and the same unit qualifies
+    res2 = _classify(tracer_result=low, recall_threshold=0.1)
+    assert res2["label"] == S.LABEL_GOOD
+
+
+# Required: 29 days elapsed (window open) → no label yet (pending) ------------------------------------
+def test_window_not_closed_is_pending():
+    res = _classify(now_ts=NOW_OPEN)
+    assert res["label"] == S.LABEL_PENDING
+    assert res["label"] not in (S.LABEL_GOOD, S.LABEL_UNVERIFIED, S.LABEL_CORRECTION)
+    # exactly 30d → closed (inclusive boundary)
+    boundary = S.window_closed("2026-05-01T00:00:00Z", "2026-05-31T00:00:00Z", 30)
+    assert boundary is True
+    assert S.window_closed("2026-05-01T00:00:00Z", "2026-05-30T00:00:00Z", 30) is False
+
+
+# Required: tests-exist but not tests-ran → condition fails → unverified ------------------------------
+def test_tests_exist_but_not_ran_is_unverified():
+    # "tests exist" is modeled as ran=False/covered=False — existence alone is not execution
+    exposure = {**FULL_EXPOSURE, "tests_ran": False, "tests_covered_changed": False}
+    res = _classify(exposure=exposure)
+    assert res["label"] == S.LABEL_UNVERIFIED
+    # tests ran but did NOT cover changed paths → still unverified
+    partial = {**FULL_EXPOSURE, "tests_covered_changed": False}
+    assert _classify(exposure=partial)["label"] == S.LABEL_UNVERIFIED
+
+
+# Required: reviewer coverage missing → unverified ---------------------------------------------------
+def test_missing_reviewer_coverage_is_unverified():
+    exposure = {**FULL_EXPOSURE, "reviewer_coverage": False}
+    res = _classify(exposure=exposure)
+    assert res["label"] == S.LABEL_UNVERIFIED
+    assert "reviewer_coverage" in res["missing_exposure"]
+
+
+# Output schema shape (AC) ---------------------------------------------------------------------------
+def test_output_schema():
+    res = _classify()
+    for k in (
+        "unit_id",
+        "label",
+        "exposure_evidence",
+        "tracer_coverage_pct",
+        "window_days",
+    ):
+        assert k in res, k
+    assert set(res["exposure_evidence"]) == set(S.REQUIRED_EXPOSURE)
+    assert res["window_days"] == 30
+
+
+# Naming discipline (AC): no first_pass_correct anywhere in the new module ----------------------------
+def test_no_first_pass_correct_in_source():
+    src = (
+        Path(__file__).resolve().parents[1] / "scripts" / "positive_signal_sensor.py"
+    ).read_text()
+    assert "first_pass_correct" not in src
+    assert S.LABEL_GOOD == "no_observed_defect"
+
+
+# Integration: full pipeline session→tracer→exposure→label -------------------------------------------
+def test_integration_full_pipeline():
+    prs = DT.from_gh_json(
+        [
+            {
+                "number": 42,
+                "title": "feat",
+                "body": "",
+                "mergedAt": "2026-04-02T00:00:00Z",
+            },
+            {
+                "number": 43,
+                "title": 'Revert "feat"',
+                "body": "This reverts #42.",
+                "mergedAt": "2026-04-05T00:00:00Z",
+            },
+            {
+                "number": 44,
+                "title": "chore",
+                "body": "",
+                "mergedAt": "2026-04-02T00:00:00Z",
+            },
+        ]
+    )
+    units = [
+        {
+            "unit_id": "uA",
+            "pr": 42,
+            "freeze_ts": "2026-04-01T00:00:00Z",
+        },  # got reverted
+        {
+            "unit_id": "uB",
+            "pr": 44,
+            "freeze_ts": "2026-04-01T00:00:00Z",
+        },  # clean, full exposure
+        {
+            "unit_id": "uC",
+            "pr": 44,
+            "freeze_ts": "2026-04-01T00:00:00Z",
+        },  # clean, missing exposure
+    ]
+    exposure_by_unit = {
+        "uA": FULL_EXPOSURE,
+        "uB": FULL_EXPOSURE,
+        "uC": {"deployed": True},
+    }
+    cal = DT.run_calibration(
+        [{"predicted": "defect", "truth": "defect"} for _ in range(27)]
+        + [{"predicted": "defect", "truth": "clean"} for _ in range(2)]
+        + [{"predicted": "clean", "truth": "clean"} for _ in range(5)]
+    )
+    out = S.run_sensor(
+        prs,
+        units,
+        exposure_by_unit=exposure_by_unit,
+        recall_threshold=0.0,
+        now_ts="2026-06-10T00:00:00Z",
+        calibration=cal,
+    )
+    by_unit = {c["unit_id"]: c["label"] for c in out["classifications"]}
+    assert by_unit["uA"] == S.LABEL_CORRECTION  # reverted within window
+    assert by_unit["uB"] == S.LABEL_GOOD  # clean + full exposure
+    assert by_unit["uC"] == S.LABEL_UNVERIFIED  # clean but missing exposure
+
+
+# Integration: blocked calibration gate → every unit unverified (can't confirm a positive) -----------
+def test_blocked_gate_makes_units_unverified():
+    prs = DT.from_gh_json(
+        [
+            {
+                "number": 44,
+                "title": "chore",
+                "body": "",
+                "mergedAt": "2026-04-02T00:00:00Z",
+            }
+        ]
+    )
+    units = [{"unit_id": "uB", "pr": 44, "freeze_ts": "2026-04-01T00:00:00Z"}]
+    out = S.run_sensor(
+        prs,
+        units,
+        exposure_by_unit={"uB": FULL_EXPOSURE},
+        recall_threshold=0.0,
+        now_ts="2026-06-10T00:00:00Z",
+        calibration={"passed": True},  # forged → gate blocked
+    )
+    assert out["anchor_emission"] == "blocked"
+    assert out["classifications"][0]["label"] == S.LABEL_UNVERIFIED
+
+
+# Integration: no_observed_defect emits a tk-auto-observe-consumable event ----------------------------
+def test_auto_observe_event_only_for_confirmed_positive():
+    good = _classify()
+    ev = S.auto_observe_event(good)
+    assert ev is not None
+    assert ev["event"] == "positive_example"
+    assert ev["source"] == "no_observed_defect_30d"
+    assert ev["unit_id"] == "u1"
+    # unverified / correction / pending are NOT auto-observable
+    assert S.auto_observe_event(_classify(exposure={})) is None
+    assert S.auto_observe_event(_classify(now_ts=NOW_OPEN)) is None
+    assert (
+        S.auto_observe_event(
+            _classify(tracer_result={"label": DT.LABEL_OBSERVED_DEFECT})
+        )
+        is None
+    )

--- a/claude-config/tests/test_positive_signal_sensor.py
+++ b/claude-config/tests/test_positive_signal_sensor.py
@@ -282,3 +282,14 @@ def test_auto_observe_rejects_forged_label():
     assert S.auto_observe_event(forged) is None
     # a label claiming good but with no confirmation fields at all is also rejected
     assert S.auto_observe_event({"label": S.LABEL_GOOD}) is None
+    # confirmation flags present but missing_exposure ABSENT (None, not []) must still be rejected
+    assert (
+        S.auto_observe_event(
+            {
+                "label": S.LABEL_GOOD,
+                "no_correction_confirmed": True,
+                "coverage_ok": True,
+            }
+        )
+        is None
+    )


### PR DESCRIPTION
## Summary
The honest positive-signal metric — telemetry-validation **§3/§0.6**, build item 7. Breaks the failure-only learning dependency **without** manufacturing a false "correct" label. **P0 — gates both this spec's anchor and the team-knowledge auto-observe pipeline** (tk-mvp-v1 §1.2).

- **Naming discipline (Codex F3):** the metric is `no_observed_defect_30d`; the legacy `first_pass_correct` identifier appears nowhere in new code (guarded by a test).
- **Six-condition gate** for the positive label: no correction in the 30d window **+** deployed/used **+** tests *ran* and covered changed paths **+** reviewer coverage **+** CI scope **+** tracer coverage ≥ recall threshold. Miss any → `unverified` (never silently "good"). Correction in window → `correction_detected`. Window open → `pending`.
- **30d window** from the task-freeze timestamp (#229); fail-safe `pending` on an unparsable timestamp.
- Builds on the merged **`defect_tracer`** (#233); honors its calibration gate — a **blocked** anchor gate makes every unit `unverified` (can't confirm a positive without a calibrated tracer).
- **Cross-spec hookpoint:** emits a tk-auto-observe `positive_example` event **only** for a confirmed `no_observed_defect`.

## Test Plan
- 12 acceptance tests — every AC + every required test (missing test-execution, all-six-met, correction-terminal, low-coverage-forces-unverified, 29d-pending + boundary, tests-exist-not-ran, missing-reviewer, output schema, naming guard, full pipeline, blocked-gate, auto-observe event).
- `python3 -m pytest claude-config/tests/` → 97 passed. ruff clean.

Closes #236.

🤖 Generated with [Claude Code](https://claude.com/claude-code)