### PR TITLE
feat(usage): Claude transcript collector + activity-miner

### DIFF
--- a/claude-config/scripts/usage_collector_claude.py
+++ b/claude-config/scripts/usage_collector_claude.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import glob
 import json
 import re
+import shlex
 import sys
 from pathlib import Path
 
@@ -52,9 +53,36 @@ _SKIP_MODELS = {"<synthetic>", "<compact>"}
 _ISSUE_RE = re.compile(r"issue-(\d+)", re.IGNORECASE)
 _CLOSES_RE = re.compile(r"\b(?:closes|fixes|resolves)\s+#(\d+)", re.IGNORECASE)
 _CHECKOUT_RE = re.compile(r"git\s+checkout\s+-b\s+(\S+)")
-_SSH_RE = re.compile(r"\bssh\s+(?:-\S+\s+|-o\s+\S+\s+)*([A-Za-z0-9_.-]+)")
 _CD_RE = re.compile(r"\bcd\s+([~\w./-]+)")
 _NONTASK_BRANCHES = {"head", "main", "master", "", None}
+# OpenSSH short flags that consume the NEXT token as their argument — so the host parser skips both
+# (else `ssh -p 22 host` mis-reads "22" as the host; Codex #262).
+_SSH_ARG_FLAGS = set("bcDEeFIiJLlmOopQRSWw")
+
+
+def _msg(entry: dict) -> dict:
+    """The entry's message as a dict — never crashes on transcript shape drift (a non-dict message
+    or usage becomes {}). Codex #262: real transcripts can carry unexpected shapes."""
+    m = entry.get("message") if isinstance(entry, dict) else None
+    return m if isinstance(m, dict) else {}
+
+
+def _ssh_host(tokens: list) -> str | None:
+    """First real host token after `ssh`, correctly skipping flags AND their arguments (`-p 22`,
+    `-i key`, `-pVALUE`). Returns the host (user@ stripped), or None."""
+    i = 0
+    while i < len(tokens):
+        t = tokens[i]
+        if t.startswith("-"):
+            if (
+                len(t) == 2 and t[1] in _SSH_ARG_FLAGS
+            ):  # `-p 22` form → skip flag + its arg
+                i += 2
+            else:  # `-v`, `-pVALUE`, `--opt` → skip just the flag
+                i += 1
+            continue
+        return t.split("@")[-1]
+    return None
 
 
 def _task_from_branch(branch) -> str | None:
@@ -77,8 +105,7 @@ def _project_from_path(path) -> str | None:
 
 def _iter_commands(entry: dict):
     """Yield Bash command strings from the assistant message's tool_use blocks."""
-    msg = entry.get("message") or {}
-    content = msg.get("content")
+    content = _msg(entry).get("content")
     if not isinstance(content, list):
         return
     for block in content:
