### PR TITLE
Document agent capabilities and expand validation

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -2,16 +2,20 @@ name: Validate config
 on:
   pull_request:
     paths:
+      - '.github/workflows/validate.yml'
       - 'claude-config/**'
       - 'knowledge/**'
       - 'codex-config/**'
+      - 'docs/**'
+      - 'project-template/**'
+      - 'new-project-agents.sh'
       - 'install*.sh'
   workflow_dispatch: {}
 
 jobs:
   validate:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -21,19 +25,71 @@ jobs:
         with:
           python-version: '3.12'
 
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
       - name: Install dependencies
-        run: pip install pyyaml
+        run: |
+          pip install pyyaml
+          npm install -g @openai/codex
 
       - name: Validate settings.json is valid JSON
         run: python3 -c "import json; json.load(open('claude-config/settings.json'))"
 
-      - name: Validate install.sh shell syntax
-        run: bash -n claude-config/install.sh
+      - name: Validate shell script syntax
+        run: |
+          bash -n install-all.sh
+          bash -n claude-config/install.sh
+          bash -n codex-config/install.sh
+          bash -n new-project-agents.sh
+          bash -n claude-config/new-project-claude.sh
 
       - name: Validate hook script paths in settings.json
         env:
           SETTINGS_PATH: ${{ github.workspace }}/claude-config/settings.json
         run: python3 claude-config/scripts/validate-hooks.py
