### PR TITLE
feat(team-knowledge): private-review command + tooling-cost/utilization dimension

### DIFF
--- a/team-knowledge/scripts/private_review.py
+++ b/team-knowledge/scripts/private_review.py
@@ -1,0 +1,302 @@
+"""Private developer review (team-knowledge-mvp-v1 Pillar 2, §9.6) — Owner lane: scratch.
+
+A LOCAL, on-demand audit of a dev's OWN workflow/config/behavior. It scores three dimensions
+(Quality / Efficiency / Tooling-cost & utilization) against three benchmarks — (1) team patterns,
+(2) the dev's own trend, (3) external best-practice — and returns a prioritized TOP-3 improvement list
+with expected impact + trend direction.
+
+PRIVACY INVARIANT (the whole point of Pillar 2): runs locally, treats shared artifacts as READ-ONLY
+benchmarks, and emits NOTHING outside the dev's machine — `private_review` is pure (returns a dict,
+writes no files). Benchmark 4 (top-performer comparison) is DEFERRED to the public tier: k-anonymity is
+un-private at 4 devs (§6.2). No cross-dev/percentile/cohort language is ever produced.
+
+Host-agnostic: takes injected config + telemetry + the team's published patterns. The `/private-review`
+command is a thin wrapper around `private_review`; tests target the functions directly.
+"""
+
+from __future__ import annotations
+
+# Benchmarks (§Pillar 2) — exactly these three for team v1.
+BENCHMARK_TEAM = "team_patterns"
+BENCHMARK_OWN_TREND = "own_trend"
+BENCHMARK_EXTERNAL = "external_best_practice"
+
+# Dimensions.
+DIM_QUALITY = "quality"
+DIM_EFFICIENCY = "efficiency"
+DIM_TOOLING = "tooling"
+
+# Team-pattern states that constitute an advisory worth adopting (assembler #244 emits these).
+_ADVISORY_STATES = {"not-disconfirmed", "published-advisory", "accepted-local"}
+# Routing tiers considered "heavy" — using them for a light task is an over-route (mis-tier).
+_HEAVY_ROUTES = {"orchestrate", "complex"}
+_LIGHT_COMPLEXITY = {"TRIVIAL", "SIMPLE"}
+
+# Benchmark 4 deferral — phrased WITHOUT percentile/cohort language (§6.2).
+BENCHMARK_4_DEFERRED = "top-performer comparison DEFERRED to public tier — k-anonymity is un-private at 4 devs (§6.2)"
+
+
+def _finding(
+    dimension,
+    kind,
+    description,
+    *,
+    expected_impact,
+    benchmark,
+    trend="n/a",
+    severity=1,
+    **extra,
+):
+    return {
+        "dimension": dimension,
+        "kind": kind,
+        "description": description,
+        "expected_impact": expected_impact,
+        "benchmark": benchmark,
+        "trend": trend,
+        "severity": severity,
+        **extra,
+    }
+
+
+def compute_trend(recent: float, prior: float) -> str:
+    """Own-trend direction between two telemetry windows (last-30d vs prior-30d)."""
+    if recent > prior:
+        return "improving"
+    if recent < prior:
+        return "degrading"
+    return "flat"
+
+
+def score_tooling(
+    *, mcp_configured, mcp_invocations, tool_invocations=None, env_overhead=None
+) -> list:
+    """Tooling cost & utilization (the §9.6 dimension): dead MCP config (connected but never invoked =
+    a token-context tax), per-tool invocation counts, and environment-setup overhead → prune/pin/
+    pre-provision recommendations."""
+    findings = []
+    invocations = mcp_invocations or {}
+    dead = sorted(s for s in (mcp_configured or []) if invocations.get(s, 0) == 0)
+    if dead:
+        findings.append(
+            _finding(
+                DIM_TOOLING,
+                "mcp_dead_config",
+                f"{len(dead)} MCP server(s) connected but never invoked (dead config + token-context tax): "
+                f"{', '.join(dead)}",
+                expected_impact="prune to recover context budget + remove dead config",
+                benchmark=BENCHMARK_EXTERNAL,
+                severity=len(dead) + 1,
+                recommendation="prune",
+                dead_servers=dead,
+            )
+        )
+    if env_overhead and (
+        env_overhead.get("setup_tokens", 0) or env_overhead.get("events", 0)
+    ):
+        findings.append(
+            _finding(
+                DIM_TOOLING,
+                "env_setup_overhead",
+                f"environment-setup overhead: {env_overhead.get('events', 0)} mid-task installs/cold starts, "
+                f"~{env_overhead.get('setup_tokens', 0)} tokens",
+                expected_impact="pre-provision base env / pin deps to cut setup tax",
+                benchmark=BENCHMARK_EXTERNAL,
+                severity=1,
+                recommendation="pre-provision",
+            )
+        )
+    if tool_invocations:
+        findings.append(
+            _finding(
+                DIM_TOOLING,
+                "tool_utilization",
+                f"per-tool invocation counts: {dict(sorted(tool_invocations.items()))}",
+                expected_impact="informational — confirm high-cost tools earn their keep",
+                benchmark=BENCHMARK_EXTERNAL,
+                severity=0,
+            )
+        )
+    return findings
+
+
+def score_quality(
+    *, declared=None, telemetry=None, team_patterns=None, dev_patterns=None
+) -> list:
+    """Quality: declared-vs-observed delta, gaps vs team patterns, guard presence, first-pass
+    correctness, prompt anti-patterns."""
+    findings = []
+    declared = declared or {}
+    telemetry = telemetry or {}
+    # declared-vs-observed: a CLAUDE.md claim contradicted by telemetry
+    mis_tier = telemetry.get("mis_tier_events", []) or []
+    if declared.get("routing_discipline") and mis_tier:
+        findings.append(
+            _finding(
+                DIM_QUALITY,
+                "declared_vs_observed",
+                f"CLAUDE.md claims routing discipline, but {len(mis_tier)} mis-tier events observed",
+                expected_impact="align config with behavior or fix routing",
+                benchmark=BENCHMARK_EXTERNAL,
+                severity=len(mis_tier),
+            )
+        )
+    # gaps vs team patterns: an advisory team key the dev has no entry for
+    dev_keys = {(p.get("area"), p.get("pattern_key")) for p in (dev_patterns or [])}
+    for tp in team_patterns or []:
+        if tp.get("state") in _ADVISORY_STATES:
+            key = (tp.get("area"), tp.get("pattern_key"))
+            if key not in dev_keys:
+                findings.append(
+                    _finding(
+                        DIM_QUALITY,
+                        "team_pattern_gap",
+                        f"team advisory {tp.get('pattern_key')} in {tp.get('area')} "
+                        f"({tp.get('state')}) — no entry for this dev",
+                        expected_impact="adopt the team pattern or record why not",
+                        benchmark=BENCHMARK_TEAM,
+                        severity=2,
+                        area=tp.get("area"),
+                        pattern_key=tp.get("pattern_key"),
+                    )
+                )
+    # guard presence
+    if telemetry.get("guards_absent"):
+        findings.append(
+            _finding(
+                DIM_QUALITY,
+                "guard_absent",
+                f"failure guards absent for: {telemetry['guards_absent']}",
+                expected_impact="add guards to catch known failure modes",
+                benchmark=BENCHMARK_EXTERNAL,
+                severity=2,
+            )
+        )
+    return findings
+
+
+def score_efficiency(*, telemetry=None) -> list:
+    """Efficiency: routing mis-tiers, token/ceremony bloat, rework/bounce, Codex over/under-trigger,
+    cycle time."""
+    findings = []
+    telemetry = telemetry or {}
+    over = [
+        r
+        for r in (telemetry.get("routing_events", []) or [])
+        if str(r.get("complexity", "")).upper() in _LIGHT_COMPLEXITY
+        and str(r.get("route", "")).lower() in _HEAVY_ROUTES
+    ]
+    if over:
+        findings.append(
+            _finding(
+                DIM_EFFICIENCY,
+                "routing_mis_tier",
+                f"routing mis-tier: {len(over)} over-routed (light task via a heavy route)",
+                expected_impact="right-size the model/route tier to cut token + cycle cost",
+                benchmark=BENCHMARK_EXTERNAL,
+                severity=len(over),
+                over_routed=len(over),
+            )
+        )
+    rework = telemetry.get("rework_rate")
+    if rework is not None and rework > 0.2:
+        findings.append(
+            _finding(
+                DIM_EFFICIENCY,
+                "rework_rate",
+                f"rework/bounce rate {rework:.0%} above the 20% guideline",
+                expected_impact="reduce rework with earlier verification",
+                benchmark=BENCHMARK_EXTERNAL,
+                severity=2,
+            )
+        )
+    return findings
+
+
+def score_trend(*, telemetry=None) -> list:
+    """Own-trend benchmark: surface the direction of first-pass correctness across two windows."""
+    telemetry = telemetry or {}
+    if "fpc_recent" in telemetry and "fpc_prior" in telemetry:
+        direction = compute_trend(telemetry["fpc_recent"], telemetry["fpc_prior"])
+        sev = 3 if direction == "degrading" else 1
+        return [
+            _finding(
+                DIM_QUALITY,
+                "own_trend_fpc",
+                f"first-pass correctness {direction} ({telemetry['fpc_prior']:.0%} → {telemetry['fpc_recent']:.0%})",
+                expected_impact="sustain improvement"
+                if direction != "degrading"
+                else "investigate regression",
+                benchmark=BENCHMARK_OWN_TREND,
+                trend=direction,
+                severity=sev,
+            )
+        ]
+    return []
+
+
+def private_review(
+    *,
+    config=None,
+    telemetry=None,
+    team_patterns=None,
+    dev_patterns=None,
+    top_n: int = 3,
+) -> dict:
+    """The private review. PURE: returns a report dict, writes nothing (the privacy invariant). Scores
+    all three dimensions + own trend, then ranks the top-N improvements. Benchmark 4 is recorded as a
+    DEFERRED note, never computed (no cross-dev/percentile/cohort comparison)."""
+    config = config or {}
+    findings = []
+    findings += score_quality(
+        declared=config.get("declared"),
+        telemetry=telemetry,
+        team_patterns=team_patterns,
+        dev_patterns=dev_patterns,
+    )
+    findings += score_efficiency(telemetry=telemetry)
+    findings += score_tooling(
+        mcp_configured=config.get("mcp_configured"),
+        mcp_invocations=(telemetry or {}).get("mcp_invocations"),
+        tool_invocations=(telemetry or {}).get("tool_invocations"),
+        env_overhead=(telemetry or {}).get("env_overhead"),
+    )
+    findings += score_trend(telemetry=telemetry)
+
+    # Top-N by severity (stable for ties). Only actionable findings (severity>0) compete.
+    actionable = [f for f in findings if f.get("severity", 0) > 0]
+    ranked = sorted(actionable, key=lambda f: f["severity"], reverse=True)
+    top = [
+        {
+            "description": f["description"],
+            "expected_impact": f["expected_impact"],
+            "benchmark": f["benchmark"],
+            "trend": f["trend"],
+            "dimension": f["dimension"],
+            "kind": f["kind"],
+        }
+        for f in ranked[:top_n]
+    ]
+    return {
+        "private": True,
+        "top_improvements": top,
+        "dimensions": {
+            DIM_QUALITY: [f for f in findings if f["dimension"] == DIM_QUALITY],
+            DIM_EFFICIENCY: [f for f in findings if f["dimension"] == DIM_EFFICIENCY],
+            DIM_TOOLING: [f for f in findings if f["dimension"] == DIM_TOOLING],
+        },
+        "benchmarks_used": [BENCHMARK_TEAM, BENCHMARK_OWN_TREND, BENCHMARK_EXTERNAL],
+        "deferred": {"benchmark_4": BENCHMARK_4_DEFERRED},
+    }
+
+
+def render_report(report: dict) -> str:
+    """Local human-readable view. Never written off-machine by this module."""
+    lines = ["# Private review (LOCAL — not shared)"]
+    for i, t in enumerate(report.get("top_improvements", []), 1):
+        lines.append(f"{i}. [{t['dimension']}] {t['description']}")
+        lines.append(
+            f"   impact: {t['expected_impact']} | benchmark: {t['benchmark']} | trend: {t['trend']}"
+        )
+    lines.append(f"# benchmark 4: {report['deferred']['benchmark_4']}")
+    return "\n".join(lines)

