### PR TITLE
feat(git): add PR readiness helper

### DIFF
--- a/claude-config/rules/git-workflow.md
+++ b/claude-config/rules/git-workflow.md
@@ -46,6 +46,9 @@ pytest tests/ --timeout=60
 
 # 3. Verify only relevant files changed
 git diff --name-only origin/main
+
+# 4. Verify branch, issue, commit, scope, and test evidence
+~/agents/bin/agent-git readiness --issue <N> --summary "<summary>" --test-evidence "<command/result>"
 ```
 
 If any check fails, fix it before creating the PR. Never skip checks.

--- a/codex-config/AGENTS.md
+++ b/codex-config/AGENTS.md
@@ -64,6 +64,8 @@ and verify behavior before declaring completion.
   the standardized git process in `~/agents/docs/git-process.md`.
 - Before agent-owned edits, run `~/agents/bin/agent-git preflight` when it is
   available and treat reported errors as stop gates.
+- Before opening or merging an agent-owned PR, run
+  `~/agents/bin/agent-git readiness` when it is available.
 - Agent-owned issues default to shipped work: commit, PR, validate, squash
   merge, sync `main`, prune stale refs, delete the merged branch, and close or
   update the linked issue unless a documented stop gate applies.

--- a/docs/git-process.md
+++ b/docs/git-process.md
@@ -205,6 +205,21 @@ Every PR must include:
 Use draft PRs only when validation is incomplete or user review is required
 before merge.
 
+Use the shared readiness helper before creating or merging an agent-owned PR:
+
+```bash
+~/agents/bin/agent-git readiness \
+  --issue 123 \
+  --summary "implemented the scoped change" \
+  --test-evidence "pytest tests/test_example.py -q" \
+  --allowed-path src/ \
+  --generate-pr-body
+```
+
+Use `--stage merge` before merge to distinguish final readiness from initial PR
+creation. The helper validates local branch evidence; GitHub CI remains the
+source of truth for hosted checks.
+
 ## Merge And Cleanup
 
 Default merge strategy is squash merge. Before merge:

--- a/lib/agent_git.py
+++ b/lib/agent_git.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
+import re
 import shutil
 import subprocess
 from dataclasses import dataclass, field
@@ -94,6 +94,43 @@ class PreflightResult:
         }
 
 
+@dataclass
+class ReadinessResult:
+    repo: str
+    stage: str
+    branch: str | None
+    default_branch: str
+    issue: int | None
+    commits: list[str]
+    changed_files: list[str]
+    summary: str | None
+    test_evidence: list[str]
+    pr_body: str | None = None
+    errors: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return not self.errors
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "ok": self.ok,
+            "repo": self.repo,
+            "stage": self.stage,
+            "branch": self.branch,
+            "default_branch": self.default_branch,
+            "issue": self.issue,
+            "commits": self.commits,
+            "changed_files": self.changed_files,
+            "summary": self.summary,
+            "test_evidence": self.test_evidence,
+            "pr_body": self.pr_body,
+            "errors": self.errors,
+            "warnings": self.warnings,
+        }
+
+
 class Runner:
     def __call__(self, args: list[str], cwd: Path) -> CommandResult:
         completed = subprocess.run(
@@ -105,6 +142,14 @@ class Runner:
             check=False,
         )
         return CommandResult(completed.returncode, completed.stdout, completed.stderr)
+
+
+BRANCH_RE = re.compile(
+    r"^(feature|fix|docs|test|chore|perf|refactor)/issue-(?P<issue>\d+)-[a-z0-9][a-z0-9-]*$"
+)
+COMMIT_RE = re.compile(
+    r"^(feat|fix|docs|test|chore|perf|refactor|ci|style)(\([a-z0-9_.-]+\))?: [a-z0-9].{0,70}$"
+)
 
 
 def is_generated_path(path: str) -> bool:
@@ -351,6 +396,171 @@ def render_preflight_text(result: PreflightResult) -> str:
     return "\n".join(lines) + "\n"
 
 
+def extract_issue_from_branch(branch: str | None) -> int | None:
+    if not branch:
+        return None
+    match = BRANCH_RE.match(branch)
+    if not match:
+        return None
+    return int(match.group("issue"))
+
+
+def list_commits(runner: Runner, repo: Path, default_branch: str) -> list[str]:
+    log = run_git(runner, repo, ["log", "--format=%s", f"origin/{default_branch}..HEAD"])
+    if log.returncode != 0:
+        return []
+    return [line for line in log.stdout.splitlines() if line.strip()]
+
+
+def list_changed_files(runner: Runner, repo: Path, default_branch: str) -> list[str]:
+    diff = run_git(runner, repo, ["diff", "--name-only", f"origin/{default_branch}...HEAD"])
+    if diff.returncode != 0:
+        return []
+    return [line for line in diff.stdout.splitlines() if line.strip()]
+
+
+def build_pr_body(issue: int | None, summary: str | None, test_evidence: list[str], local_only: bool) -> str:
+    summary_lines = [f"- {summary}"] if summary else ["- "]
+    test_lines = [f"- {item}" for item in test_evidence] or ["- "]
+    issue_line = "Local-only exception." if local_only else f"Closes #{issue}"
+    return "\n".join(
+        [
+            "## Summary",
+            *summary_lines,
+            "",
+            "## Test Plan",
+            *test_lines,
+            "",
+            issue_line,
+            "",
+        ]
+    )
+
+
+def readiness(
+    repo: Path,
+    *,
+    stage: str = "open",
+    issue: int | None = None,
+    local_only: bool = False,
+    summary: str | None = None,
+    test_evidence: list[str] | None = None,
+    allowed_paths: list[str] | None = None,
+    generate_pr_body: bool = False,
+    runner: Runner | None = None,
+) -> ReadinessResult:
+    runner = runner or Runner()
+    repo = repo.resolve()
+    test_evidence = test_evidence or []
+    allowed_paths = allowed_paths or []
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    inside = run_git(runner, repo, ["rev-parse", "--is-inside-work-tree"])
+    if inside.returncode != 0:
+        return ReadinessResult(
+            repo=str(repo),
+            stage=stage,
+            branch=None,
+            default_branch="main",
+            issue=issue,
+            commits=[],
+            changed_files=[],
+            summary=summary,
+            test_evidence=test_evidence,
+            errors=[f"Not a git repository: {repo}"],
+        )
+
+    branch_result = run_git(runner, repo, ["branch", "--show-current"])
+    branch = branch_result.stdout.strip() or None
+    default_branch = detect_default_branch(runner, repo)
+    branch_issue = extract_issue_from_branch(branch)
+    resolved_issue = issue or branch_issue
+
+    if not branch or not BRANCH_RE.match(branch):
+        errors.append("Branch name must match <type>/issue-<number>-<slug>.")
+    if issue and branch_issue and issue != branch_issue:
+        errors.append(f"Provided issue #{issue} does not match branch issue #{branch_issue}.")
+    if not local_only and resolved_issue is None:
+        errors.append("Issue linkage is required unless --local-only is used.")
+
+    status = parse_status(run_git(runner, repo, ["status", "--porcelain=v1"]).stdout)
+    for item in status:
+        if item.kind != "ignored" and not item.generated:
+            errors.append(f"Working tree is not ready: {item.path} ({item.status}).")
+        elif item.kind != "ignored" and item.generated:
+            warnings.append(f"Generated or runtime dirty file present: {item.path} ({item.status}).")
+
+    commits = list_commits(runner, repo, default_branch)
+    if not commits:
+        errors.append(f"No commits found relative to origin/{default_branch}.")
+    for commit in commits:
+        if not COMMIT_RE.match(commit):
+            errors.append(f"Commit summary is not Conventional Commits format: {commit}")
+
+    changed_files = list_changed_files(runner, repo, default_branch)
+    if not changed_files:
+        errors.append("No changed files found relative to default branch.")
+
+    if allowed_paths:
+        allowed = tuple(allowed_paths)
+        outside = [path for path in changed_files if not path.startswith(allowed)]
+        for path in outside:
+            errors.append(f"Changed file outside allowed scope: {path}")
+    else:
+        warnings.append("No allowed paths provided; changed-file scope was not constrained.")
+
+    if not summary or not summary.strip():
+        errors.append("Summary evidence is required.")
+    if not test_evidence:
+        errors.append("Test Plan evidence is required.")
+
+    if stage == "merge":
+        warnings.append("Merge-stage readiness currently validates local branch evidence only; CI state is handled by GitHub checks.")
+
+    body = build_pr_body(resolved_issue, summary, test_evidence, local_only) if generate_pr_body else None
+
+    return ReadinessResult(
+        repo=str(repo),
+        stage=stage,
+        branch=branch,
+        default_branch=default_branch,
+        issue=resolved_issue,
+        commits=commits,
+        changed_files=changed_files,
+        summary=summary,
+        test_evidence=test_evidence,
+        pr_body=body,
+        errors=errors,
+        warnings=warnings,
+    )
+
+
+def render_readiness_text(result: ReadinessResult) -> str:
+    lines = [
+        f"readiness: {'pass' if result.ok else 'fail'}",
+        f"stage: {result.stage}",
+        f"repo: {result.repo}",
+        f"branch: {result.branch or '(detached)'}",
+        f"default_branch: {result.default_branch}",
+        f"issue: {result.issue if result.issue is not None else '(none)'}",
+        f"commits: {len(result.commits)}",
+        f"changed_files: {len(result.changed_files)}",
+        f"test_evidence: {len(result.test_evidence)}",
+    ]
+    if result.pr_body:
+        lines.extend(["", "pr_body:", result.pr_body.rstrip()])
+    if result.errors:
+        lines.append("")
+        lines.append("errors:")
+        lines.extend(f"- {item}" for item in result.errors)
+    if result.warnings:
+        lines.append("")
+        lines.append("warnings:")
+        lines.extend(f"- {item}" for item in result.warnings)
+    return "\n".join(lines) + "\n"
+
+
 def add_preflight_parser(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
     parser = subparsers.add_parser("preflight", help="inspect git state before agent-owned edits")
     parser.add_argument("--repo", default=".", help="repository path")
@@ -361,10 +571,24 @@ def add_preflight_parser(subparsers: argparse._SubParsersAction[argparse.Argumen
     parser.add_argument("--path", action="append", default=[], help="intended changed path for open PR overlap checks")
 
 
+def add_readiness_parser(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
+    parser = subparsers.add_parser("readiness", help="verify a branch is ready to open or merge a PR")
+    parser.add_argument("--repo", default=".", help="repository path")
+    parser.add_argument("--json", action="store_true", help="emit JSON")
+    parser.add_argument("--stage", choices=["open", "merge"], default="open", help="readiness stage")
+    parser.add_argument("--issue", type=int, help="linked GitHub issue number")
+    parser.add_argument("--local-only", action="store_true", help="allow no issue linkage")
+    parser.add_argument("--summary", help="summary evidence for the PR body")
+    parser.add_argument("--test-evidence", action="append", default=[], help="test plan evidence; repeatable")
+    parser.add_argument("--allowed-path", action="append", default=[], help="allowed changed-file prefix; repeatable")
+    parser.add_argument("--generate-pr-body", action="store_true", help="include generated PR body in output")
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(prog="agent-git")
     subparsers = parser.add_subparsers(dest="command", required=True)
     add_preflight_parser(subparsers)
+    add_readiness_parser(subparsers)
 
     args = parser.parse_args(argv)
 
@@ -380,6 +604,23 @@ def main(argv: list[str] | None = None) -> int:
             print(json.dumps(result.to_dict(), indent=2, sort_keys=True))
         else:
             print(render_preflight_text(result), end="")
+        return 0 if result.ok else 1
+
+    if args.command == "readiness":
+        result = readiness(
+            Path(args.repo),
+            stage=args.stage,
+            issue=args.issue,
+            local_only=args.local_only,
+            summary=args.summary,
+            test_evidence=args.test_evidence,
+            allowed_paths=args.allowed_path,
+            generate_pr_body=args.generate_pr_body,
+        )
+        if args.json:
+            print(json.dumps(result.to_dict(), indent=2, sort_keys=True))
+        else:
+            print(render_readiness_text(result), end="")
         return 0 if result.ok else 1
 
     parser.error(f"unknown command: {args.command}")

--- a/lib/tests/test_agent_git.py
+++ b/lib/tests/test_agent_git.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import pytest
 
-from lib.agent_git import parse_status, preflight
+from lib.agent_git import parse_status, preflight, readiness
 
 
 def run(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
@@ -37,6 +37,18 @@ def make_repo(tmp_path: Path) -> Path:
 
 def branch(work: Path) -> None:
     git(["switch", "-c", "feature/issue-1-test", "origin/main"], work)
+
+
+def branch_for_issue(work: Path, issue: int = 42) -> None:
+    git(["switch", "-c", f"feature/issue-{issue}-add-tooling", "origin/main"], work)
+
+
+def commit_file(work: Path, path: str = "tooling.txt", message: str = "feat(git): add tooling") -> None:
+    target = work / path
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("content\n", encoding="utf-8")
+    git(["add", path], work)
+    git(["commit", "-m", message], work)
 
 
 def test_preflight_fails_on_main_branch(tmp_path: Path) -> None:
@@ -141,3 +153,118 @@ def test_github_cli_missing_degrades(monkeypatch: pytest.MonkeyPatch, tmp_path: 
 
     assert result.ok
     assert any("GitHub CLI not found" in warning for warning in result.warnings)
+
+
+def test_readiness_passes_with_issue_summary_tests_and_scope(tmp_path: Path) -> None:
+    work = make_repo(tmp_path)
+    branch_for_issue(work, 42)
+    commit_file(work, "src/tool.py")
+
+    result = readiness(
+        work,
+        issue=42,
+        summary="add shared git tooling",
+        test_evidence=["pytest lib/tests/test_agent_git.py -q"],
+        allowed_paths=["src/"],
+        generate_pr_body=True,
+    )
+
+    assert result.ok
+    assert result.issue == 42
+    assert "Closes #42" in (result.pr_body or "")
+
+
+def test_readiness_fails_invalid_branch(tmp_path: Path) -> None:
+    work = make_repo(tmp_path)
+    git(["switch", "-c", "feature/no-issue", "origin/main"], work)
+    commit_file(work)
+
+    result = readiness(
+        work,
+        issue=42,
+        summary="add shared git tooling",
+        test_evidence=["pytest -q"],
+    )
+
+    assert not result.ok
+    assert any("Branch name must match" in error for error in result.errors)
+
+
+def test_readiness_fails_missing_test_evidence(tmp_path: Path) -> None:
+    work = make_repo(tmp_path)
+    branch_for_issue(work, 42)
+    commit_file(work)
+
+    result = readiness(work, issue=42, summary="add shared git tooling")
+
+    assert not result.ok
+    assert any("Test Plan evidence is required" in error for error in result.errors)
+
+
+def test_readiness_fails_invalid_commit_summary(tmp_path: Path) -> None:
+    work = make_repo(tmp_path)
+    branch_for_issue(work, 42)
+    commit_file(work, message="bad commit")
+
+    result = readiness(
+        work,
+        issue=42,
+        summary="add shared git tooling",
+        test_evidence=["pytest -q"],
+    )
+
+    assert not result.ok
+    assert any("Commit summary is not Conventional Commits" in error for error in result.errors)
+
+
+def test_readiness_fails_changed_file_outside_allowed_scope(tmp_path: Path) -> None:
+    work = make_repo(tmp_path)
+    branch_for_issue(work, 42)
+    commit_file(work, "docs/tooling.md", "docs(git): add tooling docs")
+
+    result = readiness(
+        work,
+        issue=42,
+        summary="add shared git tooling",
+        test_evidence=["pytest -q"],
+        allowed_paths=["src/"],
+    )
+
+    assert not result.ok
+    assert any("outside allowed scope" in error for error in result.errors)
+
+
+def test_readiness_cli_generates_pr_body(tmp_path: Path) -> None:
+    work = make_repo(tmp_path)
+    branch_for_issue(work, 42)
+    commit_file(work, "src/tool.py")
+    script = Path(__file__).resolve().parents[2] / "bin" / "agent-git"
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            "readiness",
+            "--repo",
+            str(work),
+            "--issue",
+            "42",
+            "--summary",
+            "add shared git tooling",
+            "--test-evidence",
+            "pytest lib/tests/test_agent_git.py -q",
+            "--allowed-path",
+            "src/",
+            "--generate-pr-body",
+            "--json",
+        ],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+    assert completed.returncode == 0
+    payload = json.loads(completed.stdout)
+    assert payload["ok"] is True
+    assert "Closes #42" in payload["pr_body"]

--- a/project-template/common/AGENTS.md
+++ b/project-template/common/AGENTS.md
@@ -54,6 +54,8 @@ Required baseline:
 - Prove implementation through the intended entrypoint. Completion requires the
   change to be implemented, wired, exercised, observed, documented when
   operationally meaningful, and shipped or explicitly blocked.
+- Run `~/agents/bin/agent-git readiness` before opening or merging an
+  agent-owned PR when the helper is available.
 - Stop before merge only for a documented stop gate: failing validation, unsafe
   approval requirement, branch protection requiring human review, blocking dirty
   user work, ambiguous scope, GitHub/network/credential failure, or explicit


### PR DESCRIPTION
## Summary
- add agent-git readiness for branch, issue, commit, changed-file, and evidence checks
- generate PR body content from summary and test evidence
- wire readiness into canonical docs plus Claude and Codex guidance
- extend git helper tests for readiness pass/fail cases

## Test Plan
- python -m pytest lib/tests/test_agent_git.py -q
- python bin/agent-git readiness --issue 289 --summary "add PR readiness helper" --test-evidence "python -m pytest lib/tests/test_agent_git.py -q" --allowed-path lib/ --allowed-path docs/ --allowed-path project-template/ --allowed-path codex-config/ --allowed-path claude-config/ --generate-pr-body
- git diff --check

Closes #289