### PR TITLE
feat(usage): Tier-A static HTML usage report

### DIFF
--- a/claude-config/scripts/usage_aggregator.py
+++ b/claude-config/scripts/usage_aggregator.py
@@ -78,8 +78,8 @@ def task_tier(files_changed) -> str:
 
 
 def cache_pct(rec: dict) -> float:
-    inp = int(rec.get("input", 0) or 0)
-    cr = int(rec.get("cache_read", 0) or 0)
+    inp = _i(rec.get("input"))
+    cr = _i(rec.get("cache_read"))
     denom = inp + cr
     return round(cr / denom, 4) if denom else 0.0
 
@@ -87,7 +87,7 @@ def cache_pct(rec: dict) -> float:
 def cache_saved_usd(rec: dict) -> float:
     """$ saved by reading from cache vs paying full input price: cache_read_tokens × (input − cache_read price)."""
     row = O._price_for(rec.get("model", ""))
-    cr = int(rec.get("cache_read", 0) or 0)
+    cr = _i(rec.get("cache_read"))
     return round(cr * (row["input"] - row["cache_read"]), 10)
 
 
@@ -97,6 +97,14 @@ def _f(v) -> float:
         return float(v)
     except (TypeError, ValueError):
         return 0.0
+
+
+def _i(v) -> int:
+    """Coerce a token count to int; malformed values → 0 (never crash, Codex #267 follow-on)."""
+    try:
+        return int(v)
+    except (TypeError, ValueError):
+        return 0
 
 
 def _billing_label(records: list) -> str | None:
@@ -215,8 +223,8 @@ def cache_by_project(records: list) -> dict:
         out[r.get("project")].append(r)
     res = {}
     for proj, rs in out.items():
-        inp = sum(int(r.get("input", 0) or 0) for r in rs)
-        cr = sum(int(r.get("cache_read", 0) or 0) for r in rs)
+        inp = sum(_i(r.get("input")) for r in rs)
+        cr = sum(_i(r.get("cache_read")) for r in rs)
         # cache savings is a $ figure too → split by billing; flat only when single-type (Codex #266)
         saved_by_billing: dict = defaultdict(float)
         for r in rs:

--- a/claude-config/scripts/usage_report.py
+++ b/claude-config/scripts/usage_report.py
@@ -63,6 +63,19 @@ def _pct(v) -> str:
         return "n/a"
 
 
+def _fnum(v) -> float:
+    """Numeric value or 0.0 — crash-safe coercion for chart/trend math (Codex #267)."""
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+# Cost charts plot API-EQUIVALENT value; subscription is notional (not cash) — labeled in the chart
+# title since a per-bar `*` isn't possible on a canvas (Codex #267, §6).
+_COST_AXIS_TITLE = "API-equivalent $ (subscription = notional, not cash)"
+
+
 def _fmt_cost(grp: dict) -> str:
     """A billing-aware cost cell (PLAIN TEXT). subscription → `$X *` (notional); mixed → each bucket
     broken out with the subscription bucket ALSO marked `*`; metered → `$X`. Crash-safe via _money."""
@@ -104,12 +117,9 @@ def trends(records: list, *, period: str = "week") -> dict:
         cell = out.setdefault(proj, {}).setdefault(
             bucket, {"cost": 0.0, "input": 0, "cache_read": 0}
         )
-        try:
-            cell["cost"] += float(r.get("cost_usd", 0) or 0)
-        except (TypeError, ValueError):
-            pass
-        cell["input"] += int(r.get("input", 0) or 0)
-        cell["cache_read"] += int(r.get("cache_read", 0) or 0)
+        cell["cost"] += _fnum(r.get("cost_usd"))
+        cell["input"] += int(_fnum(r.get("input")))
+        cell["cache_read"] += int(_fnum(r.get("cache_read")))
     for proj, buckets in out.items():
         for b, c in buckets.items():
             denom = c["input"] + c["cache_read"]
@@ -125,7 +135,9 @@ def _right_sizing_callout(agg: dict) -> str:
     for proj, tiers in (agg.get("cost_by_model_tier") or {}).items():
         complex_models = tiers.get("COMPLEX") or {}
         if len(complex_models) >= 2:
-            costs = {m: (g.get("cost_usd") or 0) for m, g in complex_models.items()}
+            costs = {
+                m: _fnum((g or {}).get("cost_usd")) for m, g in complex_models.items()
+            }
             top = max(costs, key=costs.get)
             lines.append(
                 f"{html.escape(str(proj))}: COMPLEX work spans {len(costs)} models "
@@ -253,17 +265,19 @@ table{{border-collapse:collapse;margin:.5rem 0}}th,td{{border:1px solid #ccc;pad
      innerHTML / DOM-injection path; no HTML-tooltip plugin is used), and the embedded blob is
      breakout-escaped by _safe_json — so a malicious project/host/tier name cannot execute (Codex #267 B2). -->
 <script>const D=JSON.parse({json.dumps(data_blob)});
-function line(id,series){{const el=document.getElementById(id);if(!el)return;
+const COST_T={json.dumps(_COST_AXIS_TITLE)};
+function titleOpt(t){{return {{plugins:{{title:{{display:true,text:t}}}}}};}}
+function line(id,series,title){{const el=document.getElementById(id);if(!el)return;
  const labels=[...new Set([].concat(...Object.values(series).map(b=>Object.keys(b))))].sort();
  const ds=Object.entries(series).map(([k,b])=>({{label:k,data:labels.map(l=>(b[l]||{{}}).cost||0)}}));
- if(ds.length)new Chart(el,{{type:'line',data:{{labels,datasets:ds}}}});}}
-try{{line('c_pr_trend',D.trends);
+ if(ds.length)new Chart(el,{{type:'line',data:{{labels,datasets:ds}},options:titleOpt(title)}});}}
+try{{line('c_pr_trend',D.trends,COST_T);
  const ct={{}};for(const[p,b]of Object.entries(D.trends)){{ct[p]={{}};for(const[k,v]of Object.entries(b))ct[p][k]={{cost:v.cache_pct}};}}
- line('c_cache_trend',ct);
+ line('c_cache_trend',ct,'cache read %');
  const te=document.getElementById('c_tier');if(te){{const t=D.by_tier;new Chart(te,{{type:'bar',
-  data:{{labels:Object.keys(t),datasets:[{{label:'cost',data:Object.values(t).map(g=>g.cost_usd||0)}}]}}}});}}
+  data:{{labels:Object.keys(t),datasets:[{{label:'cost',data:Object.values(t).map(g=>g.cost_usd||0)}}]}},options:titleOpt(COST_T)}});}}
  const ce=document.getElementById('c_conc');if(ce){{const c=D.concurrency;new Chart(ce,{{type:'bar',
-  data:{{labels:Object.keys(c),datasets:[{{label:'peak concurrent',data:Object.values(c).map(h=>h.peak_concurrent_sessions||0)}}]}}}});}}
+  data:{{labels:Object.keys(c),datasets:[{{label:'peak concurrent',data:Object.values(c).map(h=>h.peak_concurrent_sessions||0)}}]}},options:titleOpt('peak concurrent sessions')}});}}
 }}catch(e){{console.error(e);}}</script>
 </body></html>"""
 

--- a/claude-config/scripts/usage_report.py
+++ b/claude-config/scripts/usage_report.py
@@ -1,0 +1,289 @@
+"""Tier-A static HTML usage report (fleet-usage-monitor §7, §8 step 6).
+
+Pure RENDERER: reads the aggregator's JSON (#266) and emits a SELF-CONTAINED HTML page (inline data +
+Chart.js from CDN, no server — Tier B FastAPI is the P2 #268 item). Six sections (§7): cost-by-project +
+$/PR trend, model mix + right-sizing callout, cache efficiency trend, by-account/by-computer,
+cost-by-task-tier, concurrency/utilization.
+
+billing_type invariant (§6): subscription `cost_usd` is NOTIONAL API-equivalent value, never cash —
+every subscription figure is marked `*` and a footnote explains; `mixed` figures are shown broken out,
+never as one unlabeled number; `metered` figures are plain dollars.
+
+Time-bucketed trends need the raw records (the aggregate summary collapses time); pass `records=` for
+trends, else those sections show a no-data state. Changing this renderer never touches the collectors
+or aggregator (clean data-layer separation, §7).
+"""
+
+from __future__ import annotations
+
+import html
+import json
+from datetime import datetime
+
+CHARTJS_CDN = "https://cdn.jsdelivr.net/npm/chart.js@4"
+SECTIONS = [
+    ("cost_by_project", "Cost by Project & $/PR Trend"),
+    ("model_mix", "Model Mix & Right-Sizing"),
+    ("cache", "Cache Efficiency"),
+    ("by_account", "By Account & Computer"),
+    ("by_tier", "Cost by Task Tier"),
+    ("concurrency", "Concurrency & Utilization"),
+]
+_NOTIONAL_FOOTNOTE = (
+    "* notional API-equivalent value (subscription billing) — NOT cash paid"
+)
+
+
+def _safe_json(obj) -> str:
+    """JSON safe to embed in a <script> block: escapes the `</` sequence, HTML-comment openers, and
+    the U+2028/U+2029 line separators so a value can never break out of the script element (XSS guard)."""
+    return (
+        json.dumps(obj, default=str)
+        .replace("</", "<\\/")
+        .replace("<!--", "<\\!--")
+        .replace("\u2028", "\\u2028")
+        .replace("\u2029", "\\u2029")
+    )
+
+
+def _fmt_cost(grp: dict) -> str:
+    """A billing-aware cost cell. subscription → `$X *` (notional); mixed → broken out; metered → `$X`."""
+    if not isinstance(grp, dict):
+        return "n/a"
+    bt = grp.get("billing_type")
+    if bt == "mixed":
+        parts = ", ".join(
+            f"{html.escape(str(b))}: ${v:,.2f}"
+            for b, v in (grp.get("cost_by_billing") or {}).items()
+        )
+        return f"mixed ({parts})"
+    c = grp.get("cost_usd")
+    if c is None:
+        return "n/a"
+    return f"${c:,.2f}" + (" *" if bt == "subscription" else "")
+
+
+def _period_key(ts, period: str) -> str | None:
+    try:
+        dt = datetime.fromisoformat(str(ts).replace("Z", "+00:00"))
+    except (ValueError, TypeError):
+        return None
+    if period == "month":
+        return dt.strftime("%Y-%m")
+    iso = dt.isocalendar()
+    return f"{iso[0]}-W{iso[1]:02d}"
+
+
+def trends(records: list, *, period: str = "week") -> dict:
+    """Time-bucketed series from raw records (the aggregate summary has no time axis): per project per
+    bucket → cost (by billing), cache_read %. Used by the $/PR and cache-efficiency trend charts."""
+    out: dict = {}
+    for r in records or []:
+        bucket = _period_key(r.get("ts"), period)
+        if bucket is None:
+            continue
+        proj = r.get("project") or "unknown"
+        cell = out.setdefault(proj, {}).setdefault(
+            bucket, {"cost": 0.0, "input": 0, "cache_read": 0}
+        )
+        try:
+            cell["cost"] += float(r.get("cost_usd", 0) or 0)
+        except (TypeError, ValueError):
+            pass
+        cell["input"] += int(r.get("input", 0) or 0)
+        cell["cache_read"] += int(r.get("cache_read", 0) or 0)
+    for proj, buckets in out.items():
+        for b, c in buckets.items():
+            denom = c["input"] + c["cache_read"]
+            c["cache_pct"] = round(c["cache_read"] / denom, 4) if denom else 0.0
+            c["cost"] = round(c["cost"], 6)
+    return out
+
+
+def _right_sizing_callout(agg: dict) -> str:
+    """Cost-only right-sizing hint (rework companion is P2 #268): for each project's COMPLEX tier, if a
+    cheaper model also appears, note the cheaper-model share."""
+    lines = []
+    for proj, tiers in (agg.get("cost_by_model_tier") or {}).items():
+        complex_models = tiers.get("COMPLEX") or {}
+        if len(complex_models) >= 2:
+            costs = {m: (g.get("cost_usd") or 0) for m, g in complex_models.items()}
+            top = max(costs, key=costs.get)
+            lines.append(
+                f"{html.escape(str(proj))}: COMPLEX work spans {len(costs)} models "
+                f"(most spend on {html.escape(str(top))}) — review if a cheaper tier suffices."
+            )
+    return (
+        "<br>".join(lines)
+        if lines
+        else "No multi-model COMPLEX tiers to right-size yet."
+    )
+
+
+def _table(headers: list, rows: list) -> str:
+    if not rows:
+        return '<p class="nodata">no data</p>'
+    th = "".join(f"<th>{html.escape(str(h))}</th>" for h in headers)
+    trs = "".join(
+        "<tr>" + "".join(f"<td>{c}</td>" for c in row) + "</tr>" for row in rows
+    )
+    return f"<table><thead><tr>{th}</tr></thead><tbody>{trs}</tbody></table>"
+
+
+def render_html(
+    agg: dict,
+    *,
+    records: list | None = None,
+    period: str = "week",
+    title: str = "Fleet Usage Report",
+) -> str:
+    agg = agg or {}
+    tr = trends(records or [], period=period)
+    totals = agg.get("totals") or {}
+    has_subscription = "subscription" in json.dumps(agg)
+
+    # Section 1: cost by project (table) — $/PR trend chart fed by `tr`
+    proj_rows = [
+        [html.escape(str(p)), _fmt_cost(_proj_group(agg, p))] for p in _projects(agg)
+    ]
+    s1 = (
+        f"<h2 id='cost_by_project'>{SECTIONS[0][1]}</h2>"
+        + _table(["Project", "Cost"], proj_rows)
+        + "<canvas id='c_pr_trend'></canvas>"
+    )
+    # Section 2: model mix + right-sizing
+    mm_rows = [
+        [html.escape(str(p)), html.escape(str(m)), _fmt_cost(g)]
+        for p, models in (agg.get("model_mix") or {}).items()
+        for m, g in models.items()
+    ]
+    s2 = (
+        f"<h2 id='model_mix'>{SECTIONS[1][1]}</h2>"
+        + _table(["Project", "Model", "Cost"], mm_rows)
+        + f"<p class='callout'>{_right_sizing_callout(agg)}</p>"
+    )
+    # Section 3: cache efficiency (table + trend chart)
+    cache_rows = [
+        [
+            html.escape(str(p)),
+            f"{(c.get('cache_pct') or 0) * 100:.1f}%",
+            (
+                "n/a"
+                if c.get("cache_saved_usd") is None
+                else f"${c['cache_saved_usd']:,.2f}"
+            ),
+        ]
+        for p, c in (agg.get("cache_by_project") or {}).items()
+    ]
+    s3 = (
+        f"<h2 id='cache'>{SECTIONS[2][1]}</h2>"
+        + _table(["Project", "cache %", "$ saved"], cache_rows)
+        + "<canvas id='c_cache_trend'></canvas>"
+    )
+    # Section 4: by account / by computer
+    s4 = (
+        f"<h2 id='by_account'>{SECTIONS[3][1]}</h2>"
+        + "<h3>By account</h3>"
+        + _table(["Account", "Cost"], _dim_rows(records, "account"))
+        + "<h3>By inference host</h3>"
+        + _table(["Host", "Cost"], _dim_rows(records, "inference_host"))
+        + "<h3>By work host</h3>"
+        + _table(["Host", "Cost"], _dim_rows(records, "work_host"))
+    )
+    # Section 5: cost by tier
+    tier_rows = [
+        [html.escape(str(t)), _fmt_cost(g)]
+        for t, g in (agg.get("by_tier") or {}).items()
+    ]
+    s5 = (
+        f"<h2 id='by_tier'>{SECTIONS[4][1]}</h2>"
+        + _table(["Tier", "Cost"], tier_rows)
+        + "<canvas id='c_tier'></canvas>"
+    )
+    # Section 6: concurrency
+    conc_rows = [
+        [
+            html.escape(str(h)),
+            c.get("peak_concurrent_sessions", 0),
+            (c.get("burn_rate_usd_per_hour")),
+        ]
+        for h, c in (agg.get("concurrency") or {}).items()
+    ]
+    s6 = (
+        f"<h2 id='concurrency'>{SECTIONS[5][1]}</h2>"
+        + _table(["Host", "peak concurrent", "burn $/hr"], conc_rows)
+        + "<canvas id='c_conc'></canvas>"
+    )
+
+    footnote = (
+        f"<p class='footnote'>{_NOTIONAL_FOOTNOTE}</p>" if has_subscription else ""
+    )
+    data_blob = _safe_json(
+        {
+            "trends": tr,
+            "by_tier": agg.get("by_tier") or {},
+            "concurrency": agg.get("concurrency") or {},
+        }
+    )
+    return f"""<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf-8"><title>{html.escape(title)}</title>
+<script src="{CHARTJS_CDN}"></script>
+<style>body{{font-family:system-ui,sans-serif;margin:2rem;max-width:1100px}}
+table{{border-collapse:collapse;margin:.5rem 0}}th,td{{border:1px solid #ccc;padding:.3rem .6rem}}
+.nodata{{color:#999;font-style:italic}}.footnote{{color:#666;font-size:.85rem;margin-top:2rem}}
+.callout{{background:#f5f7ff;padding:.6rem;border-left:3px solid #36c}}canvas{{max-height:320px}}</style>
+</head><body>
+<h1>{html.escape(title)}</h1>
+<p>Total: {_fmt_cost(totals)} &middot; {totals.get("records", 0)} records</p>
+{s1}{s2}{s3}{s4}{s5}{s6}
+{footnote}
+<script>const D=JSON.parse({json.dumps(data_blob)});
+function line(id,series){{const el=document.getElementById(id);if(!el)return;
+ const labels=[...new Set([].concat(...Object.values(series).map(b=>Object.keys(b))))].sort();
+ const ds=Object.entries(series).map(([k,b])=>({{label:k,data:labels.map(l=>(b[l]||{{}}).cost||0)}}));
+ if(ds.length)new Chart(el,{{type:'line',data:{{labels,datasets:ds}}}});}}
+try{{line('c_pr_trend',D.trends);
+ const ct={{}};for(const[p,b]of Object.entries(D.trends)){{ct[p]={{}};for(const[k,v]of Object.entries(b))ct[p][k]={{cost:v.cache_pct}};}}
+ line('c_cache_trend',ct);
+ const te=document.getElementById('c_tier');if(te){{const t=D.by_tier;new Chart(te,{{type:'bar',
+  data:{{labels:Object.keys(t),datasets:[{{label:'cost',data:Object.values(t).map(g=>g.cost_usd||0)}}]}}}});}}
+ const ce=document.getElementById('c_conc');if(ce){{const c=D.concurrency;new Chart(ce,{{type:'bar',
+  data:{{labels:Object.keys(c),datasets:[{{label:'peak concurrent',data:Object.values(c).map(h=>h.peak_concurrent_sessions||0)}}]}}}});}}
+}}catch(e){{console.error(e);}}</script>
+</body></html>"""
+
+
+def _projects(agg: dict) -> list:
+    s = set((agg.get("model_mix") or {})) | set((agg.get("cache_by_project") or {}))
+    return sorted(str(p) for p in s)
+
+
+def _proj_group(agg: dict, project: str) -> dict:
+    return (agg.get("cache_by_project") or {}).get(project, {})
+
+
+def _dim_rows(records: list | None, field: str) -> list:
+    from collections import defaultdict
+
+    groups = defaultdict(list)
+    for r in records or []:
+        groups[r.get(field)].append(r)
+    rows = []
+    for key, rs in sorted(groups.items(), key=lambda kv: str(kv[0])):
+        from importlib import import_module
+
+        agg_mod = import_module("usage_aggregator")
+        rows.append([html.escape(str(key)), _fmt_cost(agg_mod._cost_group(rs))])
+    return rows
+
+
+def write_report(
+    agg: dict, out_path, *, records: list | None = None, period: str = "week"
+) -> str:
+    from pathlib import Path
+
+    html_str = render_html(agg, records=records, period=period)
+    p = Path(out_path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(html_str, encoding="utf-8")
+    return str(p)

--- a/claude-config/scripts/usage_report.py
+++ b/claude-config/scripts/usage_report.py
@@ -46,21 +46,39 @@ def _safe_json(obj) -> str:
     )
 
 
+def _money(v) -> str:
+    """`$X.XX` for a numeric value, else `n/a` — never crashes on a malformed cost field (Codex #267).
+    Returns PLAIN TEXT (no HTML); `_table` escapes cells, so callers must not pre-escape."""
+    try:
+        return f"${float(v):,.2f}"
+    except (TypeError, ValueError):
+        return "n/a"
+
+
+def _pct(v) -> str:
+    """`X.X%` for a numeric fraction, else `n/a` — crash-safe (Codex #267)."""
+    try:
+        return f"{float(v) * 100:.1f}%"
+    except (TypeError, ValueError):
+        return "n/a"
+
+
 def _fmt_cost(grp: dict) -> str:
-    """A billing-aware cost cell. subscription → `$X *` (notional); mixed → broken out; metered → `$X`."""
+    """A billing-aware cost cell (PLAIN TEXT). subscription → `$X *` (notional); mixed → each bucket
+    broken out with the subscription bucket ALSO marked `*`; metered → `$X`. Crash-safe via _money."""
     if not isinstance(grp, dict):
         return "n/a"
     bt = grp.get("billing_type")
     if bt == "mixed":
         parts = ", ".join(
-            f"{html.escape(str(b))}: ${v:,.2f}"
+            f"{b}: {_money(v)}" + (" *" if b == "subscription" else "")
             for b, v in (grp.get("cost_by_billing") or {}).items()
         )
         return f"mixed ({parts})"
     c = grp.get("cost_usd")
-    if c is None:
+    if not isinstance(c, (int, float)):
         return "n/a"
-    return f"${c:,.2f}" + (" *" if bt == "subscription" else "")
+    return _money(c) + (" *" if bt == "subscription" else "")
 
 
 def _period_key(ts, period: str) -> str | None:
@@ -121,11 +139,14 @@ def _right_sizing_callout(agg: dict) -> str:
 
 
 def _table(headers: list, rows: list) -> str:
+    """Render a table. EVERY cell + header is html.escaped here (single, consistent escaping layer,
+    Codex #267) — callers pass RAW values (incl. _fmt_cost plain text); no caller pre-escaping."""
     if not rows:
         return '<p class="nodata">no data</p>'
     th = "".join(f"<th>{html.escape(str(h))}</th>" for h in headers)
     trs = "".join(
-        "<tr>" + "".join(f"<td>{c}</td>" for c in row) + "</tr>" for row in rows
+        "<tr>" + "".join(f"<td>{html.escape(str(c))}</td>" for c in row) + "</tr>"
+        for row in rows
     )
     return f"<table><thead><tr>{th}</tr></thead><tbody>{trs}</tbody></table>"
 
@@ -142,10 +163,8 @@ def render_html(
     totals = agg.get("totals") or {}
     has_subscription = "subscription" in json.dumps(agg)
 
-    # Section 1: cost by project (table) — $/PR trend chart fed by `tr`
-    proj_rows = [
-        [html.escape(str(p)), _fmt_cost(_proj_group(agg, p))] for p in _projects(agg)
-    ]
+    # Section 1: cost by project (table) — $/PR trend chart fed by `tr`. _table escapes cells (raw in).
+    proj_rows = [[p, _fmt_cost(_proj_group(agg, p))] for p in _projects(agg)]
     s1 = (
         f"<h2 id='cost_by_project'>{SECTIONS[0][1]}</h2>"
         + _table(["Project", "Cost"], proj_rows)
@@ -153,7 +172,7 @@ def render_html(
     )
     # Section 2: model mix + right-sizing
     mm_rows = [
-        [html.escape(str(p)), html.escape(str(m)), _fmt_cost(g)]
+        [p, m, _fmt_cost(g)]
         for p, models in (agg.get("model_mix") or {}).items()
         for m, g in models.items()
     ]
@@ -162,15 +181,15 @@ def render_html(
         + _table(["Project", "Model", "Cost"], mm_rows)
         + f"<p class='callout'>{_right_sizing_callout(agg)}</p>"
     )
-    # Section 3: cache efficiency (table + trend chart)
+    # Section 3: cache efficiency (table + trend chart). _pct/_money are crash-safe on malformed data.
     cache_rows = [
         [
-            html.escape(str(p)),
-            f"{(c.get('cache_pct') or 0) * 100:.1f}%",
+            p,
+            _pct(c.get("cache_pct")),
             (
                 "n/a"
                 if c.get("cache_saved_usd") is None
-                else f"${c['cache_saved_usd']:,.2f}"
+                else _money(c.get("cache_saved_usd"))
             ),
         ]
         for p, c in (agg.get("cache_by_project") or {}).items()
@@ -190,11 +209,8 @@ def render_html(
         + "<h3>By work host</h3>"
         + _table(["Host", "Cost"], _dim_rows(records, "work_host"))
     )
-    # Section 5: cost by tier
-    tier_rows = [
-        [html.escape(str(t)), _fmt_cost(g)]
-        for t, g in (agg.get("by_tier") or {}).items()
-    ]
+    # Section 5: cost by tier (raw cells; _table escapes)
+    tier_rows = [[t, _fmt_cost(g)] for t, g in (agg.get("by_tier") or {}).items()]
     s5 = (
         f"<h2 id='by_tier'>{SECTIONS[4][1]}</h2>"
         + _table(["Tier", "Cost"], tier_rows)
@@ -202,11 +218,7 @@ def render_html(
     )
     # Section 6: concurrency
     conc_rows = [
-        [
-            html.escape(str(h)),
-            c.get("peak_concurrent_sessions", 0),
-            (c.get("burn_rate_usd_per_hour")),
-        ]
+        [h, c.get("peak_concurrent_sessions", 0), c.get("burn_rate_usd_per_hour")]
         for h, c in (agg.get("concurrency") or {}).items()
     ]
     s6 = (
@@ -234,9 +246,12 @@ table{{border-collapse:collapse;margin:.5rem 0}}th,td{{border:1px solid #ccc;pad
 .callout{{background:#f5f7ff;padding:.6rem;border-left:3px solid #36c}}canvas{{max-height:320px}}</style>
 </head><body>
 <h1>{html.escape(title)}</h1>
-<p>Total: {_fmt_cost(totals)} &middot; {totals.get("records", 0)} records</p>
+<p>Total: {html.escape(_fmt_cost(totals))} &middot; {html.escape(str(totals.get("records", 0)))} records</p>
 {s1}{s2}{s3}{s4}{s5}{s6}
 {footnote}
+<!-- Chart labels are data-derived strings, but Chart.js renders them on the CANVAS as text (no
+     innerHTML / DOM-injection path; no HTML-tooltip plugin is used), and the embedded blob is
+     breakout-escaped by _safe_json — so a malicious project/host/tier name cannot execute (Codex #267 B2). -->
 <script>const D=JSON.parse({json.dumps(data_blob)});
 function line(id,series){{const el=document.getElementById(id);if(!el)return;
  const labels=[...new Set([].concat(...Object.values(series).map(b=>Object.keys(b))))].sort();
@@ -268,12 +283,14 @@ def _dim_rows(records: list | None, field: str) -> list:
     groups = defaultdict(list)
     for r in records or []:
         groups[r.get(field)].append(r)
+    from importlib import import_module
+
+    agg_mod = import_module("usage_aggregator")
     rows = []
     for key, rs in sorted(groups.items(), key=lambda kv: str(kv[0])):
-        from importlib import import_module
-
-        agg_mod = import_module("usage_aggregator")
-        rows.append([html.escape(str(key)), _fmt_cost(agg_mod._cost_group(rs))])
+        rows.append(
+            [key, _fmt_cost(agg_mod._cost_group(rs))]
+        )  # raw; _table escapes cells
     return rows
 
 

--- a/claude-config/tests/test_usage_report.py
+++ b/claude-config/tests/test_usage_report.py
@@ -65,8 +65,9 @@ def test_metered_not_starred():
     html = R.render_html(A.aggregate([_rec(billing_type="metered", cost_usd=2.0)]))
     assert (
         "$2.00" in html and "$2.00 *" not in html
-    )  # metered cash is not marked notional
-    assert "notional" not in html  # no subscription anywhere → no footnote
+    )  # metered cash is not starred
+    assert R._NOTIONAL_FOOTNOTE not in html  # no subscription → no notional footnote
+    # (the cost-chart axis title carries a general notional caveat — that's expected, not the footnote)
 
 
 # mixed billing → both labeled, never a single unlabeled figure ------------------------------------

--- a/claude-config/tests/test_usage_report.py
+++ b/claude-config/tests/test_usage_report.py
@@ -77,7 +77,33 @@ def test_mixed_billing_labeled():
     ]
     html = R.render_html(A.aggregate(recs))
     assert "mixed (" in html  # broken out, not summed
-    assert "subscription: $3.00" in html and "metered: $2.00" in html
+    # subscription bucket inside mixed is ALSO marked notional (*); metered is plain
+    assert "subscription: $3.00 *" in html and "metered: $2.00" in html
+
+
+# malformed numeric fields render safely, never crash ----------------------------------------------
+def test_malformed_fields_no_crash():
+    # a malicious/malformed cost_usd must not crash AND must not inject HTML
+    agg = {
+        "totals": {
+            "cost_usd": "</script><img onerror=alert(1)>",
+            "billing_type": "metered",
+            "records": 1,
+        },
+        "by_issue": {},
+        "by_tier": {"SIMPLE": {"cost_usd": "n/a", "billing_type": "metered"}},
+        "cost_per_pr": {},
+        "model_mix": {},
+        "cost_by_model_tier": {},
+        "cache_by_project": {
+            "p": {"cache_pct": "bad", "cache_saved_usd": "x", "billing_type": "metered"}
+        },
+        "concurrency": {},
+    }
+    html = R.render_html(agg)  # must not raise
+    assert _parses(html)
+    assert "n/a" in html  # malformed cost rendered as n/a
+    assert "</script><img" not in html  # not injected
 
 
 # zero records → no crash, no-data states ----------------------------------------------------------

--- a/claude-config/tests/test_usage_report.py
+++ b/claude-config/tests/test_usage_report.py
@@ -1,0 +1,155 @@
+"""Acceptance tests for issue #267 — Tier-A static HTML usage report (§7)."""
+
+import sys
+from html.parser import HTMLParser
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+import usage_report as R  # noqa: E402
+import usage_aggregator as A  # noqa: E402
+
+
+def _rec(**kw):
+    base = {
+        "provider": "claude",
+        "model": "claude-opus-4",
+        "project": "agents",
+        "task": "issue:42",
+        "input": 900_000,
+        "output": 1000,
+        "cache_read": 100_000,
+        "cache_creation": 0,
+        "cost_usd": 2.0,
+        "inference_host": "mac",
+        "work_host": "mac",
+        "session_id": "s1",
+        "ts": "2026-06-01T00:00:00Z",
+        "billing_type": "subscription",
+        "files_changed": 3,
+    }
+    base.update(kw)
+    return base
+
+
+def _parses(html: str) -> bool:
+    HTMLParser().feed(html)  # raises on nothing-fatal; structural sanity
+    return (
+        "<!DOCTYPE html>" in html
+        and html.count("<body>") == 1
+        and html.count("</body>") == 1
+    )
+
+
+# all six section headers present -------------------------------------------------------------------
+def test_six_sections():
+    agg = A.aggregate(
+        [_rec(model="claude-opus-4"), _rec(model="claude-haiku-4", session_id="s2")],
+        files_by_task={"issue:42": 3},
+    )
+    html = R.render_html(agg)
+    for sid, _ in R.SECTIONS:
+        assert f"id='{sid}'" in html, sid
+    assert _parses(html)
+
+
+# subscription → notional annotation -----------------------------------------------------------------
+def test_subscription_notional_labeled():
+    html = R.render_html(A.aggregate([_rec(billing_type="subscription")]))
+    assert "notional" in html  # footnote present
+    assert "$2.00 *" in html  # the subscription figure is starred
+
+
+# metered → plain, no notional star next to it -----------------------------------------------------
+def test_metered_not_starred():
+    html = R.render_html(A.aggregate([_rec(billing_type="metered", cost_usd=2.0)]))
+    assert (
+        "$2.00" in html and "$2.00 *" not in html
+    )  # metered cash is not marked notional
+    assert "notional" not in html  # no subscription anywhere → no footnote
+
+
+# mixed billing → both labeled, never a single unlabeled figure ------------------------------------
+def test_mixed_billing_labeled():
+    recs = [
+        _rec(billing_type="subscription", cost_usd=3.0, session_id="a"),
+        _rec(billing_type="metered", cost_usd=2.0, session_id="b"),
+    ]
+    html = R.render_html(A.aggregate(recs))
+    assert "mixed (" in html  # broken out, not summed
+    assert "subscription: $3.00" in html and "metered: $2.00" in html
+
+
+# zero records → no crash, no-data states ----------------------------------------------------------
+def test_zero_records():
+    html = R.render_html(A.aggregate([]))
+    assert _parses(html)
+    assert "no data" in html
+    for sid, _ in R.SECTIONS:
+        assert f"id='{sid}'" in html
+
+
+# cache_pct 0.10 surfaces in the cache section -----------------------------------------------------
+def test_cache_pct_rendered():
+    # input 900k + cache_read 100k → 10%
+    html = R.render_html(A.aggregate([_rec(input=900_000, cache_read=100_000)]))
+    assert "10.0%" in html
+
+
+# two hosts with overlapping sessions → per-host peak in concurrency --------------------------------
+def test_concurrency_per_host():
+    recs = []
+    for host in ("mac", "server"):
+        for sid in ("A", "B"):  # two overlapping sessions per host
+            recs.append(
+                _rec(
+                    inference_host=host,
+                    session_id=f"{host}{sid}",
+                    ts="2026-06-01T01:00:00Z",
+                )
+            )
+            recs.append(
+                _rec(
+                    inference_host=host,
+                    session_id=f"{host}{sid}",
+                    ts="2026-06-01T02:00:00Z",
+                )
+            )
+    agg = A.aggregate(recs)
+    assert agg["concurrency"]["mac"]["peak_concurrent_sessions"] == 2
+    html = R.render_html(agg)
+    assert "id='concurrency'" in html and "mac" in html and "server" in html
+
+
+# XSS guard: a malicious string in data cannot break out of the <script> block ----------------------
+def test_xss_guard():
+    html = R.render_html(
+        A.aggregate([_rec(project="</script><img src=x onerror=alert(1)>")])
+    )
+    assert (
+        "</script><img" not in html
+    )  # escaped in both the table (html.escape) and the JSON blob
+
+
+# integration: aggregator fixture → file on disk → valid HTML --------------------------------------
+def test_integration_write_report(tmp_path):
+    recs = [
+        _rec(files_changed=3),
+        _rec(
+            project="buddy",
+            model="gpt-5.5",
+            provider="codex",
+            billing_type="metered",
+            cost_usd=0.1,
+            session_id="s9",
+            ts="2026-06-08T00:00:00Z",
+            files_changed=1,
+            task="issue:9",
+        ),
+    ]
+    agg = A.aggregate(recs, files_by_task={"issue:42": 3, "issue:9": 1})
+    out = tmp_path / "reports" / "usage.html"
+    path = R.write_report(agg, out, records=recs)
+    written = Path(path).read_text()
+    assert _parses(written)
+    assert "Cost by Project" in written and "Concurrency" in written


### PR DESCRIPTION
The deliverable (fleet-usage-monitor §7, §8 step 6). Self-contained HTML (inline data + Chart.js CDN) from the #266 aggregator JSON. Six sections; subscription figures marked notional (`*` + footnote), mixed broken out, metered plain $. XSS-guarded embedded JSON (escapes </, <!--, U+2028/9) + html.escaped cells. Trends from raw records; zero-records → no-data, no crash. 9 tests. Closes #267.

🤖 Generated with [Claude Code](https://claude.com/claude-code)