### PR TITLE
feat: earshot transcribe client + transcribe-meeting skill

### DIFF
--- a/bin/earshot
+++ b/bin/earshot
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# earshot — transcribe + diarize any recording on the jns GPU server.
+#   earshot <file> [opts]          sync: upload, run, write <name>.transcript.md/.json to cwd
+#   earshot --async <file> [opts]  submit a background job, print its id, return immediately
+#   earshot --collect <id> [dir]   fetch a finished async job's results (default: cwd)
+# Extra opts pass through to the engine, e.g.:  --num-speakers 2  --model large-v3-turbo
+set -euo pipefail
+
+REMOTE_PROJ='~/projects/earshot'
+
+usage(){ sed -n '2,6p' "$0" | sed 's/^# \{0,1\}//'; }
+
+pick_host(){
+  local h
+  for h in jns jns-server; do
+    ssh -o BatchMode=yes -o ConnectTimeout=5 "$h" true 2>/dev/null && { printf '%s' "$h"; return 0; }
+  done
+  return 1
+}
+
+MODE=sync
+case "${1:-}" in
+  -h|--help) usage; exit 0 ;;
+  --async)   MODE=async;   shift ;;
+  --collect) MODE=collect; shift ;;
+esac
+[ $# -ge 1 ] || { usage; exit 1; }
+
+HOST="$(pick_host)" || { echo "earshot: cannot reach jns or jns-server over ssh" >&2; exit 1; }
+
+# ---- collect a finished async job ----
+if [ "$MODE" = collect ]; then
+  ID="$1"; DEST="${2:-$PWD}"
+  st="$(ssh "$HOST" "cat ~/earshot-jobs/$ID/status 2>/dev/null || echo missing")"
+  case "$st" in
+    done)
+      ssh "$HOST" "cd ~/earshot-jobs/$ID && tar cf - *.transcript.* 2>/dev/null" | tar xf - -C "$DEST"
+      echo "earshot: collected job $ID -> $DEST" >&2
+      ls "$DEST"/*.transcript.md 2>/dev/null | tail -1
+      ;;
+    running) echo "earshot: job $ID still running" >&2; exit 2 ;;
+    failed)  echo "earshot: job $ID FAILED — log tail:" >&2; ssh "$HOST" "tail -20 ~/earshot-jobs/$ID/log" >&2; exit 1 ;;
+    *)       echo "earshot: no such job '$ID'" >&2; exit 1 ;;
+  esac
+  exit 0
+fi
+
+# ---- sync or async: need a local input file ----
+SRC="$1"; shift
+[ -f "$SRC" ] || { echo "earshot: no such file: $SRC" >&2; exit 1; }
+base="$(basename "$SRC")"; stem="${base%.*}"; ext="${base##*.}"
+safe="$(printf '%s' "$stem" | tr ' /:' '___')"
+remote_in="/tmp/earshot-in/$safe.$ext"
+
+extra=""; for a in "$@"; do extra+=" $(printf '%q' "$a")"; done
+
+ssh "$HOST" "mkdir -p /tmp/earshot-in"
+echo "earshot: uploading $base to $HOST..." >&2
+scp -q "$SRC" "$HOST:$remote_in"
+
+if [ "$MODE" = async ]; then
+  ID="$safe-$(date +%Y%m%d-%H%M%S)"
+  ssh "$HOST" "cd $REMOTE_PROJ && nohup ./run-job.sh $(printf %q "$ID") $(printf %q "$remote_in")$extra >/dev/null 2>&1 & echo ok" >/dev/null
+  echo "earshot: submitted async job $ID on $HOST" >&2
+  echo "  collect when done:  earshot --collect $ID" >&2
+  echo "$ID"
+  exit 0
+fi
+
+# sync
+src_dir="$(cd "$(dirname "$SRC")" && pwd)"
+echo "earshot: transcribing on $HOST (GPU STT + diarization)..." >&2
+ssh "$HOST" "cd $REMOTE_PROJ && .venv/bin/python transcribe.py $(printf %q "$remote_in") --out /tmp/earshot-out$extra" >/dev/null
+scp -q "$HOST:/tmp/earshot-out/$safe.transcript.md"   "$src_dir/$stem.transcript.md"
+scp -q "$HOST:/tmp/earshot-out/$safe.transcript.json" "$src_dir/$stem.transcript.json"
+ssh "$HOST" "rm -f $(printf %q "$remote_in") /tmp/earshot-out/$safe.transcript.*" || true
+echo "earshot: done ✓" >&2
+echo "$src_dir/$stem.transcript.md"

--- a/claude-config/skills/transcribe-meeting/SKILL.md
+++ b/claude-config/skills/transcribe-meeting/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: transcribe-meeting
+version: 1.0
+description: Transcribe + diarize a meeting audio file on the jns GPU server, then map speakers to real names (with your confirmation) and write a summary + action items in the standard meeting format. Use when given an audio/video recording of a meeting to turn into notes. Handles the file transfer to the server itself.
+---
+
+# /transcribe-meeting
+
+Turn a recorded meeting (audio/video file) into a speaker-labeled transcript plus a
+summary with action items. The heavy lifting (transcription + diarization) runs on
+the **jns** GPU server; this skill orchestrates that and adds the LLM layer (speaker
+naming, summary, actions). The file transfer to the server is handled for you.
+
+## Usage
+
+```
+/transcribe-meeting <audio-file>
+/transcribe-meeting ~/Downloads/weekly-vitalai.m4a
+/transcribe-meeting call.wav --model large-v3      # extra args pass through to the engine
+```
+
+Accepts any ffmpeg-readable audio/video (`.m4a`, `.mp3`, `.wav`, `.mp4`, …).
+
+## Behavior
+
+Execute these steps in order. Do not skip the speaker-confirmation step (3).
+
+### 1. Transcribe + diarize on the GPU server
+Run the client wrapper (it scp's the file to jns, runs whisper.cpp on the AMD GPU +
+pyannote diarization on CPU, and writes the results next to the input):
+
+```bash
+~/agents/bin/earshot "<audio-file>" [passthrough args]
+```
+
+It prints progress (`[1/3]…[3/3]`) and, on success, the path to
+`<name>.transcript.md`. It also writes `<name>.transcript.json` (turns + timestamps)
+in the same directory. If it reports it cannot reach `jns`/`jns-server`, stop and tell
+the user (the engine only runs on the server).
+
+### 2. Read the outputs
+Read `<name>.transcript.md` (speaker-labeled with generic `SPEAKER_00/01/02`) and, if
+useful, `<name>.transcript.json` for turn timestamps and the speaker count.
+
+### 3. Map speakers to real names — PROPOSE, then CONFIRM
+The diarizer uses generic labels. **Never guess silently** — first-speaker order is
+unreliable (it caused a real Jason/Ryan mix-up before). Instead:
+- Infer each speaker's identity from the content: names they're addressed by, roles,
+  self-references, who owns which topic.
+- Present a proposed mapping as a short table — `SPEAKER_00 → <name>` with the **quote
+  or evidence** that supports each guess.
+- Ask the user to confirm or correct the mapping (use AskUserQuestion or a direct
+  question) **before** relabeling.
+- If the user already supplied names (e.g. they said "it's Jason, Ryan, John"), still
+  show the mapping you'll apply and let them correct it.
+
+Once confirmed, replace the `SPEAKER_xx` labels with the real names throughout.
+
+### 4. Summarize + extract action items
+Using the now name-labeled transcript, write notes in the **standard meeting format**:
+- `# <Meeting title> — <date>` and an **Attendees** line.
+- **Summary** organized by topic (decisions, status, discussion).
+- **Action Items** as a table: `# | Action | Owner | Notes / Context`.
+- **Full Transcript** appended verbatim at the bottom (the name-labeled version), under
+  a heading, noting it's machine-transcribed.
+
+Save this as `<name>.summary.md` next to the audio file.
+
+### 5. Report (save only — do not email)
+Tell the user the two files written:
+- `<name>.transcript.md` — speaker-labeled transcript
+- `<name>.summary.md` — summary + action items
+
+Do not send anything anywhere; this skill is save-only. (If the user later wants it
+emailed, that's `~/agents/google/send_mail.py`.)
+
+## Notes
+- The engine lives at `~/projects/earshot` on jns; this skill never
+  re-implements transcription — it calls the `earshot` CLI.
+- Speakers map by *first appearance* if names are passed straight to the engine via
+  `--speakers`, which is why this skill does the mapping in the LLM layer instead.
+- Honor any meeting-specific naming/handling rules from the user's CLAUDE.md memory.


### PR DESCRIPTION
## Summary
Laptop-side glue for the **earshot** transcriber (engine: github.com/jwj2002/earshot, runs on the jns GPU server).

- `bin/earshot` — ship any recording to jns; **sync**, **`--async`** (submit+return), **`--collect <id>`}; passes `--num-speakers`/`--model` through.
- `claude-config/skills/transcribe-meeting/` — skill: audio → speaker-labeled transcript → summary + actions, with agent-confirmed speaker naming.

Pairs with `pluck` (github.com/jwj2002/pluck). Extracted as a clean standalone commit (the same change also rode the concurrent auto-observe branch and will no-op when that merges).

## Test Plan
- `bash -n` clean (bash 3.2); async path validated end-to-end (submit→run→collect)
- only these two files; secrets confirmed git-ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)