### PR TITLE
feat(team-knowledge): map_patterns.py — divergence map + §1.6 lifecycle gates

### DIFF
--- a/team-knowledge/scripts/map_patterns.py
+++ b/team-knowledge/scripts/map_patterns.py
@@ -1,0 +1,256 @@
+"""map_patterns — the divergence-map assembler (team-knowledge-mvp-v1 §1.0/§1.4/§1.6, build item §9.4).
+
+The TARGET stage of SENSE→TARGET→INVEST: it POINTS at where a shared pattern would pay off; it does
+NOT decide. It reads every patterns/<area>/<dev>.yaml (written by auto-observe #243), builds the
+`CELL[area][dev]` matrix, classifies each area row, and enforces the §1.6 adopted-pattern lifecycle
+gates — producing states only up through `published-advisory` (validated-and-beyond is per-dev and
+needs `efficacy_confidence`, which no assembler step provides).
+
+Row classification (§1.4), precedence CONFLICT → CONSENSUS → DIVERGENCE → GAP:
+- CONFLICT  — ≥2 mutually-exclusive keys present in the same area → arbiter = Jason, NEVER auto-promoted.
+- CONSENSUS — a key reaches quorum (3/4) of devs with `occurrence_confidence ≥ floor` AND `source`
+  including `observed`. Purely-declared agreement NEVER trips quorum (§1.3 guard).
+- DIVERGENCE — ≥2 different, non-contradictory observed keys, none at quorum.
+- GAP — coverage missing for some/all devs, only sub-floor/declared support, or only UNMAPPED.
+
+§1.6 gates on a CONSENSUS candidate:
+- DISCONFIRM: is there a clear signal that devs practicing key K have WORSE outcomes in area A?
+  contradicted → `blocked-contradicted` (route to arbiter, never publish); else → `not-disconfirmed`
+  (cleared for ADVISORY publish — NEVER renamed `validated`; the §1.6 step-2 name is enforced).
+- Low-confidence CONTRADICTORY signals STAY VISIBLE (§1.3 rule 3): the floor mutes a key from quorum,
+  never from the conflict/gap surface.
+- UNMAPPED entries are surfaced as taxonomy-gap signals (counted toward GAP), never force-bucketed.
+
+Owner lane: server-a (§9.4/§11). Reads via PyYAML; pure classification otherwise.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover
+    yaml = None
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import patterns as P  # noqa: E402
+
+QUORUM = 3  # 3 of 4 devs (§1.4)
+# Lifecycle states the ASSEMBLER may emit (the rest are per-dev, efficacy-gated — §1.6).
+STATE_NOT_DISCONFIRMED = "not-disconfirmed"
+STATE_BLOCKED = "blocked-contradicted"
+# Row outcomes (§1.4).
+CONSENSUS, DIVERGENCE, CONFLICT, GAP = "CONSENSUS", "DIVERGENCE", "CONFLICT", "GAP"
+
+
+def _require_yaml():
+    if yaml is None:
+        raise RuntimeError("PyYAML required for map_patterns")
+
+
+def build_cell(patterns_dir, devs=None) -> dict:
+    """CELL[area][dev] = list of pattern entries, read from patterns/<area>/<dev>.yaml."""
+    _require_yaml()
+    root = Path(patterns_dir)
+    cell: dict = {}
+    if not root.exists():
+        return cell
+    for area_dir in sorted(p for p in root.iterdir() if p.is_dir()):
+        area = area_dir.name
+        for f in sorted(area_dir.glob("*.yaml")):
+            dev = f.stem
+            if devs is not None and dev not in devs:
+                continue
+            data = yaml.safe_load(f.read_text(encoding="utf-8")) or {}
+            cell.setdefault(area, {})[dev] = data.get("patterns", []) or []
+    return cell
+
+
+def within_dev_divergence(cell: dict) -> dict:
+    """Per dev: areas where the dev applies ≥2 different observed `pattern_key`s — i.e. diverges from
+    THEMSELVES across their own work (§1.4 within-developer scope)."""
+    out: dict = {}
+    for area, devmap in cell.items():
+        for dev, entries in devmap.items():
+            keys = sorted(
+                {
+                    e.get("pattern_key")
+                    for e in entries
+                    if e.get("pattern_key")
+                    and e.get("pattern_key") != P.UNMAPPED
+                    and "observed" in (e.get("source") or "")
+                }
+            )
+            if len(keys) >= 2:
+                out.setdefault(dev, {})[area] = keys
+    return out
+
+
+def taxonomy_gaps(cell: dict) -> list:
+    """All UNMAPPED entries, surfaced as taxonomy-gap signals (never force-bucketed)."""
+    gaps = []
+    for area, devmap in cell.items():
+        for dev, entries in devmap.items():
+            for e in entries:
+                if e.get("pattern_key") == P.UNMAPPED:
+                    gaps.append(
+                        {
+                            "area": area,
+                            "dev": dev,
+                            "raw_behavior": e.get("raw_behavior"),
+                            "observation_count": e.get("observation_count", 0),
+                        }
+                    )
+    return gaps
+
+
+def classify_row(
+    area: str,
+    devmap: dict,
+    *,
+    team_devs,
+    quorum: int = QUORUM,
+    floor: float = P.DEFAULT_CONSENSUS_FLOOR,
+    contradictions: dict | None = None,
+    is_disconfirmed=None,
+) -> dict:
+    """Classify one area row across devs. `contradictions[area]` is a list of mutually-exclusive key
+    groups; `is_disconfirmed(area, key) -> bool` is the telemetry-outcome gate (§1.6 step 2)."""
+    contradictions = contradictions or {}
+    present = sorted(devmap)
+    missing = sorted(set(team_devs) - set(present))
+
+    key_devs: dict = {}  # observed, non-UNMAPPED key -> set(devs present with it)
+    elig_devs: dict = {}  # key -> set(devs whose entry is consensus-eligible)
+    declared_keys: set = set()
+    low_conf: list = []  # sub-floor observed entries — kept VISIBLE (§1.3 rule 3)
+    for dev, entries in devmap.items():
+        for e in entries:
+            k = e.get("pattern_key")
+            if not k or k == P.UNMAPPED:
+                continue
+            src = e.get("source") or ""
+            conf = e.get("occurrence_confidence", 0.0) or 0.0
+            if "observed" in src:
+                key_devs.setdefault(k, set()).add(dev)
+                if conf < floor:
+                    low_conf.append(
+                        {
+                            "dev": dev,
+                            "area": area,
+                            "pattern_key": k,
+                            "occurrence_confidence": conf,
+                        }
+                    )
+            else:
+                declared_keys.add(k)
+            if P.is_consensus_eligible(conf, src, floor):
+                elig_devs.setdefault(k, set()).add(dev)
+
+    row = {
+        "area": area,
+        "present_devs": present,
+        "missing_devs": missing,
+        "keys": {k: sorted(d) for k, d in key_devs.items()},
+        "contradictions_visible": low_conf,
+    }
+
+    # 1. CONFLICT — mutually-exclusive keys present in the same area (never auto-promoted)
+    present_keys = set(key_devs)
+    for grp in contradictions.get(area, []):
+        inter = sorted(k for k in grp if k in present_keys)
+        if len(inter) >= 2:
+            row.update(outcome=CONFLICT, conflict_keys=inter, arbiter="jason")
+            return row
+
+    # 2. CONSENSUS — a key at quorum of eligible devs → run the §1.6 disconfirm gate
+    consensus_key = next((k for k, d in elig_devs.items() if len(d) >= quorum), None)
+    if consensus_key:
+        row.update(
+            outcome=CONSENSUS,
+            consensus_key=consensus_key,
+            consensus_devs=sorted(elig_devs[consensus_key]),
+        )
+        contradicted = (
+            bool(is_disconfirmed(area, consensus_key)) if is_disconfirmed else False
+        )
+        if contradicted:
+            row.update(state=STATE_BLOCKED, arbiter="jason")
+        else:
+            row.update(state=STATE_NOT_DISCONFIRMED, advisory_publishable=True)
+        return row
+
+    # 3. DIVERGENCE — ≥2 different non-contradictory observed keys, none at quorum
+    if len(present_keys) >= 2:
+        row.update(outcome=DIVERGENCE)
+        return row
+
+    # 4. GAP — missing coverage / declared-only / sub-floor / single-key-without-quorum
+    note = None
+    if not present_keys and declared_keys:
+        note = "quorum_blocked_purely_declared"
+    elif present_keys and not elig_devs:
+        note = "quorum_blocked_subfloor"
+    row.update(outcome=GAP, note=note)
+    return row
+
+
+def assemble(
+    patterns_dir,
+    *,
+    team_devs,
+    quorum: int = QUORUM,
+    floor: float = P.DEFAULT_CONSENSUS_FLOOR,
+    contradictions: dict | None = None,
+    is_disconfirmed=None,
+    devs=None,
+) -> dict:
+    """Full divergence map: classified rows + within-dev divergence + taxonomy gaps + the visible
+    low-confidence contradictions. Machine-readable; `render_map` produces the human view."""
+    cell = build_cell(patterns_dir, devs=devs)
+    rows = {
+        area: classify_row(
+            area,
+            devmap,
+            team_devs=team_devs,
+            quorum=quorum,
+            floor=floor,
+            contradictions=contradictions,
+            is_disconfirmed=is_disconfirmed,
+        )
+        for area, devmap in cell.items()
+    }
+    return {
+        "areas": rows,
+        "within_dev_divergence": within_dev_divergence(cell),
+        "taxonomy_gaps": taxonomy_gaps(cell),
+        "low_confidence_contradictions": [
+            c for r in rows.values() for c in r["contradictions_visible"]
+        ],
+    }
+
+
+def render_map(result: dict) -> str:
+    """Human-readable divergence map. Mirrors the machine output; emits no lifecycle state the
+    assembler isn't allowed to ('validated' never appears here)."""
+    lines = ["# Divergence map (TARGET stage — advisory, not a decision)"]
+    for area, r in sorted(result["areas"].items()):
+        seg = f"- {area}: {r['outcome']}"
+        if r.get("consensus_key"):
+            seg += f" key={r['consensus_key']} state={r.get('state')}"
+        if r.get("arbiter"):
+            seg += f" arbiter={r['arbiter']}"
+        if r.get("note"):
+            seg += f" ({r['note']})"
+        if r.get("missing_devs"):
+            seg += f" missing={','.join(r['missing_devs'])}"
+        lines.append(seg)
+    if result["taxonomy_gaps"]:
+        lines.append(f"# taxonomy gaps (UNMAPPED): {len(result['taxonomy_gaps'])}")
+    if result["within_dev_divergence"]:
+        lines.append(
+            f"# within-dev divergence: {sorted(result['within_dev_divergence'])}"
+        )
+    return "\n".join(lines)