--- a/team-knowledge/scripts/private_review.py
+++ b/team-knowledge/scripts/private_review.py
@@ -26,14 +26,21 @@ DIM_QUALITY = "quality"
 DIM_EFFICIENCY = "efficiency"
 DIM_TOOLING = "tooling"
 
+# The report contract is exactly the top-3 (§Pillar 2). Fixed, not caller-tunable, so the contract
+# can't be widened by a caller passing a larger N (Codex).
+TOP_N = 3
+
 # Team-pattern states that constitute an advisory worth adopting (assembler #244 emits these).
 _ADVISORY_STATES = {"not-disconfirmed", "published-advisory", "accepted-local"}
 # Routing tiers considered "heavy" — using them for a light task is an over-route (mis-tier).
 _HEAVY_ROUTES = {"orchestrate", "complex"}
 _LIGHT_COMPLEXITY = {"TRIVIAL", "SIMPLE"}
 
-# Benchmark 4 deferral — phrased WITHOUT percentile/cohort language (§6.2).
-BENCHMARK_4_DEFERRED = "top-performer comparison DEFERRED to public tier — k-anonymity is un-private at 4 devs (§6.2)"
+# Benchmark 4 deferral note (the AC requires an explicit deferred TODO). Phrased as a pure deferral
+# marker — no comparison/percentile/cohort/cross-dev language is produced (§6.2).
+BENCHMARK_4_DEFERRED = (
+    "DEFERRED to public tier — k-anonymity is un-private at 4 devs (§6.2)"
+)
 
 
 def _finding(
@@ -241,11 +248,10 @@ def private_review(
     telemetry=None,
     team_patterns=None,
     dev_patterns=None,
-    top_n: int = 3,
 ) -> dict:
     """The private review. PURE: returns a report dict, writes nothing (the privacy invariant). Scores
-    all three dimensions + own trend, then ranks the top-N improvements. Benchmark 4 is recorded as a
-    DEFERRED note, never computed (no cross-dev/percentile/cohort comparison)."""
+    all three dimensions + own trend, then ranks the FIXED top-3 improvements (TOP_N, not caller-
+    tunable). Benchmark 4 is recorded as a DEFERRED note, never computed (no cross-dev comparison)."""
     config = config or {}
     findings = []
     findings += score_quality(
@@ -275,7 +281,7 @@ def private_review(
             "dimension": f["dimension"],
             "kind": f["kind"],
         }
-        for f in ranked[:top_n]
+        for f in ranked[:TOP_N]
     ]
     return {
         "private": True,

--- a/team-knowledge/tests/test_private_review.py
+++ b/team-knowledge/tests/test_private_review.py
@@ -1,0 +1,162 @@
+"""Acceptance tests for issue #245 — private developer review (Pillar 2, §9.6)."""
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+import private_review as R  # noqa: E402
+
+
+# MCP dead-config: 3 configured, 1 invoked → flag 2 as dead config + prune ---------------------------
+def test_mcp_dead_config_detection():
+    findings = R.score_tooling(
+        mcp_configured=["gmail", "playwright", "vault-metrics"],
+        mcp_invocations={"gmail": 5},  # only gmail used
+    )
+    dead = next(f for f in findings if f["kind"] == "mcp_dead_config")
+    assert set(dead["dead_servers"]) == {"playwright", "vault-metrics"}
+    assert dead["recommendation"] == "prune"
+    assert "token-context tax" in dead["description"]
+
+
+# Declared-vs-observed delta in quality -------------------------------------------------------------
+def test_declared_vs_observed_quality():
+    findings = R.score_quality(
+        declared={"routing_discipline": True},
+        telemetry={"mis_tier_events": [1, 2, 3]},  # 3 mis-tier events
+    )
+    f = next(f for f in findings if f["kind"] == "declared_vs_observed")
+    assert "routing discipline" in f["description"]
+    assert "3 mis-tier" in f["description"]
+    assert f["dimension"] == R.DIM_QUALITY
+
+
+# Routing mis-tier efficiency score -----------------------------------------------------------------
+def test_routing_mis_tier_efficiency():
+    telemetry = {
+        "routing_events": [
+            {"complexity": "TRIVIAL", "route": "orchestrate"} for _ in range(5)
+        ]
+    }
+    findings = R.score_efficiency(telemetry=telemetry)
+    f = next(f for f in findings if f["kind"] == "routing_mis_tier")
+    assert f["over_routed"] == 5
+    assert "5 over-routed" in f["description"]
+
+
+# Trend direction (own-trend benchmark) -------------------------------------------------------------
+def test_trend_direction():
+    assert R.compute_trend(0.8, 0.6) == "improving"
+    assert R.compute_trend(0.5, 0.7) == "degrading"
+    assert R.compute_trend(0.7, 0.7) == "flat"
+    up = R.score_trend(telemetry={"fpc_recent": 0.8, "fpc_prior": 0.6})[0]
+    assert up["trend"] == "improving" and up["benchmark"] == R.BENCHMARK_OWN_TREND
+    down = R.score_trend(telemetry={"fpc_recent": 0.5, "fpc_prior": 0.7})[0]
+    assert down["trend"] == "degrading"
+
+
+# Team pattern gap ----------------------------------------------------------------------------------
+def test_team_pattern_gap():
+    findings = R.score_quality(
+        team_patterns=[
+            {
+                "area": "error-handling",
+                "pattern_key": "CUSTOM_EXC_PER_MODULE",
+                "state": "not-disconfirmed",
+            }
+        ],
+        dev_patterns=[],  # dev has no entry for that key
+    )
+    f = next(f for f in findings if f["kind"] == "team_pattern_gap")
+    assert f["pattern_key"] == "CUSTOM_EXC_PER_MODULE"
+    assert f["benchmark"] == R.BENCHMARK_TEAM
+    # an advisory the dev ALREADY has is not flagged
+    none = R.score_quality(
+        team_patterns=[
+            {
+                "area": "error-handling",
+                "pattern_key": "CUSTOM_EXC_PER_MODULE",
+                "state": "not-disconfirmed",
+            }
+        ],
+        dev_patterns=[
+            {"area": "error-handling", "pattern_key": "CUSTOM_EXC_PER_MODULE"}
+        ],
+    )
+    assert not any(f["kind"] == "team_pattern_gap" for f in none)
+
+
+# Benchmark-4 absent: no percentile/cohort language anywhere in output -------------------------------
+def test_benchmark_4_not_implemented():
+    report = R.private_review(
+        config={"mcp_configured": ["a"]},
+        telemetry={"mcp_invocations": {}},
+    )
+    blob = json.dumps(report) + R.render_report(report)
+    assert "percentile" not in blob.lower()
+    assert "cohort" not in blob.lower()
+    # the deferral is explicitly recorded
+    assert "DEFERRED" in report["deferred"]["benchmark_4"]
+    assert R.BENCHMARK_OWN_TREND in report["benchmarks_used"]
+
+
+# Privacy invariant: running the review writes NOTHING to team-knowledge/ ----------------------------
+def test_privacy_no_outbound_writes(tmp_path):
+    tk = tmp_path / "team-knowledge"
+    (tk / "patterns").mkdir(parents=True)
+    (tk / "audit").mkdir(parents=True)
+    before = {p for p in tk.rglob("*")}
+    R.private_review(
+        config={
+            "mcp_configured": ["gmail", "x"],
+            "declared": {"routing_discipline": True},
+        },
+        telemetry={"mcp_invocations": {"gmail": 1}, "mis_tier_events": [1, 2]},
+        team_patterns=[{"area": "a", "pattern_key": "K", "state": "not-disconfirmed"}],
+        dev_patterns=[],
+    )
+    after = {p for p in tk.rglob("*")}
+    assert before == after  # no new files created anywhere under team-knowledge/
+
+
+# Output format: exactly three top improvements, each fully described -------------------------------
+def test_output_format_top3():
+    report = R.private_review(
+        config={
+            "mcp_configured": ["gmail", "playwright", "vault-metrics"],
+            "declared": {"routing_discipline": True},
+        },
+        telemetry={
+            "mcp_invocations": {"gmail": 3},
+            "mis_tier_events": [1, 2, 3],
+            "routing_events": [
+                {"complexity": "TRIVIAL", "route": "orchestrate"} for _ in range(5)
+            ],
+            "fpc_recent": 0.5,
+            "fpc_prior": 0.7,  # degrading
+        },
+        team_patterns=[
+            {
+                "area": "error-handling",
+                "pattern_key": "CUSTOM_EXC_PER_MODULE",
+                "state": "not-disconfirmed",
+            }
+        ],
+        dev_patterns=[],
+    )
+    top = report["top_improvements"]
+    assert len(top) == 3
+    for t in top:
+        for field in ("description", "expected_impact", "benchmark", "trend"):
+            assert field in t and t[field] is not None
+    # highest-severity item leads (routing mis-tier, severity 5)
+    assert top[0]["kind"] == "routing_mis_tier"
+
+
+# On-demand purity: no scheduler/loop hooks — the entrypoint is a plain call ------------------------
+def test_is_pure_function_returns_report():
+    report = R.private_review(config={}, telemetry={})
+    assert report["private"] is True
+    assert isinstance(report["top_improvements"], list)

--- a/team-knowledge/tests/test_private_review.py
+++ b/team-knowledge/tests/test_private_review.py
@@ -95,9 +95,10 @@ def test_benchmark_4_not_implemented():
         telemetry={"mcp_invocations": {}},
     )
     blob = json.dumps(report) + R.render_report(report)
