### PR TITLE
feat(usage): price gpt-5.x / codex model family in PRICES

### DIFF
--- a/claude-config/scripts/otel_sink.py
+++ b/claude-config/scripts/otel_sink.py
@@ -64,7 +64,7 @@ PRICES = {
         "cache_creation": 0.0,
         "cache_read": 0.10e-6,
     },
-    "gpt-5-codex": {  # catch-all: gpt-5-codex and older gpt-5.N-codex variants — VERIFY rates
+    "gpt-5-codex": {  # the literal gpt-5-codex model (prefix match only; a future gpt-5.N-codex with no row intentionally raises under strict, per #231) — VERIFY rates
         "input": 0.75e-6,
         "output": 6e-6,
         "cache_creation": 0.0,
@@ -82,7 +82,7 @@ PRICES = {
         "cache_creation": 0.0,
         "cache_read": 0.025e-6,
     },
-    "gpt-5-mini": {  # catch-all: gpt-5-mini and gpt-5.N-mini variants — VERIFY rates
+    "gpt-5-mini": {  # the literal gpt-5-mini model (prefix match only; a future gpt-5.N-mini with no row intentionally raises under strict, per #231) — VERIFY rates
         "input": 0.10e-6,
         "output": 0.40e-6,
         "cache_creation": 0.0,
@@ -129,7 +129,9 @@ def _matches_family(m: str, family: str) -> bool:
     GPT families use startswith-only: the numeric guard (token.isalpha()) prevents cross-family
     matches via numeric tokens — e.g. "5.2" must NOT match gpt-5.2-mini against gpt-5.2-codex.
     """
-    token = family.split("-")[1]
+    parts = family.split("-")
+    # hyphenless family key → no alpha-substring branch (avoids IndexError)
+    token = parts[1] if len(parts) > 1 else ""
     return m.startswith(family) or (token.isalpha() and token in m)
 
 

--- a/claude-config/scripts/otel_sink.py
+++ b/claude-config/scripts/otel_sink.py
@@ -46,14 +46,71 @@ PRICES = {
         "cache_creation": 1.0e-6,
         "cache_read": 0.08e-6,
     },
-    # OpenAI / Codex. gpt-5.5 verified in use (Codex CLI, §2.2). OpenAI bills cached input at a discount
-    # and charges no separate cache-WRITE, so cache_creation = 0. Rates are representative (per-MTok/1e6)
-    # — VERIFY against OpenAI's published pricing when finalizing billing.
-    "gpt-5.5": {
+    # OpenAI / Codex. OpenAI bills cached input at a discount and charges no separate cache-WRITE,
+    # so cache_creation = 0 for all GPT rows. Rates are representative (per-MTok / 1e6) —
+    # VERIFY against OpenAI published pricing before treating these as authoritative for billing.
+    #
+    # INSERTION ORDER IS LOAD-BEARING: more-specific prefixes MUST precede any prefix they could
+    # shadow (e.g. gpt-5.4-mini before gpt-5.4; gpt-5.2-codex before gpt-5-codex).
+    "gpt-5.2-codex": {  # real data: 2694 events in ~/.codex/sessions — VERIFY rates
+        "input": 0.75e-6,
+        "output": 6e-6,
+        "cache_creation": 0.0,
+        "cache_read": 0.075e-6,
+    },
+    "gpt-5.3-codex": {  # real data: 704 events — VERIFY rates
+        "input": 1.0e-6,
+        "output": 8e-6,
+        "cache_creation": 0.0,
+        "cache_read": 0.10e-6,
+    },
+    "gpt-5-codex": {  # catch-all: gpt-5-codex and older gpt-5.N-codex variants — VERIFY rates
+        "input": 0.75e-6,
+        "output": 6e-6,
+        "cache_creation": 0.0,
+        "cache_read": 0.075e-6,
+    },
+    "gpt-5.4-mini": {  # mini tier, cheaper than flagship — VERIFY rates
+        "input": 0.10e-6,
+        "output": 0.40e-6,
+        "cache_creation": 0.0,
+        "cache_read": 0.025e-6,
+    },
+    "gpt-5.2-mini": {  # mini tier — VERIFY rates
+        "input": 0.10e-6,
+        "output": 0.40e-6,
+        "cache_creation": 0.0,
+        "cache_read": 0.025e-6,
+    },
+    "gpt-5-mini": {  # catch-all: gpt-5-mini and gpt-5.N-mini variants — VERIFY rates
+        "input": 0.10e-6,
+        "output": 0.40e-6,
+        "cache_creation": 0.0,
+        "cache_read": 0.025e-6,
+    },
+    "gpt-4o-mini": {  # VERIFY rates
+        "input": 0.15e-6,
+        "output": 0.60e-6,
+        "cache_creation": 0.0,
+        "cache_read": 0.075e-6,
+    },
+    "gpt-5.4": {  # real data: 354 events, flagship tier — VERIFY rates
         "input": 1.25e-6,
         "output": 10e-6,
         "cache_creation": 0.0,
         "cache_read": 0.125e-6,
+    },
+    "gpt-5.5": {  # verified in use (Codex CLI, §2.2) — VERIFY rates
+        "input": 1.25e-6,
+        "output": 10e-6,
+        "cache_creation": 0.0,
+        "cache_read": 0.125e-6,
+    },
+    "gpt-4o": {  # VERIFY rates
+        "input": 2.50e-6,
+        "output": 10e-6,
+        "cache_creation": 0.0,
+        "cache_read": 1.25e-6,
     },
 }
 DEFAULT_PRICE = PRICES[
@@ -65,15 +122,24 @@ EXPORTER_FRESHNESS_SLA_DEFAULT = (
 )  # 24h: sink must be written within SLA or alarm (§0.1)
 
 
+def _matches_family(m: str, family: str) -> bool:
+    """True if lowercase model string `m` belongs to `family`.
+
+    Claude families use alphabetic-token substring (opus/sonnet/haiku are alpha → substring fires).
+    GPT families use startswith-only: the numeric guard (token.isalpha()) prevents cross-family
+    matches via numeric tokens — e.g. "5.2" must NOT match gpt-5.2-mini against gpt-5.2-codex.
+    """
+    token = family.split("-")[1]
+    return m.startswith(family) or (token.isalpha() and token in m)
+
+
 def _price_for(model: str) -> dict:
     """Pick a price row by model-family prefix; fall back to DEFAULT_PRICE for unknown models."""
     if not model:
         return DEFAULT_PRICE
     m = str(model).lower()
     for family, row in PRICES.items():
-        if (
-            m.startswith(family) or family.split("-")[1] in m
-        ):  # 'opus'/'sonnet'/'haiku' substring
+        if _matches_family(m, family):
             return row
     return DEFAULT_PRICE
 

--- a/claude-config/scripts/token_collector.py
+++ b/claude-config/scripts/token_collector.py
@@ -8,7 +8,6 @@ only as `diagnostic_only`.
 server-a's lane; built host-agnostic by scratch against simulated sink data (live data lands once
 the #252 collector deploy runs on jns-server). Pure logic, no side effects.
 """
-
 from __future__ import annotations
 
 import sys
@@ -19,14 +18,12 @@ import otel_sink as O  # noqa: E402
 
 # Work types with no valid code-quality measurement — cost-tracked but EXCLUDED from targets (§2.5).
 EXCLUDED_WORK_TYPES = frozenset({"deliberative", "ops"})
-RECONCILE_TOLERANCE_DEFAULT = (
-    0.01  # 1% — per-task sum must reconcile vs global OTEL (§2.5 watchdog)
-)
+RECONCILE_TOLERANCE_DEFAULT = 0.01  # 1% — per-task sum must reconcile vs global OTEL (§2.5 watchdog)
 
 
 def is_known_model(model: str) -> bool:
-    """True if the model maps to a real price row (not the DEFAULT_PRICE fallback).
-    Uses O._matches_family — the single source of truth for family matching."""
+    """True if the model maps to a real price row. Uses O._matches_family — the single
+    source of truth for family matching — so this never drifts from _price_for."""
     if not model:
         return False
     m = str(model).lower()
@@ -56,9 +53,7 @@ def _task_link(meta: dict) -> str | None:
     return None
 
 
-def collect_sessions(
-    sink_records: list, session_meta: dict | None = None, *, strict: bool = True
-) -> list:
+def collect_sessions(sink_records: list, session_meta: dict | None = None, *, strict: bool = True) -> list:
     """Per-session cost records (the primary unit, §1.3). `session_meta` joins capture metadata
     (work_type / issue / branch from #229) onto the OTEL token records by session_id."""
     session_meta = session_meta or {}
@@ -67,17 +62,15 @@ def collect_sessions(
         sid = r.get("session_id")
         meta = session_meta.get(sid, {})
         work_type = meta.get("work_type") or r.get("work_type")
-        out.append(
-            {
-                "session_id": sid,
-                "model": r.get("model"),
-                "work_type": work_type,
-                "tokens": {f: int(r.get(f, 0) or 0) for f in O.TOKEN_FIELDS},
-                "cost_usd": session_cost(r, strict=strict),
-                "task_link": _task_link({**meta, **r}),
-                "excluded": work_type in EXCLUDED_WORK_TYPES,
-            }
-        )
+        out.append({
+            "session_id": sid,
+            "model": r.get("model"),
+            "work_type": work_type,
+            "tokens": {f: int(r.get(f, 0) or 0) for f in O.TOKEN_FIELDS},
+            "cost_usd": session_cost(r, strict=strict),
+            "task_link": _task_link({**meta, **r}),
+            "excluded": work_type in EXCLUDED_WORK_TYPES,
+        })
     return out
 
 
@@ -108,25 +101,15 @@ def aggregate(session_costs: list) -> dict:
         "attributed_cost_usd": round(attributed, 10),
         "unattributed_cost_usd": round(unattributed, 10),
         "excluded_cost_usd": round(excluded, 10),
-        "attribution_coverage": round(
-            coverage, 4
-        ),  # feeds the §0.5 target-promotion gate
+        "attribution_coverage": round(coverage, 4),  # feeds the §0.5 target-promotion gate
     }
 
 
-def reconcile(
-    attributed_total: float,
-    otel_global_total: float,
-    tolerance: float = RECONCILE_TOLERANCE_DEFAULT,
-) -> dict:
+def reconcile(attributed_total: float, otel_global_total: float, tolerance: float = RECONCILE_TOLERANCE_DEFAULT) -> dict:
     """Token-coverage reconciliation (§2.5 watchdog): per-task attributed cost must track the global
     OTEL total within tolerance, else attribution gaps are hiding spend → alarm."""
     if otel_global_total <= 0:
-        return {
-            "alarm": attributed_total > 0,
-            "reason": "no_global_total",
-            "deviation": None,
-        }
+        return {"alarm": attributed_total > 0, "reason": "no_global_total", "deviation": None}
     deviation = abs(attributed_total - otel_global_total) / otel_global_total
     return {
         "alarm": deviation > tolerance,
@@ -135,20 +118,15 @@ def reconcile(
     }
 
 
-def build_report(
-    sink_records: list,
-    session_meta: dict | None = None,
-    *,
-    otel_global_total: float | None = None,
-    strict: bool = True,
-) -> dict:
+def build_report(sink_records: list, session_meta: dict | None = None, *,
+                 otel_global_total: float | None = None, strict: bool = True) -> dict:
     """The collector's emitted record. Per-session cost + per-task rollup are diagnostics. Cost-per-
     outcome / waste-share are TARGET-GATED (§0.5) so they are explicitly labeled diagnostic_only."""
     sessions = collect_sessions(sink_records, session_meta, strict=strict)
     agg = aggregate(sessions)
     report = {
         "schema_version": 1,
-        "sessions": sessions,  # diagnostic: raw per-session cost
+        "sessions": sessions,            # diagnostic: raw per-session cost
         **agg,
         "diagnostic_only": {
             # not targets until the §0.5 gate clears (source+coverage+proxy-validated+companions)
@@ -158,7 +136,5 @@ def build_report(
         },
     }
     if otel_global_total is not None:
-        report["reconciliation"] = reconcile(
-            agg["attributed_cost_usd"], otel_global_total
-        )
+        report["reconciliation"] = reconcile(agg["attributed_cost_usd"], otel_global_total)
     return report

--- a/claude-config/scripts/token_collector.py
+++ b/claude-config/scripts/token_collector.py
@@ -8,6 +8,7 @@ only as `diagnostic_only`.
 server-a's lane; built host-agnostic by scratch against simulated sink data (live data lands once
 the #252 collector deploy runs on jns-server). Pure logic, no side effects.
 """
+
 from __future__ import annotations
 
 import sys
@@ -18,15 +19,18 @@ import otel_sink as O  # noqa: E402
 
 # Work types with no valid code-quality measurement — cost-tracked but EXCLUDED from targets (§2.5).
 EXCLUDED_WORK_TYPES = frozenset({"deliberative", "ops"})
-RECONCILE_TOLERANCE_DEFAULT = 0.01  # 1% — per-task sum must reconcile vs global OTEL (§2.5 watchdog)
+RECONCILE_TOLERANCE_DEFAULT = (
+    0.01  # 1% — per-task sum must reconcile vs global OTEL (§2.5 watchdog)
+)
 
 
 def is_known_model(model: str) -> bool:
-    """True if the model maps to a real price row (family prefix or opus/sonnet/haiku substring)."""
+    """True if the model maps to a real price row (not the DEFAULT_PRICE fallback).
+    Uses O._matches_family — the single source of truth for family matching."""
     if not model:
         return False
     m = str(model).lower()
-    return any(m.startswith(fam) or fam.split("-")[1] in m for fam in O.PRICES)
+    return any(O._matches_family(m, fam) for fam in O.PRICES)
 
 
 def session_cost(record: dict, *, strict: bool = True) -> float:
@@ -52,7 +56,9 @@ def _task_link(meta: dict) -> str | None:
     return None
 
 
-def collect_sessions(sink_records: list, session_meta: dict | None = None, *, strict: bool = True) -> list:
+def collect_sessions(
+    sink_records: list, session_meta: dict | None = None, *, strict: bool = True
+) -> list:
     """Per-session cost records (the primary unit, §1.3). `session_meta` joins capture metadata
     (work_type / issue / branch from #229) onto the OTEL token records by session_id."""
     session_meta = session_meta or {}
@@ -61,15 +67,17 @@ def collect_sessions(sink_records: list, session_meta: dict | None = None, *, st
         sid = r.get("session_id")
         meta = session_meta.get(sid, {})
         work_type = meta.get("work_type") or r.get("work_type")
-        out.append({
-            "session_id": sid,
-            "model": r.get("model"),
-            "work_type": work_type,
-            "tokens": {f: int(r.get(f, 0) or 0) for f in O.TOKEN_FIELDS},
-            "cost_usd": session_cost(r, strict=strict),
-            "task_link": _task_link({**meta, **r}),
-            "excluded": work_type in EXCLUDED_WORK_TYPES,
-        })
+        out.append(
+            {
+                "session_id": sid,
+                "model": r.get("model"),
+                "work_type": work_type,
+                "tokens": {f: int(r.get(f, 0) or 0) for f in O.TOKEN_FIELDS},
+                "cost_usd": session_cost(r, strict=strict),
+                "task_link": _task_link({**meta, **r}),
+                "excluded": work_type in EXCLUDED_WORK_TYPES,
+            }
+        )
     return out
 
 
@@ -100,15 +108,25 @@ def aggregate(session_costs: list) -> dict:
         "attributed_cost_usd": round(attributed, 10),
         "unattributed_cost_usd": round(unattributed, 10),
         "excluded_cost_usd": round(excluded, 10),
-        "attribution_coverage": round(coverage, 4),  # feeds the §0.5 target-promotion gate
+        "attribution_coverage": round(
+            coverage, 4
+        ),  # feeds the §0.5 target-promotion gate
     }
 
 
-def reconcile(attributed_total: float, otel_global_total: float, tolerance: float = RECONCILE_TOLERANCE_DEFAULT) -> dict:
+def reconcile(
+    attributed_total: float,
+    otel_global_total: float,
+    tolerance: float = RECONCILE_TOLERANCE_DEFAULT,
+) -> dict:
     """Token-coverage reconciliation (§2.5 watchdog): per-task attributed cost must track the global
     OTEL total within tolerance, else attribution gaps are hiding spend → alarm."""
     if otel_global_total <= 0:
-        return {"alarm": attributed_total > 0, "reason": "no_global_total", "deviation": None}
+        return {
+            "alarm": attributed_total > 0,
+            "reason": "no_global_total",
+            "deviation": None,
+        }
     deviation = abs(attributed_total - otel_global_total) / otel_global_total
     return {
         "alarm": deviation > tolerance,
@@ -117,15 +135,20 @@ def reconcile(attributed_total: float, otel_global_total: float, tolerance: floa
     }
 
 
-def build_report(sink_records: list, session_meta: dict | None = None, *,
-                 otel_global_total: float | None = None, strict: bool = True) -> dict:
+def build_report(
+    sink_records: list,
+    session_meta: dict | None = None,
+    *,
+    otel_global_total: float | None = None,
+    strict: bool = True,
+) -> dict:
     """The collector's emitted record. Per-session cost + per-task rollup are diagnostics. Cost-per-
     outcome / waste-share are TARGET-GATED (§0.5) so they are explicitly labeled diagnostic_only."""
     sessions = collect_sessions(sink_records, session_meta, strict=strict)
     agg = aggregate(sessions)
     report = {
         "schema_version": 1,
-        "sessions": sessions,            # diagnostic: raw per-session cost
+        "sessions": sessions,  # diagnostic: raw per-session cost
         **agg,
         "diagnostic_only": {
             # not targets until the §0.5 gate clears (source+coverage+proxy-validated+companions)
@@ -135,5 +158,7 @@ def build_report(sink_records: list, session_meta: dict | None = None, *,
         },
     }
     if otel_global_total is not None:
-        report["reconciliation"] = reconcile(agg["attributed_cost_usd"], otel_global_total)
+        report["reconciliation"] = reconcile(
+            agg["attributed_cost_usd"], otel_global_total
+        )
     return report

--- a/claude-config/tests/test_multiprovider_pricing.py
+++ b/claude-config/tests/test_multiprovider_pricing.py
@@ -73,3 +73,136 @@ def test_opus_rates_sanity_vs_real_session():
     assert cost == pytest.approx(2159, rel=0.05), (
         f"opus rates drifted: ${cost:,.2f} vs $2,159 ref"
     )
+
+
+# --- New GPT families: each resolves to its own row, not DEFAULT -------------------------------------
+
+
+@pytest.mark.parametrize(
+    "model,family_key",
+    [
+        ("gpt-5.2-codex", "gpt-5.2-codex"),
+        ("gpt-5.3-codex", "gpt-5.3-codex"),
+        ("gpt-5-codex", "gpt-5-codex"),
+        ("gpt-5.4-mini", "gpt-5.4-mini"),
+        ("gpt-5.2-mini", "gpt-5.2-mini"),
+        ("gpt-5-mini", "gpt-5-mini"),
+        ("gpt-4o-mini", "gpt-4o-mini"),
+        ("gpt-5.4", "gpt-5.4"),
+        ("gpt-4o", "gpt-4o"),
+    ],
+)
+def test_new_gpt_model_resolves_to_own_row(model, family_key):
+    row = O._price_for(model)
+    assert row is O.PRICES[family_key], f"{model!r} resolved wrong row"
+    assert row is not O.DEFAULT_PRICE
+
+
+# --- Numeric-guard: mini must NOT match flagship / codex row -----------------------------------------
+
+
+@pytest.mark.parametrize(
+    "mini,forbidden_family",
+    [
+        ("gpt-5.4-mini", "gpt-5.4"),
+        ("gpt-5.2-mini", "gpt-5.2-codex"),  # dangerous cross-numeric case
+        ("gpt-4o-mini", "gpt-4o"),
+        ("gpt-5-mini", "gpt-5-codex"),
+    ],
+)
+def test_mini_does_not_match_flagship(mini, forbidden_family):
+    row = O._price_for(mini)
+    assert row is not O.PRICES.get(forbidden_family), (
+        f"{mini!r} must not resolve to {forbidden_family!r} price row"
+    )
+
+
+# --- Codex does NOT match mini -----------------------------------------------------------------------
+
+
+def test_codex_does_not_match_mini():
+    # gpt-5.2-codex must not accidentally resolve to a gpt-5.2-mini row
+    row = O._price_for("gpt-5.2-codex")
+    assert row is O.PRICES["gpt-5.2-codex"]
+    assert row is not O.PRICES.get("gpt-5.2-mini")
+
+
+# --- is_known_model covers new families --------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "gpt-5.2-codex",
+        "gpt-5.3-codex",
+        "gpt-5-codex",
+        "gpt-5.4-mini",
+        "gpt-5.2-mini",
+        "gpt-5-mini",
+        "gpt-4o-mini",
+        "gpt-5.4",
+        "gpt-4o",
+    ],
+)
+def test_new_models_are_known(model):
+    assert C.is_known_model(model) is True
+    # strict=True must not raise
+    cost = C.session_cost({"model": model, "input": 1_000_000}, strict=True)
+    assert cost > 0
+
+
+# --- Mini rates are cheaper than flagship for same base version --------------------------------------
+
+
+def test_mini_cheaper_than_flagship():
+    # input rate: gpt-5.4-mini < gpt-5.4
+    mini_input = O.PRICES["gpt-5.4-mini"]["input"]
+    flagship_input = O.PRICES["gpt-5.4"]["input"]
+    assert mini_input < flagship_input, "mini input rate must be cheaper than flagship"
+
+
+def test_mini_cheaper_than_codex():
+    # output rate: gpt-5.2-mini < gpt-5.2-codex
+    mini_out = O.PRICES["gpt-5.2-mini"]["output"]
+    codex_out = O.PRICES["gpt-5.2-codex"]["output"]
+    assert mini_out < codex_out, "mini output rate must be cheaper than codex"
+
+
+# --- Predicate DRY: _matches_family is the canonical predicate ---------------------------------------
+
+
+def test_matches_family_exported_and_consistent():
+    # Confirm _matches_family exists on otel_sink and is callable
+    assert callable(O._matches_family)
+    # Confirm is_known_model uses the same predicate as _price_for:
+    # for every real model, is_known_model == any(_matches_family(...)) over PRICES keys.
+    # NOTE: we do NOT use `_price_for(m) is not DEFAULT_PRICE` as the oracle — claude-sonnet-4
+    # IS the DEFAULT_PRICE row, so that identity check gives a false negative (the DEFAULT_PRICE
+    # trap documented in the MAP-PLAN). Instead we compare directly against the family predicate.
+    real_models = [
+        "gpt-5.2-codex",
+        "gpt-5.3-codex",
+        "gpt-5-codex",
+        "gpt-5.4",
+        "gpt-5.5",
+        "gpt-4o",
+        "gpt-4o-mini",
+        "gpt-5.4-mini",
+        "gpt-5.2-mini",
+        "gpt-5-mini",
+        "claude-opus-4",
+        "claude-sonnet-4",
+        "claude-haiku-4",
+    ]
+    for m in real_models:
+        known_via_collector = C.is_known_model(m)
+        known_via_predicate = any(O._matches_family(m.lower(), fam) for fam in O.PRICES)
+        assert known_via_collector == known_via_predicate, (
+            f"is_known_model and _matches_family disagree for {m!r}"
+        )
+        # All real models must be known
+        assert known_via_collector is True, f"{m!r} should be a known model"
+
+
+# --- Unknown model still raises under strict (existing test_unknown_model_still_loud covers this) ---
+# gpt-99-unknown test is preserved above; no additional test needed here.


### PR DESCRIPTION
Adds the GPT-5/Codex model families to `otel_sink.PRICES` so the usage report runs strict on real fleet data (the strict gate caught `gpt-5.2-codex` unpriced — working as designed), and hardens family matching.

## Changes
- **`_matches_family(model, family)`** — substring match fires only for ALPHABETIC family tokens (opus/sonnet/haiku); numeric GPT version tokens (5.2/5.4) match by `startswith` only, so `gpt-5.2-codex` can't cross-match `gpt-5.2-mini`. Guarded against hyphenless keys (no `IndexError`).
- **9 new price rows** in specific-before-general order (so `gpt-5.4-mini` doesn't resolve to `gpt-5.4`). Rates representative, flagged VERIFY; mini < flagship/codex.
- **`is_known_model`** now calls `O._matches_family` (single source of truth — can't drift from `_price_for`; avoids the DEFAULT_PRICE-identity trap).
- **+26 tests**: per-family resolution, numeric guard, DRY consistency, tier ordering, all real models known & non-raising under strict, unknown still raises.

## Validation
- Opus real-mix cross-check holds ($2,158.97 ≈ $2,159). Suite 181→**207**, all green. ruff clean.
- **Codex review R1: REQUEST_CHANGES** — two findings: (1) `gpt-5-codex`/`gpt-5-mini` comments claimed "catch-all" for `gpt-5.N` variants that startswith-matching doesn't deliver; (2) `family.split("-")[1]` fragile for hyphenless keys. **Both addressed:** comments corrected to state each row matches its literal family by prefix and that an unpriced future `gpt-5.N` variant *intentionally* raises under strict (per #231 — catch-all pricing of unknowns would violate the no-silent-cost design); hyphenless-key guard added.
- **Codex review R2 (re-review): hung** (known ~50% codex-exec stdin hang; watchdog killed at ~9min). Fell back to self-review per protocol — resolution is comment-accuracy + a defensive guard, no behavior change, tests green.

Closes #309