--- a/team-knowledge/tests/test_map_patterns.py
+++ b/team-knowledge/tests/test_map_patterns.py
@@ -1,0 +1,274 @@
+"""Acceptance tests for issue #244 — map_patterns divergence assembler (§1.0/§1.4/§1.6)."""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+yaml = pytest.importorskip("yaml")
+
+import map_patterns as M  # noqa: E402
+import patterns as P  # noqa: E402
+
+TEAM = ["jason", "server-a", "laptop-wsl", "agent-b"]
+
+
+def _e(dev, area, key, *, conf=0.5, source="observed", count=5, raw=None):
+    e = {
+        "id": f"{dev}:{area}:{key}",
+        "dev": dev,
+        "area": area,
+        "pattern_key": key,
+        "practice": "p",
+        "source": source,
+        "observation_count": count,
+        "occurrence_confidence": conf,
+        "efficacy_confidence": None,
+    }
+    if raw is not None:
+        e["raw_behavior"] = raw
+    return e
+
+
+def _write(patterns_dir, area, dev, entries):
+    d = Path(patterns_dir) / area
+    d.mkdir(parents=True, exist_ok=True)
+    (d / f"{dev}.yaml").write_text(
+        yaml.safe_dump(
+            {"schema_version": 1, "dev": dev, "area": area, "patterns": entries}
+        )
+    )
+
+
+# CONSENSUS detection: 3/4 share a key, eligible -----------------------------------------------------
+def test_consensus_detection(tmp_path):
+    for dev in ("jason", "server-a", "laptop-wsl"):
+        _write(
+            tmp_path,
+            "error-handling",
+            dev,
+            [_e(dev, "error-handling", "CUSTOM_EXC_PER_MODULE")],
+        )
+    res = M.assemble(tmp_path, team_devs=TEAM)
+    row = res["areas"]["error-handling"]
+    assert row["outcome"] == M.CONSENSUS
+    assert row["consensus_key"] == "CUSTOM_EXC_PER_MODULE"
+    assert row["state"] == M.STATE_NOT_DISCONFIRMED
+
+
+# Purely-declared quorum block: 3/4 same key but all declared → NOT consensus -------------------------
+def test_purely_declared_blocked_from_quorum(tmp_path):
+    for dev in ("jason", "server-a", "laptop-wsl"):
+        _write(
+            tmp_path,
+            "error-handling",
+            dev,
+            [
+                _e(
+                    dev,
+                    "error-handling",
+                    "CUSTOM_EXC_PER_MODULE",
+                    source="declared",
+                    count=0,
+                    conf=0.0,
+                )
+            ],
+        )
+    row = M.assemble(tmp_path, team_devs=TEAM)["areas"]["error-handling"]
+    assert row["outcome"] != M.CONSENSUS
+    assert row["outcome"] in (M.GAP, M.DIVERGENCE)
+    assert row.get("note") == "quorum_blocked_purely_declared"
+
+
+# Disconfirm gate — blocked-contradicted ------------------------------------------------------------
+def test_disconfirm_blocked_contradicted(tmp_path):
+    for dev in ("jason", "server-a", "laptop-wsl"):
+        _write(
+            tmp_path,
+            "error-handling",
+            dev,
+            [_e(dev, "error-handling", "CUSTOM_EXC_PER_MODULE")],
+        )
+    res = M.assemble(
+        tmp_path,
+        team_devs=TEAM,
+        is_disconfirmed=lambda a, k: (
+            (a, k) == ("error-handling", "CUSTOM_EXC_PER_MODULE")
+        ),
+    )
+    row = res["areas"]["error-handling"]
+    assert row["state"] == M.STATE_BLOCKED
+    assert row["arbiter"] == "jason"
+    assert row.get("state") != M.STATE_NOT_DISCONFIRMED
+
+
+# Disconfirm gate — not-disconfirmed, never "validated" ----------------------------------------------
+def test_not_disconfirmed_never_validated(tmp_path):
+    for dev in ("jason", "server-a", "laptop-wsl"):
+        _write(
+            tmp_path,
+            "error-handling",
+            dev,
+            [_e(dev, "error-handling", "CUSTOM_EXC_PER_MODULE")],
+        )
+    res = M.assemble(tmp_path, team_devs=TEAM)  # no disconfirmation
+    row = res["areas"]["error-handling"]
+    assert row["state"] == "not-disconfirmed"
+    # the string "validated" must NOT appear anywhere in the assembler output (§1.6 step-2 name)
+    assert "validated" not in json.dumps(res)
+    assert "validated" not in M.render_map(res)
+
+
+# CONFLICT routing: mutually-exclusive keys → arbiter jason, no auto-promotion -----------------------
+def test_conflict_routing(tmp_path):
+    for dev in ("jason", "server-a"):
+        _write(
+            tmp_path, "error-handling", dev, [_e(dev, "error-handling", "BARE_EXCEPT")]
+        )
+    for dev in ("laptop-wsl", "agent-b"):
+        _write(
+            tmp_path,
+            "error-handling",
+            dev,
+            [_e(dev, "error-handling", "CUSTOM_EXC_PER_MODULE")],
+        )
+    contradictions = {"error-handling": [["BARE_EXCEPT", "CUSTOM_EXC_PER_MODULE"]]}
+    row = M.assemble(tmp_path, team_devs=TEAM, contradictions=contradictions)["areas"][
+        "error-handling"
+    ]
+    assert row["outcome"] == M.CONFLICT
+    assert row["arbiter"] == "jason"
+    assert sorted(row["conflict_keys"]) == ["BARE_EXCEPT", "CUSTOM_EXC_PER_MODULE"]
+    assert "state" not in row  # never auto-promoted
+
+
+# GAP detection: 2/4 devs have no entry for an area ------------------------------------------------
+def test_gap_detection(tmp_path):
+    for dev in ("jason", "server-a"):
+        _write(
+            tmp_path,
+            "concurrency",
+            dev,
+            [_e(dev, "concurrency", "NO_BLOCKING_IN_ASYNC")],
+        )
+    row = M.assemble(tmp_path, team_devs=TEAM)["areas"]["concurrency"]
+    assert row["outcome"] == M.GAP
+    assert set(row["missing_devs"]) == {"laptop-wsl", "agent-b"}
+
+
+# UNMAPPED taxonomy-gap signal --------------------------------------------------------------------
+def test_unmapped_taxonomy_gap(tmp_path):
+    _write(
+        tmp_path,
+        "security",
+        "jason",
+        [_e("jason", "security", P.UNMAPPED, raw="WEIRD_BEHAVIOR", count=3)],
+    )
+    res = M.assemble(tmp_path, team_devs=TEAM)
+    gaps = res["taxonomy_gaps"]
+    assert any(
+        g["area"] == "security"
+        and g["raw_behavior"] == "WEIRD_BEHAVIOR"
+        and g["observation_count"] == 3
+        for g in gaps
+    )
+    # the row is not bucketed to a real key
+    assert res["areas"]["security"]["outcome"] == M.GAP
+
+
+# Low-confidence contradiction stays visible (not filtered by the floor) ---------------------------
+def test_low_confidence_contradiction_visible(tmp_path):
+    for dev in ("jason", "server-a", "laptop-wsl"):
+        _write(
+            tmp_path,
+            "error-handling",
+            dev,
+            [_e(dev, "error-handling", "CUSTOM_EXC_PER_MODULE")],
+        )
+    # 4th dev: a contradictory key BELOW the floor (0.2 < 0.4) — must still surface
+    _write(
+        tmp_path,
+        "error-handling",
+        "agent-b",
+        [
+            _e(
+                "agent-b",
+                "error-handling",
+                "STRUCTURED_ERROR_RESPONSE",
+                conf=0.2,
+                count=1,
+            )
+        ],
+    )
+    res = M.assemble(tmp_path, team_devs=TEAM)
+    low = res["low_confidence_contradictions"]
+    assert any(
+        c["pattern_key"] == "STRUCTURED_ERROR_RESPONSE" and c["dev"] == "agent-b"
+        for c in low
+    )
+    # consensus still detected, but the sub-floor signal is NOT silently dropped
+    assert res["areas"]["error-handling"]["outcome"] == M.CONSENSUS
+
+
+# §1.3 rule 3 + §1.6 consistency: low-conf contradictory stays visible AND CONFLICT never promotes --
+def test_conflict_keeps_low_conf_and_never_promotes(tmp_path):
+    # mutually-exclusive keys → CONFLICT, with one side sub-floor
+    _write(
+        tmp_path,
+        "error-handling",
+        "jason",
+        [_e("jason", "error-handling", "BARE_EXCEPT")],
+    )
+    _write(
+        tmp_path,
+        "error-handling",
+        "server-a",
+        [_e("server-a", "error-handling", "BARE_EXCEPT")],
+    )
+    _write(
+        tmp_path,
+        "error-handling",
+        "laptop-wsl",
+        [
+            _e(
+                "laptop-wsl",
+                "error-handling",
+                "CUSTOM_EXC_PER_MODULE",
+                conf=0.2,
+                count=1,
+            )
+        ],
+    )
+    contradictions = {"error-handling": [["BARE_EXCEPT", "CUSTOM_EXC_PER_MODULE"]]}
+    row = M.assemble(tmp_path, team_devs=TEAM, contradictions=contradictions)["areas"][
+        "error-handling"
+    ]
+    assert row["outcome"] == M.CONFLICT
+    # §1.6: never auto-promoted
+    assert "state" not in row and not row.get("advisory_publishable")
+    # §1.3 rule 3: the sub-floor contradictory signal stays visible
+    assert any(
+        c["pattern_key"] == "CUSTOM_EXC_PER_MODULE"
+        for c in row["contradictions_visible"]
+    )
+
+
+# Within-dev divergence: a dev applying two different keys in one area ------------------------------
+def test_within_dev_divergence(tmp_path):
+    _write(
+        tmp_path,
+        "testing",
+        "jason",
+        [
+            _e("jason", "testing", "SQLITE_COMPAT_TESTS"),
+            _e("jason", "testing", "FIXTURE_FACTORIES"),
+        ],
+    )
+    res = M.assemble(tmp_path, team_devs=TEAM)
+    assert set(res["within_dev_divergence"]["jason"]["testing"]) == {
+        "FIXTURE_FACTORIES",
+        "SQLITE_COMPAT_TESTS",
+    }


