### PR TITLE
Fix Codex global config and rules

### DIFF
--- a/codex-config/AGENTS.md
+++ b/codex-config/AGENTS.md
@@ -1,0 +1,62 @@
+# Jason's Codex Global Guidance
+
+This file is the shared global instruction surface for Codex. It is installed
+to `~/.codex/AGENTS.md` by `codex-config/install.sh`.
+
+## Operating Role
+
+Use Codex as a pragmatic implementation and adversarial review partner.
+Default to editing code when the user asks for a fix, but preserve user work
+and verify behavior before declaring completion.
+
+## Quality Bar
+
+- Read the actual files before making assumptions about APIs, enums, schemas,
+  or component props.
+- Prefer small, intentional diffs over broad rewrites.
+- Keep one logical change per branch or pull request.
+- Run the narrowest useful checks first, then the full relevant gate before
+  handoff.
+- Treat tool failures, skipped tests, and missing dependencies as explicit
+  risks, not success.
+
+## High-Frequency Failure Checks
+
+- `VERIFICATION_GAP`: Do not infer code structure from memory. Inspect source.
+- `ENUM_VALUE`: For fullstack enum, status, or role fields, use backend enum
+  values, not Python or TypeScript names.
+- `COMPONENT_API`: Before reusing a UI component or hook, read its source,
+  types, or PropTypes.
+- `MODEL_WITHOUT_MIGRATION`: SQLAlchemy or persistence-model changes require a
+  migration or an explicit reason.
+- `AUTH_DEPENDENCY_MISSING`: New write endpoints need auth and permission
+  checks.
+- `SECRETS_IN_CODE`: Never read, print, edit, or commit secrets or `.env`
+  files.
+
+## Verification Gates
+
+- Backend: `cd backend && ruff check . && pytest -q`
+- Frontend: `cd frontend && npm run lint && npm run build`
+- Config/tooling: run the repository-specific test or validation script when
+  present.
+- If a gate cannot run, state exactly why and what remains unverified.
+
+## Claude And Codex Workflow
+
+- Claude is currently the preferred conductor for `/orchestrate`, issue
+  routing, and Claude-specific artifact generation.
+- Codex is preferred for direct implementation, local test/debug loops, and
+  adversarial reviews.
+- For complex work, use issue artifacts or plans as shared context. Keep
+  Codex findings tied to concrete changed code, tests, contracts, or security
+  risk.
+- Feed recurring Codex review findings back into shared instructions,
+  project `AGENTS.md`, or Claude learning rules as appropriate.
+
+## Git Safety
+
+- Never use `git reset --hard`, `git checkout -- <file>`, force-push, or
+  destructive cleanup unless explicitly requested.
+- Do not bypass hooks with `--no-verify` unless explicitly authorized.
+- Before commit or PR work, check branch and status.

--- a/codex-config/README.md
+++ b/codex-config/README.md
@@ -1,6 +1,9 @@
 # Codex Configuration
 
-Portable Codex configuration that can be installed on any machine. Uses symlinks from `~/.codex` to this repo for shared rules and user skills while preserving local auth/history/sessions and machine-specific approval rules.
+Portable Codex configuration that can be installed on any machine. Uses
+symlinks from `~/.codex` to this repo for shared Codex guidance, shared
+command-policy rules, and user skills while preserving local
+auth/history/sessions and machine-specific approval rules.
 
 ## Installation
 
@@ -15,9 +18,13 @@ git clone https://github.com/jwj2002/agents.git ~/agents
 ## What It Links
 
 ```text
+~/.codex/AGENTS.md               -> ~/agents/codex-config/AGENTS.md
 ~/.codex/rules/shared.rules      -> ~/agents/codex-config/rules/shared.rules
 ~/.codex/skills/user             -> ~/agents/codex-config/skills/
 ```
+
+`AGENTS.md` is the behavioral instruction surface. `.rules` files are Codex
+command-policy files written in Starlark; do not put prose instructions there.
 
 ## What Stays Local
 

--- a/codex-config/install.sh
+++ b/codex-config/install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Install Codex configuration: shared rules and user skills symlinks.
+# Install Codex configuration: shared guidance, rules, and user skills symlinks.
 #
 # Usage: ./install.sh
 #
@@ -53,6 +53,7 @@ echo ""
 echo "Phase 1: Symlinks"
 mkdir -p "$CODEX_DIR" "$CODEX_DIR/rules" "$CODEX_DIR/skills"
 
+link_item "$SCRIPT_DIR/AGENTS.md" "$CODEX_DIR/AGENTS.md" "AGENTS.md"
 link_item "$SCRIPT_DIR/rules/shared.rules" "$CODEX_DIR/rules/shared.rules" "rules/shared.rules"
 link_item "$SCRIPT_DIR/skills" "$CODEX_DIR/skills/user" "skills/user"
 
