### PR TITLE
chore(config): harden Claude/Codex parity (review findings)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -51,6 +51,28 @@ jobs:
           SETTINGS_PATH: ${{ github.workspace }}/claude-config/settings.json
         run: python3 claude-config/scripts/validate-hooks.py
 
+      - name: Generated post-merge hook must be non-interactive
+        run: |
+          # The post-merge hook re-syncs config on `git pull` and runs
+          # non-interactively, so it MUST call install-all.sh with --skip-profile
+          # (otherwise install-all.sh prompts for a profile and hangs the pull).
+          # Guard: every line that *executes* install-all.sh must carry
+          # --skip-profile. We select execution lines as those mentioning
+          # `install-all.sh"` and exclude the `[ -x ... ]` existence test, so the
+          # check catches a future bare invocation even if it drops the `2>&1`
+          # redirect (does not rely on the sed pipe being present).
+          inv="$(grep -nE 'install-all\.sh"' claude-config/install.sh | grep -vE '\[[[:space:]]*-x' || true)"
+          echo "$inv"
+          if [ -z "$inv" ]; then
+            echo "::error::no install-all.sh invocation found in generated post-merge hook"
+            exit 1
+          fi
+          if echo "$inv" | grep -v -- '--skip-profile' | grep -q .; then
+            echo "::error::post-merge hook invokes install-all.sh without --skip-profile"
+            exit 1
+          fi
+          echo "OK: post-merge hook is non-interactive (--skip-profile present)"
+
       - name: Validate Codex command-policy rules
         run: |
           set -e
@@ -60,11 +82,29 @@ jobs:
 
       - name: Validate shared skill portability
         run: |
-          set -e
+          # Exit-code contract of check-skill-portability.sh (matches the
+          # installer's skip-and-continue behavior):
+          #   0 = portable      → symlinked into Codex
+          #   1 = Claude-only   → skipped for Codex (NOTICE, not a failure)
+          #   2 = invalid/usage → real lint error (FAIL the job)
+          # CI must NOT red-X on exit 1 — a legitimate Claude-only skill is the
+          # documented contract (docs/SKILL-SURFACES.md), not a defect.
+          fail=0
           for f in codex-config/skills/*/SKILL.md claude-config/skills/*/SKILL.md; do
             [ -f "$f" ] || continue
-            claude-config/scripts/check-skill-portability.sh "$f"
+            name="$(basename "$(dirname "$f")")"
+            out="$(claude-config/scripts/check-skill-portability.sh "$f")" && rc=0 || rc=$?
+            case "$rc" in
+              0) echo "::notice::portable: $name" ;;
+              1) echo "::notice::claude-only (skipped for Codex): $name"
+                 [ -n "$out" ] && echo "$out" ;;
+              2) echo "::error::invalid skill (lint/usage error): $name"
+                 echo "$out"; fail=1 ;;
+              *) echo "::error::unexpected exit $rc from portability check: $name"
+                 echo "$out"; fail=1 ;;
+            esac
           done
+          [ "$fail" = "0" ] || exit 1
 
       - name: Smoke test Codex install in temp HOME
         run: |

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ git pull
 
 - Claude package: `claude-config/README.md`
 - Codex package: `codex-config/README.md`
+- Claude + Codex collaboration model: `docs/CLAUDE-CODEX-COLLABORATION.md`
 - Agent capability map: `docs/AGENT-CAPABILITIES.md`
 - Skill surfaces: `docs/SKILL-SURFACES.md`
 - Full operations guide: `docs/CONFIG-BOOTSTRAP.md`

--- a/claude-config/CLAUDE.md
+++ b/claude-config/CLAUDE.md
@@ -15,6 +15,10 @@ in `~/.claude/rules/` and are loaded conditionally — read this first.
 If you ever need to change the deployed config, edit `~/agents/claude-config/`
 and let `install.sh` handle the symlinks. Don't edit `~/.claude/` directly.
 
