### PR TITLE
feat(telemetry): dead-man's-switch watchdog alarm-logic core (#232 logic; deploy deferred)

### DIFF
--- a/claude-config/scripts/watchdog.py
+++ b/claude-config/scripts/watchdog.py
@@ -38,6 +38,9 @@ DEFAULT_SLA_SECONDS = 24 * 3600  # matches otel_sink's exporter SLA
 # --- liveness alert names (the five distinct failure states + the roster signal) ------------------
 ALERT_HUB_UNREACHABLE = "hub-unreachable"
 ALERT_POLLER_DOWN = "poller-down"
+ALERT_CAPTURE_DOWN = (
+    "capture-down"  # the capture heartbeat itself is absent/stale (hook is silent)
+)
 ALERT_HEARTBEAT_ONLY = "heartbeat-only"
 ALERT_CORRUPT = "corrupt-payload"
 ALERT_STALE_EXPORTER = "stale-exporter"
@@ -100,10 +103,14 @@ def classify_liveness(
     # else the watchdog dies silently and every host looks fine)
     if _stale(obs.get("poller_last_beat"), now_ts, sla_seconds):
         alerts.append({"alert": ALERT_POLLER_DOWN, "host": host})
-    # capture heartbeat present & fresh, but...
-    if not _stale(obs.get("capture_last_beat"), now_ts, sla_seconds):
+    if _stale(obs.get("capture_last_beat"), now_ts, sla_seconds):
+        # FAIL-CLOSED: a stale/absent CAPTURE heartbeat is a dead capture path — it must alarm on its
+        # own, NOT be masked by a fresh poller beat (Codex re-review). Distinct from poller-down.
+        alerts.append({"alert": ALERT_CAPTURE_DOWN, "host": host})
+    else:
+        # capture heartbeat present & fresh, but...
         if not obs.get("payload"):
-            # ...payload empty → heartbeat-only (alive but emitting nothing), NOT poller-down
+            # ...payload empty → heartbeat-only (alive but emitting nothing)
             alerts.append({"alert": ALERT_HEARTBEAT_ONLY, "host": host})
         elif obs.get("payload_valid") is False:
             # ...payload present but malformed → corrupt, naming the offending shard

--- a/claude-config/scripts/watchdog.py
+++ b/claude-config/scripts/watchdog.py
@@ -1,0 +1,308 @@
+"""Dead-man's-switch watchdog — alarm logic core (telemetry-validation §0.1 / §2.5, build item 3).
+
+"A host that goes silent IS the fleet alarm" — but absence is only a signal if something OWNS the
+expectation and no component watches only itself (§0.1). This module is the host-agnostic ALARM LOGIC:
+pure functions that turn observations into DISTINCT named alerts. The deploy that produces those
+observations — the launchd poller (#221), the hub-side expected-host registry, the poller-health
+heartbeat — is server-a's lane and is DEFERRED (documented), exactly like #230's collector deploy.
+The logic here is what the hub/poller call; it is fully tested against simulated observations.
+
+Two watchdog families:
+
+  LIVENESS (§0.1) — FIVE distinct reporting-failure states, each its OWN named alert (never one generic
+  "silent"): `hub-unreachable`, `poller-down` (poller heartbeat absent/stale — distinct from the capture
+  heartbeat, so the watchdog can't die silently), `heartbeat-only` (capture alive but empty payload),
+  `corrupt-payload` (malformed record, names the offending shard), `stale-exporter` (OTEL sink past SLA,
+  wired from #230). Plus a roster check: an expected host past its `last_seen` SLA → `host-silent`.
+
+  EXCLUSION (§2.5, Codex F7) — the watchdog must NOT share the classifier's eyes, so these use evidence
+  INDEPENDENT of per-session capture: `exclusion-rate`/`unclassified-rate` too high, an
+  `implementation-like-but-excluded` session (code artifacts inside a deliberative/ops session),
+  `prove-coverage-missing` (code change with no PROVE/CI/test evidence), and a `reconciliation-gap`
+  (a file changed on disk that the session never reported).
+
+Pure + host-agnostic. Owner lane: server-a (deploy); built host-agnostic by scratch.
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import otel_sink as O  # noqa: E402  (reuse the #230 exporter-freshness check)
+
+DEFAULT_SLA_SECONDS = 24 * 3600  # matches otel_sink's exporter SLA
+
+# --- liveness alert names (the five distinct failure states + the roster signal) ------------------
+ALERT_HUB_UNREACHABLE = "hub-unreachable"
+ALERT_POLLER_DOWN = "poller-down"
+ALERT_HEARTBEAT_ONLY = "heartbeat-only"
+ALERT_CORRUPT = "corrupt-payload"
+ALERT_STALE_EXPORTER = "stale-exporter"
+ALERT_HOST_SILENT = (
+    "host-silent"  # roster: an expected host past its last_seen SLA (§0.1)
+)
+
+# --- content-completeness + exclusion alert names -------------------------------------------------
+ALERT_SEQUENCE_GAP = "sequence-gap"
+ALERT_FIELD_INCOMPLETE = "field-incomplete"
+ALERT_EXCLUSION_RATE = "exclusion-rate-high"
+ALERT_UNCLASSIFIED_RATE = "unclassified-rate-high"
+ALERT_IMPL_EXCLUDED = "implementation-like-but-excluded"
+ALERT_PROVE_COVERAGE = "prove-coverage-missing"
+ALERT_RECONCILIATION_GAP = "reconciliation-gap"
+
+# Work types with no valid code-quality measurement — they should carry NO implementation artifacts.
+EXCLUDED_WORK_TYPES = frozenset({"deliberative", "ops"})
+# Artifact fields that indicate implementation work happened in a session.
+IMPL_ARTIFACT_KEYS = ("files_edited", "commits", "prs", "tests_changed")
+
+
+def _parse_ts(value) -> float | None:
+    """ISO-8601 (trailing Z ok) or epoch seconds → epoch float; None/unparseable → None."""
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    try:
+        return datetime.fromisoformat(str(value).replace("Z", "+00:00")).timestamp()
+    except ValueError:
+        return None
+
+
+def _stale(last, now_ts, sla_seconds: int) -> bool:
+    """True if `last` is absent or older than the SLA. An ABSENT beat is stale (fail-safe: a missing
+    heartbeat is the alarm, never silently 'ok')."""
+    lt, n = _parse_ts(last), _parse_ts(now_ts)
+    if lt is None:
+        return True
+    if n is None:
+        return False
+    return (n - lt) > sla_seconds
+
+
+# --- liveness: five distinct states per reporting source -----------------------------------------
+def classify_liveness(
+    obs: dict, *, now_ts, sla_seconds: int = DEFAULT_SLA_SECONDS
+) -> list:
+    """Distinct named liveness alerts for ONE reporting source. `obs`: {host, hub_reachable(bool),
+    poller_last_beat, capture_last_beat, payload(dict|None), payload_valid(bool), shard}. Each failure
+    mode is its OWN alert (§0.1) — never collapsed into one generic 'silent'."""
+    host = obs.get("host")
+    if obs.get("hub_reachable") is False:
+        # the hub is the source of truth; if it's unreachable, downstream beats are unknowable
+        return [{"alert": ALERT_HUB_UNREACHABLE, "host": host}]
+    alerts = []
+    # poller-down: the poller's OWN heartbeat is absent/stale (distinct from the capture heartbeat —
+    # else the watchdog dies silently and every host looks fine)
+    if _stale(obs.get("poller_last_beat"), now_ts, sla_seconds):
+        alerts.append({"alert": ALERT_POLLER_DOWN, "host": host})
+    # capture heartbeat present & fresh, but...
+    if not _stale(obs.get("capture_last_beat"), now_ts, sla_seconds):
+        if not obs.get("payload"):
+            # ...payload empty → heartbeat-only (alive but emitting nothing), NOT poller-down
+            alerts.append({"alert": ALERT_HEARTBEAT_ONLY, "host": host})
+        elif obs.get("payload_valid") is False:
+            # ...payload present but malformed → corrupt, naming the offending shard
+            alerts.append(
+                {"alert": ALERT_CORRUPT, "host": host, "shard": obs.get("shard")}
+            )
+    return alerts
+
+
+def check_exporter(
+    sink_path, *, now_ts, sla_seconds: int = DEFAULT_SLA_SECONDS
+) -> dict | None:
+    """Stale-exporter alert, wired from #230's `otel_sink.check_exporter_freshness`. `sink_missing`
+    and `stale_exporter` both surface as a `stale-exporter` alert carrying the underlying reason."""
+    res = O.check_exporter_freshness(sink_path, now_ts=now_ts, sla_seconds=sla_seconds)
+    if res.get("alarm"):
+        return {
+            "alert": ALERT_STALE_EXPORTER,
+            "reason": res.get("reason"),
+            "sink": str(sink_path),
+        }
+    return None
+
+
+def check_roster(
+    expected_hosts,
+    last_seen_by_host: dict,
+    *,
+    now_ts,
+    sla_seconds: int = DEFAULT_SLA_SECONDS,
+) -> list:
+    """Expected-host registry cross-check (§0.1): an expected host that is never-seen or past its
+    `last_seen` SLA → `host-silent`. This is the 'absence is the signal' alarm — the hub OWNS the
+    roster, so a missing member is detectable (a host can't report its own silence)."""
+    last_seen_by_host = last_seen_by_host or {}
+    alerts = []
+    for h in expected_hosts:
+        ls = last_seen_by_host.get(h)
+        if _stale(ls, now_ts, sla_seconds):
+            alerts.append(
+                {
+                    "alert": ALERT_HOST_SILENT,
+                    "host": h,
+                    "reason": "never_seen" if ls is None else "last_seen_exceeded_sla",
+                }
+            )
+    return alerts
+
+
+# --- content-completeness ------------------------------------------------------------------------
+def sequence_gaps(shard, records: list) -> dict | None:
+    """Per-shard monotonic sequence check: `records` carry int `seq`; a missing or duplicated seq means
+    dropped/replayed data. Returns one alert naming the shard + the missing/duplicate seqs, or None."""
+    seqs = [r.get("seq") for r in records if isinstance(r.get("seq"), int)]
+    if not seqs:
+        return None
+    full = set(range(min(seqs), max(seqs) + 1))
+    missing = sorted(full - set(seqs))
+    seen, dups = set(), set()
+    for s in seqs:
+        (dups if s in seen else seen).add(s)
+    if missing or dups:
+        return {
+            "alert": ALERT_SEQUENCE_GAP,
+            "shard": shard,
+            "missing": missing,
+            "duplicates": sorted(dups),
+        }
+    return None
+
+
+def field_completeness(record: dict, expected_fields, *, shard=None) -> dict | None:
+    """Expected-field-count check: a present record missing expected fields is incomplete (catches the
+    heartbeat-present-but-payload-thin case at the field granularity)."""
+    missing = [f for f in expected_fields if record.get(f) in (None, "")]
+    if missing:
+        return {
+            "alert": ALERT_FIELD_INCOMPLETE,
+            "shard": shard,
+            "missing_fields": missing,
+        }
+    return None
+
+
+# --- exclusion watchdog (evidence INDEPENDENT of per-session capture, §2.5) -----------------------
+def _impl_artifacts(session: dict) -> list:
+    return [k for k in IMPL_ARTIFACT_KEYS if session.get(k)]
+
+
+def implementation_like_but_excluded(session: dict) -> dict | None:
+    """A session marked deliberative/ops that nonetheless carries implementation artifacts (edits/
+    commits/PRs/tests) — its work was misclassified out of the targets (§2.5, Codex F7)."""
+    wt = session.get("work_type")
+    artifacts = _impl_artifacts(session)
+    if wt in EXCLUDED_WORK_TYPES and artifacts:
+        return {
+            "alert": ALERT_IMPL_EXCLUDED,
+            "session_id": session.get("session_id"),
+            "work_type": wt,
+            "artifacts": artifacts,
+        }
+    return None
+
+
+def prove_coverage_alarm(session: dict) -> dict | None:
+    """Code change present but NO PROVE/CI/test evidence — the change was never verified (§2.5). Uses
+    independent artifact evidence, not the session's self-reported success."""
+    has_code = bool(session.get("files_edited") or session.get("commits"))
+    has_prove = bool(
+        session.get("prove") or session.get("ci") or session.get("tests_ran")
+    )
+    if has_code and not has_prove:
+        return {"alert": ALERT_PROVE_COVERAGE, "session_id": session.get("session_id")}
+    return None
+
+
+def reconciliation_gap(reported_files, filesystem_changed_files) -> dict | None:
+    """Ground-truth reconciliation (§2.5): files changed ON DISK that the session never reported —
+    independent of capture, so it catches gaps the capture hook itself missed."""
+    gap = sorted(set(filesystem_changed_files or []) - set(reported_files or []))
+    if gap:
+        return {"alert": ALERT_RECONCILIATION_GAP, "unreported_changed_files": gap}
+    return None
+
+
+def exclusion_rate_alarm(sessions: list, *, threshold: float = 0.5) -> list:
+    """High excluded-/unclassified-token share is target-disqualifying (§0.5) until resolved. Alarms
+    when either rate exceeds `threshold`."""
+    total = len(sessions)
+    if total == 0:
+        return []
+    excluded = sum(1 for s in sessions if s.get("work_type") in EXCLUDED_WORK_TYPES)
+    unclassified = sum(1 for s in sessions if not s.get("work_type"))
+    alerts = []
+    if excluded / total > threshold:
+        alerts.append(
+            {
+                "alert": ALERT_EXCLUSION_RATE,
+                "rate": round(excluded / total, 4),
+                "threshold": threshold,
+            }
+        )
+    if unclassified / total > threshold:
+        alerts.append(
+            {
+                "alert": ALERT_UNCLASSIFIED_RATE,
+                "rate": round(unclassified / total, 4),
+                "threshold": threshold,
+            }
+        )
+    return alerts
+
+
+# --- aggregators ---------------------------------------------------------------------------------
+def run_liveness_watchdog(
+    observations: list,
+    *,
+    now_ts,
+    expected_hosts=None,
+    last_seen_by_host: dict | None = None,
+    sink_path=None,
+    sla_seconds: int = DEFAULT_SLA_SECONDS,
+) -> list:
+    """All liveness alerts across reporting sources + the roster cross-check + the exporter freshness
+    check. Returns a flat list of distinct named alerts."""
+    alerts = []
+    for obs in observations:
+        alerts.extend(classify_liveness(obs, now_ts=now_ts, sla_seconds=sla_seconds))
+    if expected_hosts is not None:
+        alerts.extend(
+            check_roster(
+                expected_hosts,
+                last_seen_by_host or {},
+                now_ts=now_ts,
+                sla_seconds=sla_seconds,
+            )
+        )
+    if sink_path is not None:
+        ex = check_exporter(sink_path, now_ts=now_ts, sla_seconds=sla_seconds)
+        if ex:
+            alerts.append(ex)
+    return alerts
+
+
+def run_exclusion_watchdog(
+    sessions: list, *, reconciliation: dict | None = None, threshold: float = 0.5
+) -> list:
+    """All exclusion-family alerts: rate alarms + per-session impl-excluded / prove-coverage +
+    (optionally) a filesystem reconciliation gap."""
+    alerts = list(exclusion_rate_alarm(sessions, threshold=threshold))
+    for s in sessions:
+        for detector in (implementation_like_but_excluded, prove_coverage_alarm):
+            a = detector(s)
+            if a:
+                alerts.append(a)
+    if reconciliation:
+        g = reconciliation_gap(
+            reconciliation.get("reported_files"),
+            reconciliation.get("filesystem_changed_files"),
+        )
+        if g:
+            alerts.append(g)
+    return alerts

--- a/claude-config/scripts/watchdog.py
+++ b/claude-config/scripts/watchdog.py
@@ -73,13 +73,12 @@ def _parse_ts(value) -> float | None:
 
 
 def _stale(last, now_ts, sla_seconds: int) -> bool:
-    """True if `last` is absent or older than the SLA. An ABSENT beat is stale (fail-safe: a missing
-    heartbeat is the alarm, never silently 'ok')."""
+    """True if `last` is absent/unparseable, the eval time is unknown, or `last` is older than the SLA.
+    FAIL-CLOSED: a missing heartbeat OR an unknown 'now' both count as stale — a watchdog that can't
+    confirm freshness must alarm, never read silence as 'ok' (Codex)."""
     lt, n = _parse_ts(last), _parse_ts(now_ts)
-    if lt is None:
+    if lt is None or n is None:
         return True
-    if n is None:
-        return False
     return (n - lt) > sla_seconds
 
 
@@ -91,8 +90,10 @@ def classify_liveness(
     poller_last_beat, capture_last_beat, payload(dict|None), payload_valid(bool), shard}. Each failure
     mode is its OWN alert (§0.1) — never collapsed into one generic 'silent'."""
     host = obs.get("host")
-    if obs.get("hub_reachable") is False:
-        # the hub is the source of truth; if it's unreachable, downstream beats are unknowable
+    if obs.get("hub_reachable") is not True:
+        # FAIL-CLOSED: only an explicit True is "reachable"; a missing/None hub signal is unknowable,
+        # so we alarm rather than let other fresh-looking fields pass as healthy (Codex). If the hub is
+        # unreachable, downstream beats are unknowable anyway.
         return [{"alert": ALERT_HUB_UNREACHABLE, "host": host}]
     alerts = []
     # poller-down: the poller's OWN heartbeat is absent/stale (distinct from the capture heartbeat —
@@ -155,21 +156,38 @@ def check_roster(
 # --- content-completeness ------------------------------------------------------------------------
 def sequence_gaps(shard, records: list) -> dict | None:
     """Per-shard monotonic sequence check: `records` carry int `seq`; a missing or duplicated seq means
-    dropped/replayed data. Returns one alert naming the shard + the missing/duplicate seqs, or None."""
-    seqs = [r.get("seq") for r in records if isinstance(r.get("seq"), int)]
+    dropped/replayed data. FAIL-CLOSED: records with a missing/non-int seq are NOT silently dropped —
+    they are counted as `unsequenced` and themselves raise the alert (malformed sequence evidence is a
+    completeness failure, Codex). Returns one alert naming the shard, or None when fully intact."""
+    seqs = [
+        r.get("seq")
+        for r in records
+        if isinstance(r.get("seq"), int) and not isinstance(r.get("seq"), bool)
+    ]
+    unsequenced = len(records) - len(seqs)
     if not seqs:
+        # no usable sequence numbers at all — alarm iff there were records to sequence
+        if records:
+            return {
+                "alert": ALERT_SEQUENCE_GAP,
+                "shard": shard,
+                "missing": [],
+                "duplicates": [],
+                "unsequenced": unsequenced,
+            }
         return None
     full = set(range(min(seqs), max(seqs) + 1))
     missing = sorted(full - set(seqs))
     seen, dups = set(), set()
     for s in seqs:
         (dups if s in seen else seen).add(s)
-    if missing or dups:
+    if missing or dups or unsequenced:
         return {
             "alert": ALERT_SEQUENCE_GAP,
             "shard": shard,
             "missing": missing,
             "duplicates": sorted(dups),
+            "unsequenced": unsequenced,
         }
     return None
 
@@ -207,14 +225,15 @@ def implementation_like_but_excluded(session: dict) -> dict | None:
     return None
 
 
-def prove_coverage_alarm(session: dict) -> dict | None:
-    """Code change present but NO PROVE/CI/test evidence — the change was never verified (§2.5). Uses
-    independent artifact evidence, not the session's self-reported success."""
-    has_code = bool(session.get("files_edited") or session.get("commits"))
-    has_prove = bool(
-        session.get("prove") or session.get("ci") or session.get("tests_ran")
-    )
-    if has_code and not has_prove:
+def prove_coverage_alarm(session: dict, *, verified_ids=frozenset()) -> dict | None:
+    """Code change present but NOT independently verified — the change may never have been PROVEd (§2.5).
+    Independence (Codex F7): verification comes from `verified_ids` — the set of session ids an
+    INDEPENDENT source (CI API / test runner / PROVE record) confirmed — NOT from the session's own
+    self-reported `prove`/`ci`/`tests_ran` fields. Code-change detection uses the FULL artifact set
+    (files/commits/PRs/tests), so a PR-only or tests-only change can't dodge the alarm (Codex)."""
+    has_code = bool(_impl_artifacts(session))
+    verified = session.get("session_id") in (verified_ids or frozenset())
+    if has_code and not verified:
         return {"alert": ALERT_PROVE_COVERAGE, "session_id": session.get("session_id")}
     return None
 
@@ -288,16 +307,23 @@ def run_liveness_watchdog(
 
 
 def run_exclusion_watchdog(
-    sessions: list, *, reconciliation: dict | None = None, threshold: float = 0.5
+    sessions: list,
+    *,
+    reconciliation: dict | None = None,
+    threshold: float = 0.5,
+    verified_ids=frozenset(),
 ) -> list:
     """All exclusion-family alerts: rate alarms + per-session impl-excluded / prove-coverage +
-    (optionally) a filesystem reconciliation gap."""
+    (optionally) a filesystem reconciliation gap. `verified_ids` is the INDEPENDENT verification set
+    (CI/PROVE) used by the prove-coverage check — never the sessions' self-reported success."""
     alerts = list(exclusion_rate_alarm(sessions, threshold=threshold))
     for s in sessions:
-        for detector in (implementation_like_but_excluded, prove_coverage_alarm):
-            a = detector(s)
-            if a:
-                alerts.append(a)
+        impl = implementation_like_but_excluded(s)
+        if impl:
+            alerts.append(impl)
+        prove = prove_coverage_alarm(s, verified_ids=verified_ids)
+        if prove:
+            alerts.append(prove)
     if reconciliation:
         g = reconciliation_gap(
             reconciliation.get("reported_files"),

--- a/claude-config/tests/test_watchdog.py
+++ b/claude-config/tests/test_watchdog.py
@@ -303,3 +303,21 @@ def test_fail_closed_paths():
     # bool seq values are not mistaken for ints
     g2 = W.sequence_gaps("s", [{"seq": True}, {"seq": 2}])
     assert g2 is not None and g2["unsequenced"] == 1
+
+
+# Fail-closed (Codex re-review): a dead CAPTURE heartbeat alarms even when the poller beat is fresh ---
+def test_capture_down_not_masked_by_fresh_poller():
+    dead_capture = {
+        "host": "h",
+        "hub_reachable": True,
+        "poller_last_beat": FRESH,
+        "capture_last_beat": STALE,
+        "payload": {"x": 1},
+        "payload_valid": True,
+    }
+    names = _names(W.classify_liveness(dead_capture, now_ts=NOW))
+    assert W.ALERT_CAPTURE_DOWN in names
+    assert W.ALERT_POLLER_DOWN not in names  # poller is fine; only capture is down
+    # an entirely absent capture beat likewise alarms
+    absent = {"host": "h", "hub_reachable": True, "poller_last_beat": FRESH}
+    assert W.ALERT_CAPTURE_DOWN in _names(W.classify_liveness(absent, now_ts=NOW))

--- a/claude-config/tests/test_watchdog.py
+++ b/claude-config/tests/test_watchdog.py
@@ -1,0 +1,262 @@
+"""Acceptance tests for issue #232 — dead-man's-switch watchdog alarm logic (§0.1 / §2.5).
+
+Host-agnostic: simulated observations, no live hub/poller. The deploy (launchd poller #221, hub
+registry persistence) is server-a's lane and deferred; this validates the alarm LOGIC it calls.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+import watchdog as W  # noqa: E402
+import otel_sink as O  # noqa: E402
+
+NOW = 1_000_000.0
+FRESH = NOW - 60  # 1 min ago
+STALE = NOW - 100 * 3600  # 100h ago, well past the 24h SLA
+
+
+def _names(alerts):
+    return {a["alert"] for a in alerts}
+
+
+# Required: hub-unreachable → correct named alert (not generic) --------------------------------------
+def test_hub_unreachable_named():
+    obs = {"host": "server-a", "hub_reachable": False}
+    alerts = W.classify_liveness(obs, now_ts=NOW)
+    assert _names(alerts) == {W.ALERT_HUB_UNREACHABLE}
+    assert alerts[0]["host"] == "server-a"
+
+
+# Required: poller-down (poller heartbeat absent > SLA) → alarm --------------------------------------
+def test_poller_down():
+    obs = {
+        "host": "h",
+        "hub_reachable": True,
+        "poller_last_beat": STALE,
+        "capture_last_beat": FRESH,
+        "payload": {"x": 1},
+        "payload_valid": True,
+    }
+    assert W.ALERT_POLLER_DOWN in _names(W.classify_liveness(obs, now_ts=NOW))
+    # absent poller beat is also poller-down (fail-safe)
+    obs2 = {
+        "host": "h",
+        "hub_reachable": True,
+        "poller_last_beat": None,
+        "capture_last_beat": FRESH,
+        "payload": {"x": 1},
+        "payload_valid": True,
+    }
+    assert W.ALERT_POLLER_DOWN in _names(W.classify_liveness(obs2, now_ts=NOW))
+
+
+# Required: heartbeat present but empty payload → heartbeat-only, NOT poller-down --------------------
+def test_heartbeat_only_not_poller_down():
+    obs = {
+        "host": "h",
+        "hub_reachable": True,
+        "poller_last_beat": FRESH,
+        "capture_last_beat": FRESH,
+        "payload": {},
+        "payload_valid": True,
+    }
+    names = _names(W.classify_liveness(obs, now_ts=NOW))
+    assert names == {W.ALERT_HEARTBEAT_ONLY}
+    assert W.ALERT_POLLER_DOWN not in names
+
+
+# Required: corrupt payload → corrupt alert WITH offending shard id ----------------------------------
+def test_corrupt_payload_with_shard():
+    obs = {
+        "host": "h",
+        "hub_reachable": True,
+        "poller_last_beat": FRESH,
+        "capture_last_beat": FRESH,
+        "payload": {"raw": "{bad json"},
+        "payload_valid": False,
+        "shard": "jns-mac/2026-06-06",
+    }
+    alerts = W.classify_liveness(obs, now_ts=NOW)
+    corrupt = [a for a in alerts if a["alert"] == W.ALERT_CORRUPT]
+    assert corrupt and corrupt[0]["shard"] == "jns-mac/2026-06-06"
+
+
+# Required: stale-exporter (OTEL sink last-write > SLA) → stale-exporter alert -----------------------
+def test_stale_exporter_alert(tmp_path):
+    sink = tmp_path / "otel.jsonl"
+    O.append_sink_record(sink, {"input": 1, "model": "claude-sonnet-4"})
+    last = O.sink_last_write_ts(sink)
+    res = W.check_exporter(sink, now_ts=last + 100 * 3600)  # 100h later
+    assert res is not None and res["alert"] == W.ALERT_STALE_EXPORTER
+    # fresh sink → no alert
+    assert W.check_exporter(sink, now_ts=last + 60) is None
+    # missing sink → still a stale-exporter alert (reason sink_missing), never silent
+    missing = W.check_exporter(tmp_path / "nope.jsonl", now_ts=NOW)
+    assert (
+        missing["alert"] == W.ALERT_STALE_EXPORTER
+        and missing["reason"] == "sink_missing"
+    )
+
+
+# Required: exclusion-rate alarm — deliberative session containing a diff → flagged -----------------
+def test_implementation_like_but_excluded():
+    session = {
+        "session_id": "s1",
+        "work_type": "deliberative",
+        "files_edited": ["a.py"],
+        "commits": ["abc123"],
+    }
+    a = W.implementation_like_but_excluded(session)
+    assert a is not None and a["alert"] == W.ALERT_IMPL_EXCLUDED
+    assert "files_edited" in a["artifacts"]
+    # a clean deliberative session (no artifacts) is fine
+    assert W.implementation_like_but_excluded({"work_type": "deliberative"}) is None
+    # an implementation session with edits is expected — not flagged
+    assert (
+        W.implementation_like_but_excluded(
+            {"work_type": "implementation", "files_edited": ["a.py"]}
+        )
+        is None
+    )
+
+
+# Required: PROVE-coverage alarm — code edits but no PROVE/CI reference → alarm ----------------------
+def test_prove_coverage_alarm():
+    session = {"session_id": "s2", "files_edited": ["a.py"], "commits": ["abc"]}
+    assert W.prove_coverage_alarm(session)["alert"] == W.ALERT_PROVE_COVERAGE
+    # with test/CI evidence → no alarm
+    assert W.prove_coverage_alarm({**session, "tests_ran": True}) is None
+    assert W.prove_coverage_alarm({**session, "ci": "https://ci/run/1"}) is None
+    # no code change → nothing to verify
+    assert W.prove_coverage_alarm({"session_id": "s3"}) is None
+
+
+# Required: reconciliation gap — filesystem change not in session report → flagged ------------------
+def test_reconciliation_gap():
+    g = W.reconciliation_gap(
+        reported_files=["a.py"], filesystem_changed_files=["a.py", "secret_leak.py"]
+    )
+    assert g["alert"] == W.ALERT_RECONCILIATION_GAP
+    assert g["unreported_changed_files"] == ["secret_leak.py"]
+    # everything reported → no gap
+    assert W.reconciliation_gap(["a.py", "b.py"], ["a.py", "b.py"]) is None
+
+
+# Integration: host goes silent for > SLA → roster detects and raises host-silent -------------------
+def test_roster_detects_silent_host():
+    expected = ["scratch", "server-a", "laptop-wsl"]
+    last_seen = {"scratch": FRESH, "server-a": STALE}  # laptop-wsl never seen
+    alerts = W.check_roster(expected, last_seen, now_ts=NOW)
+    silent = {a["host"]: a["reason"] for a in alerts}
+    assert silent == {"server-a": "last_seen_exceeded_sla", "laptop-wsl": "never_seen"}
+    assert "scratch" not in silent  # fresh host not alarmed
+
+
+# Integration: all five liveness states are distinguishable in the alert output --------------------
+def test_all_five_states_distinguishable():
+    observations = [
+        {"host": "a", "hub_reachable": False},
+        {
+            "host": "b",
+            "hub_reachable": True,
+            "poller_last_beat": STALE,
+            "capture_last_beat": STALE,
+            "payload": {"x": 1},
+            "payload_valid": True,
+        },
+        {
+            "host": "c",
+            "hub_reachable": True,
+            "poller_last_beat": FRESH,
+            "capture_last_beat": FRESH,
+            "payload": {},
+            "payload_valid": True,
+        },
+        {
+            "host": "d",
+            "hub_reachable": True,
+            "poller_last_beat": FRESH,
+            "capture_last_beat": FRESH,
+            "payload": {"raw": "x"},
+            "payload_valid": False,
+            "shard": "d/1",
+        },
+    ]
+    alerts = W.run_liveness_watchdog(observations, now_ts=NOW)
+    names = _names(alerts)
+    assert W.ALERT_HUB_UNREACHABLE in names
+    assert W.ALERT_POLLER_DOWN in names
+    assert W.ALERT_HEARTBEAT_ONLY in names
+    assert W.ALERT_CORRUPT in names
+    # add a stale exporter via the aggregator's sink check using a missing sink
+    with_sink = W.run_liveness_watchdog(
+        observations, now_ts=NOW, sink_path="/nonexistent.jsonl"
+    )
+    assert W.ALERT_STALE_EXPORTER in _names(with_sink)
+    # five DISTINCT names, not one generic "silent"
+    assert len(_names(with_sink)) >= 5
+
+
+# Content-completeness: monotonic sequence gaps + field counts --------------------------------------
+def test_sequence_gaps_and_field_completeness():
+    # missing seq 3 in a 1..5 shard
+    recs = [{"seq": 1}, {"seq": 2}, {"seq": 4}, {"seq": 5}, {"seq": 5}]
+    g = W.sequence_gaps("shardX", recs)
+    assert g["alert"] == W.ALERT_SEQUENCE_GAP
+    assert g["missing"] == [3] and g["duplicates"] == [5]
+    # contiguous, unique → no gap
+    assert W.sequence_gaps("ok", [{"seq": 1}, {"seq": 2}, {"seq": 3}]) is None
+    # field completeness
+    fc = W.field_completeness(
+        {"ts": 1, "model": ""}, ("ts", "model", "session_id"), shard="s"
+    )
+    assert fc["alert"] == W.ALERT_FIELD_INCOMPLETE
+    assert set(fc["missing_fields"]) == {"model", "session_id"}
+    assert W.field_completeness({"ts": 1, "model": "m"}, ("ts", "model")) is None
+
+
+# Exclusion-rate aggregate alarms ------------------------------------------------------------------
+def test_exclusion_rate_alarms():
+    sessions = [
+        {"work_type": "deliberative"},
+        {"work_type": "ops"},
+        {"work_type": "deliberative"},
+        {"work_type": "implementation"},
+    ]  # 3/4 excluded
+    names = _names(W.exclusion_rate_alarm(sessions, threshold=0.5))
+    assert W.ALERT_EXCLUSION_RATE in names
+    # unclassified rate
+    unclassified = [
+        {"work_type": None},
+        {"work_type": None},
+        {"work_type": "implementation"},
+    ]
+    assert W.ALERT_UNCLASSIFIED_RATE in _names(
+        W.exclusion_rate_alarm(unclassified, threshold=0.5)
+    )
+    # empty input → no alarms, no division error
+    assert W.exclusion_rate_alarm([]) == []
+
+
+# run_exclusion_watchdog aggregates everything -----------------------------------------------------
+def test_run_exclusion_watchdog():
+    sessions = [
+        {
+            "session_id": "s1",
+            "work_type": "deliberative",
+            "files_edited": ["a.py"],
+        },  # impl-excluded
+        {
+            "session_id": "s2",
+            "work_type": "implementation",
+            "files_edited": ["b.py"],
+        },  # no prove
+    ]
+    recon = {"reported_files": ["a.py"], "filesystem_changed_files": ["a.py", "c.py"]}
+    alerts = W.run_exclusion_watchdog(sessions, reconciliation=recon, threshold=0.9)
+    names = _names(alerts)
+    assert W.ALERT_IMPL_EXCLUDED in names
+    assert W.ALERT_PROVE_COVERAGE in names
+    assert W.ALERT_RECONCILIATION_GAP in names

--- a/claude-config/tests/test_watchdog.py
+++ b/claude-config/tests/test_watchdog.py
@@ -122,15 +122,30 @@ def test_implementation_like_but_excluded():
     )
 
 
-# Required: PROVE-coverage alarm — code edits but no PROVE/CI reference → alarm ----------------------
+# Required: PROVE-coverage alarm — code edits but no INDEPENDENT verification → alarm ----------------
 def test_prove_coverage_alarm():
     session = {"session_id": "s2", "files_edited": ["a.py"], "commits": ["abc"]}
-    assert W.prove_coverage_alarm(session)["alert"] == W.ALERT_PROVE_COVERAGE
-    # with test/CI evidence → no alarm
-    assert W.prove_coverage_alarm({**session, "tests_ran": True}) is None
-    assert W.prove_coverage_alarm({**session, "ci": "https://ci/run/1"}) is None
+    # not in the independently-verified set → alarm
+    assert (
+        W.prove_coverage_alarm(session, verified_ids=set())["alert"]
+        == W.ALERT_PROVE_COVERAGE
+    )
+    # INDEPENDENTLY verified (CI/test record from an external source) → no alarm
+    assert W.prove_coverage_alarm(session, verified_ids={"s2"}) is None
+    # SELF-REPORTED success must NOT suppress the alarm (Codex F7 independence)
+    assert (
+        W.prove_coverage_alarm(
+            {**session, "tests_ran": True, "ci": "x"}, verified_ids=set()
+        )["alert"]
+        == W.ALERT_PROVE_COVERAGE
+    )
     # no code change → nothing to verify
-    assert W.prove_coverage_alarm({"session_id": "s3"}) is None
+    assert W.prove_coverage_alarm({"session_id": "s3"}, verified_ids=set()) is None
+    # a PR-only or tests-only artifact still counts as a code change (B5)
+    assert W.prove_coverage_alarm({"session_id": "s4", "prs": [12]}, verified_ids=set())
+    assert W.prove_coverage_alarm(
+        {"session_id": "s5", "tests_changed": ["t.py"]}, verified_ids=set()
+    )
 
 
 # Required: reconciliation gap — filesystem change not in session report → flagged ------------------
@@ -255,8 +270,36 @@ def test_run_exclusion_watchdog():
         },  # no prove
     ]
     recon = {"reported_files": ["a.py"], "filesystem_changed_files": ["a.py", "c.py"]}
-    alerts = W.run_exclusion_watchdog(sessions, reconciliation=recon, threshold=0.9)
+    alerts = W.run_exclusion_watchdog(
+        sessions, reconciliation=recon, threshold=0.9, verified_ids=set()
+    )
     names = _names(alerts)
     assert W.ALERT_IMPL_EXCLUDED in names
     assert W.ALERT_PROVE_COVERAGE in names
     assert W.ALERT_RECONCILIATION_GAP in names
+
+
+# Fail-closed (Codex review): missing/unknown evidence must ALARM, never read as healthy ------------
+def test_fail_closed_paths():
+    # missing hub_reachable field → hub-unreachable (not silently healthy)
+    assert _names(W.classify_liveness({"host": "h"}, now_ts=NOW)) == {
+        W.ALERT_HUB_UNREACHABLE
+    }
+    # unknown 'now' makes any heartbeat stale → poller-down fires (fail-closed staleness)
+    obs = {
+        "host": "h",
+        "hub_reachable": True,
+        "poller_last_beat": FRESH,
+        "capture_last_beat": FRESH,
+        "payload": {"x": 1},
+        "payload_valid": True,
+    }
+    assert W.ALERT_POLLER_DOWN in _names(W.classify_liveness(obs, now_ts=None))
+    # a shard whose records lack usable seq numbers is NOT silently contiguous
+    g = W.sequence_gaps("s", [{"ts": 1}, {"ts": 2}])
+    assert (
+        g is not None and g["alert"] == W.ALERT_SEQUENCE_GAP and g["unsequenced"] == 2
+    )
+    # bool seq values are not mistaken for ints
+    g2 = W.sequence_gaps("s", [{"seq": True}, {"seq": 2}])
+    assert g2 is not None and g2["unsequenced"] == 1


### PR DESCRIPTION
## Summary
Host-agnostic **alarm-logic core** for the layered watchdog — telemetry-validation **§0.1/§2.5**, build item 3. "A host that goes silent IS the fleet alarm" — and absence is only a signal if something OWNS the expectation and no component watches only itself.

**Scope note:** this is the pure, tested LOGIC the hub/poller call. The **deploy** that produces the observations — launchd poller (#221), hub-side expected-host registry persistence, the poller-health heartbeat process — is **server-a's lane and deferred** (documented in the module), mirroring #230's deploy-deferred pattern. Every required test is covered host-agnostically.

### Liveness — five DISTINCT named states (never one generic "silent")
`hub-unreachable` · `poller-down` (poller beat distinct from the capture beat, so the watchdog can't die silently) · `heartbeat-only` (alive but empty payload) · `corrupt-payload` (names the offending shard) · `stale-exporter` (wired from #230). Plus a roster cross-check → `host-silent` on `last_seen` SLA (the §0.1 "absence is the signal"). Content-completeness: per-shard monotonic sequence gaps + expected-field counts.

### Exclusion watchdog — evidence INDEPENDENT of per-session capture (§2.5, Codex F7)
`exclusion-rate`/`unclassified-rate` · `implementation-like-but-excluded` (code artifacts in a deliberative/ops session) · `prove-coverage-missing` · `reconciliation-gap` (a file changed on disk the session never reported).

## Test Plan
- 13 acceptance tests — all 10 required tests + content-completeness + rate alarms + aggregator.
- `python3 -m pytest claude-config/tests/` → 98 passed. ruff clean.

Partially addresses #232 (logic core). Remaining for server-a: the launchd poller, hub registry persistence, and live wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)