@@ -120,7 +121,7 @@ echo ""
 echo "Phase 3: Verify"
 ERRORS=0
 
-for target in "$CODEX_DIR/rules/shared.rules" "$CODEX_DIR/skills/user"; do
+for target in "$CODEX_DIR/AGENTS.md" "$CODEX_DIR/rules/shared.rules" "$CODEX_DIR/skills/user"; do
     if [ -L "$target" ] && [ -e "$target" ]; then
         :
     else
@@ -139,6 +140,7 @@ echo "  Symlinks:    ✓ $LINKS_TOTAL/$LINKS_TOTAL linked"
 echo "  Claude→Codex: $SKILLS_PORTED skill(s) shared, $SKILLS_SKIPPED skipped (Claude-only)"
 echo "  Notes:       ~/.codex/skills/.system remains local and untouched"
 echo "               ~/.codex/rules/default.rules remains local (machine approvals)"
+echo "               ~/.codex/AGENTS.md is shared Codex guidance"
 
 if [ "$BACKUP_CREATED" = true ]; then
     echo "  Backups:     $BACKUP_DIR"

--- a/codex-config/rules/shared.rules
+++ b/codex-config/rules/shared.rules
@@ -1,45 +1,9 @@
-# Shared Codex rules tracked in git.
-# Keep machine-specific approvals in ~/.codex/rules/default.rules.
-
-## Operating Role
-
-Use Codex as a pragmatic implementation and adversarial review partner.
-Default to editing code when the user asks for a fix, but preserve user work
-and verify behavior before declaring completion.
-
-## Quality Bar
-
-- Read the actual files before making assumptions about APIs, enums, schemas, or component props.
-- Prefer small, intentional diffs over broad rewrites.
-- Keep one logical change per branch/PR.
-- Run the narrowest useful checks first, then the full relevant gate before handoff.
-- Treat tool failures, skipped tests, and missing dependencies as explicit risks, not success.
-
-## High-Frequency Failure Checks
-
-- `VERIFICATION_GAP`: Do not infer code structure from memory. Inspect source.
-- `ENUM_VALUE`: For fullstack enum/status/role fields, use backend enum values, not Python/TypeScript names.
-- `COMPONENT_API`: Before reusing a UI component or hook, read its source/types/PropTypes.
-- `MODEL_WITHOUT_MIGRATION`: SQLAlchemy/model persistence changes require a migration or an explicit reason.
-- `AUTH_DEPENDENCY_MISSING`: New write endpoints need auth/permission checks.
-- `SECRETS_IN_CODE`: Never read, print, edit, or commit secrets or `.env` files.
-
-## Verification Gates
-
-- Backend: `cd backend && ruff check . && pytest -q`
-- Frontend: `cd frontend && npm run lint && npm run build`
-- Config/tooling: run the repository-specific test or validation script when present.
-- If a gate cannot run, state exactly why and what remains unverified.
-
-## Claude + Codex Workflow
-
-- Claude is the preferred conductor for `/orchestrate`, issue routing, and artifact generation.
-- Codex is preferred for direct implementation, local test/debug loops, and adversarial reviews.
-- For complex work, ask Claude to produce MAP/PLAN, have Codex review the plan for gaps, implement, then have Codex review the diff before Claude runs PROVE.
-- Feed recurring Codex review findings back into Claude learning rules or project `CLAUDE.md`.
-
-## Git Safety
-
-- Never use `git reset --hard`, `git checkout -- <file>`, force-push, or destructive cleanup unless explicitly requested.
-- Do not bypass hooks with `--no-verify` unless explicitly authorized.
-- Before commit or PR work, check branch and status.
+# Shared Codex command-policy rules tracked in git.
+#
+# Codex .rules files are Starlark policy files, not prose instruction files.
+# Behavioral guidance belongs in codex-config/AGENTS.md, installed as
+# ~/.codex/AGENTS.md. Machine-specific approval decisions remain local in
+# ~/.codex/rules/default.rules.
+#
+# Add shared prefix_rule(...) entries here only when a command policy should
+# apply on every machine.


### PR DESCRIPTION
## Summary

- moves Codex behavioral guidance into `codex-config/AGENTS.md`
- installs that guidance as `~/.codex/AGENTS.md`
- converts `codex-config/rules/shared.rules` into a valid Starlark policy placeholder
- updates Codex config docs to distinguish instructions from command policy

Closes #275

## Validation

- `bash -n codex-config/install.sh`
- `codex execpolicy check --pretty --rules codex-config/rules/shared.rules -- git status`
- temp-HOME `./codex-config/install.sh` smoke test