+
+      - name: Validate Codex command-policy rules
+        run: |
+          set -e
+          for f in codex-config/rules/*.rules; do
+            codex execpolicy check --pretty --rules "$f" -- git status
+          done
+
+      - name: Validate shared skill portability
+        run: |
+          set -e
+          for f in codex-config/skills/*/SKILL.md claude-config/skills/*/SKILL.md; do
+            [ -f "$f" ] || continue
+            claude-config/scripts/check-skill-portability.sh "$f"
+          done
+
+      - name: Smoke test Codex install in temp HOME
+        run: |
+          set -e
+          tmp="$(mktemp -d)"
+          HOME="$tmp" ./codex-config/install.sh
+          test -L "$tmp/.codex/AGENTS.md"
+          test -L "$tmp/.codex/rules/shared.rules"
+          test -L "$tmp/.codex/skills/technical-spec-review"
+          test -L "$tmp/.agents/skills/technical-spec-review"
+
+      - name: Smoke test project bootstrap idempotency
+        run: |
+          set -e
+          tmp="$(mktemp -d)"
+          ./new-project-agents.sh "$tmp"
+          ./new-project-agents.sh "$tmp"
+          test -f "$tmp/AGENTS.md"
+          test -f "$tmp/CLAUDE.md"
+          test -f "$tmp/.claude/settings.json"
+          test -f "$tmp/.agents/skills/.gitkeep"
+
+          tmp_codex="$(mktemp -d)"
+          ./new-project-agents.sh --with-codex-config "$tmp_codex"
+          test -f "$tmp_codex/.codex/config.toml"
 
       - name: Verify pattern ID slug format
         run: |

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ git pull
 
 - Claude package: `claude-config/README.md`
 - Codex package: `codex-config/README.md`
+- Agent capability map: `docs/AGENT-CAPABILITIES.md`
+- Skill surfaces: `docs/SKILL-SURFACES.md`
 - Full operations guide: `docs/CONFIG-BOOTSTRAP.md`
 - Claude system reference: `docs/CLAUDE-SETUP.md`
 

--- a/codex-config/README.md
+++ b/codex-config/README.md
@@ -30,7 +30,8 @@ command-policy files written in Starlark; do not put prose instructions there.
 
 Codex skill links are written to both `~/.codex/skills` and
 `~/.agents/skills`. The former preserves current local behavior; the latter is
-the documented Codex user skill location. See `docs/SKILL-SURFACES.md`.
+the documented Codex user skill location. See `docs/SKILL-SURFACES.md` and
+`docs/AGENT-CAPABILITIES.md`.
 
 ## What Stays Local
 

--- a/docs/AGENT-CAPABILITIES.md
+++ b/docs/AGENT-CAPABILITIES.md
@@ -1,0 +1,149 @@
+# Agent Capabilities
+
+This repo is the shared configuration and operations source for Claude Code and
+OpenAI Codex. Claude and Codex are both first-class maintainers, but they use
+different runtime surfaces.
+
+## Shared Capabilities
+
+- Project instructions: `AGENTS.md`
+- Repo-local reusable workflows: `.agents/skills/`
+- Project bootstrap: `new-project-agents.sh`
+- Shared project artifacts: `.agents/outputs/`
+- CLI-backed workflows: `action`, `project`, `decision`, `pulse`,
+  `email-digest`, and related Python CLIs
+- Validation scripts and CI in `.github/workflows/validate.yml`
+
+Shared rules belong in `AGENTS.md` or shared skills. Do not duplicate shared
+behavior into separate Claude and Codex files unless the runtimes require a
+tool-specific adapter.
+
+## Claude-Only Capabilities
+
+- Global Claude install: `claude-config/install.sh`
+- Global Claude guidance: `claude-config/CLAUDE.md`
+- Claude commands: `claude-config/commands/`
+- Claude subagents: `claude-config/agents/`
+- Claude hooks and statusline: `claude-config/hooks/`,
+  `claude-config/statusline.py`
+- Claude settings: `claude-config/settings.json`
+- Claude-specific project adapter: `CLAUDE.md` and `.claude/`
+
+The current `/orchestrate` command is Claude-only. It depends on Claude slash
+commands, Claude `Task(...)` subagent dispatch, `.claude/agents`, and Claude
+state hooks.
+
+## Codex-Only Capabilities
+
+- Global Codex install: `codex-config/install.sh`
+- Global Codex guidance: `codex-config/AGENTS.md` -> `~/.codex/AGENTS.md`
+- Codex config template: `codex-config/config.toml.example`
+- Codex command policy: `codex-config/rules/*.rules`
+- Codex-native skills: `codex-config/skills/`
+- Optional project Codex config: `.codex/config.toml`
+
+Codex `.rules` files are Starlark command-policy files. They are not
+instruction files. Prose guidance belongs in `AGENTS.md`.
+
+## Skill Support
+
+See `docs/SKILL-SURFACES.md`.
+
+`codex-config/install.sh` links shared skills into both:
+
+- `~/.codex/skills/<name>` for current local compatibility
+- `~/.agents/skills/<name>` for documented Codex user skill discovery
+
+The portability gate is:
+
+```bash
+claude-config/scripts/check-skill-portability.sh path/to/SKILL.md
+```
+
+## Project Bootstrap
+
+Default:
+
+```bash
+~/agents/new-project-agents.sh /path/to/project
+```
+
+Creates:
+
+- `AGENTS.md`
+- `CLAUDE.md`
+- `.claude/settings.json`
+- `.claude/rules/project-rules.md`
+- `.claude/context/project-stack.md`
+- `.claude/memory/runbooks.md`
+- `.agents/skills/.gitkeep`
+
+Optional trusted Codex project config:
+
+```bash
+~/agents/new-project-agents.sh --with-codex-config /path/to/project
+```
+
+Adds:
+
+- `.codex/config.toml`
+
+## Local-Only Runtime State
+
+Do not commit or edit these as shared config:
+
+- `~/.claude/history.jsonl`
+- `~/.claude/projects/`
+- `~/.claude/debug/`
+- `~/.claude.json`
+- `~/.codex/auth.json`
+- `~/.codex/history.jsonl`
+- `~/.codex/sessions/`
+- `~/.codex/tmp/`
+- `~/.codex/rules/default.rules`
+- `~/.codex/skills/.system/`
+
+## Validation
+
+Core local checks:
+
+```bash
+bash -n install-all.sh
+bash -n claude-config/install.sh
+bash -n codex-config/install.sh
+bash -n new-project-agents.sh
+bash -n claude-config/new-project-claude.sh
+python3 -c "import json; json.load(open('claude-config/settings.json'))"
+SETTINGS_PATH=$PWD/claude-config/settings.json python3 claude-config/scripts/validate-hooks.py
+codex execpolicy check --pretty --rules codex-config/rules/shared.rules -- git status
+```
+
+Installer smoke:
+
+```bash
+tmp="$(mktemp -d)"
+HOME="$tmp" ./codex-config/install.sh
+find "$tmp/.codex" "$tmp/.agents/skills" -maxdepth 3 -type l | sort
+```
+
+Bootstrap smoke:
+
+```bash
+tmp="$(mktemp -d)"
+./new-project-agents.sh "$tmp"
+./new-project-agents.sh "$tmp"
+./new-project-agents.sh --with-codex-config "$(mktemp -d)"
+```
+
+Python tests require `pytest`; if it is unavailable, report that explicitly
+instead of claiming test coverage.
+
+## Known Gaps
+
+- `/orchestrate` is still Claude-only.
+- Codex can maintain this repo directly, but there is no Codex-native
+  orchestrate equivalent yet.
+- Codex hooks are not ported from Claude hooks. Port only after reviewing
+  Codex hook event semantics and trust behavior.
+- CI installs Codex CLI only for unauthenticated policy parsing. It does not
+  validate authenticated Codex sessions, app connectors, or cloud tasks.

--- a/docs/CONFIG-BOOTSTRAP.md
+++ b/docs/CONFIG-BOOTSTRAP.md
@@ -30,11 +30,13 @@ git clone https://github.com/jwj2002/agents.git ~/agents
 
 ```bash
 ls -la ~/.claude
-ls -la ~/.codex/rules ~/.codex/skills
+ls -la ~/.codex ~/.codex/rules ~/.codex/skills ~/.agents/skills
 ```
 
 Notes:
 - Codex system skills stay local at `~/.codex/skills/.system/`.
+- Shared Codex user skills are linked into both `~/.codex/skills/` and
+  `~/.agents/skills/`.
 - Machine-specific Codex approvals stay local at `~/.codex/rules/default.rules`.
 - Prefer WSL on Windows desktop for parity with Linux/mac shell workflows.
 
@@ -96,10 +98,13 @@ The installer registers them automatically via `claude mcp add --scope user`.
 
 | Server | Command | Platform |
 |--------|---------|----------|
-| `knowledge` | `<repo>/knowledge-mcp/node_modules/.bin/tsx <repo>/knowledge-mcp/index.ts` | All |
 | `vault-metrics` | `<repo>/mcp-server/.venv/bin/python <repo>/mcp-server/server.py` | All |
 | `context7` | `npx -y @upstash/context7-mcp@latest` | All |
 | `apple-mcp` | `npx -y apple-mcp@latest` | macOS only |
+
+The old `knowledge` MCP server was retired and archived under
+`_archived/knowledge-mcp/`. Project, decision, and action surfaces now use
+filesystem-backed Python CLIs and Obsidian vault notes.
 
 **Paths are absolute and platform-specific.** On Linux/WSL `<repo>` is `/home/<user>/agents`, on macOS it's `/Users/<user>/agents`. The installer resolves paths at install time — no manual editing needed.
 
@@ -107,7 +112,6 @@ The installer registers them automatically via `claude mcp add --scope user`.
 
 ```bash
 # Linux / WSL
-claude mcp add --scope user knowledge -- ~/agents/knowledge-mcp/node_modules/.bin/tsx ~/agents/knowledge-mcp/index.ts
 claude mcp add --scope user vault-metrics -- ~/agents/mcp-server/.venv/bin/python ~/agents/mcp-server/server.py
 claude mcp add --scope user context7 -- npx -y @upstash/context7-mcp@latest
 
@@ -122,6 +126,8 @@ claude mcp add --scope user apple-mcp -- npx -y apple-mcp@latest
 Shared in git:
 - `claude-config/*`
 - `codex-config/*`
+- `project-template/*`
+- `new-project-agents.sh`
 - `install-all.sh`
 
 Local only (not shared):
@@ -129,6 +135,9 @@ Local only (not shared):
 - `~/.claude/history.jsonl`, `~/.claude/projects/`, `~/.claude/debug/`
 - `~/.codex/auth.json`, `~/.codex/history.jsonl`, `~/.codex/sessions/`, `~/.codex/tmp/`
 - `~/.codex/rules/default.rules`
+- `~/.codex/skills/.system/`
+
+For a full surface map, see `docs/AGENT-CAPABILITIES.md`.
 
 ## Per-Tool Installers
 


### PR DESCRIPTION
## Summary

- adds `docs/AGENT-CAPABILITIES.md` with shared, Claude-only, Codex-only, bootstrap, local-state, validation, and known-gap sections
- expands config CI to validate Codex rules, shared skill portability, temp-HOME Codex install, and project bootstrap idempotency
- removes stale retired Knowledge MCP registration references from bootstrap docs
- links the new capability and skill-surface docs from README/Codex docs

Closes #278

## Validation

- parsed `.github/workflows/validate.yml` as YAML
- `bash -n` for installers and bootstrap scripts
- Claude settings JSON parse and hook path validation
- `codex execpolicy check --pretty --rules codex-config/rules/shared.rules -- git status`
- portability lint across Codex and Claude skills
- temp-HOME Codex install smoke test
- project bootstrap idempotency and optional Codex config smoke test
- `npm view @openai/codex version` -> `0.137.0`