### PR TITLE
docs(git): make ship-by-default the explicit norm

### DIFF
--- a/claude-config/CLAUDE.md
+++ b/claude-config/CLAUDE.md
@@ -93,9 +93,12 @@ GitLab access (jbox06 only): `~/.claude/rules/gitlab-access.md`.
 - Canonical process: `~/agents/docs/git-process.md`
 - Claude rule adapter: `~/.claude/rules/git-workflow.md`
 - Project-local instructions: read `AGENTS.md` first when present.
-- Agent-owned issues default to shipped work: commit, PR, validate, squash
-  merge, sync `main`, prune stale refs, delete the merged branch, and close or
-  update the issue unless a documented stop gate applies.
+- **Ship by default.** Agent-owned issues are taken end-to-end — commit, PR,
+  validate, squash-merge, sync `main`, prune the branch, post-merge verify,
+  close the issue — **without pausing to ask for merge approval.** Stop before
+  merge ONLY on a specific agreement ("PR only" / "hold") or a documented stop
+  gate. CI-red / unresolved REQUEST_CHANGES / conflicts are "fix then ship",
+  not stop gates. Full rule: `~/.claude/rules/git-workflow.md`.
 - Completion requires implementation to be wired through its intended
   entrypoint and exercised with evidence, not merely present in files.
 

--- a/claude-config/rules/git-workflow.md
+++ b/claude-config/rules/git-workflow.md
@@ -10,9 +10,35 @@ paths: ["**"]
 
 All agents MUST follow these rules for every git operation. Main stays green at all times.
 
-Agent-owned issue work defaults to shipped work: commit, PR, validate, squash
-merge, sync `main`, prune stale refs, delete the merged branch, and close or
-update the linked issue unless a documented stop gate applies.
+## Ship by default
+
+**Agent-owned issue work is shipped end-to-end, including the merge — without
+pausing to ask for merge approval.** The terminal state of a task is a merged
+PR, not an open one. The full default path:
+
+```text
+commit → push → PR → validate/review → squash-merge → prune branch
+       → sync main → post-merge verify → close/update the issue
+```
+
+**Stop before merge ONLY when:**
+
+- The user gives a specific instruction for that task ("PR only", "I'll merge
+  this one", "hold", "don't merge yet").
+- The issue or spec documents a stop gate (explicit human sign-off, release
+  coordination, an irreversible/destructive production operation).
+
+**These are NOT stop gates — they are "fix, then ship":** CI red, unresolved
+`REQUEST_CHANGES`, merge conflicts, or branch protection requiring outside
+approval. Resolve them and proceed to merge; do not hand merging back to the
+user as a question.
+
+High-risk classes (auth, payments, migrations, data-loss, secrets) still ship,
+but run the Codex review BEFORE merge (see `implementation-routing.md`). Review
+is a gate to clear, not a reason to stop shipping.
+
+Do not ask "want me to merge?" as a matter of course. If there is genuine doubt
+about whether a stop gate applies, that is the only time to ask.
 
 ## Branch Rules
 

--- a/codex-config/AGENTS.md
+++ b/codex-config/AGENTS.md
@@ -24,6 +24,18 @@ and verify behavior before declaring completion.
 - Treat tool failures, skipped tests, and missing dependencies as explicit
   risks, not success.
 
+## Ship by Default
+
+Take issue work end-to-end, including the merge — do not pause to ask for merge
+approval. The terminal state of a task is a merged PR: commit → push → PR →
+validate/review → squash-merge → prune branch → sync main → close the issue.
+Stop before merge ONLY when the user gave a specific instruction for that task
+("PR only", "hold") or the issue/spec documents a stop gate (human sign-off,
+release coordination, an irreversible/destructive production operation). CI red,
+unresolved change requests, and merge conflicts are "fix, then ship" — not
+reasons to stop. High-risk work (auth, payments, migrations, data-loss, secrets)
+still ships, but runs adversarial review before merge.
+
 ## High-Frequency Failure Checks
 
 - `VERIFICATION_GAP`: Do not infer code structure from memory. Inspect source.


### PR DESCRIPTION
Makes ship-by-default explicit across both agent surfaces. Agents take issue work end-to-end (including squash-merge) without pausing to ask for merge approval; stop gates are narrow and enumerated (specific user agreement or a documented issue/spec gate). CI-red / REQUEST_CHANGES / conflicts are 'fix then ship', not stop gates.

Jason: 'ship all issues unless there is a specific agreement not to' (2026-06-07).

Closes #307

🤖 Generated with [Claude Code](https://claude.com/claude-code)