### PR TITLE
feat(usage): aggregator + normalization — $/PR, cache-%, tiers, concurrency

### DIFF
--- a/claude-config/scripts/usage_aggregator.py
+++ b/claude-config/scripts/usage_aggregator.py
@@ -91,6 +91,14 @@ def cache_saved_usd(rec: dict) -> float:
     return round(cr * (row["input"] - row["cache_read"]), 10)
 
 
+def _f(v) -> float:
+    """Coerce cost_usd to float; malformed values → 0.0 (never crash aggregation, Codex #266)."""
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return 0.0
+
+
 def _billing_label(records: list) -> str | None:
     """Single billing_type across records, else `mixed` (never sum disparate billing types into cash)."""
     kinds = {r.get("billing_type") for r in records if r.get("billing_type")}
@@ -100,7 +108,27 @@ def _billing_label(records: list) -> str | None:
 
 
 def _cost(records: list) -> float:
-    return round(sum(float(r.get("cost_usd", 0) or 0) for r in records), 10)
+    return round(sum(_f(r.get("cost_usd", 0)) for r in records), 10)
+
+
+def _cost_by_billing(records: list) -> dict:
+    """Cost split BY billing_type (subscription notional vs metered cash) — the only safe way to total
+    a mixed set. `unknown` bucket for records with no billing_type."""
+    out: dict = defaultdict(float)
+    for r in records:
+        out[r.get("billing_type") or "unknown"] += _f(r.get("cost_usd", 0))
+    return {bt: round(c, 10) for bt, c in out.items()}
+
+
+def _cost_group(records: list) -> dict:
+    """A cost aggregate that NEVER presents a single mixed cash figure (§6): `cost_usd` is the flat
+    total ONLY when billing is single-type, else None; `cost_by_billing` always carries the breakdown."""
+    label = _billing_label(records)
+    return {
+        "cost_usd": _cost(records) if label != "mixed" else None,
+        "billing_type": label,
+        "cost_by_billing": _cost_by_billing(records),
+    }
 
 
 def by_issue(records: list) -> dict:
@@ -109,11 +137,10 @@ def by_issue(records: list) -> dict:
         groups[r.get("task")].append(r)
     return {
         task: {
-            "cost_usd": _cost(rs),
+            **_cost_group(rs),
             "sessions": sorted(
                 {r.get("session_id") for r in rs if r.get("session_id")}
             ),
-            "billing_type": _billing_label(rs),
         }
         for task, rs in groups.items()
     }
@@ -125,10 +152,7 @@ def by_tier(records: list, files_by_task: dict | None = None) -> dict:
     for r in records:
         tier = task_tier(r.get("files_changed", files_by_task.get(r.get("task"))))
         groups[tier].append(r)
-    return {
-        tier: {"cost_usd": _cost(rs), "billing_type": _billing_label(rs)}
-        for tier, rs in groups.items()
-    }
+    return {tier: _cost_group(rs) for tier, rs in groups.items()}
 
 
 def cost_per_pr(records: list, files_by_task: dict) -> dict:
@@ -138,37 +162,48 @@ def cost_per_pr(records: list, files_by_task: dict) -> dict:
     for r in records:
         groups[r.get("task")].append(r)
     for task, rs in groups.items():
-        cost = _cost(rs)
+        grp = _cost_group(rs)
+        cost = grp["cost_usd"]  # None when billing is mixed
         nf = files_by_task.get(task)
+        if cost is None:  # mixed billing → no single cash figure to divide (§6)
+            per_pr = per_file = "mixed"
+        elif nf is None:
+            per_pr = per_file = UNAVAILABLE
+        else:
+            per_pr = cost
+            per_file = round(cost / nf, 10) if nf else UNAVAILABLE
         out[task] = {
-            "cost_usd": cost,
-            "cost_per_pr": cost if nf is not None else UNAVAILABLE,
+            **grp,
+            "cost_per_pr": per_pr,
             "files_changed": nf if nf is not None else UNAVAILABLE,
-            "cost_per_file_changed": round(cost / nf, 10) if nf else UNAVAILABLE,
+            "cost_per_file_changed": per_file,
         }
     return out
 
 
 def model_mix(records: list) -> dict:
-    out: dict = defaultdict(lambda: defaultdict(float))
+    """Per project, cost share by model. Each model leaf carries its own billing_type (a model maps to
+    one provider/account), so no mixed cash sum is hidden (Codex #266)."""
+    groups: dict = defaultdict(lambda: defaultdict(list))
     for r in records:
-        out[r.get("project")][r.get("model")] += float(r.get("cost_usd", 0) or 0)
+        groups[r.get("project")][r.get("model")].append(r)
     return {
-        proj: {m: round(c, 10) for m, c in models.items()}
-        for proj, models in out.items()
+        proj: {m: _cost_group(rs) for m, rs in models.items()}
+        for proj, models in groups.items()
     }
 
 
 def cost_by_model_tier(records: list, files_by_task: dict | None = None) -> dict:
-    """cost-by-(project × tier × model) — the right-sizing breakdown (recommendation is P2 #268)."""
+    """cost-by-(project × tier × model) — the right-sizing breakdown (recommendation is P2 #268).
+    Each leaf is a billing-aware cost group (no silent mixed cash sum)."""
     files_by_task = files_by_task or {}
-    out: dict = defaultdict(lambda: defaultdict(lambda: defaultdict(float)))
+    groups: dict = defaultdict(lambda: defaultdict(lambda: defaultdict(list)))
     for r in records:
         tier = task_tier(r.get("files_changed", files_by_task.get(r.get("task"))))
-        out[r.get("project")][tier][r.get("model")] += float(r.get("cost_usd", 0) or 0)
+        groups[r.get("project")][tier][r.get("model")].append(r)
     return {
-        p: {t: {m: round(c, 10) for m, c in ms.items()} for t, ms in tiers.items()}
-        for p, tiers in out.items()
+        p: {t: {m: _cost_group(rs) for m, rs in ms.items()} for t, ms in tiers.items()}
+        for p, tiers in groups.items()
     }
 
 
@@ -181,7 +216,7 @@ def cache_by_project(records: list) -> dict:
         inp = sum(int(r.get("input", 0) or 0) for r in rs)
         cr = sum(int(r.get("cache_read", 0) or 0) for r in rs)
         res[proj] = {
-            "cost_usd": _cost(rs),
+            **_cost_group(rs),
             "cache_pct": round(cr / (inp + cr), 4) if (inp + cr) else 0.0,
             "cache_saved_usd": round(sum(cache_saved_usd(r) for r in rs), 10),
         }
@@ -217,11 +252,11 @@ def concurrency(records: list) -> dict:
         by_host[r.get("inference_host")][r.get("session_id")].append(r)
     out = {}
     for host, sessions in by_host.items():
-        spans, host_cost = [], 0.0
+        spans = []
         events = []  # (ts, +1/-1) for the sweep
+        host_records = [r for rs in sessions.values() for r in rs]
         for rs in sessions.values():
             ts = [t for t in (_parse_ts(r.get("ts")) for r in rs) if t is not None]
-            host_cost += sum(float(r.get("cost_usd", 0) or 0) for r in rs)
             if ts:
                 s, e = min(ts), max(ts)
                 spans.append((s, e))
@@ -239,17 +274,22 @@ def concurrency(records: list) -> dict:
             peak = max(peak, active)
             prev_t = t
         union_hours = _merge_intervals(spans) / 3600.0
+        grp = _cost_group(host_records)  # cost_usd None when billing is mixed (§6)
+        flat = grp["cost_usd"]
+        if flat is None:
+            burn = "mixed"
+        elif union_hours:
+            burn = round(flat / union_hours, 4)
+        else:
+            burn = UNAVAILABLE
         out[host] = {
             "peak_concurrent_sessions": peak,
-            "cost_usd": round(host_cost, 10),
+            **grp,
             "active_wall_clock_hours": round(union_hours, 4),
-            "burn_rate_usd_per_hour": round(host_cost / union_hours, 4)
-            if union_hours
-            else UNAVAILABLE,
+            "burn_rate_usd_per_hour": burn,
             "host_hours_by_active_count": {
                 str(k): round(v, 4) for k, v in sorted(hours_by_count.items())
             },
-            "billing_type": _billing_label([r for rs in sessions.values() for r in rs]),
         }
     return out
 