### PR DESCRIPTION
## Summary
The TARGET-stage assembler — team-knowledge-mvp-v1 **§1.0/§1.4/§1.6** (§9.4). Reads every `patterns/<area>/<dev>.yaml` (from #243), builds `CELL[area][dev]`, classifies each area row, and enforces the §1.6 adopted-pattern lifecycle gates. **It points at where a shared pattern would pay off; it does not decide.**

### Row classification (precedence CONFLICT → CONSENSUS → DIVERGENCE → GAP)
- **CONSENSUS** — a key at quorum (**3/4**) of devs with `occurrence_confidence ≥ floor` AND `source` including `observed`. Purely-declared agreement **never** trips quorum (§1.3 guard).
- **CONFLICT** — ≥2 mutually-exclusive keys → `arbiter: jason`, **never auto-promoted**.
- **DIVERGENCE** / **GAP** — per §1.4.

### §1.6 gates
- **Disconfirm:** contradicted by telemetry → `blocked-contradicted` (arbiter); else `not-disconfirmed` — **never renamed `validated`** (the step-2 name is enforced; a test asserts the string never appears in output).
- **UNMAPPED** surfaced as taxonomy-gap signals (counted toward GAP), never force-bucketed.
- **Low-confidence contradictory** signals stay **visible** (§1.3 rule 3) — the floor mutes a key from quorum, never from the conflict/gap surface.
- Within-dev divergence + human-readable `render_map` alongside machine-readable output.

## Test Plan
- 10 acceptance tests — every AC + required test (consensus, purely-declared block, disconfirm both branches, conflict routing, gap, UNMAPPED, low-conf visibility, §1.3+§1.6 consistency, within-dev).
- `python3 -m pytest team-knowledge/tests/` → 44 passed. ruff clean.

Closes #244. Next: #245 private-review (scratch's lane).

🤖 Generated with [Claude Code](https://claude.com/claude-code)