+This repo is shared with **Codex**. `AGENTS.md` is shared policy; `CLAUDE.md`
+and Codex config are adapters. When changing shared instructions, verify both
+surfaces. See `~/agents/docs/CLAUDE-CODEX-COLLABORATION.md`.
+
 ---
 
 ## Three failure patterns to actively prevent

--- a/claude-config/install.sh
+++ b/claude-config/install.sh
@@ -491,8 +491,15 @@ if [ -n "$CONFIG_CHANGED" ]; then
     # Prefer the orchestrator so BOTH Claude and Codex re-sync (Codex skill
     # symlinks are created by codex-config/install.sh). Fall back to the
     # Claude installer alone if the orchestrator is absent.
+    #
+    # --skip-profile is MANDATORY: a post-merge hook runs non-interactively
+    # during automated `git pull`, and install-all.sh prompts (read -rp) for a
+    # profile on any machine lacking ~/.config/agents-profile. Without the flag
+    # the hook blocks on stdin and hangs the pull. Profile setup is an explicit
+    # user-run install action, never something a hook performs. (CI enforces
+    # this invariant — see .github/workflows/validate.yml.)
     if [ -x "$REPO_DIR/install-all.sh" ]; then
-        "$REPO_DIR/install-all.sh" 2>&1 | sed 's/^/[post-merge] /'
+        "$REPO_DIR/install-all.sh" --skip-profile 2>&1 | sed 's/^/[post-merge] /'
     else
         "$REPO_DIR/claude-config/install.sh" 2>&1 | sed 's/^/[post-merge] /'
     fi

--- a/codex-config/AGENTS.md
+++ b/codex-config/AGENTS.md
@@ -3,6 +3,10 @@
 This file is the shared global instruction surface for Codex. It is installed
 to `~/.codex/AGENTS.md` by `codex-config/install.sh`.
 
+How Codex and Claude share this repo (AGENTS.md is shared policy; CLI-first
+shared tooling; per-agent capabilities documented): see
+`docs/CLAUDE-CODEX-COLLABORATION.md`.
+
 ## Operating Role
 
 Use Codex as a pragmatic implementation and adversarial review partner.

--- a/docs/CLAUDE-CODEX-COLLABORATION.md
+++ b/docs/CLAUDE-CODEX-COLLABORATION.md
@@ -1,0 +1,75 @@
+# Claude + Codex Collaboration Model
+
+This repo is used by **two** coding agents — Anthropic **Claude Code** and OpenAI
+**Codex** — plus the human owner. These principles keep both agents first-class.
+The guiding rule: **do not make Claude worse to make Codex better, or Codex worse
+to preserve Claude conventions.** Shared abstractions should improve both.
+
+## 1. `AGENTS.md` is shared project policy
+
+`AGENTS.md` is the canonical, agent-neutral instruction file for a project.
+`CLAUDE.md` and Codex config (`.codex/config.toml`, Codex skills) are **adapters**
+around it, not competing sources of truth.
+
+- Put shared behavior in `AGENTS.md`.
+- `CLAUDE.md` carries the minimum load-bearing context Claude must always see
+  (so Claude is never starved if the harness does not auto-load `AGENTS.md`)
+  plus Claude-only notes — it does **not** duplicate `AGENTS.md` wholesale.
+- Codex config carries Codex-only adapters (command policy, skill links).
+
+## 2. Shared behavior is CLI-first
+
+For behavior both agents need, implement it once in **repo-native CLI/script
+code** (shell or Python), then wrap it with a thin Claude command or Codex skill.
+This minimizes prompt-instruction drift and token cost, and gives deterministic,
+testable output. Example: the `agent-git` helpers — both agents call the same
+binary instead of each re-deriving the git process from prose.
+
+## 3. Per-agent capabilities are allowed — but must be documented
+
+A capability that only one agent can use today is fine. Document it as such (see
+`docs/AGENT-CAPABILITIES.md`) so the asymmetry is intentional and visible, not a
+silent gap. Example: `/orchestrate` is Claude-only (depends on `.claude/agents/`
+subagent dispatch).
+
+## 4. New agent workflows declare their surface
+
+When adding an agent workflow, document:
+
+- whether **Claude** can use it,
+- whether **Codex** can use it,
+- a **parity note** if one side cannot use it yet (and what it would take).
+
+## 5. Changing shared instructions means verifying both surfaces
+
+When you modify shared policy, check it still holds on **both** sides:
+
+- **Claude:** `CLAUDE.md`, `.claude/rules/`, slash commands (if relevant).
+- **Codex:** `AGENTS.md`, `.codex/config.toml`, Codex skills/agents (if relevant).
+
+## 6. Prefer deterministic CLI output for high-frequency workflows
+
+For anything run often, a short deterministic CLI is better than a long prompt
+instruction: lower token cost, less drift, and it can be unit-tested. Reserve
+prose instructions for judgment-heavy, low-frequency guidance.
+
+## 7. Shared abstractions must improve both agents
+
+Never regress one agent to help the other. If a change helps Codex but weakens
+Claude's guaranteed context (or vice versa), redesign it so both benefit — e.g.
+keep `AGENTS.md` canonical *and* keep `CLAUDE.md` self-sufficient for the minimum
+Claude must see.
+
+## Skill portability contract
+
+Claude and Codex read the same `SKILL.md` format, so portable skills are
+**symlinked** (not copied) into both runtimes for zero drift. The gate is
+`claude-config/scripts/check-skill-portability.sh`:
+
+- exit `0` — portable; linked into Codex.
+- exit `1` — Claude-only (references a Claude-only harness construct); **skipped**
+  for Codex, not an error.
+- exit `2` — invalid/usage error; a real failure.
+
+Both the installer (`codex-config/install.sh`) and CI
+(`.github/workflows/validate.yml`) honor this contract.