@@ -302,11 +342,7 @@ def aggregate(records: list, *, files_by_task: dict | None = None) -> dict:
     files_by_task = files_by_task or {}
     return {
         "schema_version": 1,
-        "totals": {
-            "cost_usd": _cost(records),
-            "records": len(records),
-            "billing_type": _billing_label(records),
-        },
+        "totals": {**_cost_group(records), "records": len(records)},
         "by_issue": by_issue(records),
         "by_tier": by_tier(records, files_by_task),
         "cost_per_pr": cost_per_pr(records, files_by_task),

--- a/claude-config/scripts/usage_aggregator.py
+++ b/claude-config/scripts/usage_aggregator.py
@@ -100,10 +100,12 @@ def _f(v) -> float:
 
 
 def _billing_label(records: list) -> str | None:
-    """Single billing_type across records, else `mixed` (never sum disparate billing types into cash)."""
-    kinds = {r.get("billing_type") for r in records if r.get("billing_type")}
-    if not kinds:
+    """Single billing_type across records, else `mixed`. A MISSING billing_type counts as its own
+    `unknown` kind (Codex #266 re-review) — so {metered + unknown} is `mixed`, never folded into a flat
+    `metered` cash figure. Empty input → None."""
+    if not records:
         return None
+    kinds = {r.get("billing_type") or "unknown" for r in records}
     return next(iter(kinds)) if len(kinds) == 1 else "mixed"
 
 
@@ -215,10 +217,20 @@ def cache_by_project(records: list) -> dict:
     for proj, rs in out.items():
         inp = sum(int(r.get("input", 0) or 0) for r in rs)
         cr = sum(int(r.get("cache_read", 0) or 0) for r in rs)
+        # cache savings is a $ figure too → split by billing; flat only when single-type (Codex #266)
+        saved_by_billing: dict = defaultdict(float)
+        for r in rs:
+            saved_by_billing[r.get("billing_type") or "unknown"] += cache_saved_usd(r)
+        label = _billing_label(rs)
         res[proj] = {
             **_cost_group(rs),
             "cache_pct": round(cr / (inp + cr), 4) if (inp + cr) else 0.0,
-            "cache_saved_usd": round(sum(cache_saved_usd(r) for r in rs), 10),
+            "cache_saved_usd": (
+                round(sum(saved_by_billing.values()), 10) if label != "mixed" else None
+            ),
+            "cache_saved_by_billing": {
+                bt: round(v, 10) for bt, v in saved_by_billing.items()
+            },
         }
     return res
 

--- a/claude-config/scripts/usage_aggregator.py
+++ b/claude-config/scripts/usage_aggregator.py
@@ -1,0 +1,317 @@
+"""Usage aggregator + normalization (fleet-usage-monitor §5, §8 step 5).
+
+Reads all `telemetry/<host>/usage.jsonl` shards (cross-fleet = concatenation; the shard path encodes
+`inference_host`, the record carries `work_host`) and computes the NORMALIZED efficiency metrics — the
+whole point, because raw tokens-by-project is misleading:
+  - $/issue, $/task-tier, and $/PR + $/file-changed (joined from git files-changed; missing → `unavailable`)
+  - cache_read % and $ saved by cache (the biggest lever)
+  - model mix per project + cost-by-(model×tier) (the right-sizing breakdown; the recommendation itself
+    is the P2 #268 item)
+  - concurrency/utilization: peak concurrent sessions, host-hours by active-count, and host burn-rate
+    over the UNION of overlapping session spans (4 parallel ≠ 4× serial wall-clock, §4.4)
+  - billing_type propagated to every aggregate; mixed billing types are labeled `mixed`, NEVER summed
+    into one cash figure (subscription cost is notional value, not dollars, §6)
+
+Output is structured JSON for the Tier-A report generator (#267). Pure given injected records.
+"""
+
+from __future__ import annotations
+
+import glob
+import json
+import subprocess
+import sys
+from collections import defaultdict
+from datetime import datetime
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import otel_sink as O  # noqa: E402
+
+TIER_TRIVIAL, TIER_SIMPLE, TIER_COMPLEX, TIER_UNKNOWN = (
+    "TRIVIAL",
+    "SIMPLE",
+    "COMPLEX",
+    "unknown",
+)
+UNAVAILABLE = "unavailable"
+_TOKEN = ("input", "output", "cache_read", "cache_creation")
+
+
+def _parse_ts(value):
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    try:
+        return datetime.fromisoformat(str(value).replace("Z", "+00:00")).timestamp()
+    except ValueError:
+        return None
+
+
+def read_shards(telemetry_dir) -> list:
+    """All usage records across `telemetry/*/usage.jsonl` (cross-fleet concatenation)."""
+    out = []
+    for path in sorted(glob.glob(str(Path(telemetry_dir) / "*" / "usage.jsonl"))):
+        for line in (
+            Path(path).read_text(encoding="utf-8", errors="ignore").splitlines()
+        ):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                out.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+    return out
+
+
+def task_tier(files_changed) -> str:
+    """File-count band: 1→TRIVIAL, 2-3→SIMPLE, 4+→COMPLEX, unknown when files_changed is absent."""
+    if not isinstance(files_changed, int) or files_changed <= 0:
+        return TIER_UNKNOWN
+    if files_changed == 1:
+        return TIER_TRIVIAL
+    if files_changed <= 3:
+        return TIER_SIMPLE
+    return TIER_COMPLEX
+
+
+def cache_pct(rec: dict) -> float:
+    inp = int(rec.get("input", 0) or 0)
+    cr = int(rec.get("cache_read", 0) or 0)
+    denom = inp + cr
+    return round(cr / denom, 4) if denom else 0.0
+
+
+def cache_saved_usd(rec: dict) -> float:
+    """$ saved by reading from cache vs paying full input price: cache_read_tokens × (input − cache_read price)."""
+    row = O._price_for(rec.get("model", ""))
+    cr = int(rec.get("cache_read", 0) or 0)
+    return round(cr * (row["input"] - row["cache_read"]), 10)
+
+
+def _billing_label(records: list) -> str | None:
+    """Single billing_type across records, else `mixed` (never sum disparate billing types into cash)."""
+    kinds = {r.get("billing_type") for r in records if r.get("billing_type")}
+    if not kinds:
+        return None
+    return next(iter(kinds)) if len(kinds) == 1 else "mixed"
+
+
+def _cost(records: list) -> float:
+    return round(sum(float(r.get("cost_usd", 0) or 0) for r in records), 10)
+
+
+def by_issue(records: list) -> dict:
+    groups = defaultdict(list)
+    for r in records:
+        groups[r.get("task")].append(r)
+    return {
+        task: {
+            "cost_usd": _cost(rs),
+            "sessions": sorted(
+                {r.get("session_id") for r in rs if r.get("session_id")}
+            ),
+            "billing_type": _billing_label(rs),
+        }
+        for task, rs in groups.items()
+    }
+
+
+def by_tier(records: list, files_by_task: dict | None = None) -> dict:
+    files_by_task = files_by_task or {}
+    groups = defaultdict(list)
+    for r in records:
+        tier = task_tier(r.get("files_changed", files_by_task.get(r.get("task"))))
+        groups[tier].append(r)
+    return {
+        tier: {"cost_usd": _cost(rs), "billing_type": _billing_label(rs)}
+        for tier, rs in groups.items()
+    }
+
+
+def cost_per_pr(records: list, files_by_task: dict) -> dict:
+    """$/PR and $/file-changed per task; `unavailable` (not 0) when git files data is missing."""
+    out = {}
+    groups = defaultdict(list)
+    for r in records:
+        groups[r.get("task")].append(r)
+    for task, rs in groups.items():
+        cost = _cost(rs)
+        nf = files_by_task.get(task)
+        out[task] = {
+            "cost_usd": cost,
+            "cost_per_pr": cost if nf is not None else UNAVAILABLE,
+            "files_changed": nf if nf is not None else UNAVAILABLE,
+            "cost_per_file_changed": round(cost / nf, 10) if nf else UNAVAILABLE,
+        }
+    return out
+
+
+def model_mix(records: list) -> dict:
+    out: dict = defaultdict(lambda: defaultdict(float))
+    for r in records:
+        out[r.get("project")][r.get("model")] += float(r.get("cost_usd", 0) or 0)
+    return {
+        proj: {m: round(c, 10) for m, c in models.items()}
+        for proj, models in out.items()
+    }
+
+
+def cost_by_model_tier(records: list, files_by_task: dict | None = None) -> dict:
+    """cost-by-(project × tier × model) — the right-sizing breakdown (recommendation is P2 #268)."""
+    files_by_task = files_by_task or {}
+    out: dict = defaultdict(lambda: defaultdict(lambda: defaultdict(float)))
+    for r in records:
+        tier = task_tier(r.get("files_changed", files_by_task.get(r.get("task"))))
+        out[r.get("project")][tier][r.get("model")] += float(r.get("cost_usd", 0) or 0)
+    return {
+        p: {t: {m: round(c, 10) for m, c in ms.items()} for t, ms in tiers.items()}
+        for p, tiers in out.items()
+    }
+
+
+def cache_by_project(records: list) -> dict:
+    out: dict = defaultdict(list)
+    for r in records:
+        out[r.get("project")].append(r)
+    res = {}
+    for proj, rs in out.items():
+        inp = sum(int(r.get("input", 0) or 0) for r in rs)
+        cr = sum(int(r.get("cache_read", 0) or 0) for r in rs)
+        res[proj] = {
+            "cost_usd": _cost(rs),
+            "cache_pct": round(cr / (inp + cr), 4) if (inp + cr) else 0.0,
+            "cache_saved_usd": round(sum(cache_saved_usd(r) for r in rs), 10),
+        }
+    return res
+
+
+def _merge_intervals(spans: list) -> float:
+    """Total duration (seconds) of the UNION of [start,end] spans — overlaps counted once."""
+    spans = sorted(
+        (s, e) for s, e in spans if s is not None and e is not None and e >= s
+    )
+    if not spans:
+        return 0.0
+    total = 0.0
+    cur_s, cur_e = spans[0]
+    for s, e in spans[1:]:
+        if s <= cur_e:
+            cur_e = max(cur_e, e)
+        else:
+            total += cur_e - cur_s
+            cur_s, cur_e = s, e
+    total += cur_e - cur_s
+    return total
+
+
+def concurrency(records: list) -> dict:
+    """Per inference_host: peak concurrent sessions, host-hours by active-session-count, and burn-rate
+    ($/wall-clock-hour) over the UNION of overlapping session spans (NOT sum of serial wall-clock)."""
+    by_host: dict = defaultdict(
+        lambda: defaultdict(list)
+    )  # host -> session -> [records]
+    for r in records:
+        by_host[r.get("inference_host")][r.get("session_id")].append(r)
+    out = {}
+    for host, sessions in by_host.items():
+        spans, host_cost = [], 0.0
+        events = []  # (ts, +1/-1) for the sweep
+        for rs in sessions.values():
+            ts = [t for t in (_parse_ts(r.get("ts")) for r in rs) if t is not None]
+            host_cost += sum(float(r.get("cost_usd", 0) or 0) for r in rs)
+            if ts:
+                s, e = min(ts), max(ts)
+                spans.append((s, e))
+                events.append((s, 1))
+                events.append((e, -1))
+        # peak concurrency + host-hours by active count via a sweep
+        events.sort()
+        active = peak = 0
+        hours_by_count: dict = defaultdict(float)
+        prev_t = None
+        for t, delta in events:
+            if prev_t is not None and active > 0:
+                hours_by_count[active] += (t - prev_t) / 3600.0
+            active += delta
+            peak = max(peak, active)
+            prev_t = t
+        union_hours = _merge_intervals(spans) / 3600.0
+        out[host] = {
+            "peak_concurrent_sessions": peak,
+            "cost_usd": round(host_cost, 10),
+            "active_wall_clock_hours": round(union_hours, 4),
+            "burn_rate_usd_per_hour": round(host_cost / union_hours, 4)
+            if union_hours
+            else UNAVAILABLE,
+            "host_hours_by_active_count": {
+                str(k): round(v, 4) for k, v in sorted(hours_by_count.items())
+            },
+            "billing_type": _billing_label([r for rs in sessions.values() for r in rs]),
+        }
+    return out
+
+
+def git_files_by_task(repo_dir) -> dict:
+    """Best-effort {`issue:N`: files_changed} from squash-merge commits whose subject ends `(#N)`.
+    Returns {} on any git error (the aggregator then marks $/PR `unavailable`)."""
+    out: dict = {}
+    try:
+        log = subprocess.run(
+            ["git", "-C", str(repo_dir), "log", "--pretty=%H\t%s", "-n", "500"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        return out
+    import re
+
+    for line in log.splitlines():
+        sha, _, subj = line.partition("\t")
+        m = re.search(r"\(#(\d+)\)\s*$", subj)
+        if not m:
+            continue
+        try:
+            files = subprocess.run(
+                [
+                    "git",
+                    "-C",
+                    str(repo_dir),
+                    "show",
+                    "--stat",
+                    "--name-only",
+                    "--format=",
+                    sha,
+                ],
+                capture_output=True,
+                text=True,
+                check=True,
+            ).stdout
+        except (subprocess.CalledProcessError, OSError):
+            continue
+        n = len([line_ for line_ in files.splitlines() if line_.strip()])
+        out.setdefault(f"issue:{m.group(1)}", n)
+    return out
+
+
+def aggregate(records: list, *, files_by_task: dict | None = None) -> dict:
+    """The full structured aggregation (consumed by the #267 report)."""
+    files_by_task = files_by_task or {}
+    return {
+        "schema_version": 1,
+        "totals": {
+            "cost_usd": _cost(records),
+            "records": len(records),
+            "billing_type": _billing_label(records),
+        },
+        "by_issue": by_issue(records),
+        "by_tier": by_tier(records, files_by_task),
+        "cost_per_pr": cost_per_pr(records, files_by_task),
+        "model_mix": model_mix(records),
+        "cost_by_model_tier": cost_by_model_tier(records, files_by_task),
+        "cache_by_project": cache_by_project(records),
+        "concurrency": concurrency(records),
+    }

--- a/claude-config/tests/test_usage_aggregator.py
+++ b/claude-config/tests/test_usage_aggregator.py
@@ -120,6 +120,32 @@ def test_mixed_billing_not_summed():
     assert single["cost_usd"] == 5.0 and single["billing_type"] == "subscription"
 
 
+# missing billing_type counts as a distinct kind → mixed (not folded into a real type) -------------
+def test_missing_billing_is_mixed():
+    recs = [
+        _r(billing_type="metered", session_id="a", cost_usd=2.0),
+        _r(billing_type=None, session_id="b", cost_usd=3.0),
+    ]
+    grp = A.by_issue(recs)["issue:42"]
+    assert grp["billing_type"] == "mixed"  # metered + unknown → mixed, NOT "metered"
+    assert grp["cost_usd"] is None
+    assert grp["cost_by_billing"] == {"metered": 2.0, "unknown": 3.0}
+
+
+# cache_saved_usd is mixed-guarded too -------------------------------------------------------------
+def test_cache_saved_mixed_guard():
+    recs = [
+        _r(billing_type="subscription", session_id="a", cache_read=100_000),
+        _r(billing_type="metered", session_id="b", cache_read=100_000),
+    ]
+    proj = A.cache_by_project(recs)["agents"]
+    assert proj["cache_saved_usd"] is None  # mixed → no single savings figure
+    assert set(proj["cache_saved_by_billing"]) == {"subscription", "metered"}
+    # single-billing project → flat savings present
+    single = A.cache_by_project([_r(cache_read=100_000)])["agents"]
+    assert single["cache_saved_usd"] is not None
+
+
 # malformed cost_usd does not crash aggregation ----------------------------------------------------
 def test_malformed_cost_no_crash():
     recs = [_r(cost_usd="n/a", session_id="a"), _r(cost_usd=2.0, session_id="b")]

--- a/claude-config/tests/test_usage_aggregator.py
+++ b/claude-config/tests/test_usage_aggregator.py
@@ -1,0 +1,172 @@
+"""Acceptance tests for issue #266 — usage aggregator + normalization (§5)."""
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+import usage_aggregator as A  # noqa: E402
+import otel_sink as O  # noqa: E402
+
+
+def _r(**kw):
+    base = {
+        "provider": "claude",
+        "model": "claude-opus-4",
+        "project": "agents",
+        "task": "issue:42",
+        "input": 1000,
+        "output": 100,
+        "cache_read": 0,
+        "cache_creation": 0,
+        "cost_usd": 1.0,
+        "inference_host": "mac",
+        "work_host": "mac",
+        "session_id": "s1",
+        "ts": "2026-06-01T00:00:00Z",
+        "billing_type": "subscription",
+    }
+    base.update(kw)
+    return base
+
+
+# cross-host shards attributed by inference_host -----------------------------------------------------
+def test_read_shards_two_hosts(tmp_path):
+    for host, cost in (("mac", 1.0), ("server", 2.0)):
+        d = tmp_path / host
+        d.mkdir()
+        (d / "usage.jsonl").write_text(
+            json.dumps(_r(inference_host=host, cost_usd=cost)) + "\n"
+        )
+    recs = A.read_shards(tmp_path)
+    assert {r["inference_host"] for r in recs} == {"mac", "server"}
+    assert A._cost(recs) == 3.0
+
+
+# $/issue = sum of the task's records ---------------------------------------------------------------
+def test_cost_per_issue():
+    recs = [
+        _r(cost_usd=1.0, session_id="a"),
+        _r(cost_usd=2.0, session_id="b"),
+        _r(cost_usd=3.0, session_id="c"),
+    ]
+    assert A.by_issue(recs)["issue:42"]["cost_usd"] == 6.0
+
+
+# task_tier bands ----------------------------------------------------------------------------------
+def test_task_tier_bands():
+    assert A.task_tier(1) == A.TIER_TRIVIAL
+    assert A.task_tier(3) == A.TIER_SIMPLE
+    assert A.task_tier(8) == A.TIER_COMPLEX
+    assert A.task_tier(None) == A.TIER_UNKNOWN
+
+
+# cache_pct ----------------------------------------------------------------------------------------
+def test_cache_pct():
+    assert A.cache_pct({"input": 900_000, "cache_read": 100_000}) == 0.10
+
+
+# cache_saved_usd vs full input price --------------------------------------------------------------
+def test_cache_saved_usd():
+    row = O.PRICES["claude-opus-4"]
+    expected = 100_000 * (row["input"] - row["cache_read"])
+    assert A.cache_saved_usd(
+        {"model": "claude-opus-4", "cache_read": 100_000}
+    ) == round(expected, 10)
+
+
+# burn-rate over UNION of overlapping spans, not 2x serial ------------------------------------------
+def test_burn_rate_union_span():
+    # A [00:00,02:00] $10 ; B [01:00,03:00] $10 ; union = 3h → burn = 20/3
+    recs = [
+        _r(session_id="A", ts="2026-06-01T00:00:00Z", cost_usd=5.0),
+        _r(session_id="A", ts="2026-06-01T02:00:00Z", cost_usd=5.0),
+        _r(session_id="B", ts="2026-06-01T01:00:00Z", cost_usd=5.0),
+        _r(session_id="B", ts="2026-06-01T03:00:00Z", cost_usd=5.0),
+    ]
+    c = A.concurrency(recs)["mac"]
+    assert c["active_wall_clock_hours"] == 3.0  # union, not 2+2=4 serial
+    assert round(c["burn_rate_usd_per_hour"], 2) == round(20 / 3, 2)
+
+
+# peak concurrent sessions -------------------------------------------------------------------------
+def test_peak_concurrent():
+    # 3 sessions all overlapping 01:00-01:30
+    recs = []
+    for sid in ("A", "B", "C"):
+        recs.append(_r(session_id=sid, ts="2026-06-01T01:00:00Z"))
+        recs.append(_r(session_id=sid, ts="2026-06-01T02:00:00Z"))
+    assert A.concurrency(recs)["mac"]["peak_concurrent_sessions"] == 3
+
+
+# mixed billing_type labeled mixed, never summed to one cash figure ---------------------------------
+def test_mixed_billing_label():
+    recs = [
+        _r(billing_type="subscription", session_id="a"),
+        _r(billing_type="metered", session_id="b"),
+    ]
+    assert A.by_issue(recs)["issue:42"]["billing_type"] == "mixed"
+    assert A.aggregate(recs)["totals"]["billing_type"] == "mixed"
+
+
+# git join missing → unavailable, not 0 ------------------------------------------------------------
+def test_cost_per_pr_unavailable():
+    recs = [_r(task="issue:99", cost_usd=5.0)]
+    out = A.cost_per_pr(recs, files_by_task={})  # no git data for issue:99
+    assert out["issue:99"]["cost_per_file_changed"] == A.UNAVAILABLE
+    assert out["issue:99"]["cost_per_pr"] == A.UNAVAILABLE
+    # with files data → computed
+    out2 = A.cost_per_pr(recs, files_by_task={"issue:99": 5})
+    assert out2["issue:99"]["cost_per_file_changed"] == 1.0
+
+
+# model mix per project ----------------------------------------------------------------------------
+def test_model_mix():
+    recs = [
+        _r(model="claude-opus-4", cost_usd=10.0),
+        _r(model="gpt-5.5", cost_usd=2.0, provider="codex"),
+    ]
+    mix = A.model_mix(recs)["agents"]
+    assert mix["claude-opus-4"] == 10.0 and mix["gpt-5.5"] == 2.0
+
+
+# full pipeline: two shards → aggregate JSON with all sections --------------------------------------
+def test_integration_aggregate(tmp_path):
+    for host in ("mac", "server"):
+        d = tmp_path / host
+        d.mkdir()
+        (d / "usage.jsonl").write_text(
+            "\n".join(
+                json.dumps(r)
+                for r in [
+                    _r(
+                        inference_host=host,
+                        session_id=f"{host}1",
+                        files_changed=3,
+                        ts="2026-06-01T00:00:00Z",
+                    ),
+                    _r(
+                        inference_host=host,
+                        session_id=f"{host}1",
+                        files_changed=3,
+                        ts="2026-06-01T01:00:00Z",
+                    ),
+                ]
+            )
+        )
+    out = A.aggregate(A.read_shards(tmp_path), files_by_task={"issue:42": 3})
+    for section in (
+        "totals",
+        "by_issue",
+        "by_tier",
+        "cost_per_pr",
+        "model_mix",
+        "cost_by_model_tier",
+        "cache_by_project",
+        "concurrency",
+    ):
+        assert section in out, section
+    assert out["totals"]["records"] == 4
+    assert out["by_tier"]["SIMPLE"]["cost_usd"] == 4.0  # files_changed=3 → SIMPLE
+    assert set(out["concurrency"]) == {"mac", "server"}

--- a/claude-config/tests/test_usage_aggregator.py
+++ b/claude-config/tests/test_usage_aggregator.py
@@ -100,14 +100,32 @@ def test_peak_concurrent():
     assert A.concurrency(recs)["mac"]["peak_concurrent_sessions"] == 3
 
 
-# mixed billing_type labeled mixed, never summed to one cash figure ---------------------------------
-def test_mixed_billing_label():
+# mixed billing_type labeled mixed, NEVER summed to one cash figure --------------------------------
+def test_mixed_billing_not_summed():
     recs = [
-        _r(billing_type="subscription", session_id="a"),
-        _r(billing_type="metered", session_id="b"),
+        _r(billing_type="subscription", session_id="a", cost_usd=3.0),
+        _r(billing_type="metered", session_id="b", cost_usd=2.0),
     ]
-    assert A.by_issue(recs)["issue:42"]["billing_type"] == "mixed"
-    assert A.aggregate(recs)["totals"]["billing_type"] == "mixed"
+    grp = A.by_issue(recs)["issue:42"]
+    assert grp["billing_type"] == "mixed"
+    assert grp["cost_usd"] is None  # no single mixed cash figure
+    assert grp["cost_by_billing"] == {
+        "subscription": 3.0,
+        "metered": 2.0,
+    }  # broken out instead
+    tot = A.aggregate(recs)["totals"]
+    assert tot["cost_usd"] is None and tot["cost_by_billing"]["metered"] == 2.0
+    # single-billing still gets a flat cost_usd
+    single = A.by_issue([_r(cost_usd=5.0)])["issue:42"]
+    assert single["cost_usd"] == 5.0 and single["billing_type"] == "subscription"
+
+
+# malformed cost_usd does not crash aggregation ----------------------------------------------------
+def test_malformed_cost_no_crash():
+    recs = [_r(cost_usd="n/a", session_id="a"), _r(cost_usd=2.0, session_id="b")]
+    assert (
+        A.by_issue(recs)["issue:42"]["cost_usd"] == 2.0
+    )  # bad value coerced to 0, no crash
 
 
 # git join missing → unavailable, not 0 ------------------------------------------------------------
@@ -128,7 +146,9 @@ def test_model_mix():
         _r(model="gpt-5.5", cost_usd=2.0, provider="codex"),
     ]
     mix = A.model_mix(recs)["agents"]
-    assert mix["claude-opus-4"] == 10.0 and mix["gpt-5.5"] == 2.0
+    assert (
+        mix["claude-opus-4"]["cost_usd"] == 10.0 and mix["gpt-5.5"]["cost_usd"] == 2.0
+    )
 
 
 # full pipeline: two shards → aggregate JSON with all sections --------------------------------------


### PR DESCRIPTION
The analytical core (fleet-usage-monitor §5, §8 step 5). Reads telemetry/*/usage.jsonl → normalized metrics: $/issue, $/task-tier, $/PR + $/file-changed (git join; missing→unavailable), cache-% + $ saved, model mix, cost-by-(project×tier×model) right-sizing breakdown, and concurrency/utilization (peak concurrent, burn-rate over UNION of overlapping spans — 4 parallel ≠ 4× serial). billing_type propagated; mixed never summed to one cash figure. 11 tests. Closes #266.

🤖 Generated with [Claude Code](https://claude.com/claude-code)