### PR TITLE
feat(usage): right-sizing recommendation engine + report section (#268 phase 1)

### DIFF
--- a/claude-config/scripts/usage_aggregator.py
+++ b/claude-config/scripts/usage_aggregator.py
@@ -232,6 +232,7 @@ def cache_by_project(records: list) -> dict:
         label = _billing_label(rs)
         res[proj] = {
             **_cost_group(rs),
+            "total_input_tokens": inp,  # consumed by usage_recommend type-4 (cache inefficiency)
             "cache_pct": round(cr / (inp + cr), 4) if (inp + cr) else 0.0,
             "cache_saved_usd": (
                 round(sum(saved_by_billing.values()), 10) if label != "mixed" else None

--- a/claude-config/scripts/usage_recommend.py
+++ b/claude-config/scripts/usage_recommend.py
@@ -1,0 +1,348 @@
+"""Right-sizing recommendation engine (fleet-usage-monitor §7, §8 step 7, issue #268 Phase 1).
+
+Consumes `usage_aggregator.aggregate()` output + raw records and emits structured recommendations
+across four analysis types:
+
+  1. model_tier_mismatch  — priciest model used on TRIVIAL/SIMPLE work (downshift savings computed
+                            from raw token counts via otel_sink.compute_cost, not ratios)
+  2. cost_outlier         — $/file-changed tasks above 3× fleet median (flag for investigation)
+  3. model_mix_skew       — project with >70% Claude spend on opus including TRIVIAL/SIMPLE records
+  4. cache_inefficiency   — project below 10% cache-read ratio with >100k tokens
+
+billing_type invariant (§6): subscription savings are NOTIONAL API-equivalent value, never cash.
+The estimated_impact string bakes the correct framing so the renderer never branches on billing_type.
+Mixed-billing findings carry estimated_impact=None — never sum subscription + metered into one figure.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import otel_sink as O  # noqa: E402
+from usage_aggregator import _billing_label, _cost_group, _f, _i  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+_CLAUDE_TIER_ORDER = ["claude-haiku-4", "claude-sonnet-4", "claude-opus-4"]
+_SKEW_THRESHOLD = 0.70
+_OUTLIER_RATIO = 3.0
+_MIN_TASKS_FOR_OUTLIER = 3
+_CACHE_PCT_THRESHOLD = 0.10
+_MIN_TOKENS_FOR_CACHE_REC = 100_000
+
+# Tiers that should prefer cheaper models (TRIVIAL and SIMPLE only)
+_DOWNSHIFT_TIERS = {"TRIVIAL", "SIMPLE"}
+
+
+# ---------------------------------------------------------------------------
+# Private helpers
+# ---------------------------------------------------------------------------
+
+
+def _downshift_savings(records: list, target_model: str) -> float:
+    """API-equivalent savings if all records were recomputed at target_model rates.
+
+    Uses otel_sink.compute_cost per record (exact token-level recomputation, not a ratio).
+    Returns 0.0 when records is empty.
+    """
+    if not records:
+        return 0.0
+    current_cost = sum(
+        O.compute_cost(r, prices={r.get("model", ""): O._price_for(r.get("model", ""))})
+        for r in records
+    )
+    target_prices = {target_model: O._price_for(target_model)}
+    target_cost = sum(
+        O.compute_cost({**r, "model": target_model}, prices=target_prices)
+        for r in records
+    )
+    return round(current_cost - target_cost, 10)
+
+
+def _impact_label(savings: float, billing_type: str) -> str | None:
+    """Format the impact string per billing_type.
+
+    subscription → 'API-equiv $X.XX reduction (notional)'
+    metered      → '$X.XX'
+    mixed/unknown/zero → None
+    """
+    if not savings or savings <= 0:
+        return None
+    if billing_type == "subscription":
+        return f"API-equiv ${savings:.2f} reduction (notional)"
+    if billing_type == "metered":
+        return f"${savings:.2f}"
+    return None
+
+
+def _cheaper_claude_target(model: str) -> str | None:
+    """Given a Claude model name, return the cheapest cheaper tier or None if already cheapest."""
+    try:
+        idx = _CLAUDE_TIER_ORDER.index(model)
+    except ValueError:
+        return None
+    if idx == 0:
+        return None  # already cheapest
+    return _CLAUDE_TIER_ORDER[0]  # downshift to haiku (cheapest)
+
+
+def _type1_mismatch(agg: dict, records: list) -> list[dict]:
+    """Detect priciest-model use on TRIVIAL/SIMPLE tiers."""
+    out = []
+    cost_by_model_tier = agg.get("cost_by_model_tier") or {}
+
+    # Build a lookup: (project, tier, model) -> records
+    from collections import defaultdict
+
+    rec_index: dict = defaultdict(list)
+    for r in records:
+        proj = r.get("project")
+        tier = _tier_of(r)
+        model = r.get("model")
+        if tier in _DOWNSHIFT_TIERS:
+            rec_index[(proj, tier, model)].append(r)
+
+    for proj, tiers in cost_by_model_tier.items():
+        for tier, models in tiers.items():
+            if tier not in _DOWNSHIFT_TIERS:
+                continue
+            # Check each model: is there a cheaper Claude alternative?
+            for model, _grp in models.items():
+                target = _cheaper_claude_target(model)
+                if target is None:
+                    continue  # already cheapest or non-Claude
+                affected_records = rec_index.get((proj, tier, model), [])
+                if not affected_records:
+                    continue
+                billing = _billing_label(affected_records)
+                savings = _downshift_savings(affected_records, target)
+                affected_cost_group = _cost_group(affected_records)
+                token_total = sum(
+                    _i(r.get("input"))
+                    + _i(r.get("output"))
+                    + _i(r.get("cache_read"))
+                    + _i(r.get("cache_creation"))
+                    for r in affected_records
+                )
+                out.append(
+                    {
+                        "type": "model_tier_mismatch",
+                        "project": proj,
+                        "finding": (
+                            f"{tier} tasks in '{proj}' used {model} "
+                            f"({len(affected_records)} task(s), {token_total:,} tokens) — "
+                            f"{target} would suffice."
+                        ),
+                        "evidence": {
+                            "tier": tier,
+                            "model_used": model,
+                            "suggested_model": target,
+                            "task_count": len(affected_records),
+                            "token_total": token_total,
+                            "affected_cost_group": affected_cost_group,
+                        },
+                        "estimated_impact": _impact_label(
+                            savings, billing or "unknown"
+                        ),
+                        "billing_type": billing or "unknown",
+                        "action": f"Route {tier} tasks in '{proj}' to {target}.",
+                    }
+                )
+    return out
+
+
+def _tier_of(record: dict) -> str:
+    """Derive tier from files_changed on a single record."""
+    from usage_aggregator import task_tier
+
+    return task_tier(record.get("files_changed"))
+
+
+def _type2_outliers(agg: dict) -> list[dict]:
+    """Flag $/file-changed tasks above 3× fleet median."""
+    cost_per_pr = agg.get("cost_per_pr") or {}
+    # Collect tasks with a numeric cost_per_file_changed value
+    numeric_tasks = []
+    for task, info in cost_per_pr.items():
+        cpf = info.get("cost_per_file_changed")
+        if isinstance(cpf, (int, float)) and not isinstance(cpf, bool):
+            numeric_tasks.append((task, float(cpf), info))
+    if len(numeric_tasks) < _MIN_TASKS_FOR_OUTLIER:
+        return []
+    values = sorted(t[1] for t in numeric_tasks)
+    mid = len(values) // 2
+    if len(values) % 2 == 0:
+        median = (values[mid - 1] + values[mid]) / 2
+    else:
+        median = values[mid]
+    if median <= 0:
+        return []
+    out = []
+    for task, cpf, info in numeric_tasks:
+        ratio = cpf / median
+        if ratio >= _OUTLIER_RATIO:
+            out.append(
+                {
+                    "type": "cost_outlier",
+                    "project": None,
+                    "finding": (
+                        f"Task '{task}' costs ${cpf:.4f}/file-changed, "
+                        f"{ratio:.1f}× the fleet median (${median:.4f}/file-changed)."
+                    ),
+                    "evidence": {
+                        "task": task,
+                        "cost_per_file": cpf,
+                        "median_cost_per_file": median,
+                        "ratio": round(ratio, 2),
+                    },
+                    "estimated_impact": None,
+                    "billing_type": info.get("billing_type") or "unknown",
+                    "action": f"Investigate task '{task}' for rework, large diffs, or over-tiered model use.",
+                }
+            )
+    return out
+
+
+def _type3_skew(agg: dict, records: list) -> list[dict]:
+    """Detect projects where opus > 70% of Claude spend and TRIVIAL/SIMPLE opus records exist."""
+    out = []
+    cost_by_model_tier = agg.get("cost_by_model_tier") or {}
+
+    # Build per-project opus-on-TRIVIAL/SIMPLE records lookup
+    from collections import defaultdict
+
+    trivial_simple_opus_recs: dict = defaultdict(list)
+    for r in records:
+        if r.get("model") == "claude-opus-4" and _tier_of(r) in _DOWNSHIFT_TIERS:
+            trivial_simple_opus_recs[r.get("project")].append(r)
+
+    for proj, tiers in cost_by_model_tier.items():
+        # Compute total Claude spend and opus share across ALL tiers for this project
+        total_claude_cost = 0.0
+        opus_cost = 0.0
+        for tier_models in tiers.values():
+            for model, grp in tier_models.items():
+                if model not in _CLAUDE_TIER_ORDER:
+                    continue
+                c = _f((grp or {}).get("cost_usd"))
+                total_claude_cost += c
+                if model == "claude-opus-4":
+                    opus_cost += c
+        if total_claude_cost <= 0:
+            continue
+        opus_share = opus_cost / total_claude_cost
+        if opus_share <= _SKEW_THRESHOLD:
+            continue
+        # Must also have TRIVIAL/SIMPLE opus records to flag
+        ts_recs = trivial_simple_opus_recs.get(proj, [])
+        if not ts_recs:
+            continue
+        billing = _billing_label(ts_recs)
+        ts_cost_group = _cost_group(ts_recs)
+        out.append(
+            {
+                "type": "model_mix_skew",
+                "project": proj,
+                "finding": (
+                    f"'{proj}' directs {opus_share * 100:.0f}% of Claude spend to claude-opus-4, "
+                    f"including {len(ts_recs)} TRIVIAL/SIMPLE task(s)."
+                ),
+                "evidence": {
+                    "project": proj,
+                    "opus_share_pct": round(opus_share * 100, 1),
+                    "trivial_simple_opus_cost_group": ts_cost_group,
+                    "trivial_simple_task_count": len(ts_recs),
+                },
+                "estimated_impact": None,
+                "billing_type": billing or "unknown",
+                "action": (
+                    f"Review TRIVIAL/SIMPLE task routing in '{proj}'; "
+                    "redirect those tasks to claude-haiku-4 or claude-sonnet-4."
+                ),
+            }
+        )
+    return out
+
+
+def _type4_cache(agg: dict) -> list[dict]:
+    """Flag projects with low cache-read ratio and sufficient token volume."""
+    out = []
+    cache_by_project = agg.get("cache_by_project") or {}
+    for proj, info in cache_by_project.items():
+        cache_pct_val = _f(info.get("cache_pct"))
+        # Recover total input tokens from cost_by_billing / cost_usd hints
+        # The aggregator stores total input on the project only indirectly;
+        # use cache_saved_by_billing as a proxy — but we need token counts.
+        # The aggregator stores cache_pct = cache_read / (input + cache_read),
+        # and we need total input tokens. We derive from whatever is available:
+        # cache_by_project doesn't carry raw token totals, so we compute from
+        # the cache_pct and the presence of cost data as a volume signal.
+        # To avoid re-aggregating, accept cache_pct < threshold as the primary
+        # gate and use a token_total field if present (set by tests or extended agg).
+        total_input_tokens = _i(info.get("total_input_tokens"))
+        if total_input_tokens < _MIN_TOKENS_FOR_CACHE_REC:
+            continue
+        if cache_pct_val >= _CACHE_PCT_THRESHOLD:
+            continue
+        billing = info.get("billing_type") or "unknown"
+        out.append(
+            {
+                "type": "cache_inefficiency",
+                "project": proj,
+                "finding": (
+                    f"'{proj}' has a {cache_pct_val * 100:.1f}% cache-read ratio "
+                    f"on {total_input_tokens:,} input tokens — below the {_CACHE_PCT_THRESHOLD * 100:.0f}% threshold."
+                ),
+                "evidence": {
+                    "project": proj,
+                    "cache_pct": cache_pct_val,
+                    "total_input_tokens": total_input_tokens,
+                    "cache_saved_by_billing": info.get("cache_saved_by_billing") or {},
+                },
+                "estimated_impact": None,
+                "billing_type": billing,
+                "action": (
+                    f"Enable prompt caching for '{proj}' to reduce repeated context tokens."
+                ),
+            }
+        )
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Public interface
+# ---------------------------------------------------------------------------
+
+
+def recommend(agg: dict, records: list) -> list[dict]:
+    """Return a list of recommendation dicts, sorted by type then project.
+
+    Always returns a list (empty when no findings). Never raises on missing keys.
+
+    Each dict schema:
+      type            : str  — one of model_tier_mismatch | cost_outlier | model_mix_skew | cache_inefficiency
+      project         : str | None — None for fleet-wide findings
+      finding         : str  — human sentence, billing-aware
+      evidence        : dict — numeric facts
+      estimated_impact: str | None — pre-formatted with correct billing framing; None when uncomputable
+      billing_type    : str  — subscription | metered | mixed | unknown
+      action          : str  — concrete next step
+    """
+    agg = agg or {}
+    records = records or []
+    try:
+        findings = (
+            _type1_mismatch(agg, records)
+            + _type2_outliers(agg)
+            + _type3_skew(agg, records)
+            + _type4_cache(agg)
+        )
+    except Exception:  # noqa: BLE001 — never crash the renderer
+        return []
+    return sorted(
+        findings, key=lambda r: (r.get("type") or "", str(r.get("project") or ""))
+    )

--- a/claude-config/scripts/usage_report.py
+++ b/claude-config/scripts/usage_report.py
@@ -28,6 +28,7 @@ SECTIONS = [
     ("by_account", "By Account & Computer"),
     ("by_tier", "Cost by Task Tier"),
     ("concurrency", "Concurrency & Utilization"),
+    ("recommendations", "Right-Sizing Recommendations"),
 ]
 _NOTIONAL_FOOTNOTE = (
     "* notional API-equivalent value (subscription billing) — NOT cash paid"
@@ -128,26 +129,35 @@ def trends(records: list, *, period: str = "week") -> dict:
     return out
 
 
-def _right_sizing_callout(agg: dict) -> str:
-    """Cost-only right-sizing hint (rework companion is P2 #268): for each project's COMPLEX tier, if a
-    cheaper model also appears, note the cheaper-model share."""
-    lines = []
-    for proj, tiers in (agg.get("cost_by_model_tier") or {}).items():
-        complex_models = tiers.get("COMPLEX") or {}
-        if len(complex_models) >= 2:
-            costs = {
-                m: _fnum((g or {}).get("cost_usd")) for m, g in complex_models.items()
-            }
-            top = max(costs, key=costs.get)
-            lines.append(
-                f"{html.escape(str(proj))}: COMPLEX work spans {len(costs)} models "
-                f"(most spend on {html.escape(str(top))}) — review if a cheaper tier suffices."
-            )
-    return (
-        "<br>".join(lines)
-        if lines
-        else "No multi-model COMPLEX tiers to right-size yet."
-    )
+def _render_recommendations(agg: dict, records: list | None) -> str:
+    """Render the Recommendations section HTML.
+
+    Imports usage_recommend lazily (same pattern as _dim_rows imports usage_aggregator) to
+    avoid circular deps. Each recommendation finding is rendered as an <li> with finding,
+    impact, and action. estimated_impact is pre-formatted with the correct billing framing
+    so this renderer never branches on billing_type.
+    """
+    from importlib import import_module
+
+    rec_mod = import_module("usage_recommend")
+    recs = rec_mod.recommend(agg, records or [])
+    if not recs:
+        return '<p class="nodata">No recommendations — data looks well-optimized.</p>'
+    parts = []
+    for r in recs:
+        impact = (
+            r.get("estimated_impact")
+            or "impact not computable (mixed billing or insufficient data)"
+        )
+        proj_label = f" — {html.escape(str(r['project']))}" if r.get("project") else ""
+        parts.append(
+            f"<li><strong>{html.escape(r['type'])}</strong>"
+            f"{proj_label}: "
+            f"{html.escape(r['finding'])} "
+            f"<em>Impact: {html.escape(impact)}</em> "
+            f"<strong>Action:</strong> {html.escape(r['action'])}</li>"
+        )
+    return "<ul>" + "".join(parts) + "</ul>"
 
 
 def _table(headers: list, rows: list) -> str:
@@ -182,16 +192,14 @@ def render_html(
         + _table(["Project", "Cost"], proj_rows)
         + "<canvas id='c_pr_trend'></canvas>"
     )
-    # Section 2: model mix + right-sizing
+    # Section 2: model mix
     mm_rows = [
         [p, m, _fmt_cost(g)]
         for p, models in (agg.get("model_mix") or {}).items()
         for m, g in models.items()
     ]
-    s2 = (
-        f"<h2 id='model_mix'>{SECTIONS[1][1]}</h2>"
-        + _table(["Project", "Model", "Cost"], mm_rows)
-        + f"<p class='callout'>{_right_sizing_callout(agg)}</p>"
+    s2 = f"<h2 id='model_mix'>{SECTIONS[1][1]}</h2>" + _table(
+        ["Project", "Model", "Cost"], mm_rows
     )
     # Section 3: cache efficiency (table + trend chart). _pct/_money are crash-safe on malformed data.
     cache_rows = [
@@ -238,6 +246,10 @@ def render_html(
         + _table(["Host", "peak concurrent", "burn $/hr"], conc_rows)
         + "<canvas id='c_conc'></canvas>"
     )
+    # Section 7: right-sizing recommendations (usage_recommend loaded lazily)
+    s7 = f"<h2 id='recommendations'>{SECTIONS[6][1]}</h2>" + _render_recommendations(
+        agg, records
+    )
 
     footnote = (
         f"<p class='footnote'>{_NOTIONAL_FOOTNOTE}</p>" if has_subscription else ""
@@ -259,7 +271,7 @@ table{{border-collapse:collapse;margin:.5rem 0}}th,td{{border:1px solid #ccc;pad
 </head><body>
 <h1>{html.escape(title)}</h1>
 <p>Total: {html.escape(_fmt_cost(totals))} &middot; {html.escape(str(totals.get("records", 0)))} records</p>
-{s1}{s2}{s3}{s4}{s5}{s6}
+{s1}{s2}{s3}{s4}{s5}{s6}{s7}
 {footnote}
 <!-- Chart labels are data-derived strings, but Chart.js renders them on the CANVAS as text (no
      innerHTML / DOM-injection path; no HTML-tooltip plugin is used), and the embedded blob is

--- a/claude-config/tests/test_usage_recommend.py
+++ b/claude-config/tests/test_usage_recommend.py
@@ -1,0 +1,587 @@
+"""Tests for issue #268 Phase 1 — right-sizing recommendation engine."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+import usage_recommend as REC  # noqa: E402
+import usage_aggregator as A  # noqa: E402
+import usage_report as R  # noqa: E402
+import otel_sink as O  # noqa: E402
+
+
+def _r(**kw):
+    """Minimal synthetic usage record factory (matches test_usage_aggregator convention)."""
+    base = {
+        "provider": "claude",
+        "model": "claude-opus-4",
+        "project": "agents",
+        "task": "issue:42",
+        "input": 1000,
+        "output": 100,
+        "cache_read": 0,
+        "cache_creation": 0,
+        "cost_usd": 1.0,
+        "inference_host": "mac",
+        "work_host": "mac",
+        "session_id": "s1",
+        "ts": "2026-06-01T00:00:00Z",
+        "billing_type": "subscription",
+        "files_changed": 1,  # TRIVIAL by default
+    }
+    base.update(kw)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# Empty / edge input
+# ---------------------------------------------------------------------------
+
+
+def test_empty_records_returns_empty_list():
+    agg = A.aggregate([])
+    result = REC.recommend(agg, [])
+    assert result == []
+
+
+def test_none_records_returns_empty_list():
+    """recommend() must not crash when records=None."""
+    agg = A.aggregate([])
+    result = REC.recommend(agg, None)
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# Type 1 — model_tier_mismatch
+# ---------------------------------------------------------------------------
+
+
+def test_no_mismatch_when_cheapest_model_used():
+    """TRIVIAL records on claude-haiku-4 (cheapest) → no type1 finding."""
+    recs = [_r(model="claude-haiku-4", files_changed=1)]
+    agg = A.aggregate(recs)
+    findings = REC.recommend(agg, recs)
+    type1 = [f for f in findings if f["type"] == "model_tier_mismatch"]
+    assert type1 == []
+
+
+def test_mismatch_detected_opus_on_trivial():
+    """TRIVIAL record using claude-opus-4 → one type1 finding."""
+    recs = [_r(model="claude-opus-4", files_changed=1, billing_type="subscription")]
+    agg = A.aggregate(recs)
+    findings = REC.recommend(agg, recs)
+    type1 = [f for f in findings if f["type"] == "model_tier_mismatch"]
+    assert len(type1) == 1
+    assert type1[0]["type"] == "model_tier_mismatch"
+    assert type1[0]["evidence"]["model_used"] == "claude-opus-4"
+    assert type1[0]["evidence"]["tier"] == "TRIVIAL"
+
+
+def test_mismatch_detected_sonnet_on_simple():
+    """SIMPLE record on claude-sonnet-4 → type1 finding (haiku is cheaper)."""
+    recs = [_r(model="claude-sonnet-4", files_changed=2, billing_type="metered")]
+    agg = A.aggregate(recs)
+    findings = REC.recommend(agg, recs)
+    type1 = [f for f in findings if f["type"] == "model_tier_mismatch"]
+    assert len(type1) == 1
+    assert type1[0]["evidence"]["suggested_model"] == "claude-haiku-4"
+
+
+def test_no_mismatch_on_complex_tier():
+    """COMPLEX records with expensive model are not flagged (downshift only for TRIVIAL/SIMPLE)."""
+    recs = [_r(model="claude-opus-4", files_changed=5, billing_type="subscription")]
+    agg = A.aggregate(recs)
+    findings = REC.recommend(agg, recs)
+    type1 = [f for f in findings if f["type"] == "model_tier_mismatch"]
+    assert type1 == []
+
+
+# ---------------------------------------------------------------------------
+# Downshift savings math
+# ---------------------------------------------------------------------------
+
+
+def test_downshift_savings_math():
+    """Single opus-4 record: 1M input tokens. savings = 1M × (15e-6 - 0.80e-6) = 14.20 exactly."""
+    rec = _r(
+        model="claude-opus-4",
+        input=1_000_000,
+        output=0,
+        cache_read=0,
+        cache_creation=0,
+    )
+    # downshift to haiku (cheapest in _CLAUDE_TIER_ORDER[0])
+    savings = REC._downshift_savings([rec], "claude-haiku-4")
+    expected = 1_000_000 * (
+        O.PRICES["claude-opus-4"]["input"] - O.PRICES["claude-haiku-4"]["input"]
+    )
+    assert abs(savings - expected) < 1e-6
+
+
+def test_downshift_savings_opus_to_sonnet():
+    """1M input tokens opus→sonnet savings = 1M × (15e-6 - 3e-6) = 12.00."""
+    rec = _r(
+        model="claude-opus-4",
+        input=1_000_000,
+        output=0,
+        cache_read=0,
+        cache_creation=0,
+    )
+    savings = REC._downshift_savings([rec], "claude-sonnet-4")
+    assert abs(savings - 12.00) < 1e-6
+
+
+def test_downshift_savings_empty_records():
+    assert REC._downshift_savings([], "claude-haiku-4") == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Billing framing in estimated_impact
+# ---------------------------------------------------------------------------
+
+
+def test_subscription_impact_labeled_notional():
+    """Mismatch on subscription records → estimated_impact contains 'notional'."""
+    recs = [
+        _r(
+            model="claude-opus-4",
+            files_changed=1,
+            billing_type="subscription",
+            input=100_000,
+        )
+    ]
+    agg = A.aggregate(recs)
+    findings = REC.recommend(agg, recs)
+    type1 = [f for f in findings if f["type"] == "model_tier_mismatch"]
+    assert type1, "Expected a type1 finding"
+    impact = type1[0]["estimated_impact"]
+    assert impact is not None
+    assert "notional" in impact
+
+
+def test_metered_impact_labeled_dollar():
+    """Mismatch on metered records → estimated_impact starts with '$'."""
+    recs = [
+        _r(
+            model="claude-opus-4",
+            files_changed=1,
+            billing_type="metered",
+            input=100_000,
+        )
+    ]
+    agg = A.aggregate(recs)
+    findings = REC.recommend(agg, recs)
+    type1 = [f for f in findings if f["type"] == "model_tier_mismatch"]
+    assert type1, "Expected a type1 finding"
+    impact = type1[0]["estimated_impact"]
+    assert impact is not None
+    assert impact.startswith("$")
+    assert "notional" not in impact
+
+
+def test_mixed_billing_impact_is_none():
+    """Mismatch where records span subscription+metered → estimated_impact is None."""
+    recs = [
+        _r(
+            model="claude-opus-4",
+            files_changed=1,
+            billing_type="subscription",
+            session_id="a",
+        ),
+        _r(
+            model="claude-opus-4",
+            files_changed=1,
+            billing_type="metered",
+            session_id="b",
+        ),
+    ]
+    agg = A.aggregate(recs)
+    findings = REC.recommend(agg, recs)
+    type1 = [f for f in findings if f["type"] == "model_tier_mismatch"]
+    assert type1, "Expected a type1 finding"
+    assert type1[0]["estimated_impact"] is None
+
+
+# ---------------------------------------------------------------------------
+# Type 2 — cost_outlier
+# ---------------------------------------------------------------------------
+
+
+def test_outlier_requires_three_tasks():
+    """Only 2 tasks with numeric cost_per_file → no type2 findings."""
+    recs = [
+        _r(
+            task="issue:1",
+            files_changed=1,
+            cost_usd=1.0,
+            billing_type="metered",
+            session_id="a",
+        ),
+        _r(
+            task="issue:2",
+            files_changed=1,
+            cost_usd=10.0,
+            billing_type="metered",
+            session_id="b",
+        ),
+    ]
+    files_by_task = {"issue:1": 1, "issue:2": 1}
+    agg = A.aggregate(recs, files_by_task=files_by_task)
+    findings = REC.recommend(agg, recs)
+    type2 = [f for f in findings if f["type"] == "cost_outlier"]
+    assert type2 == []
+
+
+def test_outlier_detected_above_3x_median():
+    """3 tasks: costs 1.0, 1.0, 4.0 per file → task with 4.0 flagged (ratio=4.0)."""
+    recs = [
+        _r(
+            task="issue:1",
+            files_changed=1,
+            cost_usd=1.0,
+            billing_type="metered",
+            session_id="a",
+        ),
+        _r(
+            task="issue:2",
+            files_changed=1,
+            cost_usd=1.0,
+            billing_type="metered",
+            session_id="b",
+        ),
+        _r(
+            task="issue:3",
+            files_changed=1,
+            cost_usd=4.0,
+            billing_type="metered",
+            session_id="c",
+        ),
+    ]
+    files_by_task = {"issue:1": 1, "issue:2": 1, "issue:3": 1}
+    agg = A.aggregate(recs, files_by_task=files_by_task)
+    findings = REC.recommend(agg, recs)
+    type2 = [f for f in findings if f["type"] == "cost_outlier"]
+    assert len(type2) == 1
+    assert type2[0]["evidence"]["task"] == "issue:3"
+    assert type2[0]["evidence"]["ratio"] >= 3.0
+
+
+def test_no_outlier_below_3x_median():
+    """3 tasks: costs 1.0, 1.5, 2.9 → none flagged (max ratio < 3×)."""
+    recs = [
+        _r(
+            task="issue:1",
+            files_changed=1,
+            cost_usd=1.0,
+            billing_type="metered",
+            session_id="a",
+        ),
+        _r(
+            task="issue:2",
+            files_changed=1,
+            cost_usd=1.5,
+            billing_type="metered",
+            session_id="b",
+        ),
+        _r(
+            task="issue:3",
+            files_changed=1,
+            cost_usd=2.9,
+            billing_type="metered",
+            session_id="c",
+        ),
+    ]
+    files_by_task = {"issue:1": 1, "issue:2": 1, "issue:3": 1}
+    agg = A.aggregate(recs, files_by_task=files_by_task)
+    findings = REC.recommend(agg, recs)
+    type2 = [f for f in findings if f["type"] == "cost_outlier"]
+    assert type2 == []
+
+
+def test_outlier_impact_is_none():
+    """Cost outlier estimated_impact is always None (investigation flag, not a recomputation)."""
+    recs = [
+        _r(
+            task="issue:1",
+            files_changed=1,
+            cost_usd=1.0,
+            billing_type="metered",
+            session_id="a",
+        ),
+        _r(
+            task="issue:2",
+            files_changed=1,
+            cost_usd=1.0,
+            billing_type="metered",
+            session_id="b",
+        ),
+        _r(
+            task="issue:3",
+            files_changed=1,
+            cost_usd=4.0,
+            billing_type="metered",
+            session_id="c",
+        ),
+    ]
+    files_by_task = {"issue:1": 1, "issue:2": 1, "issue:3": 1}
+    agg = A.aggregate(recs, files_by_task=files_by_task)
+    findings = REC.recommend(agg, recs)
+    type2 = [f for f in findings if f["type"] == "cost_outlier"]
+    assert type2
+    assert type2[0]["estimated_impact"] is None
+
+
+# ---------------------------------------------------------------------------
+# Type 3 — model_mix_skew
+# ---------------------------------------------------------------------------
+
+
+def test_model_mix_skew_detected_high_opus_share():
+    """Project with 80% spend on claude-opus-4 including TRIVIAL records → type3 finding."""
+    recs = [
+        # 8 TRIVIAL records on opus (80% of spend)
+        *[
+            _r(
+                model="claude-opus-4",
+                files_changed=1,
+                cost_usd=1.0,
+                billing_type="subscription",
+                session_id=f"a{i}",
+            )
+            for i in range(8)
+        ],
+        # 2 TRIVIAL records on haiku (20% of spend)
+        *[
+            _r(
+                model="claude-haiku-4",
+                files_changed=1,
+                cost_usd=0.25,
+                billing_type="subscription",
+                session_id=f"b{i}",
+            )
+            for i in range(2)
+        ],
+    ]
+    agg = A.aggregate(recs)
+    findings = REC.recommend(agg, recs)
+    type3 = [f for f in findings if f["type"] == "model_mix_skew"]
+    assert len(type3) >= 1
+    assert type3[0]["evidence"]["opus_share_pct"] > 70
+
+
+def test_model_mix_skew_not_flagged_below_threshold():
+    """Project with 60% opus spend → no type3 finding."""
+    recs = [
+        # 6 opus records (60%)
+        *[
+            _r(
+                model="claude-opus-4",
+                files_changed=1,
+                cost_usd=1.0,
+                billing_type="subscription",
+                session_id=f"a{i}",
+            )
+            for i in range(6)
+        ],
+        # 4 haiku records (40%)
+        *[
+            _r(
+                model="claude-haiku-4",
+                files_changed=1,
+                cost_usd=1.0,
+                billing_type="subscription",
+                session_id=f"b{i}",
+            )
+            for i in range(4)
+        ],
+    ]
+    agg = A.aggregate(recs)
+    findings = REC.recommend(agg, recs)
+    type3 = [f for f in findings if f["type"] == "model_mix_skew"]
+    assert type3 == []
+
+
+def test_model_mix_skew_no_trivial_simple_opus_not_flagged():
+    """High opus share but no TRIVIAL/SIMPLE opus records → no type3 finding."""
+    recs = [
+        # Opus only on COMPLEX (8 files each)
+        *[
+            _r(
+                model="claude-opus-4",
+                files_changed=8,
+                cost_usd=1.0,
+                billing_type="subscription",
+                session_id=f"a{i}",
+            )
+            for i in range(8)
+        ],
+        # Haiku on TRIVIAL
+        _r(
+            model="claude-haiku-4",
+            files_changed=1,
+            cost_usd=0.25,
+            billing_type="subscription",
+            session_id="b0",
+        ),
+    ]
+    agg = A.aggregate(recs)
+    findings = REC.recommend(agg, recs)
+    type3 = [f for f in findings if f["type"] == "model_mix_skew"]
+    assert type3 == []
+
+
+# ---------------------------------------------------------------------------
+# Type 4 — cache_inefficiency
+# ---------------------------------------------------------------------------
+
+
+def test_cache_inefficiency_detected():
+    """Project with cache_pct=0.05, total input 500_000 → type4 finding."""
+    # Inject a synthetic agg directly (aggregator doesn't carry total_input_tokens)
+    agg = {
+        "cost_by_model_tier": {},
+        "cost_per_pr": {},
+        "cache_by_project": {
+            "agents": {
+                "cache_pct": 0.05,
+                "total_input_tokens": 500_000,
+                "billing_type": "subscription",
+                "cache_saved_by_billing": {},
+            }
+        },
+    }
+    findings = REC.recommend(agg, [])
+    type4 = [f for f in findings if f["type"] == "cache_inefficiency"]
+    assert len(type4) == 1
+    assert type4[0]["project"] == "agents"
+    assert type4[0]["evidence"]["cache_pct"] == 0.05
+
+
+def test_cache_not_flagged_small_project():
+    """Project with cache_pct=0.02, total input 50_000 (< threshold) → no finding."""
+    agg = {
+        "cost_by_model_tier": {},
+        "cost_per_pr": {},
+        "cache_by_project": {
+            "small": {
+                "cache_pct": 0.02,
+                "total_input_tokens": 50_000,
+                "billing_type": "subscription",
+                "cache_saved_by_billing": {},
+            }
+        },
+    }
+    findings = REC.recommend(agg, [])
+    type4 = [f for f in findings if f["type"] == "cache_inefficiency"]
+    assert type4 == []
+
+
+def test_cache_not_flagged_above_threshold():
+    """Project with cache_pct=0.15 → no finding (above the 10% threshold)."""
+    agg = {
+        "cost_by_model_tier": {},
+        "cost_per_pr": {},
+        "cache_by_project": {
+            "agents": {
+                "cache_pct": 0.15,
+                "total_input_tokens": 500_000,
+                "billing_type": "subscription",
+                "cache_saved_by_billing": {},
+            }
+        },
+    }
+    findings = REC.recommend(agg, [])
+    type4 = [f for f in findings if f["type"] == "cache_inefficiency"]
+    assert type4 == []
+
+
+def test_cache_impact_is_none():
+    """Cache inefficiency estimated_impact is always None."""
+    agg = {
+        "cost_by_model_tier": {},
+        "cost_per_pr": {},
+        "cache_by_project": {
+            "agents": {
+                "cache_pct": 0.02,
+                "total_input_tokens": 500_000,
+                "billing_type": "subscription",
+                "cache_saved_by_billing": {},
+            }
+        },
+    }
+    findings = REC.recommend(agg, [])
+    type4 = [f for f in findings if f["type"] == "cache_inefficiency"]
+    assert type4
+    assert type4[0]["estimated_impact"] is None
+
+
+def test_cache_inefficiency_fires_through_real_aggregate():
+    """End-to-end (regression guard against dormancy): type-4 must fire from a REAL
+    A.aggregate() output, NOT a hand-injected dict. This catches the case where
+    cache_by_project stops emitting total_input_tokens (the field type-4 reads)."""
+    # one project, 200k input, no cache reads → cache_pct=0 (<10%), input >= 100k threshold
+    recs = [_r(project="agents", input=200_000, cache_read=0, cache_creation=0)]
+    agg = A.aggregate(recs)
+    assert (
+        agg["cache_by_project"]["agents"]["total_input_tokens"] == 200_000
+    )  # wiring present
+    findings = REC.recommend(agg, recs)
+    assert [f for f in findings if f["type"] == "cache_inefficiency"], (
+        "type-4 did not fire through real aggregate() — cache_by_project wiring regressed"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Sorting
+# ---------------------------------------------------------------------------
+
+
+def test_recommend_output_is_sorted():
+    """Mixed findings → sorted by type then project (string sort)."""
+    recs = [_r(model="claude-opus-4", files_changed=1, billing_type="subscription")]
+    agg = A.aggregate(recs)
+    # Inject a cache finding as well
+    agg["cache_by_project"]["agents"]["total_input_tokens"] = 500_000
+    agg["cache_by_project"]["agents"]["cache_pct"] = 0.02
+    findings = REC.recommend(agg, recs)
+    types = [f["type"] for f in findings]
+    assert types == sorted(types), "Findings must be sorted by type"
+
+
+# ---------------------------------------------------------------------------
+# Render integration
+# ---------------------------------------------------------------------------
+
+
+def test_render_html_includes_recommendations_section():
+    """render_html with a mismatch record includes id='recommendations' and the finding text."""
+    recs = [
+        _r(
+            model="claude-opus-4",
+            files_changed=1,
+            billing_type="subscription",
+            input=100_000,
+        )
+    ]
+    agg = A.aggregate(recs)
+    html = R.render_html(agg, records=recs)
+    assert "id='recommendations'" in html
+    assert "model_tier_mismatch" in html
+
+
+def test_render_html_no_data_state():
+    """render_html with empty records includes id='recommendations' and 'No recommendations'."""
+    agg = A.aggregate([])
+    html = R.render_html(agg, records=[])
+    assert "id='recommendations'" in html
+    assert "No recommendations" in html
+
+
+def test_render_html_seven_sections():
+    """All 7 SECTIONS (including recommendations) are present in rendered HTML."""
+    recs = [_r(model="claude-opus-4", files_changed=1)]
+    agg = A.aggregate(recs)
+    html = R.render_html(agg, records=recs)
+    for sid, _ in R.SECTIONS:
+        assert f"id='{sid}'" in html, f"Missing section: {sid}"


### PR DESCRIPTION
Phase 1 of #268 — the "analyze & optimize workflow" engine (use Sonnet not Opus where it fits), rendered into the Tier-A static report. Phase 2 (FastAPI Tier-B live dashboard) deferred to a child issue.

## What ships
- **`usage_recommend.py`** — `recommend(agg, records)` → findings of 4 types:
  1. **model_tier_mismatch** — pricey model on TRIVIAL/SIMPLE work + an EXACT downshift estimate (recomputed from raw tokens via `compute_cost`, not a ratio)
  2. **cost_outlier** — tasks >3× median $/file (requires ≥3 tasks)
  3. **model_mix_skew** — >70% spend on one tier
  4. **cache_inefficiency** — low cache-hit, high-input projects
- **billing-aware (§6)**: subscription → "API-equiv $X (notional)", metered → "$X", mixed → None. The impact string bakes in framing so the renderer never branches.
- `usage_aggregator.cache_by_project` now emits `total_input_tokens` so type-4 fires on **real** data.
- `usage_report.py`: new "Right-Sizing Recommendations" section; lazy-imports the engine; every field `html.escape`-d.

## Validation
- Suite 207→**235** (+28), ruff clean. End-to-end on real `aggregate()`: types 1/3/4 fire with correct `$`/notional framing; type-2 correctly needs ≥3 tasks.
- **PROVE**: initially FAIL — caught type-4 dormant (read a field the aggregator didn't emit); fixed by wiring `total_input_tokens` + an end-to-end regression-guard test; re-verified PASS.
- **Codex review hung** (known ~50% codex-exec stdin hang; watchdog killed at ~9min) → self-reviewed per protocol: downshift math monotonic-safe (drops savings≤0), outlier/skew/median all divide-by-zero guarded, billing framing enforced+tested, HTML escaped, no-evidence→no-rec.

Part of #268

🤖 Generated with [Claude Code](https://claude.com/claude-code)