### PR TITLE
feat(usage): Codex/ChatGPT session collector

### DIFF
--- a/claude-config/scripts/usage_collector_codex.py
+++ b/claude-config/scripts/usage_collector_codex.py
@@ -1,0 +1,233 @@
+"""Codex/ChatGPT session usage collector (fleet-usage-monitor §8 step 2, §4.6).
+
+Walks `~/.codex/sessions/**/*.jsonl` and appends normalized usage records to the SAME per-host shard
+`telemetry/<host>/usage.jsonl` as the Claude collector (mixed-provider, distinguished by `provider`).
+Reuses the Claude collector's activity-miner so attribution is consistent across providers.
+
+Codex session format (verified 2026-06-06):
+- a session-meta first line whose payload holds `cwd`, a `git` block (`branch`, `repository_url`), and
+  `id`; `model` (e.g. `gpt-5.5`) appears in a payload during the run.
+- `token_count` events with `info.last_token_usage` (per-turn delta) and `info.total_token_usage`
+  (cumulative). Summing `last_token_usage` equals the final total → one record per `token_count` event,
+  no double-count. Codex `input_tokens` INCLUDES `cached_input_tokens`, so fresh input = input − cached;
+  `reasoning_output_tokens` are billed as output; OpenAI has no separate cache-write (cache_creation=0).
+- account identity comes from `~/.codex/auth.json` (account_id + JWT email) — the AUTH KEY IS NEVER
+  written to a shard. One OpenAI account spans hosts, so `inference_host` is the per-PC separator (§4.6);
+  the agent-b bridge on jns-server is captured by that host's collector as `inference_host=jns-server`.
+"""
+
+from __future__ import annotations
+
+import base64
+import glob
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import token_collector as C  # noqa: E402
+import usage_collector_claude as UC  # noqa: E402  (shared activity-miner: mine_command, _task_from_branch, …)
+
+PROVIDER = "codex"
+
+
+def _norm_tokens(last: dict) -> dict:
+    """Map a Codex `last_token_usage` to the normalized schema. input_tokens INCLUDES cached, so fresh
+    input = input − cached; reasoning tokens bill as output; OpenAI has no separate cache-write."""
+    inp = int(last.get("input_tokens", 0) or 0)
+    cached = int(last.get("cached_input_tokens", 0) or 0)
+    out = int(last.get("output_tokens", 0) or 0) + int(
+        last.get("reasoning_output_tokens", 0) or 0
+    )
+    return {
+        "input": max(0, inp - cached),
+        "output": out,
+        "cache_read": cached,
+        "cache_creation": 0,
+    }
+
+
+def _b64json(segment: str) -> dict:
+    segment += "=" * (-len(segment) % 4)
+    try:
+        return json.loads(base64.urlsafe_b64decode(segment))
+    except Exception:
+        return {}
+
+
+def read_codex_account(auth_path) -> dict:
+    """Account identity from `~/.codex/auth.json` — NEVER returns the API key/token. `billing_type` is
+    `subscription` when a ChatGPT OAuth account_id is present, else `metered` (API key)."""
+    p = Path(auth_path)
+    if not p.exists():
+        return {"account": None, "email": None, "billing_type": None}
+    try:
+        d = json.loads(p.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return {"account": None, "email": None, "billing_type": None}
+    tokens = d.get("tokens") or {}
+    account_id = tokens.get("account_id")
+    email = None
+    jwt = tokens.get("id_token") or tokens.get("access_token")
+    if isinstance(jwt, str) and jwt.count(".") >= 2:
+        email = _b64json(jwt.split(".")[1]).get("email")
+    billing = (
+        "subscription"
+        if account_id
+        else ("metered" if d.get("OPENAI_API_KEY") else None)
+    )
+    return {"account": account_id or email, "email": email, "billing_type": billing}
+
+
+def _project_from_repo_url(url) -> str | None:
+    if not url:
+        return None
+    name = str(url).rstrip("/").split("/")[-1]
+    return name[:-4] if name.endswith(".git") else (name or None)
+
+
+def _payload(entry: dict) -> dict:
+    p = entry.get("payload") if isinstance(entry, dict) else None
+    return p if isinstance(p, dict) else {}
+
+
+def _command_from_function_call(p: dict) -> str | None:
+    """Extract the shell command from a Codex function_call payload (arguments.command)."""
+    args = p.get("arguments")
+    if isinstance(args, str):
+        try:
+            args = json.loads(args)
+        except json.JSONDecodeError:
+            return args
+    if isinstance(args, dict):
+        cmd = args.get("command")
+        if isinstance(cmd, list):
+            return " ".join(map(str, cmd))
+        if isinstance(cmd, str):
+            return cmd
+    return None
+
+
+def _session_context(entries: list, *, inference_host: str) -> dict:
+    """Scan a session for cwd/git/model + mined work_host/task, producing the session-level attribution
+    shared by all its token_count records (a Codex `exec` is one task)."""
+    cwd = git = model = session_id = None
+    mined = {}
+    for entry in entries:
+        p = _payload(entry)
+        cwd = cwd or p.get("cwd")
+        git = git or p.get("git")
+        model = model or p.get("model")
+        session_id = session_id or p.get("id")
+        if p.get("type") == "function_call":
+            cmd = _command_from_function_call(p)
+            if cmd:
+                mined.update(UC.mine_command(cmd))
+    git = git if isinstance(git, dict) else {}
+    task = (
+        UC._task_from_branch(git.get("branch")) or mined.get("task") or "unattributed"
+    )
+    project = (
+        _project_from_repo_url(git.get("repository_url"))
+        or mined.get("project")
+        or UC._project_from_path(cwd)
+    )
+    return {
+        "model": model,
+        "session_id": session_id,
+        "task": task,
+        "project": project,
+        "work_host": mined.get("work_host", inference_host),
+    }
+
+
+def extract_records(
+    entries: list,
+    *,
+    inference_host: str,
+    account_info: dict | None = None,
+    strict: bool = True,
+) -> list:
+    """One normalized record per `token_count` event (per turn), using `last_token_usage`."""
+    ctx = _session_context(entries, inference_host=inference_host)
+    acct = account_info or {"account": None, "email": None, "billing_type": None}
+    records = []
+    idx = 0
+    for entry in entries:
+        p = _payload(entry)
+        if p.get("type") != "token_count":
+            continue
+        last = (p.get("info") or {}).get("last_token_usage") or {}
+        if not last:
+            continue
+        tok = _norm_tokens(last)
+        cost_rec = {**tok, "model": ctx["model"]}
+        records.append(
+            {
+                "provider": PROVIDER,
+                "account": acct.get("account"),
+                "billing_type": acct.get("billing_type"),
+                "inference_host": inference_host,
+                "work_host": ctx["work_host"],
+                "project": ctx["project"],
+                "model": ctx["model"],
+                "task": ctx["task"],
+                **tok,
+                "cost_usd": C.session_cost(cost_rec, strict=strict),
+                "ts": entry.get("timestamp"),
+                "session_id": ctx["session_id"],
+                "email": acct.get("email"),
+                "dedup_key": f"codex:{ctx['session_id']}:{idx}",
+            }
+        )
+        idx += 1
+    return records
+
+
+def read_session(path) -> list:
+    out = []
+    for line in Path(path).read_text(encoding="utf-8", errors="ignore").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            out.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    return out
+
+
+def collect(
+    sessions_dir,
+    shard_path,
+    *,
+    inference_host: str | None = None,
+    auth_path=None,
+    strict: bool = True,
+) -> dict:
+    """Walk all Codex sessions and APPEND new records to the shared `usage.jsonl` shard (idempotent
+    via dedup_key, same as the Claude collector)."""
+    inference_host = inference_host or UC.get_host_name()
+    auth_path = auth_path or (Path.home() / ".codex" / "auth.json")
+    account_info = read_codex_account(auth_path)
+    shard_path = Path(shard_path)
+    seen = UC._existing_dedup_keys(shard_path)
+    written = skipped = 0
+    shard_path.parent.mkdir(parents=True, exist_ok=True)
+    with shard_path.open("a", encoding="utf-8") as fh:
+        for spath in sorted(
+            glob.glob(str(Path(sessions_dir) / "**" / "*.jsonl"), recursive=True)
+        ):
+            for rec in extract_records(
+                read_session(spath),
+                inference_host=inference_host,
+                account_info=account_info,
+                strict=strict,
+            ):
+                if rec["dedup_key"] in seen:
+                    skipped += 1
+                    continue
+                seen.add(rec["dedup_key"])
+                fh.write(json.dumps(rec, ensure_ascii=False) + "\n")
+                written += 1
+    return {"written": written, "skipped": skipped, "shard": str(shard_path)}

--- a/claude-config/scripts/usage_collector_codex.py
+++ b/claude-config/scripts/usage_collector_codex.py
@@ -31,14 +31,21 @@ import usage_collector_claude as UC  # noqa: E402  (shared activity-miner: mine_
 PROVIDER = "codex"
 
 
+def _int(v) -> int:
+    """Coerce a token field to int; non-numeric/malformed values → 0 (never crash collection)."""
+    try:
+        return int(v)
+    except (TypeError, ValueError):
+        return 0
+
+
 def _norm_tokens(last: dict) -> dict:
     """Map a Codex `last_token_usage` to the normalized schema. input_tokens INCLUDES cached, so fresh
-    input = input − cached; reasoning tokens bill as output; OpenAI has no separate cache-write."""
-    inp = int(last.get("input_tokens", 0) or 0)
-    cached = int(last.get("cached_input_tokens", 0) or 0)
-    out = int(last.get("output_tokens", 0) or 0) + int(
-        last.get("reasoning_output_tokens", 0) or 0
-    )
+    input = input − cached; reasoning tokens bill as output; OpenAI has no separate cache-write.
+    Malformed/non-numeric token values are coerced to 0 (Codex #263)."""
+    inp = _int(last.get("input_tokens"))
+    cached = _int(last.get("cached_input_tokens"))
+    out = _int(last.get("output_tokens")) + _int(last.get("reasoning_output_tokens"))
     return {
         "input": max(0, inp - cached),
         "output": out,
@@ -153,15 +160,25 @@ def extract_records(
     acct = account_info or {"account": None, "email": None, "billing_type": None}
     records = []
     idx = 0
+    sid = ctx["session_id"]
     for entry in entries:
         p = _payload(entry)
         if p.get("type") != "token_count":
             continue
-        last = (p.get("info") or {}).get("last_token_usage") or {}
-        if not last:
-            continue
+        info = p.get("info")
+        last = info.get("last_token_usage") if isinstance(info, dict) else None
+        if not isinstance(last, dict) or not last:
+            continue  # malformed/empty token_count → skip, never crash (Codex #263)
         tok = _norm_tokens(last)
         cost_rec = {**tok, "model": ctx["model"]}
+        ts = entry.get("timestamp")
+        # dedup_key must be unique even when session_id is missing (else codex:None:idx collides
+        # across files → data loss, Codex #263) — fall back to ts + content.
+        dedup = (
+            f"codex:{sid}:{idx}"
+            if sid
+            else f"codex:nosess:{ts}:{idx}:{tok['input']}:{tok['output']}"
+        )
         records.append(
             {
                 "provider": PROVIDER,
@@ -174,10 +191,10 @@ def extract_records(
                 "task": ctx["task"],
                 **tok,
                 "cost_usd": C.session_cost(cost_rec, strict=strict),
-                "ts": entry.get("timestamp"),
-                "session_id": ctx["session_id"],
+                "ts": ts,
+                "session_id": sid,
                 "email": acct.get("email"),
-                "dedup_key": f"codex:{ctx['session_id']}:{idx}",
+                "dedup_key": dedup,
             }
         )
         idx += 1

--- a/claude-config/tests/test_usage_collector_codex.py
+++ b/claude-config/tests/test_usage_collector_codex.py
@@ -1,0 +1,277 @@
+"""Acceptance tests for issue #263 — Codex/ChatGPT session collector (§4.6)."""
+
+import base64
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+import usage_collector_codex as X  # noqa: E402
+
+HOST = "testhost"
+
+
+def _meta(sid="sess1", cwd="/home/user/agents", git=None, model="gpt-5.5", ts="t0"):
+    return {
+        "timestamp": ts,
+        "payload": {
+            "id": sid,
+            "cwd": cwd,
+            "git": git,
+            "model": model,
+            "model_provider": "openai",
+        },
+    }
+
+
+def _tc(last, ts="t1"):
+    total = {
+        **last,
+        "total_tokens": last.get("input_tokens", 0) + last.get("output_tokens", 0),
+    }
+    return {
+        "timestamp": ts,
+        "payload": {
+            "type": "token_count",
+            "info": {"last_token_usage": last, "total_token_usage": total},
+        },
+    }
+
+
+def _fn(cmd, ts="t1"):
+    return {
+        "timestamp": ts,
+        "payload": {
+            "type": "function_call",
+            "name": "shell",
+            "arguments": json.dumps({"command": ["bash", "-lc", cmd]}),
+        },
+    }
+
+
+def _extract(entries, account_info=None):
+    return X.extract_records(entries, inference_host=HOST, account_info=account_info)
+
+
+# one record per token_count, correct token mapping ------------------------------------------------
+def test_per_turn_records_and_token_mapping():
+    recs = _extract(
+        [
+            _meta(),
+            _tc(
+                {
+                    "input_tokens": 1000,
+                    "cached_input_tokens": 200,
+                    "output_tokens": 100,
+                    "reasoning_output_tokens": 50,
+                }
+            ),
+            _tc(
+                {
+                    "input_tokens": 500,
+                    "cached_input_tokens": 0,
+                    "output_tokens": 30,
+                    "reasoning_output_tokens": 0,
+                }
+            ),
+        ]
+    )
+    assert len(recs) == 2
+    # fresh input = input - cached; output += reasoning; cache_read = cached; no cache_creation
+    assert (
+        recs[0]["input"] == 800
+        and recs[0]["cache_read"] == 200
+        and recs[0]["output"] == 150
+    )
+    assert recs[0]["cache_creation"] == 0
+    assert recs[1]["input"] == 500 and recs[1]["output"] == 30
+    assert all(r["provider"] == "codex" and r["cost_usd"] > 0 for r in recs)
+
+
+# cwd → project ------------------------------------------------------------------------------------
+def test_cwd_project():
+    recs = _extract(
+        [
+            _meta(cwd="/home/user/agents", git=None),
+            _tc({"input_tokens": 10, "output_tokens": 1}),
+        ]
+    )
+    assert recs[0]["project"] == "agents"
+
+
+# git block: branch → task, repo url → project -----------------------------------------------------
+def test_git_block_task_and_project():
+    git = {
+        "branch": "fix/issue-1812-x",
+        "repository_url": "https://github.com/jwj2002/meeting-buddy.git",
+    }
+    recs = _extract([_meta(git=git), _tc({"input_tokens": 10, "output_tokens": 1})])
+    assert recs[0]["task"] == "issue:1812"
+    assert recs[0]["project"] == "meeting-buddy"
+
+
+# function_call git checkout → task ----------------------------------------------------------------
+def test_function_call_checkout_task():
+    recs = _extract(
+        [
+            _meta(git=None, cwd="/x"),
+            _fn("git checkout -b feat/issue-55-y"),
+            _tc({"input_tokens": 10, "output_tokens": 1}),
+        ]
+    )
+    assert recs[0]["task"] == "issue:55"
+
+
+# account from auth.json, key NEVER in output ------------------------------------------------------
+def test_account_from_auth_no_key_leak(tmp_path):
+    claims = (
+        base64.urlsafe_b64encode(json.dumps({"email": "u@example.com"}).encode())
+        .decode()
+        .rstrip("=")
+    )
+    jwt = f"h.{claims}.sig"
+    auth = tmp_path / "auth.json"
+    auth.write_text(
+        json.dumps(
+            {
+                "OPENAI_API_KEY": "sk-SECRET-MUST-NOT-LEAK",
+                "tokens": {"account_id": "b00eXXXX", "id_token": jwt},
+            }
+        )
+    )
+    info = X.read_codex_account(auth)
+    assert info["account"] == "b00eXXXX"
+    assert info["email"] == "u@example.com"
+    assert info["billing_type"] == "subscription"
+    recs = _extract(
+        [_meta(), _tc({"input_tokens": 10, "output_tokens": 1})], account_info=info
+    )
+    blob = json.dumps(recs)
+    assert (
+        "sk-SECRET-MUST-NOT-LEAK" not in blob
+    )  # the auth key never reaches a shard record
+    assert (
+        recs[0]["account"] == "b00eXXXX" and recs[0]["billing_type"] == "subscription"
+    )
+    # API-key-only auth → metered
+    auth2 = tmp_path / "auth2.json"
+    auth2.write_text(json.dumps({"OPENAI_API_KEY": "sk-x"}))
+    assert X.read_codex_account(auth2)["billing_type"] == "metered"
+
+
+# unknown model → loud error -----------------------------------------------------------------------
+def test_unknown_model_raises():
+    with pytest.raises(ValueError):
+        _extract(
+            [
+                _meta(model="gpt-99-unknown"),
+                _tc({"input_tokens": 10, "output_tokens": 1}),
+            ]
+        )
+
+
+# mixed shard: codex + claude records, provider distinguishes --------------------------------------
+def test_mixed_shard_provider_field(tmp_path):
+    shard = tmp_path / "telemetry" / HOST / "usage.jsonl"
+    shard.parent.mkdir(parents=True)
+    # a claude record already in the shard
+    shard.write_text(
+        json.dumps({"provider": "claude", "dedup_key": "s:1", "model": "claude-opus-4"})
+        + "\n"
+    )
+    sess = tmp_path / "sessions" / "2026" / "06"
+    sess.mkdir(parents=True)
+    (sess / "r1.jsonl").write_text(
+        "\n".join(
+            json.dumps(e)
+            for e in [_meta(), _tc({"input_tokens": 10, "output_tokens": 1})]
+        )
+    )
+    X.collect(
+        tmp_path / "sessions",
+        shard,
+        inference_host=HOST,
+        auth_path=tmp_path / "none.json",
+    )
+    providers = {
+        json.loads(line)["provider"]
+        for line in shard.read_text().splitlines()
+        if line.strip()
+    }
+    assert providers == {"claude", "codex"}
+
+
+# bridge vs local: same account, inference_host separates ------------------------------------------
+def test_inference_host_separates_same_account():
+    acct = {"account": "b00e", "email": None, "billing_type": "subscription"}
+    server = X.extract_records(
+        [_meta(sid="srv"), _tc({"input_tokens": 10, "output_tokens": 1})],
+        inference_host="jns-server",
+        account_info=acct,
+    )
+    mac = X.extract_records(
+        [_meta(sid="mac"), _tc({"input_tokens": 10, "output_tokens": 1})],
+        inference_host="jns-mac",
+        account_info=acct,
+    )
+    assert server[0]["account"] == mac[0]["account"] == "b00e"  # one account
+    assert (
+        server[0]["inference_host"] != mac[0]["inference_host"]
+    )  # host is the separator
+
+
+# idempotent collect -------------------------------------------------------------------------------
+def test_idempotent_collect(tmp_path):
+    sess = tmp_path / "sessions" / "2026"
+    sess.mkdir(parents=True)
+    (sess / "r.jsonl").write_text(
+        "\n".join(
+            json.dumps(e)
+            for e in [
+                _meta(),
+                _tc({"input_tokens": 10, "output_tokens": 1}),
+                _tc({"input_tokens": 5, "output_tokens": 1}),
+            ]
+        )
+    )
+    shard = tmp_path / "telemetry" / HOST / "usage.jsonl"
+    r1 = X.collect(
+        tmp_path / "sessions",
+        shard,
+        inference_host=HOST,
+        auth_path=tmp_path / "no.json",
+    )
+    r2 = X.collect(
+        tmp_path / "sessions",
+        shard,
+        inference_host=HOST,
+        auth_path=tmp_path / "no.json",
+    )
+    assert r1["written"] == 2 and r2["written"] == 0 and r2["skipped"] == 2
+    assert len(shard.read_text().strip().splitlines()) == 2
+
+
+# schema fields present ----------------------------------------------------------------------------
+def test_record_schema():
+    rec = _extract([_meta(), _tc({"input_tokens": 10, "output_tokens": 1})])[0]
+    for f in (
+        "provider",
+        "account",
+        "billing_type",
+        "inference_host",
+        "work_host",
+        "project",
+        "model",
+        "task",
+        "input",
+        "output",
+        "cache_read",
+        "cache_creation",
+        "cost_usd",
+        "ts",
+        "session_id",
+    ):
+        assert f in rec, f

--- a/claude-config/tests/test_usage_collector_codex.py
+++ b/claude-config/tests/test_usage_collector_codex.py
@@ -254,6 +254,40 @@ def test_idempotent_collect(tmp_path):
     assert len(shard.read_text().strip().splitlines()) == 2
 
 
+# Codex #263 hardening: malformed payloads don't crash; missing session_id doesn't collide ----------
+def test_malformed_payloads_robust():
+    # non-dict info, non-numeric token values, missing session id → no crash
+    entries = [
+        _meta(sid=None),
+        {
+            "timestamp": "t1",
+            "payload": {"type": "token_count", "info": "bad-not-a-dict"},
+        },
+        {
+            "timestamp": "t2",
+            "payload": {
+                "type": "token_count",
+                "info": {
+                    "last_token_usage": {
+                        "input_tokens": "oops",
+                        "output_tokens": [1, 2],
+                    }
+                },
+            },
+        },
+        _tc({"input_tokens": 10, "output_tokens": 1}, ts="t3"),
+        _tc({"input_tokens": 20, "output_tokens": 2}, ts="t4"),
+    ]
+    recs = X.extract_records(entries, inference_host=HOST)
+    # the non-dict info is skipped; the non-numeric one coerces to 0; the two valid ones emit
+    assert len(recs) == 3
+    bad = next(r for r in recs if r["ts"] == "t2")
+    assert bad["input"] == 0 and bad["output"] == 0  # coerced, not crashed
+    # missing session_id → distinct dedup_keys (no collision/data-loss)
+    keys = [r["dedup_key"] for r in recs]
+    assert len(set(keys)) == len(keys)
+
+
 # schema fields present ----------------------------------------------------------------------------
 def test_record_schema():
     rec = _extract([_meta(), _tc({"input_tokens": 10, "output_tokens": 1})])[0]


### PR DESCRIPTION
Codex session collector (fleet-usage-monitor §8 step 2, §4.6) → shared per-host usage.jsonl shard, provider=codex. Reuses the Claude collector's activity-miner. Per-turn records via last_token_usage (verified no double-count); Codex input includes cached (fresh=input-cached); account from auth.json (key NEVER shard-written, tested); subscription vs metered billing_type; one account spans hosts → inference_host separates (bridge→jns-server). 10 tests + real-data smoke (120 records/$3.11 today, attributed by project/issue). Closes #263.

🤖 Generated with [Claude Code](https://claude.com/claude-code)