### PR TITLE
chore(usage): activate account-capture SessionStart hook

### DIFF
--- a/claude-config/settings.json
+++ b/claude-config/settings.json
@@ -79,6 +79,10 @@
           {
             "type": "command",
             "command": "python3 ~/.claude/hooks/load_learning_rules.py"
+          },
+          {
+            "type": "command",
+            "command": "python3 ~/.claude/hooks/usage_account_capture.py"
           }
         ]
       }


### PR DESCRIPTION
Wires the pre-built, pre-tested `usage_account_capture.py` into `settings.json` as a SessionStart hook so each session's billing account is captured for the usage collector (§4.1). Authorized by Jason (2026-06-07).

## Verification
- `settings.json` valid JSON; `validate-hooks.py` resolves all **10** hook paths (was 9).
- **Live-fire safety**: with a `oauthToken` + `apiKey` present in `~/.claude.json`, the hook writes ONLY identity fields (account_uuid / org / email / seat_tier / billing_type) — **no secret leaks** (§229 no-secrets ban). `billingType: "max"` → `subscription`.
- Malformed / missing `~/.claude.json` → clean exit 0, no crash, no-op.
- 10 existing `test_account_capture` tests pass. Existing SessionStart hooks preserved.

Scoped diff: only the SessionStart hook entry. (The working tree's pre-existing `theme`/`tui` settings drift is intentionally NOT included.)

Closes #310

🤖 Generated with [Claude Code](https://claude.com/claude-code)