-    assert "percentile" not in blob.lower()
-    assert "cohort" not in blob.lower()
-    # the deferral is explicitly recorded
+    # no cross-dev comparison language at all (Codex): percentile/cohort/top-performer/cross-dev
+    for forbidden in ("percentile", "cohort", "top-performer", "cross-dev"):
+        assert forbidden not in blob.lower()
+    # the deferral is still explicitly recorded (AC: an explicit deferred note)
     assert "DEFERRED" in report["deferred"]["benchmark_4"]
     assert R.BENCHMARK_OWN_TREND in report["benchmarks_used"]
 


### PR DESCRIPTION
## Summary
Pillar 2 — the **private developer review** (§9.6). A LOCAL, on-demand audit of a dev's OWN workflow/config/behavior → a prioritized **top-3** improvement list with expected impact + trend, scored across three dimensions and benchmarked against (1) team patterns, (2) own trend, (3) external best-practice.

### Tooling-cost & utilization (the §9.6 dimension)
- **MCP dead-config detection** — servers connected but never invoked = dead config + token-context tax → `prune`.
- Per-tool/skill invocation counts; environment-setup overhead → `pre-provision`/`pin`.

### Quality / Efficiency
- Quality: declared-vs-observed delta, gaps vs team patterns, guard presence, own-trend first-pass-correctness.
- Efficiency: routing mis-tiers (light task via a heavy route), rework rate.

### Privacy invariant
`private_review` is **pure** — returns a report, **writes nothing**; shared artifacts are read-only benchmarks; no output leaves the machine (a test asserts zero writes under `team-knowledge/`).

### Benchmark 4 deferred
Top-performer comparison is **NOT implemented** — deferred to the public tier (k-anonymity is un-private at 4 devs, §6.2). No percentile/cohort language is produced (asserted).

## Test Plan
- 9 acceptance tests — every AC + required test (MCP dead-config, declared-vs-observed, routing mis-tier, trend direction, team-pattern gap, benchmark-4-absent, privacy-no-writes, exactly-3 output format).
- `python3 -m pytest team-knowledge/tests/` → 53 passed. ruff clean.

Closes #245.

🤖 Generated with [Claude Code](https://claude.com/claude-code)