--- a/project-template/common/.claude/memory/runbooks.md
+++ b/project-template/common/.claude/memory/runbooks.md
@@ -19,6 +19,17 @@ Common issues and their fixes. Check here before investigating from scratch.
 **Cause**: Model has a field that schema does not, or types diverge
 **Fix**: Compare model fields vs schema fields side-by-side. Add missing fields. Fix type mismatches.
 
+## R04: Docker Build Fails on pip install
+**Symptom**: `pip install` fails during the Docker build with permission or network errors
+**Cause**: Missing `--no-cache-dir` flag, or the base image changed upstream
+**Fix**: Add `--no-cache-dir` to the pip install step. Pin the base image by digest in the Dockerfile so upstream changes can't break the build.
+
+## R05: Optimistic Concurrency 500 (StaleDataError)
+**Symptom**: 500 Internal Server Error on concurrent edits of the same row
+**Cause**: `db.flush()`/`db.commit()` on a version-counter model without catching `StaleDataError` — two writers raced and the second lost the version check
+**Fix**: Versioned-model updates must handle stale rows. Wrap the flush in `try/except sqlalchemy.orm.exc.StaleDataError` and convert to a conflict/retry path (HTTP 409), not a 500. Add a test that exercises concurrent updates to the same row.
+**Eval**: Reinforces behavioral eval **E10 (STALE_DATA_UNHANDLED)** — a flush on a versioned model without a `StaleDataError` catch is the exact pattern E10 flags.
+
 ---
 
 Add new runbooks as issues are discovered. Each entry needs: symptom, cause, fix.

--- a/project-template/common/CLAUDE.md
+++ b/project-template/common/CLAUDE.md
@@ -2,16 +2,62 @@
 
 Claude-specific adapter for this project.
 
-## Shared Instructions
+`AGENTS.md` is the **canonical** project instruction file, shared by Claude Code
+and Codex. **Read `AGENTS.md` first.** This file carries only the minimum
+load-bearing context Claude must always see — even if `AGENTS.md` is not
+auto-loaded by the harness — plus Claude-only notes. It does **not** duplicate
+AGENTS.md; when shared policy changes, update `AGENTS.md` and keep this thin.
 
