### PR TITLE
feat(usage): extend PRICES with OpenAI/Codex models + cross-check Claude rates

### DIFF
--- a/claude-config/scripts/otel_sink.py
+++ b/claude-config/scripts/otel_sink.py
@@ -9,6 +9,7 @@ Scope note: the live collector wiring (Claude Code OTLP -> file exporter) is a p
 documented in OTEL_SINK_SETUP.md and deferred to jns-server. This module + its tests run against
 simulated pushes (the AC's "simulated OTEL push") and are host-agnostic.
 """
+
 from __future__ import annotations
 
 import json
@@ -16,17 +17,52 @@ from pathlib import Path
 
 TOKEN_FIELDS = ("input", "output", "cache_creation", "cache_read")
 
-# Per-token USD prices. Ratios are the load-bearing part (§1.2): cache_read = 0.10x fresh input,
-# output dearest, cache_creation ~1.25x input. Absolute numbers track Anthropic's published rates
-# (per-MTok / 1e6) and are config — refine as pricing changes.
+# Per-token USD prices, MULTI-PROVIDER (fleet-usage-monitor §6). Ratios are the load-bearing part
+# (§1.2): cache_read ≈ 0.10x fresh input, output dearest, cache_creation ~1.25x input. Absolute
+# numbers track each vendor's published per-MTok rates (/1e6) and are config — refine as pricing
+# changes. `_price_for` matches by family prefix, so adding a row is the whole extension mechanism.
+#
+# Claude rates cross-check (fleet-usage-monitor §2.1, verified 2026-06-06): the real measured session
+# mix {input 657_029, output 4_070_961, cache_read 924_428_695, cache_creation 24_381_544} at
+# claude-opus-4 rates = $2,158.97 ≈ the $2,159 reference. (NOTE: the reference is the full token MIX,
+# not 954M pure input — 954M is the token TOTAL across all types.) test_multiprovider_pricing enforces
+# this within 5%.
 PRICES = {
-    "claude-opus-4":   {"input": 15e-6, "output": 75e-6, "cache_creation": 18.75e-6, "cache_read": 1.5e-6},
-    "claude-sonnet-4": {"input": 3e-6,  "output": 15e-6, "cache_creation": 3.75e-6,  "cache_read": 0.30e-6},
-    "claude-haiku-4":  {"input": 0.80e-6, "output": 4e-6, "cache_creation": 1.0e-6,  "cache_read": 0.08e-6},
+    "claude-opus-4": {
+        "input": 15e-6,
+        "output": 75e-6,
+        "cache_creation": 18.75e-6,
+        "cache_read": 1.5e-6,
+    },
+    "claude-sonnet-4": {
+        "input": 3e-6,
+        "output": 15e-6,
+        "cache_creation": 3.75e-6,
+        "cache_read": 0.30e-6,
+    },
+    "claude-haiku-4": {
+        "input": 0.80e-6,
+        "output": 4e-6,
+        "cache_creation": 1.0e-6,
+        "cache_read": 0.08e-6,
+    },
+    # OpenAI / Codex. gpt-5.5 verified in use (Codex CLI, §2.2). OpenAI bills cached input at a discount
+    # and charges no separate cache-WRITE, so cache_creation = 0. Rates are representative (per-MTok/1e6)
+    # — VERIFY against OpenAI's published pricing when finalizing billing.
+    "gpt-5.5": {
+        "input": 1.25e-6,
+        "output": 10e-6,
+        "cache_creation": 0.0,
+        "cache_read": 0.125e-6,
+    },
 }
-DEFAULT_PRICE = PRICES["claude-sonnet-4"]  # conservative fallback for unrecognized models
+DEFAULT_PRICE = PRICES[
+    "claude-sonnet-4"
+]  # conservative fallback for unrecognized models (compute_cost only)
 
-EXPORTER_FRESHNESS_SLA_DEFAULT = 24 * 3600  # 24h: sink must be written within SLA or alarm (§0.1)
+EXPORTER_FRESHNESS_SLA_DEFAULT = (
+    24 * 3600
+)  # 24h: sink must be written within SLA or alarm (§0.1)
 
 
 def _price_for(model: str) -> dict:
@@ -35,7 +71,9 @@ def _price_for(model: str) -> dict:
         return DEFAULT_PRICE
     m = str(model).lower()
     for family, row in PRICES.items():
-        if m.startswith(family) or family.split("-")[1] in m:  # 'opus'/'sonnet'/'haiku' substring
+        if (
+            m.startswith(family) or family.split("-")[1] in m
+        ):  # 'opus'/'sonnet'/'haiku' substring
             return row
     return DEFAULT_PRICE
 
@@ -59,10 +97,15 @@ def normalize_from_datapoints(datapoints: list) -> dict:
     out = {f: 0 for f in TOKEN_FIELDS}
     model = ""
     alias = {
-        "input": "input", "output": "output",
-        "cache_creation": "cache_creation", "cachecreation": "cache_creation",
-        "cache_creation_input_tokens": "cache_creation", "ephemeral_5m_input_tokens": "cache_creation",
-        "cache_read": "cache_read", "cacheread": "cache_read", "cache_read_input_tokens": "cache_read",
+        "input": "input",
+        "output": "output",
+        "cache_creation": "cache_creation",
+        "cachecreation": "cache_creation",
+        "cache_creation_input_tokens": "cache_creation",
+        "ephemeral_5m_input_tokens": "cache_creation",
+        "cache_read": "cache_read",
+        "cacheread": "cache_read",
+        "cache_read_input_tokens": "cache_read",
     }
     for dp in datapoints or []:
         attrs = dp.get("attributes", {}) or {}
@@ -117,14 +160,18 @@ def sink_last_write_ts(path):
     return p.stat().st_mtime if p.exists() else None
 
 
-def is_stale(last_write_ts, now_ts: float, sla_seconds: float = EXPORTER_FRESHNESS_SLA_DEFAULT) -> bool:
+def is_stale(
+    last_write_ts, now_ts: float, sla_seconds: float = EXPORTER_FRESHNESS_SLA_DEFAULT
+) -> bool:
     """Pure freshness predicate: stale if never written or last write older than the SLA."""
     if last_write_ts is None:
         return True
     return (now_ts - last_write_ts) > sla_seconds
 
 
-def check_exporter_freshness(path, now_ts: float, sla_seconds: float = EXPORTER_FRESHNESS_SLA_DEFAULT) -> dict:
+def check_exporter_freshness(
+    path, now_ts: float, sla_seconds: float = EXPORTER_FRESHNESS_SLA_DEFAULT
+) -> dict:
     """Exporter-freshness alarm (§0.1 stale-exporter state). Returns
     `{"alarm": bool, "reason": str, "age_seconds": float|None}` — feeds the #231/#232 watchdog."""
     last = sink_last_write_ts(path)

--- a/claude-config/tests/test_multiprovider_pricing.py
+++ b/claude-config/tests/test_multiprovider_pricing.py
@@ -1,0 +1,75 @@
+"""Acceptance tests for issue #264 — multi-provider PRICES (fleet-usage-monitor §6)."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+import otel_sink as O  # noqa: E402
+import token_collector as C  # noqa: E402
+
+
+# gpt-5.5 resolves to its own row, not the Claude DEFAULT --------------------------------------------
+def test_gpt55_price_row():
+    row = O._price_for("gpt-5.5")
+    assert row is O.PRICES["gpt-5.5"]
+    assert row is not O.DEFAULT_PRICE
+
+
+def test_gpt55_prefix_variant():
+    # a family variant still matches gpt-5.5 by prefix
+    assert O._price_for("gpt-5.5-turbo") is O.PRICES["gpt-5.5"]
+
+
+def test_gpt55_compute_cost_matches_rate():
+    cost = O.compute_cost(
+        {
+            "model": "gpt-5.5",
+            "input": 1_000_000,
+            "output": 0,
+            "cache_read": 0,
+            "cache_creation": 0,
+        }
+    )
+    assert cost == pytest.approx(O.PRICES["gpt-5.5"]["input"] * 1_000_000)
+    # output is dearer than input for gpt-5.5
+    out = O.compute_cost({"model": "gpt-5.5", "output": 1_000_000})
+    assert out > cost
+
+
+# strict known/unknown behavior preserved (token_collector) -----------------------------------------
+def test_known_codex_model_not_strict_error():
+    # gpt-5.5 is now known → session_cost(strict) must NOT raise
+    assert C.is_known_model("gpt-5.5") is True
+    val = C.session_cost({"model": "gpt-5.5", "input": 1000}, strict=True)
+    assert val > 0
+
+
+def test_unknown_model_still_loud():
+    assert C.is_known_model("gpt-99-unknown") is False
+    with pytest.raises(ValueError):
+        C.session_cost({"model": "gpt-99-unknown", "input": 1000}, strict=True)
+
+
+# compute_cost fallback still works for unknown (non-strict path) ------------------------------------
+def test_unknown_model_compute_cost_falls_back():
+    # compute_cost is the lenient path (falls back to DEFAULT_PRICE); strictness lives in session_cost
+    assert O.compute_cost({"model": "totally-unknown", "input": 1000}) > 0
+
+
+# Opus 4.8 sanity cross-check against the §2.1 real billing figure -----------------------------------
+def test_opus_rates_sanity_vs_real_session():
+    # the REAL measured mix (not 954M pure input) → ~$2,159 reference (§2.1)
+    real_mix = {
+        "model": "claude-opus-4",
+        "input": 657_029,
+        "output": 4_070_961,
+        "cache_read": 924_428_695,
+        "cache_creation": 24_381_544,
+    }
+    cost = O.compute_cost(real_mix)
+    assert cost == pytest.approx(2159, rel=0.05), (
+        f"opus rates drifted: ${cost:,.2f} vs $2,159 ref"
+    )


### PR DESCRIPTION
## Summary
Multi-provider pricing (fleet-usage-monitor §6, build step 3 — unblocks the collectors). Adds `gpt-5.5` to `otel_sink.PRICES`; `_price_for` prefix-matching + `is_known_model` + `session_cost` strict-unknown behavior all preserved (unknown model = loud error, not silent zero).

**Corrected a spec error:** the §2.1 sanity-check (954M *pure input* → $2,159) was wrong — 954M is the token *total* across all types. The test asserts the **real measured Opus session mix** computes within 5% of the $2,159 reference, so rate drift surfaces loudly.

OpenAI note: bills cached input at a discount and charges no separate cache-write → `cache_creation=0`; rates are representative, flagged to verify vs published OpenAI pricing.

## Test Plan
7 acceptance tests (gpt-5.5 row + prefix variant, compute_cost, strict known/unknown, fallback, Opus sanity). `pytest claude-config/tests/` → 121 passed. ruff clean.

Closes #264.

🤖 Generated with [Claude Code](https://claude.com/claude-code)