@@ -94,9 +121,14 @@ def mine_command(cmd: str) -> dict:
     free attribution (§4.3): a `git checkout -b feat/issue-N` names the task even cross-repo, and an
     `ssh host 'cd repo'` names the work_host + project under SSH-develop."""
     out: dict = {}
-    ssh = _SSH_RE.search(cmd)
-    if ssh and ssh.group(1) not in {"-", ""}:
-        out["work_host"] = ssh.group(1)
+    try:
+        toks = shlex.split(cmd)
+    except ValueError:
+        toks = cmd.split()
+    if "ssh" in toks:
+        host = _ssh_host(toks[toks.index("ssh") + 1 :])
+        if host:
+            out["work_host"] = host
     co = _CHECKOUT_RE.search(cmd)
     if co:
         t = _task_from_branch(co.group(1))
@@ -106,7 +138,11 @@ def mine_command(cmd: str) -> dict:
     if closes and "task" not in out:
         out["task"] = f"issue:{closes.group(1)}"
     cd = _CD_RE.search(cmd)
-    if cd:
+    if cd and cd.group(1) not in (
+        "-",
+        "~",
+        "..",
+    ):  # skip cd -, cd ~, cd .. (bogus project names)
         proj = _project_from_path(cd.group(1))
         if proj:
             out["project"] = proj
@@ -117,12 +153,8 @@ def _is_compaction(entry: dict) -> bool:
     """A compaction/continuation boundary (re-seeds the prompt cache → a cache_creation spike, §4.5)."""
     if entry.get("isCompactSummary") or entry.get("subtype") == "compact":
         return True
-    msg = entry.get("message") or {}
-    text = (
-        json.dumps(msg.get("content", ""))
-        if not isinstance(msg.get("content"), str)
-        else msg["content"]
-    )
+    content = _msg(entry).get("content", "")
+    text = content if isinstance(content, str) else json.dumps(content)
     return (
         "being continued from a previous conversation" in text
         or "ran out of context" in text
@@ -130,8 +162,8 @@ def _is_compaction(entry: dict) -> bool:
 
 
 def _is_assistant_usage(entry: dict) -> bool:
-    msg = entry.get("message") or {}
-    return bool(msg.get("usage")) and (
+    msg = _msg(entry)
+    return isinstance(msg.get("usage"), dict) and (
         msg.get("role") == "assistant" or entry.get("type") == "assistant"
     )
 
@@ -144,14 +176,14 @@ def extract_records(entries: list, *, inference_host: str, strict: bool = True) 
     active = {"task": "unattributed", "project": None, "work_host": inference_host}
     pending_compaction = False
     records = []
-    for entry in entries:
+    for idx, entry in enumerate(entries):
         if _is_compaction(entry):
             pending_compaction = True
-        if _is_assistant_usage(entry) and (
-            entry["message"].get("model") not in _SKIP_MODELS
-        ):
-            msg = entry["message"]
-            # gitBranch is the current-message fast-path; mined state is the fallback/cross-repo source
+        msg = _msg(entry)
+        if _is_assistant_usage(entry) and msg.get("model") not in _SKIP_MODELS:
+            # gitBranch is GROUND TRUTH for THIS message (Claude Code captures it at message start, so a
+            # `git checkout -b` message still shows the OLD branch → it naturally gives the "subsequent
+            # message" boundary). Mined `active` is the fallback when gitBranch is unusable (cross-repo).
             cur_task = _task_from_branch(entry.get("gitBranch")) or active["task"]
             cur_project = active["project"] or _project_from_path(entry.get("cwd"))
             usage = msg.get("usage") or {}
@@ -159,6 +191,14 @@ def extract_records(entries: list, *, inference_host: str, strict: bool = True) 
                 norm: int(usage.get(raw, 0) or 0) for raw, norm in _USAGE_MAP.items()
             }
             cost_rec = {**tok, "model": msg.get("model")}
+            sid, uuid = entry.get("sessionId"), entry.get("uuid")
+            # dedup_key must be UNIQUE even when sessionId/uuid are missing (else malformed records
+            # collapse to "None:None" and undercount, Codex #262) — fall back to a position+content key.
+            dedup_key = (
+                f"{sid}:{uuid}"
+                if uuid
+                else f"{sid}:{entry.get('timestamp')}:{idx}:{tok['input']}:{tok['output']}"
+            )
             rec = {
                 "provider": PROVIDER,
                 "account": None,
@@ -171,9 +211,9 @@ def extract_records(entries: list, *, inference_host: str, strict: bool = True) 
                 **tok,
                 "cost_usd": C.session_cost(cost_rec, strict=strict),
                 "ts": entry.get("timestamp"),
-                "session_id": entry.get("sessionId"),
+                "session_id": sid,
                 "compaction": pending_compaction,
-                "dedup_key": f"{entry.get('sessionId')}:{entry.get('uuid')}",
+                "dedup_key": dedup_key,
             }
             records.append(rec)
             pending_compaction = False

--- a/claude-config/scripts/usage_collector_claude.py
+++ b/claude-config/scripts/usage_collector_claude.py
@@ -73,12 +73,16 @@ def _ssh_host(tokens: list) -> str | None:
     i = 0
     while i < len(tokens):
         t = tokens[i]
+        if t.startswith("--"):
+            i += 1  # ssh has no GNU long opts; treat as a lone flag
+            continue
         if t.startswith("-"):
-            if (
-                len(t) == 2 and t[1] in _SSH_ARG_FLAGS
-            ):  # `-p 22` form → skip flag + its arg
+            cluster = t[1:]
+            # In a short-option cluster only the LAST option can take an argument, and only if it has
+            # no INLINE value (so `-p 22` and `-vp 22` skip the next token; `-p22`/`-v` do not). Codex #262.
+            if cluster and cluster[-1] in _SSH_ARG_FLAGS:
                 i += 2
-            else:  # `-v`, `-pVALUE`, `--opt` → skip just the flag
+            else:
                 i += 1
             continue
         return t.split("@")[-1]

--- a/claude-config/scripts/usage_collector_claude.py
+++ b/claude-config/scripts/usage_collector_claude.py
@@ -1,0 +1,236 @@
+"""Claude transcript usage collector + activity-miner (fleet-usage-monitor §8 step 1).
+
+Walks `~/.claude/projects/<proj>/<session>.jsonl`, emits ONE normalized usage record per assistant
+message (attributed by the message's OWN timestamp so 55-day sessions span 55 days of trend), and
+appends them to the per-host shard `telemetry/<host>/usage.jsonl` (same convention as failures shards).
+
+Attribution is by ACTIVITY-MINING (§4.3) — task/project/work_host are derived from the session's own
+git/`gh`/`ssh` tool calls, with NO manual tags. State is tracked chronologically so a session that
+spans several tasks/repos is SEGMENTED (each message attributed to the task active at its time). Under
+SSH-develop (§4.2) `cwd`/`gitBranch` are local, so mined `ssh <host>` commands set `work_host`/`project`
+while tokens stay on `inference_host` (this collector's host). Parallel sessions are independent
+transcripts → no double-count, no cross-session bleed (§4.4). `account`/`billing_type` are left null
+here (filled by the #265 join). Unknown model → loud error (reuses `token_collector` strict).
+"""
+
+from __future__ import annotations
+
+import glob
+import json
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import token_collector as C  # noqa: E402  (session_cost strict — wraps otel_sink pricing; unknown model = loud error)
+
+try:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "lib"))
+    from project_resolver import get_host_name
+except Exception:  # pragma: no cover - fallback when lib not importable
+    import socket
+
+    def get_host_name():
+        return socket.gethostname().split(".")[0]
+
+
+PROVIDER = "claude"
+
+# usage field name → normalized token field
+_USAGE_MAP = {
+    "input_tokens": "input",
+    "output_tokens": "output",
+    "cache_read_input_tokens": "cache_read",
+    "cache_creation_input_tokens": "cache_creation",
+}
+
+# Claude Code internal non-API model markers (injected/synthetic messages) — these are NOT billable
+# inference, so they are SKIPPED (not cost-computed). A genuinely unknown REAL model still raises
+# loudly via token_collector strict (the AC distinction; verified against real transcripts).
+_SKIP_MODELS = {"<synthetic>", "<compact>"}
+
+_ISSUE_RE = re.compile(r"issue-(\d+)", re.IGNORECASE)
+_CLOSES_RE = re.compile(r"\b(?:closes|fixes|resolves)\s+#(\d+)", re.IGNORECASE)
+_CHECKOUT_RE = re.compile(r"git\s+checkout\s+-b\s+(\S+)")
+_SSH_RE = re.compile(r"\bssh\s+(?:-\S+\s+|-o\s+\S+\s+)*([A-Za-z0-9_.-]+)")
+_CD_RE = re.compile(r"\bcd\s+([~\w./-]+)")
+_NONTASK_BRANCHES = {"head", "main", "master", "", None}
+
+
+def _task_from_branch(branch) -> str | None:
+    """A branch → task: `feat/issue-42-x` → `issue:42`; a real named branch → that branch; main/HEAD → None."""
+    if not branch:
+        return None
+    m = _ISSUE_RE.search(branch)
+    if m:
+        return f"issue:{m.group(1)}"
+    return None if branch.strip().lower() in _NONTASK_BRANCHES else branch
+
+
+def _project_from_path(path) -> str | None:
+    """Repo/project name from a cwd path: `~/agents`→`agents`, `.../projects/scratch`→`scratch`."""
+    if not path:
+        return None
+    name = Path(str(path).rstrip("/")).name
+    return name or None
+
+
+def _iter_commands(entry: dict):
+    """Yield Bash command strings from the assistant message's tool_use blocks."""
+    msg = entry.get("message") or {}
+    content = msg.get("content")
+    if not isinstance(content, list):
+        return
+    for block in content:
+        if isinstance(block, dict) and block.get("type") == "tool_use":
+            inp = block.get("input") or {}
+            cmd = inp.get("command")
+            if isinstance(cmd, str):
+                yield cmd
+
+
+def mine_command(cmd: str) -> dict:
+    """Derive {task?, project?, work_host?} from one shell command. The basis of automated, manual-tag-
+    free attribution (§4.3): a `git checkout -b feat/issue-N` names the task even cross-repo, and an
+    `ssh host 'cd repo'` names the work_host + project under SSH-develop."""
+    out: dict = {}
+    ssh = _SSH_RE.search(cmd)
+    if ssh and ssh.group(1) not in {"-", ""}:
+        out["work_host"] = ssh.group(1)
+    co = _CHECKOUT_RE.search(cmd)
+    if co:
+        t = _task_from_branch(co.group(1))
+        if t:
+            out["task"] = t
+    closes = _CLOSES_RE.search(cmd)
+    if closes and "task" not in out:
+        out["task"] = f"issue:{closes.group(1)}"
+    cd = _CD_RE.search(cmd)
+    if cd:
+        proj = _project_from_path(cd.group(1))
+        if proj:
+            out["project"] = proj
+    return out
+
+
+def _is_compaction(entry: dict) -> bool:
+    """A compaction/continuation boundary (re-seeds the prompt cache → a cache_creation spike, §4.5)."""
+    if entry.get("isCompactSummary") or entry.get("subtype") == "compact":
+        return True
+    msg = entry.get("message") or {}
+    text = (
+        json.dumps(msg.get("content", ""))
+        if not isinstance(msg.get("content"), str)
+        else msg["content"]
+    )
+    return (
+        "being continued from a previous conversation" in text
+        or "ran out of context" in text
+    )
+
+
+def _is_assistant_usage(entry: dict) -> bool:
+    msg = entry.get("message") or {}
+    return bool(msg.get("usage")) and (
+        msg.get("role") == "assistant" or entry.get("type") == "assistant"
+    )
+
+
+def extract_records(entries: list, *, inference_host: str, strict: bool = True) -> list:
+    """Core walker: chronological pass over ONE transcript's entries → normalized usage records.
+    Tracks active task/project/work_host (segmentation); attributes each assistant message to the
+    state active at its timestamp; mines each entry's commands to update state for SUBSEQUENT messages."""
+    entries = sorted(entries, key=lambda e: e.get("timestamp") or "")
+    active = {"task": "unattributed", "project": None, "work_host": inference_host}
+    pending_compaction = False
+    records = []
+    for entry in entries:
+        if _is_compaction(entry):
+            pending_compaction = True
+        if _is_assistant_usage(entry) and (
+            entry["message"].get("model") not in _SKIP_MODELS
+        ):
+            msg = entry["message"]
+            # gitBranch is the current-message fast-path; mined state is the fallback/cross-repo source
+            cur_task = _task_from_branch(entry.get("gitBranch")) or active["task"]
+            cur_project = active["project"] or _project_from_path(entry.get("cwd"))
+            usage = msg.get("usage") or {}
+            tok = {
+                norm: int(usage.get(raw, 0) or 0) for raw, norm in _USAGE_MAP.items()
+            }
+            cost_rec = {**tok, "model": msg.get("model")}
+            rec = {
+                "provider": PROVIDER,
+                "account": None,
+                "billing_type": None,
+                "inference_host": inference_host,
+                "work_host": active["work_host"],
+                "project": cur_project,
+                "model": msg.get("model"),
+                "task": cur_task,
+                **tok,
+                "cost_usd": C.session_cost(cost_rec, strict=strict),
+                "ts": entry.get("timestamp"),
+                "session_id": entry.get("sessionId"),
+                "compaction": pending_compaction,
+                "dedup_key": f"{entry.get('sessionId')}:{entry.get('uuid')}",
+            }
+            records.append(rec)
+            pending_compaction = False
+        # mine this entry's commands → update active state for subsequent messages (segmentation)
+        for cmd in _iter_commands(entry):
+            active.update(mine_command(cmd))
+    return records
+
+
+def read_transcript(path) -> list:
+    """Parse a transcript JSONL into entries (skips corrupt lines)."""
+    out = []
+    for line in Path(path).read_text(encoding="utf-8", errors="ignore").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            out.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    return out
+
+
+def _existing_dedup_keys(shard_path: Path) -> set:
+    if not shard_path.exists():
+        return set()
+    keys = set()
+    for line in shard_path.read_text(encoding="utf-8", errors="ignore").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            keys.add(json.loads(line).get("dedup_key"))
+        except json.JSONDecodeError:
+            continue
+    return keys
+
+
+def collect(
+    projects_dir, shard_path, *, inference_host: str | None = None, strict: bool = True
+) -> dict:
+    """Walk all transcripts under `projects_dir`, emit normalized records, and APPEND new ones to
+    `shard_path` (append-only, idempotent: records whose dedup_key already exists are skipped)."""
+    inference_host = inference_host or get_host_name()
+    shard_path = Path(shard_path)
+    seen = _existing_dedup_keys(shard_path)
+    written = skipped = 0
+    shard_path.parent.mkdir(parents=True, exist_ok=True)
+    with shard_path.open("a", encoding="utf-8") as fh:
+        for tpath in sorted(glob.glob(str(Path(projects_dir) / "*" / "*.jsonl"))):
+            for rec in extract_records(
+                read_transcript(tpath), inference_host=inference_host, strict=strict
+            ):
+                if rec["dedup_key"] in seen:
+                    skipped += 1
+                    continue
+                seen.add(rec["dedup_key"])
+                fh.write(json.dumps(rec, ensure_ascii=False) + "\n")
+                written += 1
+    return {"written": written, "skipped": skipped, "shard": str(shard_path)}

--- a/claude-config/tests/test_usage_collector_claude.py
+++ b/claude-config/tests/test_usage_collector_claude.py
@@ -203,6 +203,11 @@ def test_ssh_host_parsing_skips_flag_args():
     assert U.mine_command("ssh -p 22 jns 'cd ~/x'")["work_host"] == "jns"  # not "22"
     assert U.mine_command("ssh -i ~/.ssh/key deploy@server")["work_host"] == "server"
     assert U.mine_command("ssh -v jns")["work_host"] == "jns"
+    # combined short flags where the last takes an arg (Codex #262 re-review)
+    assert U.mine_command("ssh -vp 22 jns")["work_host"] == "jns"  # not "22"
+    assert (
+        U.mine_command("ssh -p22 jns")["work_host"] == "jns"
+    )  # inline value, no next-token skip
 
 
 # Codex #262: gitBranch is ground-truth per message → natural subsequent-message boundary ------------

--- a/claude-config/tests/test_usage_collector_claude.py
+++ b/claude-config/tests/test_usage_collector_claude.py
@@ -198,6 +198,46 @@ def test_idempotent_collect(tmp_path):
     assert len(shard.read_text().strip().splitlines()) == 2  # no duplicates
 
 
+# Codex #262 hardening: SSH host parsing skips flags + their args -----------------------------------
+def test_ssh_host_parsing_skips_flag_args():
+    assert U.mine_command("ssh -p 22 jns 'cd ~/x'")["work_host"] == "jns"  # not "22"
+    assert U.mine_command("ssh -i ~/.ssh/key deploy@server")["work_host"] == "server"
+    assert U.mine_command("ssh -v jns")["work_host"] == "jns"
+
+
+# Codex #262: gitBranch is ground-truth per message → natural subsequent-message boundary ------------
+def test_gitbranch_gives_subsequent_boundary():
+    # the checkout message still shows the OLD branch; the next shows the new one
+    recs = _extract(
+        [
+            _asst(
+                1,
+                ts="t1",
+                gitBranch="main",
+                content=[_bash("git checkout -b feat/issue-5-x")],
+            ),
+            _asst(2, ts="t2", gitBranch="feat/issue-5-x"),
+        ]
+    )
+    assert recs[0]["task"] == "unattributed"  # old branch (main) → not the new task
+    assert recs[1]["task"] == "issue:5"  # new branch on the subsequent message
+
+
+# Codex #262: malformed records don't crash + don't collapse on missing uuid ------------------------
+def test_malformed_and_missing_uuid_robust():
+    # non-dict message must not crash
+    entries = [{"type": "assistant", "message": "oops-not-a-dict", "timestamp": "t0"}]
+    assert _extract(entries) == []
+    # two usage records missing uuid → distinct dedup_keys (no collapse/undercount)
+    e1 = _asst(None, ts="t1", usage={"input_tokens": 1, "output_tokens": 0})
+    e2 = _asst(None, ts="t2", usage={"input_tokens": 2, "output_tokens": 0})
+    for e in (e1, e2):
+        e["uuid"] = None
+    recs = _extract([e1, e2])
+    assert len(recs) == 2
+    assert recs[0]["dedup_key"] != recs[1]["dedup_key"]
+
+
 # 11. emitted record carries the §3 schema fields --------------------------------------------------
 def test_record_schema():
     rec = _extract([_asst(1, ts="t1")])[0]

--- a/claude-config/tests/test_usage_collector_claude.py
+++ b/claude-config/tests/test_usage_collector_claude.py
@@ -1,0 +1,224 @@
+"""Acceptance tests for issue #262 — Claude transcript collector + activity-miner."""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+import usage_collector_claude as U  # noqa: E402
+
+HOST = "testhost"
+
+
+def _bash(cmd):
+    return {"type": "tool_use", "name": "Bash", "input": {"command": cmd}}
+
+
+def _asst(
+    uuid,
+    *,
+    ts,
+    sid="s1",
+    model="claude-opus-4",
+    usage=None,
+    content=None,
+    gitBranch=None,
+    cwd=None,
+):
+    return {
+        "type": "assistant",
+        "sessionId": sid,
+        "uuid": uuid,
+        "timestamp": ts,
+        "gitBranch": gitBranch,
+        "cwd": cwd,
+        "message": {
+            "role": "assistant",
+            "model": model,
+            "usage": usage or {"input_tokens": 100, "output_tokens": 50},
+            "content": content or [],
+        },
+    }
+
+
+def _extract(entries):
+    return U.extract_records(entries, inference_host=HOST)
+
+
+# 1. per-message timestamps, not one record at session start ----------------------------------------
+def test_per_message_records_and_timestamps():
+    recs = _extract(
+        [
+            _asst(1, ts="2026-04-01T00:00:00Z"),
+            _asst(2, ts="2026-05-01T00:00:00Z"),
+            _asst(3, ts="2026-06-01T00:00:00Z"),
+        ]
+    )
+    assert len(recs) == 3
+    assert [r["ts"] for r in recs] == [
+        "2026-04-01T00:00:00Z",
+        "2026-05-01T00:00:00Z",
+        "2026-06-01T00:00:00Z",
+    ]
+
+
+# 2. git checkout -b → task on subsequent messages --------------------------------------------------
+def test_checkout_sets_task_on_subsequent():
+    recs = _extract(
+        [
+            _asst(
+                1,
+                ts="t1",
+                content=[_bash("git checkout -b feat/issue-42-foo origin/main")],
+            ),
+            _asst(2, ts="t2"),
+        ]
+    )
+    assert recs[0]["task"] == "unattributed"  # the issuing msg is pre-command
+    assert recs[1]["task"] == "issue:42"  # subsequent msg gets it
+
+
+# 3. ssh host 'cd repo' → work_host + project on subsequent ------------------------------------------
+def test_ssh_sets_work_host_and_project():
+    recs = _extract(
+        [
+            _asst(1, ts="t1", content=[_bash("ssh jns 'cd ~/agents && git status'")]),
+            _asst(2, ts="t2"),
+        ]
+    )
+    assert recs[1]["work_host"] == "jns"
+    assert recs[1]["project"] == "agents"
+
+
+# 4. multi-task session: branch switch midway → segmentation ----------------------------------------
+def test_multi_task_segmentation():
+    recs = _extract(
+        [
+            _asst(1, ts="t1", content=[_bash("git checkout -b feat/issue-42-a")]),
+            _asst(2, ts="t2"),
+            _asst(3, ts="t3", content=[_bash("git checkout -b feat/issue-99-b")]),
+            _asst(4, ts="t4"),
+        ]
+    )
+    assert recs[1]["task"] == "issue:42"
+    assert recs[3]["task"] == "issue:99"
+
+
+# 5. no git/ssh activity → unattributed, work_host == inference_host ---------------------------------
+def test_no_activity_unattributed():
+    recs = _extract([_asst(1, ts="t1", gitBranch="main", cwd="/tmp/x")])
+    assert recs[0]["task"] == "unattributed"
+    assert recs[0]["work_host"] == HOST
+
+
+# 6. gitBranch field → task without any command mining ----------------------------------------------
+def test_gitbranch_fast_path():
+    recs = _extract([_asst(1, ts="t1", gitBranch="feat/issue-7-foo")])
+    assert recs[0]["task"] == "issue:7"
+
+
+# 7. parallel sessions: independent, tokens sum, no cross-session bleed ------------------------------
+def test_parallel_sessions_no_bleed():
+    a = _extract(
+        [
+            _asst(
+                1, ts="t1", sid="A", content=[_bash("git checkout -b feat/issue-1-a")]
+            ),
+            _asst(2, ts="t2", sid="A"),
+        ]
+    )
+    b = _extract(
+        [_asst(1, ts="t1", sid="B", usage={"input_tokens": 999, "output_tokens": 0})]
+    )
+    # session B's task is NOT polluted by A's checkout (separate transcripts)
+    assert b[0]["task"] == "unattributed"
+    assert b[0]["input"] == 999
+    assert a[1]["task"] == "issue:1"  # A keeps its own attribution
+    assert {r["session_id"] for r in a} == {"A"} and b[0]["session_id"] == "B"
+
+
+# 8. unknown model → loud error, not a zero-cost record ---------------------------------------------
+def test_unknown_model_raises():
+    with pytest.raises(ValueError):
+        _extract([_asst(1, ts="t1", model="gpt-99-unknown")])
+
+
+# 8b. Claude Code internal <synthetic> model is SKIPPED, not crashed (real-transcript edge) ----------
+def test_synthetic_model_skipped():
+    recs = _extract(
+        [
+            _asst(1, ts="t1", model="<synthetic>"),  # injected/non-API → skipped
+            _asst(2, ts="t2", model="claude-opus-4"),  # real → emitted
+        ]
+    )
+    assert len(recs) == 1
+    assert recs[0]["model"] == "claude-opus-4"
+
+
+# 9. compaction flagged on the record with the cache_creation spike ---------------------------------
+def test_compaction_flagged():
+    recs = _extract(
+        [
+            _asst(1, ts="t1"),
+            {"type": "summary", "isCompactSummary": True, "timestamp": "t2"},
+            _asst(
+                2,
+                ts="t3",
+                usage={"input_tokens": 10, "cache_creation_input_tokens": 200000},
+            ),
+        ]
+    )
+    by = {r["dedup_key"]: r for r in recs}
+    assert by["s1:1"]["compaction"] is False
+    assert by["s1:2"]["compaction"] is True
+    assert by["s1:2"]["cache_creation"] == 200000
+
+
+# 10. idempotent collect: running twice produces no duplicate shard records --------------------------
+def test_idempotent_collect(tmp_path):
+    proj = tmp_path / "projects" / "-proj-x"
+    proj.mkdir(parents=True)
+    (proj / "s1.jsonl").write_text(
+        "\n".join(
+            json.dumps(e)
+            for e in [
+                _asst(1, ts="t1"),
+                _asst(2, ts="t2"),
+            ]
+        )
+    )
+    shard = tmp_path / "telemetry" / HOST / "usage.jsonl"
+    r1 = U.collect(tmp_path / "projects", shard, inference_host=HOST)
+    r2 = U.collect(tmp_path / "projects", shard, inference_host=HOST)
+    assert r1["written"] == 2
+    assert r2["written"] == 0 and r2["skipped"] == 2
+    assert len(shard.read_text().strip().splitlines()) == 2  # no duplicates
+
+
+# 11. emitted record carries the §3 schema fields --------------------------------------------------
+def test_record_schema():
+    rec = _extract([_asst(1, ts="t1")])[0]
+    for f in (
+        "provider",
+        "account",
+        "billing_type",
+        "inference_host",
+        "work_host",
+        "project",
+        "model",
+        "task",
+        "input",
+        "output",
+        "cache_read",
+        "cache_creation",
+        "cost_usd",
+        "ts",
+        "session_id",
+    ):
+        assert f in rec, f
+    assert rec["provider"] == "claude"
+    assert rec["account"] is None and rec["billing_type"] is None  # filled by #265
+    assert rec["cost_usd"] > 0


### PR DESCRIPTION
## Summary
Claude transcript usage collector + activity-miner (fleet-usage-monitor §8 step 1). Walks `~/.claude/projects/*/*.jsonl` → one normalized record per assistant message → `telemetry/<host>/usage.jsonl`.

- **Per-message timestamps** (§4.5) — 55-day sessions span 55 days of trend, not lumped at start.
- **Activity-mining** (§4.3) — task/project/work_host from the session's own git/`gh`/`ssh` tool calls (no manual tags); chronological **segmentation** of multi-task sessions; `gitBranch` fast-path; `unattributed` fallback.
- **inference_host vs work_host** (§4.2); **parallel sessions** per-transcript-atomic (§4.4); **compaction flagged** (§4.5).
- Unknown **real** model → loud error; Claude Code `<synthetic>` markers **skipped** (edge found via real-data smoke). `account`/`billing_type` null (filled by #265). Idempotent via `dedup_key`.

## Test Plan
- 12 acceptance tests (every AC + required test + the synthetic-model edge).
- **Real-data smoke:** 2,480 records, $2,325 total, correctly attributed by issue/branch (issue:233, issue:245, spec/fleet-usage-monitor, …). `pytest` green, ruff clean.

Closes #262.

🤖 Generated with [Claude Code](https://claude.com/claude-code)