### PR TITLE
Rationalize shared skills across Claude and Codex

### DIFF
--- a/codex-config/README.md
+++ b/codex-config/README.md
@@ -21,10 +21,16 @@ git clone https://github.com/jwj2002/agents.git ~/agents
 ~/.codex/AGENTS.md               -> ~/agents/codex-config/AGENTS.md
 ~/.codex/rules/shared.rules      -> ~/agents/codex-config/rules/shared.rules
 ~/.codex/skills/user             -> ~/agents/codex-config/skills/
+~/.codex/skills/<name>           -> shared skill folders
+~/.agents/skills/<name>          -> shared skill folders
 ```
 
 `AGENTS.md` is the behavioral instruction surface. `.rules` files are Codex
 command-policy files written in Starlark; do not put prose instructions there.
+
+Codex skill links are written to both `~/.codex/skills` and
+`~/.agents/skills`. The former preserves current local behavior; the latter is
+the documented Codex user skill location. See `docs/SKILL-SURFACES.md`.
 
 ## What Stays Local
 

--- a/codex-config/install.sh
+++ b/codex-config/install.sh
@@ -9,6 +9,7 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CODEX_DIR="$HOME/.codex"
+AGENTS_SKILLS_DIR="$HOME/.agents/skills"
 BACKUP_DIR="$CODEX_DIR/config-backup-$(date +%Y%m%d-%H%M%S)"
 BACKUP_CREATED=false
 
@@ -31,14 +32,13 @@ link_item() {
     local label="$3"
     LINKS_TOTAL=$((LINKS_TOTAL + 1))
 
-    if [ -e "$target" ] && [ ! -L "$target" ]; then
-        backup_item "$target"
-        echo "  Backed up $label"
-    fi
-
     if [ -L "$target" ] && [ "$(readlink "$target")" = "$source" ]; then
         echo "  ✓ $label (already linked)"
     else
+        if [ -e "$target" ] || [ -L "$target" ]; then
+            backup_item "$target"
+            echo "  Backed up $label"
+        fi
         ln -sfn "$source" "$target"
         echo "  ✓ $label → linked"
         LINKS_CREATED=$((LINKS_CREATED + 1))
@@ -51,11 +51,20 @@ echo "  Target: $CODEX_DIR"
 echo ""
 
 echo "Phase 1: Symlinks"
-mkdir -p "$CODEX_DIR" "$CODEX_DIR/rules" "$CODEX_DIR/skills"
+mkdir -p "$CODEX_DIR" "$CODEX_DIR/rules" "$CODEX_DIR/skills" "$AGENTS_SKILLS_DIR"
 
 link_item "$SCRIPT_DIR/AGENTS.md" "$CODEX_DIR/AGENTS.md" "AGENTS.md"
 link_item "$SCRIPT_DIR/rules/shared.rules" "$CODEX_DIR/rules/shared.rules" "rules/shared.rules"
 link_item "$SCRIPT_DIR/skills" "$CODEX_DIR/skills/user" "skills/user"
+
+for skill_dir in "$SCRIPT_DIR/skills"/*/; do
+    [ -d "$skill_dir" ] || continue
+    name="$(basename "$skill_dir")"
+    [ -f "$skill_dir/SKILL.md" ] || continue
+
+    link_item "${skill_dir%/}" "$CODEX_DIR/skills/$name" "skills/$name (from codex-config)"
+    link_item "${skill_dir%/}" "$AGENTS_SKILLS_DIR/$name" ".agents/skills/$name (from codex-config)"
+done
 
 echo ""
 
@@ -92,6 +101,7 @@ if [ -d "$CLAUDE_SKILLS" ] && [ -x "$PORTABILITY_LINT" ]; then
 
         if "$PORTABILITY_LINT" "$skill_md" >/dev/null 2>&1; then
             link_item "${skill_dir%/}" "$CODEX_DIR/skills/$name" "skills/$name (from claude-config)"
+            link_item "${skill_dir%/}" "$AGENTS_SKILLS_DIR/$name" ".agents/skills/$name (from claude-config)"
             SKILLS_PORTED=$((SKILLS_PORTED + 1))
         else
             echo "  ⚠ skipping '$name' for Codex — Claude-only constructs:"
@@ -141,6 +151,7 @@ echo "  Claude→Codex: $SKILLS_PORTED skill(s) shared, $SKILLS_SKIPPED skipped 
 echo "  Notes:       ~/.codex/skills/.system remains local and untouched"
 echo "               ~/.codex/rules/default.rules remains local (machine approvals)"
 echo "               ~/.codex/AGENTS.md is shared Codex guidance"
+echo "               ~/.agents/skills contains documented Codex user skill links"
 
 if [ "$BACKUP_CREATED" = true ]; then
     echo "  Backups:     $BACKUP_DIR"

--- a/docs/SKILL-SURFACES.md
+++ b/docs/SKILL-SURFACES.md
@@ -1,0 +1,56 @@
+# Skill Surfaces
+
+This repo uses skills as reusable workflows for Claude Code and Codex. A skill
+is shared only when its `SKILL.md` does not assume a tool-specific harness.
+
+## Locations
+
+| Scope | Location | Purpose |
+|---|---|---|
+| Claude global | `~/.claude/skills` -> `~/agents/claude-config/skills` | Claude-installed user skills |
+| Codex compatibility | `~/.codex/skills/<name>` | Existing local Codex skill discovery used by this repo |
+| Codex documented user | `~/.agents/skills/<name>` | Current documented Codex user skill location |
+| Repo-local shared | `.agents/skills/<name>` | Project-specific skills committed with a repo |
+
+`codex-config/install.sh` links shared skills into both Codex user locations.
+This is intentional: `~/.codex/skills` preserves current local behavior, while
+`~/.agents/skills` follows the documented Codex discovery path.
+
+## Classification
+
+| Skill source | Classification | Rule |
+|---|---|---|
+| `codex-config/skills/technical-spec-review` | Codex-native, shared-capable | Authored for Codex, usable where the task matches |
+| `claude-config/skills/action` | Shared | Thin CLI wrapper; passes portability lint |
+| `claude-config/skills/dashboard` | Shared | Thin CLI wrapper; passes portability lint |
+| `claude-config/skills/decision` | Shared | Thin CLI wrapper; passes portability lint |
+| `claude-config/skills/deep-review` | Shared | Instruction-only review workflow; passes portability lint |
+| `claude-config/skills/email-digest` | Shared | Thin workflow wrapper; passes portability lint |
+| `claude-config/skills/pdf` | Shared | Tool workflow; passes portability lint |
+| `claude-config/skills/project` | Shared | Thin CLI wrapper; passes portability lint |
+| `claude-config/skills/review-session` | Shared | Thin CLI wrapper; passes portability lint |
+| `claude-config/skills/transcribe-meeting` | Shared | CLI workflow; passes portability lint |
+
+Any future Claude skill that references Claude-only constructs must remain
+Claude-only and fail portability lint instead of being linked into Codex.
+
+## Portability Gate
+
+Run:
+
+```bash
+claude-config/scripts/check-skill-portability.sh path/to/SKILL.md
+```
+
+The gate rejects unambiguous Claude-only harness constructs such as
+`allowed-tools`, `Task tool`, `Agent tool`, MCP tool IDs, or plan-mode-only
+operations.
+
+## Authoring Rules
+
+- Put shared reusable workflows in skills only when they are useful beyond one
+  repository.
+- Put project-specific instructions in `AGENTS.md`.
+- Put project-specific reusable workflows in `.agents/skills/`.
+- Put Claude-only command behavior under `.claude/` or `claude-config/`.
+- Put Codex-only config, hooks, and policy under `.codex/` or `codex-config/`.


### PR DESCRIPTION
## Summary

- links Codex skills into both existing `~/.codex/skills` and documented `$HOME/.agents/skills` locations
- links `codex-config/skills/*` as first-class Codex skills instead of only through the legacy `skills/user` symlink
- backs up pre-existing different files or symlinks before writing managed links
- documents skill locations, classification, portability gates, and authoring rules

Closes #277

## Validation

- `bash -n codex-config/install.sh`
- portability lint across `codex-config/skills/*/SKILL.md` and `claude-config/skills/*/SKILL.md`
- temp-HOME `./codex-config/install.sh` smoke test confirming `~/.codex/skills` and `~/.agents/skills` links