### PR TITLE
feat(team-knowledge): auto-observe → patterns/<area>/<dev>.yaml from telemetry

### DIFF
--- a/bin/earshot
+++ b/bin/earshot
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# earshot — transcribe + diarize any recording on the jns GPU server.
+#   earshot <file> [opts]          sync: upload, run, write <name>.transcript.md/.json to cwd
+#   earshot --async <file> [opts]  submit a background job, print its id, return immediately
+#   earshot --collect <id> [dir]   fetch a finished async job's results (default: cwd)
+# Extra opts pass through to the engine, e.g.:  --num-speakers 2  --model large-v3-turbo
+set -euo pipefail
+
+REMOTE_PROJ='~/projects/earshot'
+
+usage(){ sed -n '2,6p' "$0" | sed 's/^# \{0,1\}//'; }
+
+pick_host(){
+  local h
+  for h in jns jns-server; do
+    ssh -o BatchMode=yes -o ConnectTimeout=5 "$h" true 2>/dev/null && { printf '%s' "$h"; return 0; }
+  done
+  return 1
+}
+
+MODE=sync
+case "${1:-}" in
+  -h|--help) usage; exit 0 ;;
+  --async)   MODE=async;   shift ;;
+  --collect) MODE=collect; shift ;;
+esac
+[ $# -ge 1 ] || { usage; exit 1; }
+
+HOST="$(pick_host)" || { echo "earshot: cannot reach jns or jns-server over ssh" >&2; exit 1; }
+
+# ---- collect a finished async job ----
+if [ "$MODE" = collect ]; then
+  ID="$1"; DEST="${2:-$PWD}"
+  st="$(ssh "$HOST" "cat ~/earshot-jobs/$ID/status 2>/dev/null || echo missing")"
+  case "$st" in
+    done)
+      ssh "$HOST" "cd ~/earshot-jobs/$ID && tar cf - *.transcript.* 2>/dev/null" | tar xf - -C "$DEST"
+      echo "earshot: collected job $ID -> $DEST" >&2
+      ls "$DEST"/*.transcript.md 2>/dev/null | tail -1
+      ;;
+    running) echo "earshot: job $ID still running" >&2; exit 2 ;;
+    failed)  echo "earshot: job $ID FAILED — log tail:" >&2; ssh "$HOST" "tail -20 ~/earshot-jobs/$ID/log" >&2; exit 1 ;;
+    *)       echo "earshot: no such job '$ID'" >&2; exit 1 ;;
+  esac
+  exit 0
+fi
+
+# ---- sync or async: need a local input file ----
+SRC="$1"; shift
+[ -f "$SRC" ] || { echo "earshot: no such file: $SRC" >&2; exit 1; }
+base="$(basename "$SRC")"; stem="${base%.*}"; ext="${base##*.}"
+safe="$(printf '%s' "$stem" | tr ' /:' '___')"
+remote_in="/tmp/earshot-in/$safe.$ext"
+
+extra=""; for a in "$@"; do extra+=" $(printf '%q' "$a")"; done
+
+ssh "$HOST" "mkdir -p /tmp/earshot-in"
+echo "earshot: uploading $base to $HOST..." >&2
+scp -q "$SRC" "$HOST:$remote_in"
+
+if [ "$MODE" = async ]; then
+  ID="$safe-$(date +%Y%m%d-%H%M%S)"
+  ssh "$HOST" "cd $REMOTE_PROJ && nohup ./run-job.sh $(printf %q "$ID") $(printf %q "$remote_in")$extra >/dev/null 2>&1 & echo ok" >/dev/null
+  echo "earshot: submitted async job $ID on $HOST" >&2
+  echo "  collect when done:  earshot --collect $ID" >&2
+  echo "$ID"
+  exit 0
+fi
+
+# sync
+src_dir="$(cd "$(dirname "$SRC")" && pwd)"
+echo "earshot: transcribing on $HOST (GPU STT + diarization)..." >&2
+ssh "$HOST" "cd $REMOTE_PROJ && .venv/bin/python transcribe.py $(printf %q "$remote_in") --out /tmp/earshot-out$extra" >/dev/null
+scp -q "$HOST:/tmp/earshot-out/$safe.transcript.md"   "$src_dir/$stem.transcript.md"
+scp -q "$HOST:/tmp/earshot-out/$safe.transcript.json" "$src_dir/$stem.transcript.json"
+ssh "$HOST" "rm -f $(printf %q "$remote_in") /tmp/earshot-out/$safe.transcript.*" || true
+echo "earshot: done ✓" >&2
+echo "$src_dir/$stem.transcript.md"

--- a/claude-config/skills/transcribe-meeting/SKILL.md
+++ b/claude-config/skills/transcribe-meeting/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: transcribe-meeting
+version: 1.0
+description: Transcribe + diarize a meeting audio file on the jns GPU server, then map speakers to real names (with your confirmation) and write a summary + action items in the standard meeting format. Use when given an audio/video recording of a meeting to turn into notes. Handles the file transfer to the server itself.
+---
+
+# /transcribe-meeting
+
+Turn a recorded meeting (audio/video file) into a speaker-labeled transcript plus a
+summary with action items. The heavy lifting (transcription + diarization) runs on
+the **jns** GPU server; this skill orchestrates that and adds the LLM layer (speaker
+naming, summary, actions). The file transfer to the server is handled for you.
+
+## Usage
+
+```
+/transcribe-meeting <audio-file>
+/transcribe-meeting ~/Downloads/weekly-vitalai.m4a
+/transcribe-meeting call.wav --model large-v3      # extra args pass through to the engine
+```
+
+Accepts any ffmpeg-readable audio/video (`.m4a`, `.mp3`, `.wav`, `.mp4`, …).
+
+## Behavior
+
+Execute these steps in order. Do not skip the speaker-confirmation step (3).
+
+### 1. Transcribe + diarize on the GPU server
+Run the client wrapper (it scp's the file to jns, runs whisper.cpp on the AMD GPU +
+pyannote diarization on CPU, and writes the results next to the input):
+
+```bash
+~/agents/bin/earshot "<audio-file>" [passthrough args]
+```
+
+It prints progress (`[1/3]…[3/3]`) and, on success, the path to
+`<name>.transcript.md`. It also writes `<name>.transcript.json` (turns + timestamps)
+in the same directory. If it reports it cannot reach `jns`/`jns-server`, stop and tell
+the user (the engine only runs on the server).
+
+### 2. Read the outputs
+Read `<name>.transcript.md` (speaker-labeled with generic `SPEAKER_00/01/02`) and, if
+useful, `<name>.transcript.json` for turn timestamps and the speaker count.
+
+### 3. Map speakers to real names — PROPOSE, then CONFIRM
+The diarizer uses generic labels. **Never guess silently** — first-speaker order is
+unreliable (it caused a real Jason/Ryan mix-up before). Instead:
+- Infer each speaker's identity from the content: names they're addressed by, roles,
+  self-references, who owns which topic.
+- Present a proposed mapping as a short table — `SPEAKER_00 → <name>` with the **quote
+  or evidence** that supports each guess.
+- Ask the user to confirm or correct the mapping (use AskUserQuestion or a direct
+  question) **before** relabeling.
+- If the user already supplied names (e.g. they said "it's Jason, Ryan, John"), still
+  show the mapping you'll apply and let them correct it.
+
+Once confirmed, replace the `SPEAKER_xx` labels with the real names throughout.
+
+### 4. Summarize + extract action items
+Using the now name-labeled transcript, write notes in the **standard meeting format**:
+- `# <Meeting title> — <date>` and an **Attendees** line.
+- **Summary** organized by topic (decisions, status, discussion).
+- **Action Items** as a table: `# | Action | Owner | Notes / Context`.
+- **Full Transcript** appended verbatim at the bottom (the name-labeled version), under
+  a heading, noting it's machine-transcribed.
+
+Save this as `<name>.summary.md` next to the audio file.
+
+### 5. Report (save only — do not email)
+Tell the user the two files written:
+- `<name>.transcript.md` — speaker-labeled transcript
+- `<name>.summary.md` — summary + action items
+
+Do not send anything anywhere; this skill is save-only. (If the user later wants it
+emailed, that's `~/agents/google/send_mail.py`.)
+
+## Notes
+- The engine lives at `~/projects/earshot` on jns; this skill never
+  re-implements transcription — it calls the `earshot` CLI.
+- Speakers map by *first appearance* if names are passed straight to the engine via
+  `--speakers`, which is why this skill does the mapping in the LLM layer instead.
+- Honor any meeting-specific naming/handling rules from the user's CLAUDE.md memory.

--- a/team-knowledge/scripts/auto_observe.py
+++ b/team-knowledge/scripts/auto_observe.py
@@ -64,8 +64,8 @@ def extract_observations(records: list, *, dev: str | None = None) -> list:
         if dev is not None and rdev != dev:
             continue
         area = r.get("area")
-        if not area:
-            continue
+        if not area or not isinstance(area, str):
+            continue  # area must be a string taxonomy key — a non-str would crash dict lookups
         candidates = []
         gf = r.get("guards_fired")
         if isinstance(gf, str):

--- a/team-knowledge/scripts/auto_observe.py
+++ b/team-knowledge/scripts/auto_observe.py
@@ -58,6 +58,8 @@ def extract_observations(records: list, *, dev: str | None = None) -> list:
     — an area is required to resolve against the taxonomy."""
     out = []
     for r in records:
+        if not isinstance(r, dict):
+            continue  # skip malformed telemetry items (None/str/…) — never crash on them
         rdev = r.get("dev")
         if dev is not None and rdev != dev:
             continue
@@ -221,6 +223,17 @@ def auto_observe(
                                 "observed": e["pattern_key"],
                             }
                         )
+
+        # Normalize EVERY entry before writing (incl. untouched existing ones): occurrence_confidence
+        # is always recomputed from observation_count+source and efficacy_confidence forced to None, so
+        # an authored/stale computed field in a prior file can never leak through (Codex).
+        for e in entries.values():
+            e["efficacy_confidence"] = None
+            e["occurrence_confidence"] = P.compute_occurrence_confidence(
+                int(e.get("observation_count", 0) or 0),
+                source=e.get("source", "observed"),
+                n_cap=n_cap,
+            )
 
         _write_area_file(path, dev, area, entries)
         written.append(str(path))

--- a/team-knowledge/scripts/auto_observe.py
+++ b/team-knowledge/scripts/auto_observe.py
@@ -1,0 +1,263 @@
+"""Auto-observe — derive each dev's practices from telemetry and write patterns/<area>/<dev>.yaml.
+
+team-knowledge-mvp-v1 §1.1 (bottom-up discovery) / §1.2 (AUTO-OBSERVE primary) / §1.3 (Pattern schema).
+Practices are DISCOVERED from telemetry + git history + decision fields (guards_fired / codex_overturned),
+NOT declared by the dev. Each observed behavior is mapped onto a controlled `pattern_key` via the
+taxonomy (#223/#239); a behavior that fits NO key is written `pattern_key: UNMAPPED` (a taxonomy-gap
+signal for map_patterns #244 — NEVER force-bucketed to the closest match).
+
+Invariants (the spec's teeth):
+- `occurrence_confidence` is COMPUTED by `patterns.compute_occurrence_confidence` — never authored;
+  an authored literal in the input does not propagate.
+- `efficacy_confidence` stays None until powered outcome evidence exists — no telemetry populates it.
+- `source: observed` for auto-derived entries; `observed+declared` when a declared entry also exists;
+  a declared practice contradicted by observation is surfaced as a flagged DELTA, never suppressed.
+- DEV ISOLATION: a dev's agent observes only ITS OWN behavior and writes only its own
+  patterns/<area>/<dev>.yaml — it never touches another dev's path.
+- INCREMENTAL: re-running with new telemetry increments `observation_count` and recomputes confidence
+  on the SAME entry (keyed by id) — it does not create duplicates.
+
+Owner lane: all (§9.3 — each agent runs this on its own machine; the implementation is shared).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover
+    yaml = None
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import patterns as P  # noqa: E402
+
+SCHEMA_VERSION = 1
+
+
+def _require_yaml():
+    if yaml is None:
+        raise RuntimeError("PyYAML required for auto-observe")
+
+
+def _area_keys(taxonomy: dict, area: str) -> list:
+    return list((taxonomy.get("areas") or {}).get(area, []))
+
+
+def _n_cap(taxonomy: dict) -> int:
+    return int((taxonomy.get("config") or {}).get("n_cap", P.DEFAULT_N_CAP))
+
+
+def extract_observations(records: list, *, dev: str | None = None) -> list:
+    """Normalize raw telemetry/decision records into observations `{dev, area, candidate_key}`.
+
+    Reads `guards_fired` (str or list of guard names → candidate keys), `codex_overturned` (truthy →
+    a CODEX_OVERTURNED candidate), and explicit `{area, pattern_key}` records. If `dev` is given, only
+    that dev's records are kept (a dev observes its OWN practices). Records without an `area` are skipped
+    — an area is required to resolve against the taxonomy."""
+    out = []
+    for r in records:
+        rdev = r.get("dev")
+        if dev is not None and rdev != dev:
+            continue
+        area = r.get("area")
+        if not area:
+            continue
+        candidates = []
+        gf = r.get("guards_fired")
+        if isinstance(gf, str):
+            candidates.append(gf)
+        elif isinstance(gf, (list, tuple)):
+            candidates.extend(gf)
+        if r.get("codex_overturned"):
+            candidates.append("CODEX_OVERTURNED")
+        if r.get("pattern_key"):
+            candidates.append(r["pattern_key"])
+        for c in candidates:
+            if c:
+                out.append({"dev": rdev, "area": area, "candidate_key": str(c)})
+    return out
+
+
+def _entry_id(dev: str, area: str, pattern_key: str, candidate: str) -> str:
+    """Stable id. UNMAPPED entries also carry the raw candidate so DISTINCT unmapped behaviors stay
+    separate (never collapsed into one UNMAPPED bucket)."""
+    if pattern_key == P.UNMAPPED:
+        return f"{dev}:{area}:{P.UNMAPPED}:{candidate}"
+    return f"{dev}:{area}:{pattern_key}"
+
+
+def _patterns_file(patterns_dir, area: str, dev: str) -> Path:
+    return Path(patterns_dir) / area / f"{dev}.yaml"
+
+
+def _load_existing(path: Path) -> dict:
+    """Existing patterns/<area>/<dev>.yaml as {id: entry}, or empty."""
+    if not path.exists():
+        return {}
+    data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    return {
+        e["id"]: dict(e)
+        for e in data.get("patterns", [])
+        if isinstance(e, dict) and e.get("id")
+    }
+
+
+def _practice(pattern_key: str, candidate: str, area: str, count: int) -> str:
+    if pattern_key == P.UNMAPPED:
+        return f"auto-observed unmapped behavior {candidate!r} ({count}x) in {area}"
+    return f"auto-observed {pattern_key} ({count}x) in {area}"
+
+
+def auto_observe(
+    dev: str,
+    records: list,
+    *,
+    taxonomy: dict,
+    patterns_dir,
+    declared: list | None = None,
+) -> dict:
+    """Observe `dev`'s practices from `records` and write patterns/<area>/<dev>.yaml (incrementally).
+
+    Returns {written: [paths], entries: [entry], deltas: [delta]}. Only `dev`'s observations are used
+    and only `dev`'s files are written (isolation). `declared` is an optional list of the dev's declared
+    patterns ({area, pattern_key, practice}) used for the declared-vs-observed delta."""
+    _require_yaml()
+    observations = extract_observations(records, dev=dev)
+    n_cap = _n_cap(taxonomy)
+    declared = declared or []
+
+    # Count new observations per (area, resolved_key, candidate).
+    new_counts: dict = {}
+    for o in observations:
+        area = o["area"]
+        candidate = o["candidate_key"]
+        key = P.resolve_pattern_key(candidate, _area_keys(taxonomy, area))
+        eid = _entry_id(dev, area, key, candidate)
+        bucket = new_counts.setdefault(
+            eid, {"area": area, "pattern_key": key, "candidate": candidate, "n": 0}
+        )
+        bucket["n"] += 1
+
+    declared_by_area = {}
+    for d in declared:
+        declared_by_area.setdefault(d.get("area"), {})[d.get("pattern_key")] = d
+
+    # Group new observations + existing entries by area, then write each area's file once.
+    areas = {b["area"] for b in new_counts.values()} | set(declared_by_area)
+    written, all_entries, deltas = [], [], []
+    for area in sorted(a for a in areas if a):
+        path = _patterns_file(patterns_dir, area, dev)
+        existing = _load_existing(path)
+        entries = dict(existing)  # id -> entry
+
+        # apply declared entries first (so observed can upgrade source to observed+declared)
+        for dkey, d in declared_by_area.get(area, {}).items():
+            did = _entry_id(dev, area, dkey, dkey)
+            if did not in entries:
+                entries[did] = {
+                    "id": did,
+                    "dev": dev,
+                    "area": area,
+                    "pattern_key": dkey,
+                    "practice": d.get("practice") or f"declared {dkey} in {area}",
+                    "source": "declared",
+                    "observation_count": 0,
+                    "occurrence_confidence": P.compute_occurrence_confidence(
+                        0, source="declared", n_cap=n_cap
+                    ),
+                    "efficacy_confidence": None,
+                }
+
+        # merge observed counts (incremental: add to any existing observation_count)
+        for eid, b in new_counts.items():
+            if b["area"] != area:
+                continue
+            prior = entries.get(eid, {})
+            count = int(prior.get("observation_count", 0) or 0) + b["n"]
+            both = b["pattern_key"] in declared_by_area.get(area, {})
+            source = "observed+declared" if both else "observed"
+            entry = {
+                "id": eid,
+                "dev": dev,
+                "area": area,
+                "pattern_key": b["pattern_key"],
+                "practice": _practice(b["pattern_key"], b["candidate"], area, count),
+                "source": source,
+                "observation_count": count,
+                "occurrence_confidence": P.compute_occurrence_confidence(
+                    count, source=source, n_cap=n_cap
+                ),
+                "efficacy_confidence": None,
+            }
+            if b["pattern_key"] == P.UNMAPPED:
+                entry["raw_behavior"] = b["candidate"]
+            entries[eid] = entry
+
+        # declared-vs-observed delta: a declared key with NO observed support, while a DIFFERENT key in
+        # the same area DID get observed → flag the observed entries as a conflict (never suppress).
+        observed_keys = {
+            e["pattern_key"]
+            for e in entries.values()
+            if "observed" in e.get("source", "") and e.get("observation_count", 0) > 0
+        }
+        for dkey in declared_by_area.get(area, {}):
+            did = _entry_id(dev, area, dkey, dkey)
+            d_observed = entries.get(did, {}).get("observation_count", 0) > 0
+            if not d_observed and observed_keys - {dkey}:
+                for e in entries.values():
+                    if (
+                        "observed" in e.get("source", "")
+                        and e.get("observation_count", 0) > 0
+                        and e["pattern_key"] != dkey
+                    ):
+                        e["conflict"] = True
+                        e["conflicts_with_declared"] = dkey
+                        deltas.append(
+                            {
+                                "area": area,
+                                "declared": dkey,
+                                "observed": e["pattern_key"],
+                            }
+                        )
+
+        _write_area_file(path, dev, area, entries)
+        written.append(str(path))
+        all_entries.extend(entries.values())
+
+    return {"written": written, "entries": all_entries, "deltas": deltas}
+
+
+def _write_area_file(path: Path, dev: str, area: str, entries: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    doc = {
+        "schema_version": SCHEMA_VERSION,
+        "dev": dev,
+        "area": area,
+        "patterns": [entries[k] for k in sorted(entries)],
+    }
+    path.write_text(yaml.safe_dump(doc, sort_keys=True), encoding="utf-8")
+
+
+def validate_observed_entry(entry: dict, taxonomy: dict | None = None) -> list:
+    """Validate a SYSTEM-WRITTEN observed entry against the §1.3 schema. Unlike
+    `patterns.validate_authored_pattern`, the computed fields are REQUIRED here (the system computes
+    them) — but `efficacy_confidence` must be None and `occurrence_confidence` a float."""
+    errors = []
+    for f in P.REQUIRED_PATTERN_FIELDS:
+        if not entry.get(f):
+            errors.append(f"missing required field {f!r}")
+    if entry.get("source") not in P._VALID_SOURCES:
+        errors.append(f"invalid source {entry.get('source')!r}")
+    if not isinstance(entry.get("occurrence_confidence"), (int, float)):
+        errors.append("occurrence_confidence must be a computed float")
+    if entry.get("efficacy_confidence") is not None:
+        errors.append(
+            "efficacy_confidence must be None until powered outcome evidence exists"
+        )
+    if taxonomy is not None:
+        area, key = entry.get("area"), entry.get("pattern_key")
+        if key != P.UNMAPPED and key not in set(_area_keys(taxonomy, area)):
+            errors.append(f"pattern_key {key!r} not in taxonomy for area {area!r}")
+    return errors

--- a/team-knowledge/tests/test_auto_observe.py
+++ b/team-knowledge/tests/test_auto_observe.py
@@ -241,6 +241,23 @@ def test_extract_skips_malformed_records():
     ]
 
 
+def test_non_string_area_does_not_crash(tmp_path):
+    # a record with a non-hashable/non-str area must be skipped, not crash auto_observe (Codex re-review)
+    records = [
+        {
+            "dev": "jason",
+            "area": ["testing"],
+            "guards_fired": "MISSING_TEST",
+        },  # bad area
+        {"dev": "jason", "area": "testing", "guards_fired": "MISSING_TEST"},  # good
+    ]
+    out = A.auto_observe("jason", records, taxonomy=TAXONOMY, patterns_dir=tmp_path)
+    by_key = {e["pattern_key"]: e for e in out["entries"]}
+    assert (
+        by_key["MISSING_TEST"]["observation_count"] == 1
+    )  # only the valid record counted
+
+
 # Invariant (Codex): a stale/authored computed field in an UNTOUCHED existing entry is normalized ----
 def test_existing_entry_computed_fields_normalized(tmp_path):
     # seed a tampered existing file: authored confidence + non-null efficacy on an entry we won't touch

--- a/team-knowledge/tests/test_auto_observe.py
+++ b/team-knowledge/tests/test_auto_observe.py
@@ -225,3 +225,59 @@ def test_extract_observations():
         ("testing", "MISSING_TEST"),
         ("testing", "SKIP_TEST"),
     ]
+
+
+# Robustness (Codex): malformed (non-dict) records are skipped, never crash extraction --------------
+def test_extract_skips_malformed_records():
+    records = [
+        None,
+        "oops",
+        123,
+        {"dev": "jason", "area": "testing", "guards_fired": "MISSING_TEST"},
+    ]
+    obs = A.extract_observations(records, dev="jason")
+    assert [(o["area"], o["candidate_key"]) for o in obs] == [
+        ("testing", "MISSING_TEST")
+    ]
+
+
+# Invariant (Codex): a stale/authored computed field in an UNTOUCHED existing entry is normalized ----
+def test_existing_entry_computed_fields_normalized(tmp_path):
+    # seed a tampered existing file: authored confidence + non-null efficacy on an entry we won't touch
+    area_dir = Path(tmp_path) / "testing"
+    area_dir.mkdir(parents=True)
+    tampered = {
+        "schema_version": 1,
+        "dev": "jason",
+        "area": "testing",
+        "patterns": [
+            {
+                "id": "jason:testing:SQLITE_COMPAT_TESTS",
+                "dev": "jason",
+                "area": "testing",
+                "pattern_key": "SQLITE_COMPAT_TESTS",
+                "practice": "x",
+                "source": "observed",
+                "observation_count": 4,
+                "occurrence_confidence": 0.999,  # authored/stale
+                "efficacy_confidence": 0.5,  # must be forced to None
+            }
+        ],
+    }
+    (area_dir / "jason.yaml").write_text(yaml.safe_dump(tampered))
+    # run auto-observe on a DIFFERENT key, leaving SQLITE_COMPAT_TESTS untouched by new obs
+    A.auto_observe(
+        "jason",
+        [{"dev": "jason", "area": "testing", "guards_fired": "MISSING_TEST"}],
+        taxonomy=TAXONOMY,
+        patterns_dir=tmp_path,
+    )
+    by_key = {
+        e["pattern_key"]: e for e in _read(tmp_path, "testing", "jason")["patterns"]
+    }
+    untouched = by_key["SQLITE_COMPAT_TESTS"]
+    assert untouched["efficacy_confidence"] is None  # forced null
+    assert untouched["occurrence_confidence"] == P.compute_occurrence_confidence(
+        4, n_cap=50
+    )
+    assert untouched["occurrence_confidence"] != 0.999  # authored literal scrubbed

--- a/team-knowledge/tests/test_auto_observe.py
+++ b/team-knowledge/tests/test_auto_observe.py
@@ -1,0 +1,227 @@
+"""Acceptance tests for issue #243 — auto-observe → patterns/<area>/<dev>.yaml (§1.1/§1.2/§1.3).
+
+A taxonomy FIXTURE is used (not the controlled areas.yaml) so the behavioral keys the required tests
+exercise (MISSING_TEST / SKIP_TEST / ALWAYS_TESTS) exist for `testing` — auto_observe is taxonomy-
+driven by design, and minting real keys is a governance action, not this feature's job.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+yaml = pytest.importorskip("yaml")
+
+import auto_observe as A  # noqa: E402
+import patterns as P  # noqa: E402
+
+TAXONOMY = {
+    "config": {"n_cap": 50, "consensus_floor": 0.4},
+    "areas": {
+        "testing": ["MISSING_TEST", "SKIP_TEST", "ALWAYS_TESTS", "SQLITE_COMPAT_TESTS"],
+        "security": ["NO_SECRETS_IN_CODE"],
+    },
+}
+
+
+def _read(patterns_dir, area, dev):
+    return yaml.safe_load((Path(patterns_dir) / area / f"{dev}.yaml").read_text())
+
+
+# Basic derivation: 5 MISSING_TEST guards in testing → entry with count=5, source observed -----------
+def test_basic_derivation(tmp_path):
+    records = [
+        {"dev": "jason", "area": "testing", "guards_fired": ["MISSING_TEST"]}
+        for _ in range(5)
+    ]
+    A.auto_observe("jason", records, taxonomy=TAXONOMY, patterns_dir=tmp_path)
+    doc = _read(tmp_path, "testing", "jason")
+    entry = next(e for e in doc["patterns"] if e["pattern_key"] == "MISSING_TEST")
+    assert entry["observation_count"] == 5
+    assert entry["source"] == "observed"
+    assert entry["dev"] == "jason" and entry["area"] == "testing"
+
+
+# Confidence computed, never authored ---------------------------------------------------------------
+def test_confidence_computed_not_authored(tmp_path):
+    # an authored occurrence_confidence in the INPUT must NOT propagate to the OUTPUT
+    records = [
+        {
+            "dev": "jason",
+            "area": "testing",
+            "guards_fired": "MISSING_TEST",
+            "occurrence_confidence": 0.999,
+        }
+        for _ in range(3)
+    ]
+    A.auto_observe("jason", records, taxonomy=TAXONOMY, patterns_dir=tmp_path)
+    entry = next(
+        e
+        for e in _read(tmp_path, "testing", "jason")["patterns"]
+        if e["pattern_key"] == "MISSING_TEST"
+    )
+    expected = P.compute_occurrence_confidence(3, source="observed", n_cap=50)
+    assert entry["occurrence_confidence"] == expected
+    assert (
+        entry["occurrence_confidence"] != 0.999
+    )  # the authored literal did not propagate
+
+
+# UNMAPPED path: a behavior matching no key → UNMAPPED, not the closest match ------------------------
+def test_unmapped_not_force_bucketed(tmp_path):
+    records = [
+        {"dev": "jason", "area": "security", "guards_fired": ["WEIRD_NEW_BEHAVIOR"]}
+    ]
+    A.auto_observe("jason", records, taxonomy=TAXONOMY, patterns_dir=tmp_path)
+    doc = _read(tmp_path, "security", "jason")
+    entry = doc["patterns"][0]
+    assert entry["pattern_key"] == P.UNMAPPED
+    assert (
+        entry["pattern_key"] != "NO_SECRETS_IN_CODE"
+    )  # NOT force-bucketed to the closest key
+    assert entry["raw_behavior"] == "WEIRD_NEW_BEHAVIOR"
+
+
+# Declared-vs-observed delta: declared ALWAYS_TESTS but observed SKIP_TEST → conflict flagged --------
+def test_declared_observed_delta(tmp_path):
+    declared = [
+        {
+            "area": "testing",
+            "pattern_key": "ALWAYS_TESTS",
+            "practice": "I always write tests",
+        }
+    ]
+    records = [
+        {"dev": "jason", "area": "testing", "guards_fired": "SKIP_TEST"}
+        for _ in range(3)
+    ]
+    out = A.auto_observe(
+        "jason", records, taxonomy=TAXONOMY, patterns_dir=tmp_path, declared=declared
+    )
+    doc = _read(tmp_path, "testing", "jason")
+    by_key = {e["pattern_key"]: e for e in doc["patterns"]}
+    # declared entry retained, observed SKIP_TEST written alongside
+    assert by_key["ALWAYS_TESTS"]["source"] == "declared"
+    assert by_key["ALWAYS_TESTS"]["observation_count"] == 0
+    assert by_key["SKIP_TEST"]["source"] == "observed"
+    assert by_key["SKIP_TEST"]["observation_count"] == 3
+    # the conflict is FLAGGED, not suppressed
+    assert by_key["SKIP_TEST"]["conflict"] is True
+    assert by_key["SKIP_TEST"]["conflicts_with_declared"] == "ALWAYS_TESTS"
+    assert {
+        "area": "testing",
+        "declared": "ALWAYS_TESTS",
+        "observed": "SKIP_TEST",
+    } in out["deltas"]
+
+
+# source observed+declared when a key is both declared and observed ----------------------------------
+def test_source_observed_plus_declared(tmp_path):
+    declared = [{"area": "testing", "pattern_key": "MISSING_TEST", "practice": "x"}]
+    records = [
+        {"dev": "jason", "area": "testing", "guards_fired": "MISSING_TEST"}
+        for _ in range(2)
+    ]
+    A.auto_observe(
+        "jason", records, taxonomy=TAXONOMY, patterns_dir=tmp_path, declared=declared
+    )
+    entry = next(
+        e
+        for e in _read(tmp_path, "testing", "jason")["patterns"]
+        if e["pattern_key"] == "MISSING_TEST"
+    )
+    assert entry["source"] == "observed+declared"
+    assert entry["observation_count"] == 2
+
+
+# Incremental re-run: 5 then 3 → count 8, recomputed, no duplicates ---------------------------------
+def test_incremental_rerun(tmp_path):
+    five = [
+        {"dev": "jason", "area": "testing", "guards_fired": "MISSING_TEST"}
+        for _ in range(5)
+    ]
+    A.auto_observe("jason", five, taxonomy=TAXONOMY, patterns_dir=tmp_path)
+    three = [
+        {"dev": "jason", "area": "testing", "guards_fired": "MISSING_TEST"}
+        for _ in range(3)
+    ]
+    A.auto_observe("jason", three, taxonomy=TAXONOMY, patterns_dir=tmp_path)
+    doc = _read(tmp_path, "testing", "jason")
+    missing = [e for e in doc["patterns"] if e["pattern_key"] == "MISSING_TEST"]
+    assert len(missing) == 1  # no duplicate entry
+    assert missing[0]["observation_count"] == 8
+    assert missing[0]["occurrence_confidence"] == P.compute_occurrence_confidence(
+        8, n_cap=50
+    )
+
+
+# Dev isolation: running as jason never writes another dev's file ------------------------------------
+def test_dev_isolation(tmp_path):
+    records = [
+        {"dev": "jason", "area": "testing", "guards_fired": "MISSING_TEST"},
+        {
+            "dev": "server-a",
+            "area": "testing",
+            "guards_fired": "MISSING_TEST",
+        },  # not ours
+    ]
+    A.auto_observe("jason", records, taxonomy=TAXONOMY, patterns_dir=tmp_path)
+    assert (Path(tmp_path) / "testing" / "jason.yaml").exists()
+    assert not (Path(tmp_path) / "testing" / "server-a.yaml").exists()
+    # and jason's file did not absorb server-a's observation
+    doc = _read(tmp_path, "testing", "jason")
+    assert (
+        next(e for e in doc["patterns"] if e["pattern_key"] == "MISSING_TEST")[
+            "observation_count"
+        ]
+        == 1
+    )
+
+
+# efficacy_confidence stays null no matter how much telemetry ----------------------------------------
+def test_efficacy_stays_null(tmp_path):
+    records = [
+        {"dev": "jason", "area": "testing", "guards_fired": "MISSING_TEST"}
+        for _ in range(40)
+    ]
+    A.auto_observe("jason", records, taxonomy=TAXONOMY, patterns_dir=tmp_path)
+    for e in _read(tmp_path, "testing", "jason")["patterns"]:
+        assert e["efficacy_confidence"] is None
+
+
+# Output validates against the §1.3 schema (computed fields required, efficacy None) ----------------
+def test_output_schema_valid(tmp_path):
+    records = [
+        {"dev": "jason", "area": "testing", "guards_fired": "MISSING_TEST"}
+        for _ in range(5)
+    ]
+    out = A.auto_observe("jason", records, taxonomy=TAXONOMY, patterns_dir=tmp_path)
+    for e in out["entries"]:
+        assert A.validate_observed_entry(e, taxonomy=TAXONOMY) == []
+
+
+# extract_observations reads guards_fired + codex_overturned, filtered to the dev -------------------
+def test_extract_observations():
+    records = [
+        {
+            "dev": "jason",
+            "area": "testing",
+            "guards_fired": ["MISSING_TEST", "SKIP_TEST"],
+        },
+        {"dev": "jason", "area": "code-review", "codex_overturned": True},
+        {
+            "dev": "server-a",
+            "area": "testing",
+            "guards_fired": "MISSING_TEST",
+        },  # filtered out
+        {"dev": "jason"},  # no area → skipped
+    ]
+    obs = A.extract_observations(records, dev="jason")
+    cands = sorted((o["area"], o["candidate_key"]) for o in obs)
+    assert cands == [
+        ("code-review", "CODEX_OVERTURNED"),
+        ("testing", "MISSING_TEST"),
+        ("testing", "SKIP_TEST"),
+    ]


### PR DESCRIPTION
## Summary
The auto-observe pipeline — team-knowledge-mvp-v1 **§1.1/§1.2/§1.3**. Each dev's agent derives its OWN practices from telemetry + decision fields (`guards_fired`/`codex_overturned`), maps each behavior onto a controlled `pattern_key`, and writes `patterns/<area>/<dev>.yaml`. Unblocked by #236 (merged).

### Invariants (the spec's teeth)
- `occurrence_confidence` is **COMPUTED** via `patterns.compute_occurrence_confidence` (#239) — an authored literal in the input does not propagate.
- `efficacy_confidence` stays **None** (no telemetry populates it).
- **UNMAPPED** behaviors → `pattern_key: UNMAPPED` + `raw_behavior`, never force-bucketed to the closest key (taxonomy-gap signal for #244).
- `source: observed` / `observed+declared`; a declared practice contradicted by observation → flagged **delta**, never suppressed.
- **Dev isolation:** only the running dev's observations used, only its files written.
- **Incremental:** re-run increments `observation_count` + recomputes confidence on the same entry — no duplicates.
- **Taxonomy-driven:** resolves against an injected taxonomy; does **not** mutate the controlled `areas.yaml` (minting keys is a governance action).

## Test Plan
- 10 acceptance tests — every AC + every required test (basic derivation, confidence-computed-not-authored, UNMAPPED, declared-vs-observed delta, observed+declared, incremental re-run, dev isolation, efficacy-null, schema-valid, extract).
- `python3 -m pytest team-knowledge/tests/` → 31 passed. ruff clean.

Closes #243. Next: #244 `map_patterns` consumes these (incl. UNMAPPED gaps) → #245 private-review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)