### PR TITLE
feat(usage): account capture — SessionStart hook + collector join

### DIFF
--- a/claude-config/hooks/usage_account_capture.py
+++ b/claude-config/hooks/usage_account_capture.py
@@ -55,7 +55,10 @@ def build_entry(claude_json_path, session_id, *, now_ts: str) -> dict:
         data = json.loads(Path(claude_json_path).read_text(encoding="utf-8"))
     except (FileNotFoundError, json.JSONDecodeError, OSError):
         data = {}
-    oa = data.get("oauthAccount") or {}
+    if not isinstance(data, dict):  # well-formed JSON but non-object → no-crash
+        data = {}
+    oa = data.get("oauthAccount")
+    oa = oa if isinstance(oa, dict) else {}
     for src, dst in _OAUTH_FIELDS.items():
         entry[dst] = oa.get(src)
     raw = oa.get("billingType")

--- a/claude-config/hooks/usage_account_capture.py
+++ b/claude-config/hooks/usage_account_capture.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""SessionStart hook — capture the Claude billing account into a sidecar (fleet-usage-monitor §4.1).
+
+The billing identity lives in `~/.claude.json` → `oauthAccount` at session-start time, NOT in the
+transcript — so it must be captured then and joined later by the usage collector (#262). This hook
+writes ONE line per session to `~/.claude/telemetry/account-map.jsonl`:
+
+    {"session_id","account_uuid","org","email","billing_type","billing_type_raw","seat_tier","ts"}
+
+`billing_type` decides what `cost_usd` MEANS (§6): `subscription` (Max/Pro) → cost is notional
+API-equivalent value, not cash; `metered` (console/API) → ≈ actual dollars. The OAuth token / API key
+is NEVER written (the §229 no-secrets-in-shards ban).
+
+NOT auto-activated: this is the hook SCRIPT. To enable it, register it as a SessionStart hook in your
+Claude settings — left to the operator so a live-session hook is never installed autonomously.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+# Identity fields copied from oauthAccount — explicitly NO token/key fields.
+_OAUTH_FIELDS = {
+    "accountUuid": "account_uuid",
+    "organizationName": "org",
+    "organizationUuid": "org_uuid",
+    "emailAddress": "email",
+    "seatTier": "seat_tier",
+    "organizationRateLimitTier": "rate_limit_tier",
+}
+
+
+def classify_billing(raw) -> str | None:
+    """Normalize oauthAccount.billingType → subscription | metered (raw passthrough if unrecognized).
+    Exact Claude enum values are confirmed at activation; subscription vs metered is the load-bearing
+    distinction (§6)."""
+    r = str(raw or "").lower()
+    if not r:
+        return None
+    if "subscription" in r or r in ("max", "pro", "team", "enterprise"):
+        return "subscription"
+    if r in ("console", "api", "metered", "usage_based", "pay_as_you_go"):
+        return "metered"
+    return raw  # unknown enum → passthrough (don't silently mislabel)
+
+
+def build_entry(claude_json_path, session_id, *, now_ts: str) -> dict:
+    """Build the sidecar entry from ~/.claude.json's oauthAccount. Never includes any secret."""
+    entry = {"session_id": session_id, "ts": now_ts}
+    try:
+        data = json.loads(Path(claude_json_path).read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        data = {}
+    oa = data.get("oauthAccount") or {}
+    for src, dst in _OAUTH_FIELDS.items():
+        entry[dst] = oa.get(src)
+    raw = oa.get("billingType")
+    entry["billing_type_raw"] = raw
+    entry["billing_type"] = classify_billing(raw)
+    return entry
+
+
+def append_entry(sidecar_path, entry: dict) -> None:
+    p = Path(sidecar_path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    with p.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(entry, ensure_ascii=False) + "\n")
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def main() -> int:
+    # Claude Code passes hook input as JSON on stdin (incl. session_id); fall back to env.
+    data = {}
+    if not sys.stdin.isatty():
+        try:
+            data = json.load(sys.stdin)
+        except (json.JSONDecodeError, ValueError):
+            data = {}
+    session_id = data.get("session_id") or os.environ.get("CLAUDE_SESSION_ID")
+    if not session_id:
+        return 0  # nothing to key on; no-op rather than write a useless entry
+    home = Path.home()
+    entry = build_entry(home / ".claude.json", session_id, now_ts=_now_iso())
+    append_entry(home / ".claude" / "telemetry" / "account-map.jsonl", entry)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/claude-config/scripts/usage_collector_claude.py
+++ b/claude-config/scripts/usage_collector_claude.py
@@ -186,17 +186,19 @@ def load_account_map(sidecar_path) -> dict:
             e = json.loads(line)
         except json.JSONDecodeError:
             continue
-        if e.get("session_id"):
+        if isinstance(e, dict) and e.get(
+            "session_id"
+        ):  # ignore non-object lines (no crash)
             out[e["session_id"]] = e  # last write wins
     return out
 
 
 def current_account(claude_json_path) -> dict:
     """The CURRENT logged-in account from ~/.claude.json — the historical fallback for sessions with no
-    sidecar entry (#265 §4.1). `account_uuid: "unknown"` only when the file is absent."""
-    try:
-        data = json.loads(Path(claude_json_path).read_text(encoding="utf-8"))
-    except (FileNotFoundError, json.JSONDecodeError, OSError):
+    sidecar entry (#265 §4.1). `account_uuid: "unknown"` ONLY when the file is ABSENT; a malformed/
+    unreadable file is `account_source: "unreadable"` (a distinct reason, never silently `unknown`)."""
+    p = Path(claude_json_path)
+    if not p.exists():
         return {
             "account_uuid": "unknown",
             "org": None,
@@ -204,7 +206,20 @@ def current_account(claude_json_path) -> dict:
             "billing_type": None,
             "account_source": "unknown",
         }
-    oa = data.get("oauthAccount") or {}
+    try:
+        data = json.loads(p.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return {
+            "account_uuid": None,
+            "org": None,
+            "email": None,
+            "billing_type": None,
+            "account_source": "unreadable",
+        }
+    if not isinstance(data, dict):
+        data = {}
+    oa = data.get("oauthAccount")
+    oa = oa if isinstance(oa, dict) else {}
     return {
         "account_uuid": oa.get("accountUuid"),
         "org": oa.get("organizationName"),

--- a/claude-config/scripts/usage_collector_claude.py
+++ b/claude-config/scripts/usage_collector_claude.py
@@ -172,10 +172,95 @@ def _is_assistant_usage(entry: dict) -> bool:
     )
 
 
-def extract_records(entries: list, *, inference_host: str, strict: bool = True) -> list:
+def load_account_map(sidecar_path) -> dict:
+    """Read the SessionStart sidecar (account-map.jsonl) → {session_id: account-fields} (#265 §4.1)."""
+    p = Path(sidecar_path)
+    if not p.exists():
+        return {}
+    out = {}
+    for line in p.read_text(encoding="utf-8", errors="ignore").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            e = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if e.get("session_id"):
+            out[e["session_id"]] = e  # last write wins
+    return out
+
+
+def current_account(claude_json_path) -> dict:
+    """The CURRENT logged-in account from ~/.claude.json — the historical fallback for sessions with no
+    sidecar entry (#265 §4.1). `account_uuid: "unknown"` only when the file is absent."""
+    try:
+        data = json.loads(Path(claude_json_path).read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return {
+            "account_uuid": "unknown",
+            "org": None,
+            "email": None,
+            "billing_type": None,
+            "account_source": "unknown",
+        }
+    oa = data.get("oauthAccount") or {}
+    return {
+        "account_uuid": oa.get("accountUuid"),
+        "org": oa.get("organizationName"),
+        "email": oa.get("emailAddress"),
+        "billing_type": _classify_billing(oa.get("billingType")),
+        "account_source": "current_fallback",
+    }
+
+
+def _classify_billing(raw) -> str | None:
+    """subscription | metered (raw passthrough if unknown) — mirrors the hook's classifier (§6)."""
+    r = str(raw or "").lower()
+    if not r:
+        return None
+    if "subscription" in r or r in ("max", "pro", "team", "enterprise"):
+        return "subscription"
+    if r in ("console", "api", "metered", "usage_based", "pay_as_you_go"):
+        return "metered"
+    return raw
+
+
+def _apply_account(rec: dict, account_map: dict | None, fallback: dict | None) -> dict:
+    """Join account fields onto a record by session_id: sidecar entry → current-account fallback →
+    None (the #262 default). billing_type carries an account_source reason so it's never silently null."""
+    src = (account_map or {}).get(rec.get("session_id"))
+    if src:
+        rec.update(
+            account=src.get("account_uuid"),
+            org=src.get("org"),
+            email=src.get("email"),
+            billing_type=src.get("billing_type"),
+            account_source="sidecar",
+        )
+    elif fallback:
+        rec.update(
+            account=fallback.get("account_uuid"),
+            org=fallback.get("org"),
+            email=fallback.get("email"),
+            billing_type=fallback.get("billing_type"),
+            account_source=fallback.get("account_source", "current_fallback"),
+        )
+    return rec
+
+
+def extract_records(
+    entries: list,
+    *,
+    inference_host: str,
+    strict: bool = True,
+    account_map: dict | None = None,
+    fallback_account: dict | None = None,
+) -> list:
     """Core walker: chronological pass over ONE transcript's entries → normalized usage records.
     Tracks active task/project/work_host (segmentation); attributes each assistant message to the
-    state active at its timestamp; mines each entry's commands to update state for SUBSEQUENT messages."""
+    state active at its timestamp; mines each entry's commands to update state for SUBSEQUENT messages.
+    `account_map`/`fallback_account` (from #265) fill account/billing_type by session_id."""
     entries = sorted(entries, key=lambda e: e.get("timestamp") or "")
     active = {"task": "unattributed", "project": None, "work_host": inference_host}
     pending_compaction = False
@@ -219,7 +304,7 @@ def extract_records(entries: list, *, inference_host: str, strict: bool = True) 
                 "compaction": pending_compaction,
                 "dedup_key": dedup_key,
             }
-            records.append(rec)
+            records.append(_apply_account(rec, account_map, fallback_account))
             pending_compaction = False
         # mine this entry's commands → update active state for subsequent messages (segmentation)
         for cmd in _iter_commands(entry):
@@ -257,11 +342,22 @@ def _existing_dedup_keys(shard_path: Path) -> set:
 
 
 def collect(
-    projects_dir, shard_path, *, inference_host: str | None = None, strict: bool = True
+    projects_dir,
+    shard_path,
+    *,
+    inference_host: str | None = None,
+    strict: bool = True,
+    sidecar_path=None,
+    claude_json_path=None,
 ) -> dict:
-    """Walk all transcripts under `projects_dir`, emit normalized records, and APPEND new ones to
-    `shard_path` (append-only, idempotent: records whose dedup_key already exists are skipped)."""
+    """Walk all transcripts under `projects_dir`, emit normalized records (with #265 account join), and
+    APPEND new ones to `shard_path` (append-only, idempotent: dedup_key skip)."""
     inference_host = inference_host or get_host_name()
+    home = Path.home()
+    account_map = load_account_map(
+        sidecar_path or home / ".claude" / "telemetry" / "account-map.jsonl"
+    )
+    fallback_account = current_account(claude_json_path or home / ".claude.json")
     shard_path = Path(shard_path)
     seen = _existing_dedup_keys(shard_path)
     written = skipped = 0
@@ -269,7 +365,11 @@ def collect(
     with shard_path.open("a", encoding="utf-8") as fh:
         for tpath in sorted(glob.glob(str(Path(projects_dir) / "*" / "*.jsonl"))):
             for rec in extract_records(
-                read_transcript(tpath), inference_host=inference_host, strict=strict
+                read_transcript(tpath),
+                inference_host=inference_host,
+                strict=strict,
+                account_map=account_map,
+                fallback_account=fallback_account,
             ):
                 if rec["dedup_key"] in seen:
                     skipped += 1

--- a/claude-config/tests/test_account_capture.py
+++ b/claude-config/tests/test_account_capture.py
@@ -1,0 +1,149 @@
+"""Acceptance tests for issue #265 — account capture hook + collector join (§4.1)."""
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "hooks"))
+
+import usage_account_capture as H  # noqa: E402
+import usage_collector_claude as U  # noqa: E402
+
+OAUTH = {
+    "accountUuid": "87a-uuid",
+    "organizationName": "Jason's Org",
+    "organizationUuid": "org-uuid",
+    "emailAddress": "jas@example.com",
+    "billingType": "subscription",
+    "seatTier": "max",
+}
+SECRET = "oauth-token-SHOULD-NOT-LEAK"
+
+
+def _claude_json(tmp_path, oauth=OAUTH, secret=True):
+    d = {"oauthAccount": dict(oauth), "userID": "u1"}
+    if secret:
+        d["oauthAccount"]["accessToken"] = (
+            SECRET  # a secret field that must NOT be copied
+        )
+    p = tmp_path / "claude.json"
+    p.write_text(json.dumps(d))
+    return p
+
+
+# Hook: build_entry copies the identity fields, classifies billing, and leaks NO secret --------------
+def test_hook_build_entry(tmp_path):
+    entry = H.build_entry(
+        _claude_json(tmp_path), "sess-1", now_ts="2026-06-06T00:00:00Z"
+    )
+    assert entry["session_id"] == "sess-1"
+    assert entry["account_uuid"] == "87a-uuid"
+    assert entry["org"] == "Jason's Org"
+    assert entry["email"] == "jas@example.com"
+    assert entry["billing_type"] == "subscription"
+    assert SECRET not in json.dumps(entry)  # the auth token never reaches the sidecar
+
+
+def test_hook_classify_billing():
+    assert H.classify_billing("subscription") == "subscription"
+    assert H.classify_billing("max") == "subscription"
+    assert H.classify_billing("console") == "metered"
+    assert H.classify_billing("api") == "metered"
+    assert H.classify_billing(None) is None
+
+
+def test_hook_append_then_load_roundtrip(tmp_path):
+    sidecar = tmp_path / "account-map.jsonl"
+    H.append_entry(sidecar, H.build_entry(_claude_json(tmp_path), "sess-9", now_ts="t"))
+    amap = U.load_account_map(sidecar)
+    assert amap["sess-9"]["account_uuid"] == "87a-uuid"
+
+
+# Collector join: sidecar entry → account fields on the record --------------------------------------
+def _rec(sid):
+    return {"session_id": sid, "account": None, "billing_type": None}
+
+
+def test_join_from_sidecar():
+    amap = {
+        "sX": {
+            "account_uuid": "87a",
+            "org": "O",
+            "email": "e",
+            "billing_type": "subscription",
+        }
+    }
+    rec = U._apply_account(_rec("sX"), amap, None)
+    assert rec["account"] == "87a" and rec["billing_type"] == "subscription"
+    assert rec["account_source"] == "sidecar"
+
+
+def test_join_fallback_not_unknown():
+    fb = {
+        "account_uuid": "cur",
+        "billing_type": "metered",
+        "account_source": "current_fallback",
+    }
+    rec = U._apply_account(_rec("missing"), {}, fb)
+    assert rec["account"] == "cur"  # current-account fallback, NOT unknown
+    assert rec["account_source"] == "current_fallback"
+
+
+def test_current_account_missing_file_is_unknown(tmp_path):
+    fb = U.current_account(tmp_path / "does-not-exist.json")
+    assert fb["account_uuid"] == "unknown"
+    rec = U._apply_account(_rec("s"), {}, fb)
+    assert rec["account"] == "unknown"  # only when ~/.claude.json is absent
+
+
+def test_current_account_reads_billing(tmp_path):
+    fb = U.current_account(_claude_json(tmp_path))
+    assert fb["account_uuid"] == "87a-uuid" and fb["billing_type"] == "subscription"
+
+
+# Codex billing_type classification (lives in #263; verified here per the AC) ------------------------
+def test_codex_billing_classification(tmp_path):
+    import usage_collector_codex as X
+
+    sub = tmp_path / "a1.json"
+    sub.write_text(json.dumps({"tokens": {"account_id": "b00e"}}))
+    assert X.read_codex_account(sub)["billing_type"] == "subscription"
+    api = tmp_path / "a2.json"
+    api.write_text(json.dumps({"OPENAI_API_KEY": "sk-x"}))
+    assert X.read_codex_account(api)["billing_type"] == "metered"
+
+
+# Integration: hook captures → collector joins → record has account + billing_type -------------------
+def test_integration_hook_then_collect(tmp_path):
+    # capture
+    sidecar = tmp_path / "telemetry" / "account-map.jsonl"
+    H.append_entry(sidecar, H.build_entry(_claude_json(tmp_path), "sessZ", now_ts="t0"))
+    # a transcript for that session
+    proj = tmp_path / "projects" / "-p"
+    proj.mkdir(parents=True)
+    msg = {
+        "type": "assistant",
+        "sessionId": "sessZ",
+        "uuid": "u1",
+        "timestamp": "t1",
+        "message": {
+            "role": "assistant",
+            "model": "claude-opus-4",
+            "usage": {"input_tokens": 100, "output_tokens": 10},
+            "content": [],
+        },
+    }
+    (proj / "sessZ.jsonl").write_text(json.dumps(msg))
+    shard = tmp_path / "telemetry" / "host" / "usage.jsonl"
+    U.collect(
+        tmp_path / "projects",
+        shard,
+        inference_host="host",
+        sidecar_path=sidecar,
+        claude_json_path=_claude_json(tmp_path),
+    )
+    rec = json.loads(shard.read_text().strip().splitlines()[0])
+    assert rec["account"] == "87a-uuid"
+    assert rec["billing_type"] == "subscription"
+    assert rec["account_source"] == "sidecar"

--- a/claude-config/tests/test_account_capture.py
+++ b/claude-config/tests/test_account_capture.py
@@ -102,6 +102,36 @@ def test_current_account_reads_billing(tmp_path):
     assert fb["account_uuid"] == "87a-uuid" and fb["billing_type"] == "subscription"
 
 
+# Codex #265 robustness: malformed shapes don't crash; unknown only when ABSENT --------------------
+def test_malformed_shapes_robust(tmp_path):
+    # non-object claude.json → hook no-crash, empty fields
+    bad = tmp_path / "bad.json"
+    bad.write_text("[1, 2, 3]")
+    e = H.build_entry(bad, "s", now_ts="t")
+    assert e["account_uuid"] is None and e["session_id"] == "s"
+    # non-object oauthAccount → no crash
+    bad2 = tmp_path / "bad2.json"
+    bad2.write_text(json.dumps({"oauthAccount": "not-an-object"}))
+    assert H.build_entry(bad2, "s", now_ts="t")["account_uuid"] is None
+    # malformed sidecar lines ignored, not crashed
+    sc = tmp_path / "sc.jsonl"
+    sc.write_text(
+        '[1,2]\n"a string"\nnull\n'
+        + json.dumps({"session_id": "ok", "account_uuid": "u"})
+        + "\n"
+    )
+    amap = U.load_account_map(sc)
+    assert list(amap) == ["ok"]
+    # absent file → unknown; UNPARSEABLE file → unreadable (NOT unknown); valid-JSON-non-object → no crash
+    assert U.current_account(tmp_path / "absent.json")["account_source"] == "unknown"
+    malformed = tmp_path / "malformed.json"
+    malformed.write_text("{not valid json")
+    assert U.current_account(malformed)["account_source"] == "unreadable"
+    assert U.current_account(malformed)["account_uuid"] is None
+    # valid JSON but a non-object (list) → readable fallback with empty account, no crash
+    assert U.current_account(bad)["account_uuid"] is None
+
+
 # Codex billing_type classification (lives in #263; verified here per the AC) ------------------------
 def test_codex_billing_classification(tmp_path):
     import usage_collector_codex as X


### PR DESCRIPTION
Closes the billing-account gap (§4.1). Hook captures oauthAccount → sidecar at SessionStart (OAuth token/key NEVER written — tested); collector joins account/org/email/billing_type by session_id (sidecar → current-account fallback → None; account:unknown only when ~/.claude.json absent). billing_type subscription-vs-metered decides whether cost_usd is notional value or cash (§6). Hook is NOT auto-activated (operator registers it; no live-session hook installed autonomously). 9 tests. Closes #265.

🤖 Generated with [Claude Code](https://claude.com/claude-code)