-Read `AGENTS.md` first. It is the canonical project instruction file shared
-by Claude Code and Codex.
+## Project Overview
+
+<!-- Mirror the one-liners from AGENTS.md so Claude always has them. -->
+
+- Purpose:
+- Users:
+- Non-goals:
+
+## Development Commands
+
+See `AGENTS.md` → "Development Commands" for the full set. Quick pointers:
+
+```bash
+# Setup:
+# Run:
+# Test:
+# Lint/format:
+```
+
+## Definition of Done
+
+Work is not done when files merely exist. It must be:
+
+- implemented and wired through its intended entrypoint
+- exercised by automated or manual validation, with evidence (command output,
+  artifact, or check result)
+- passing the project's tests, lint, and format checks
+- shipped or explicitly blocked by a documented stop gate
+
+## Git / Ship Essentials
+
+- Branch from latest `origin/main`: `{type}/issue-{N}-{slug}`.
+- Conventional Commits; one logical change per branch = one PR.
+- Never commit directly to `main`; never `--force`/`--no-verify` without approval.
+- Rebase on `origin/main` before opening the PR; squash-merge; prune the branch.
+- Prefer the shared helpers where present (e.g. `agent-git preflight|readiness|ship`).
+
+## Validation Expectations
+
+Before declaring work complete, run the project's checks and paste the result:
+
+```bash
+# e.g. ruff check . && ruff format --check . && pytest -q
+```
 
 ## Claude Project Files
 
 - `.claude/rules/project-rules.md` — Claude-specific local rules.
 - `.claude/context/project-stack.md` — stack/runtime notes.
-- `.claude/memory/runbooks.md` — known issue fixes.
+- `.claude/memory/runbooks.md` — known issue fixes (check BEFORE debugging from scratch).
+- `.claude/commands/` — project-local slash commands (Claude-only).
 
-Keep shared rules in `AGENTS.md`. Put Claude-only workflow notes here or in
-`.claude/`.
+Keep shared rules in `AGENTS.md`. Put Claude-only workflow notes here or in `.claude/`.


### PR DESCRIPTION
Implements the Codex review of the recent Codex-support work. Goal: keep Claude and Codex both first-class without weakening Claude's guaranteed load path.

## Changes
1. **Post-merge hook noninteractive** — generated hook now calls `install-all.sh --skip-profile` so an automated `git pull` can never block on the profile prompt. New CI step asserts every `install-all.sh` *execution* line in the generated hook carries `--skip-profile` (excludes the `[ -x ]` test; catches a future bare invocation even without `2>&1`).
2. **Self-sufficient project `CLAUDE.md`** — keeps `AGENTS.md` canonical but carries the minimum load-bearing context (overview, dev-command pointers, definition-of-done, git/ship essentials, validation expectations, Claude project files) so Claude isn't starved if `AGENTS.md` isn't auto-loaded. No wholesale duplication.
3. **Restored runbooks R04 + R05** — Docker build (R04) and StaleDataError/optimistic concurrency (R05); R05 explicitly tied to behavioral eval **E10** (versioned models handle stale rows → catch `StaleDataError` → 409 conflict/retry → test concurrent updates).
4. **CI portability contract** — `validate.yml` now honors the `check-skill-portability.sh` exit codes: `0` portable, `1` Claude-only (skip, notice), `2` invalid (fail). Emits per-skill status; matches the installer's skip-and-continue behavior.
5. **`docs/CLAUDE-CODEX-COLLABORATION.md`** — shared collaboration principles, referenced from `README.md`, `codex-config/AGENTS.md`, and `claude-config/CLAUDE.md` (both surfaces).

## Validation
- `bash -n`, YAML parse, `validate-hooks.py` (9/9), portability contract (10 skills portable, exit-2 path verified), post-merge guard (passes real file, catches synthetic bare invocation).
- Bootstrap smoke: new project gets the self-sufficient `CLAUDE.md` (4 load-bearing sections) + R04/R05/E10 runbooks.
- **234 tests pass** (181 claude-config + 53 team-knowledge).
- Codex adversarial review: **APPROVE**, all 5 ACs `implemented`, 0 blocking.

Closes #300

🤖 Generated with [Claude Code](https://claude.com/claude-code)