### PR TITLE
feat(usage): attribute cross-repo abs-path work (gitBranch-presence)

### DIFF
--- a/claude-config/scripts/usage_collector_claude.py
+++ b/claude-config/scripts/usage_collector_claude.py
@@ -54,6 +54,12 @@ _ISSUE_RE = re.compile(r"issue-(\d+)", re.IGNORECASE)
 _CLOSES_RE = re.compile(r"\b(?:closes|fixes|resolves)\s+#(\d+)", re.IGNORECASE)
 _CHECKOUT_RE = re.compile(r"git\s+checkout\s+-b\s+(\S+)")
 _CD_RE = re.compile(r"\bcd\s+([~\w./-]+)")
+# Cross-repo attribution signals (issue #311):
+#   _GH_REPO_RE  — `gh ... --repo owner/name`  → project = <name>
+#   _GIT_C_RE    — `git -C <path> ...`          → project = _project_from_path(<path>)
+# Paths that start with '$' or '"$' are shell variables and cannot be resolved at parse time.
+_GH_REPO_RE = re.compile(r"--repo\s+[a-zA-Z0-9_.-]+/([a-zA-Z0-9_.-]+)")
+_GIT_C_RE = re.compile(r"\bgit\s+-C\s+(\S+)")
 _NONTASK_BRANCHES = {"head", "main", "master", "", None}
 # OpenSSH short flags that consume the NEXT token as their argument — so the host parser skips both
 # (else `ssh -p 22 host` mis-reads "22" as the host; Codex #262).
@@ -150,6 +156,47 @@ def mine_command(cmd: str) -> dict:
         proj = _project_from_path(cd.group(1))
         if proj:
             out["project"] = proj
+    # Cross-repo attribution: fill project gap when cd gave nothing (issue #311).
+    #
+    # PRECEDENCE (precision over recall — false attribution is worse than none):
+    #   1. cd <path>  — already handled above; most specific (context-setting)
+    #   2. --repo owner/name  — explicit gh flag; fills gap when cd is absent
+    #   3. git -C <path>  — fills gap when neither cd nor --repo is present
+    #   4. If BOTH --repo and git -C fire on the SAME command with DIFFERENT values
+    #      → clear project (conflicting signals, do not guess).
+    #   5. Per-message cwd-vs-mined precedence is enforced in extract_records (not here):
+    #      cwd-derived project wins for local work; mined wins under SSH-develop (§4.2);
+    #      mined fills the gap when cwd yields nothing (the #311 scratch-session target).
+    if "project" not in out:
+        # Determine candidates from --repo and git -C
+        repo_match = _GH_REPO_RE.search(cmd)
+        gitc_match = _GIT_C_RE.search(cmd)
+
+        repo_proj = repo_match.group(1) if repo_match else None
+
+        gitc_proj = None
+        if gitc_match:
+            raw_path = gitc_match.group(1)
+            # Skip shell variables (unresolvable at parse time)
+            if not raw_path.startswith("$") and not raw_path.startswith('"$'):
+                gitc_proj = _project_from_path(raw_path)
+                # Also extract task from `git -C <path> checkout -b <branch>` — the
+                # existing _CHECKOUT_RE requires `git\s+checkout` (no gap) and misses
+                # this form, so we handle it here alongside project extraction.
+                if gitc_proj and "task" not in out:
+                    gitc_co = re.search(r"\bcheckout\s+-b\s+(\S+)", cmd)
+                    if gitc_co:
+                        t = _task_from_branch(gitc_co.group(1))
+                        if t:
+                            out["task"] = t
+
+        if repo_proj and gitc_proj and repo_proj != gitc_proj:
+            # Conflicting signals in the same command — stay unattributed (precision over recall)
+            pass
+        elif repo_proj:
+            out["project"] = repo_proj
+        elif gitc_proj:
+            out["project"] = gitc_proj
     return out
 
 
@@ -289,7 +336,26 @@ def extract_records(
             # `git checkout -b` message still shows the OLD branch → it naturally gives the "subsequent
             # message" boundary). Mined `active` is the fallback when gitBranch is unusable (cross-repo).
             cur_task = _task_from_branch(entry.get("gitBranch")) or active["task"]
-            cur_project = active["project"] or _project_from_path(entry.get("cwd"))
+            # Per-message project precedence (AC3 precision — enforced here, not in mine_command):
+            #   1. SSH-develop (§4.2): when work_host != inference_host, cwd is LOCAL and meaningless
+            #      for attribution.  The ssh-mined active["project"] (set by ssh 'cd repo') wins.
+            #   2. Local work: the current message's cwd is GROUND TRUTH.  If cwd resolves to a repo,
+            #      use that — regardless of any mined active["project"] from a stray --repo flag in an
+            #      earlier message.  This prevents a one-off `gh pr view --repo other/repo` from
+            #      hijacking all subsequent messages in a real cwd=agents session.
+            #   3. Fallback: cwd yields nothing (scratch dir, temp path) → use mined active["project"].
+            #      This is the #311 target: scratch sessions with cross-repo `--repo`/`git -C` signals.
+            cwd_project = _project_from_path(entry.get("cwd"))
+            on_remote = active["work_host"] != inference_host
+            if on_remote:
+                # SSH-develop: trust the ssh-mined project; cwd is local and irrelevant.
+                cur_project = active["project"] or cwd_project
+            elif cwd_project:
+                # Local work with a real cwd repo: cwd wins over any stray mined signal.
+                cur_project = cwd_project
+            else:
+                # Local work, no cwd repo (scratch / temp): fall back to mined active project.
+                cur_project = active["project"]
             usage = msg.get("usage") or {}
             tok = {
                 norm: int(usage.get(raw, 0) or 0) for raw, norm in _USAGE_MAP.items()
@@ -375,7 +441,7 @@ def collect(
     fallback_account = current_account(claude_json_path or home / ".claude.json")
     shard_path = Path(shard_path)
     seen = _existing_dedup_keys(shard_path)
-    written = skipped = 0
+    written = skipped = project_attributed = 0
     shard_path.parent.mkdir(parents=True, exist_ok=True)
     with shard_path.open("a", encoding="utf-8") as fh:
         for tpath in sorted(glob.glob(str(Path(projects_dir) / "*" / "*.jsonl"))):
@@ -392,4 +458,17 @@ def collect(
                 seen.add(rec["dedup_key"])
                 fh.write(json.dumps(rec, ensure_ascii=False) + "\n")
                 written += 1
-    return {"written": written, "skipped": skipped, "shard": str(shard_path)}
+                if rec.get("project") is not None:
+                    project_attributed += 1
+    # AC4: attribution OUTCOME of THIS run's written records — honest and non-silent. We do NOT
+    # diff the append-only shard (its project=None total only ever grows as rows accumulate, so it
+    # can never show a "reduction"). The feature's actual EFFECT — records rescued from project=None
+    # by a mined --repo/git-C target that cwd alone would miss — is demonstrated by the with/without
+    # counterfactual in test_collect_repo_target_reduces_unattributed.
+    return {
+        "written": written,
+        "skipped": skipped,
+        "shard": str(shard_path),
+        "project_attributed": project_attributed,
+        "project_unattributed": written - project_attributed,
+    }

--- a/claude-config/scripts/usage_collector_claude.py
+++ b/claude-config/scripts/usage_collector_claude.py
@@ -54,12 +54,9 @@ _ISSUE_RE = re.compile(r"issue-(\d+)", re.IGNORECASE)
 _CLOSES_RE = re.compile(r"\b(?:closes|fixes|resolves)\s+#(\d+)", re.IGNORECASE)
 _CHECKOUT_RE = re.compile(r"git\s+checkout\s+-b\s+(\S+)")
 _CD_RE = re.compile(r"\bcd\s+([~\w./-]+)")
-# Cross-repo attribution signals (issue #311):
-#   _GH_REPO_RE  — `gh ... --repo owner/name`  → project = <name>
-#   _GIT_C_RE    — `git -C <path> ...`          → project = _project_from_path(<path>)
-# Paths that start with '$' or '"$' are shell variables and cannot be resolved at parse time.
-_GH_REPO_RE = re.compile(r"--repo\s+[a-zA-Z0-9_.-]+/([a-zA-Z0-9_.-]+)")
-_GIT_C_RE = re.compile(r"\bgit\s+-C\s+(\S+)")
+# Cross-repo attribution signals (issue #311) are extracted by TOKEN PARSING in mine_command —
+# NOT by raw-string regex (which would fire inside echo/comments/quoted strings).
+# _GH_REPO_RE / _GIT_C_RE are intentionally absent; see mine_command for the tokenized approach.
 _NONTASK_BRANCHES = {"head", "main", "master", "", None}
 # OpenSSH short flags that consume the NEXT token as their argument — so the host parser skips both
 # (else `ssh -p 22 host` mis-reads "22" as the host; Codex #262).
@@ -126,10 +123,77 @@ def _iter_commands(entry: dict):
                 yield cmd
 
 
+def _gh_repo_project(toks: list) -> str | None:
+    """Extract the `name` from `--repo owner/name` in a TOKENIZED gh argv.
+    Only fires when `toks[0]` is `gh` (or a bare `gh` invocation) — prevents matching
+    `echo "--repo x/y"`, comments, or strings that contain --repo but are not actual gh calls.
+    Handles both `--repo owner/name` (separate token) and `--repo=owner/name` (inline value).
+    Returns the repo name (the part after `/`), or None."""
+    if not toks or toks[0] != "gh":
+        return None
+    i = 1
+    while i < len(toks):
+        tok = toks[i]
+        if tok == "--repo" and i + 1 < len(toks):
+            val = toks[i + 1]
+            if "/" in val:
+                return val.split("/", 1)[1]
+        elif tok.startswith("--repo="):
+            val = tok[len("--repo=") :]
+            if "/" in val:
+                return val.split("/", 1)[1]
+        i += 1
+    return None
+
+
+def _git_c_project_and_task(
+    toks: list, existing_task: str | None
+) -> tuple[str | None, str | None]:
+    """Extract (project, task) from a TOKENIZED `git -C <path> ...` invocation.
+    Only fires when `toks[0]` is `git` — prevents matching `echo "git -C ..."` or shell strings.
+    Skips shell-variable paths (start with `$`).
+    Returns (project, task) where either may be None."""
+    if not toks or toks[0] != "git":
+        return None, None
+    # Find -C flag and its path argument
+    raw_path = None
+    checkout_branch = None
+    i = 1
+    while i < len(toks):
+        tok = toks[i]
+        if tok == "-C" and i + 1 < len(toks):
+            raw_path = toks[i + 1]
+            i += 2
+        elif tok == "checkout" or tok == "switch":
+            # Look for -b <branch> (or --branch <branch>)
+            j = i + 1
+            while j < len(toks):
+                if toks[j] in ("-b", "--branch") and j + 1 < len(toks):
+                    checkout_branch = toks[j + 1]
+                    break
+                j += 1
+            i += 1
+        else:
+            i += 1
+    if raw_path is None:
+        return None, None
+    # Skip shell variables (unresolvable at parse time)
+    if raw_path.startswith("$") or raw_path.startswith('"$'):
+        return None, None
+    proj = _project_from_path(raw_path)
+    task = None
+    if proj and checkout_branch and existing_task is None:
+        task = _task_from_branch(checkout_branch)
+    return proj, task
+
+
 def mine_command(cmd: str) -> dict:
     """Derive {task?, project?, work_host?} from one shell command. The basis of automated, manual-tag-
     free attribution (§4.3): a `git checkout -b feat/issue-N` names the task even cross-repo, and an
-    `ssh host 'cd repo'` names the work_host + project under SSH-develop."""
+    `ssh host 'cd repo'` names the work_host + project under SSH-develop.
+
+    Cross-repo signals (issue #311) use TOKENIZED matching — `--repo` and `-C` are only recognised
+    when they appear as actual argv of a `gh`/`git` invocation, not inside echo/quoted strings."""
     out: dict = {}
     try:
         toks = shlex.split(cmd)
@@ -158,37 +222,20 @@ def mine_command(cmd: str) -> dict:
             out["project"] = proj
     # Cross-repo attribution: fill project gap when cd gave nothing (issue #311).
     #
-    # PRECEDENCE (precision over recall — false attribution is worse than none):
+    # PRECEDENCE within a single command (precision over recall — false attribution is worse than none):
     #   1. cd <path>  — already handled above; most specific (context-setting)
-    #   2. --repo owner/name  — explicit gh flag; fills gap when cd is absent
-    #   3. git -C <path>  — fills gap when neither cd nor --repo is present
-    #   4. If BOTH --repo and git -C fire on the SAME command with DIFFERENT values
-    #      → clear project (conflicting signals, do not guess).
-    #   5. Per-message cwd-vs-mined precedence is enforced in extract_records (not here):
-    #      cwd-derived project wins for local work; mined wins under SSH-develop (§4.2);
-    #      mined fills the gap when cwd yields nothing (the #311 scratch-session target).
+    #   2. gh --repo owner/name  — explicit gh flag; fills gap when cd is absent (TOKENIZED: only
+    #      fires for actual `gh` invocations, never inside echo/comments/strings)
+    #   3. git -C <path>  — fills gap when neither cd nor --repo is present (TOKENIZED: only fires
+    #      for actual `git` invocations)
+    #   4. If BOTH --repo and git -C fire on the SAME command with DIFFERENT values → stay
+    #      unattributed (conflicting signals, precision over recall).
+    # Per-message precedence (gitBranch vs mined) is enforced in extract_records (not here).
     if "project" not in out:
-        # Determine candidates from --repo and git -C
-        repo_match = _GH_REPO_RE.search(cmd)
-        gitc_match = _GIT_C_RE.search(cmd)
+        # Tokenized extraction — only matches real gh/git argv, not substrings or quoted strings
+        repo_proj = _gh_repo_project(toks)
 
-        repo_proj = repo_match.group(1) if repo_match else None
-
-        gitc_proj = None
-        if gitc_match:
-            raw_path = gitc_match.group(1)
-            # Skip shell variables (unresolvable at parse time)
-            if not raw_path.startswith("$") and not raw_path.startswith('"$'):
-                gitc_proj = _project_from_path(raw_path)
-                # Also extract task from `git -C <path> checkout -b <branch>` — the
-                # existing _CHECKOUT_RE requires `git\s+checkout` (no gap) and misses
-                # this form, so we handle it here alongside project extraction.
-                if gitc_proj and "task" not in out:
-                    gitc_co = re.search(r"\bcheckout\s+-b\s+(\S+)", cmd)
-                    if gitc_co:
-                        t = _task_from_branch(gitc_co.group(1))
-                        if t:
-                            out["task"] = t
+        gitc_proj, gitc_task = _git_c_project_and_task(toks, out.get("task"))
 
         if repo_proj and gitc_proj and repo_proj != gitc_proj:
             # Conflicting signals in the same command — stay unattributed (precision over recall)
@@ -197,6 +244,8 @@ def mine_command(cmd: str) -> dict:
             out["project"] = repo_proj
         elif gitc_proj:
             out["project"] = gitc_proj
+            if gitc_task and "task" not in out:
+                out["task"] = gitc_task
     return out
 
 
@@ -336,26 +385,44 @@ def extract_records(
             # `git checkout -b` message still shows the OLD branch → it naturally gives the "subsequent
             # message" boundary). Mined `active` is the fallback when gitBranch is unusable (cross-repo).
             cur_task = _task_from_branch(entry.get("gitBranch")) or active["task"]
-            # Per-message project precedence (AC3 precision — enforced here, not in mine_command):
-            #   1. SSH-develop (§4.2): when work_host != inference_host, cwd is LOCAL and meaningless
-            #      for attribution.  The ssh-mined active["project"] (set by ssh 'cd repo') wins.
-            #   2. Local work: the current message's cwd is GROUND TRUTH.  If cwd resolves to a repo,
-            #      use that — regardless of any mined active["project"] from a stray --repo flag in an
-            #      earlier message.  This prevents a one-off `gh pr view --repo other/repo` from
-            #      hijacking all subsequent messages in a real cwd=agents session.
-            #   3. Fallback: cwd yields nothing (scratch dir, temp path) → use mined active["project"].
-            #      This is the #311 target: scratch sessions with cross-repo `--repo`/`git -C` signals.
-            cwd_project = _project_from_path(entry.get("cwd"))
+            # Per-message project precedence (AC3/issue #311 — gitBranch presence as discriminant):
+            #
+            #   1. SSH-develop (§4.2): work_host ≠ inference_host means an ssh command set it.
+            #      cwd is local and irrelevant; trust the ssh-mined active["project"].
+            #
+            #   2. gitBranch present/non-empty → cwd IS a real local git repo.  Use
+            #      _project_from_path(cwd): the repo the user is PHYSICALLY IN is authoritative.
+            #      A stray `gh --repo other` CANNOT override it (hijack prevented).
+            #
+            #   3. gitBranch absent/empty AND a mined project exists → cwd is NOT a git repo
+            #      (e.g. ~/projects/scratch).  The mined --repo/git-C target is the actual work
+            #      target.  THIS is the #311 target case: cwd basename ("scratch") is useless
+            #      but the explicit --repo/git-C signal tells us where the work happens.
+            #
+            #   4. Everything else → cwd basename fallback, else None/unattributed.
+            #
+            # Precision over recall: genuinely ambiguous → prefer unattributed over a guess.
             on_remote = active["work_host"] != inference_host
+            git_branch = entry.get("gitBranch")
+            git_branch_present = bool(
+                git_branch
+            )  # non-empty string = inside a git repo
+            cwd_project = _project_from_path(entry.get("cwd"))
             if on_remote:
-                # SSH-develop: trust the ssh-mined project; cwd is local and irrelevant.
+                # Branch 1 — SSH-develop: trust ssh-mined project; cwd is local, irrelevant.
                 cur_project = active["project"] or cwd_project
-            elif cwd_project:
-                # Local work with a real cwd repo: cwd wins over any stray mined signal.
+            elif git_branch_present:
+                # Branch 2 — real local repo (gitBranch confirms it): cwd is authoritative.
+                # Stray --repo flag from an earlier message cannot hijack.
                 cur_project = cwd_project
-            else:
-                # Local work, no cwd repo (scratch / temp): fall back to mined active project.
+            elif active["project"]:
+                # Branch 3 — no gitBranch (not in a repo, e.g. ~/projects/scratch): use mined
+                # signal.  This is the #311 target: cwd basename would mis-attribute to "scratch",
+                # but the explicit --repo/git-C mine is what the work is actually for.
                 cur_project = active["project"]
+            else:
+                # Branch 4 — fallback: no repo, no mined signal → cwd basename or None.
+                cur_project = cwd_project
             usage = msg.get("usage") or {}
             tok = {
                 norm: int(usage.get(raw, 0) or 0) for raw, norm in _USAGE_MAP.items()
@@ -388,8 +455,21 @@ def extract_records(
             records.append(_apply_account(rec, account_map, fallback_account))
             pending_compaction = False
         # mine this entry's commands → update active state for subsequent messages (segmentation)
+        # Cross-command conflict guard (issue #311 Finding 4): if two commands in the SAME assistant
+        # message mine DIFFERENT projects, last-write-win is a mis-attribution risk.  Detect conflict
+        # and clear project for that message so it stays unattributed rather than wrong.
+        mined_project: str | None = None
+        cross_cmd_conflict = False
         for cmd in _iter_commands(entry):
-            active.update(mine_command(cmd))
+            mined = mine_command(cmd)
+            new_proj = mined.get("project")
+            if new_proj and mined_project and new_proj != mined_project:
+                cross_cmd_conflict = True  # two commands disagree — clear project below
+            if new_proj:
+                mined_project = new_proj
+            active.update(mined)
+        if cross_cmd_conflict:
+            active["project"] = None  # ambiguous — do not mis-attribute
     return records
 
 

--- a/claude-config/tests/test_usage_collector_claude.py
+++ b/claude-config/tests/test_usage_collector_claude.py
@@ -267,3 +267,283 @@ def test_record_schema():
     assert rec["provider"] == "claude"
     assert rec["account"] is None and rec["billing_type"] is None  # filled by #265
     assert rec["cost_usd"] > 0
+
+
+# --- Issue #311: cross-repo attribution via --repo and git -C -----------------------------------
+
+
+# Test A — `gh --repo owner/name` sets project on subsequent message
+def test_gh_repo_flag_sets_project():
+    recs = _extract(
+        [
+            _asst(
+                1,
+                ts="t1",
+                content=[_bash("gh pr merge 99 --repo jwj2002/agents --squash")],
+            ),
+            _asst(2, ts="t2"),
+        ]
+    )
+    assert recs[0]["project"] is None  # issuing message: pre-command
+    assert recs[1]["project"] == "agents"
+    assert recs[1]["task"] == "unattributed"  # no branch → task still unattributed
+
+
+# Test B — `git -C <abs-path>` sets project on subsequent message
+def test_git_dash_c_sets_project():
+    recs = _extract(
+        [
+            _asst(1, ts="t1", content=[_bash("git -C /Users/jjob/agents status")]),
+            _asst(2, ts="t2"),
+        ]
+    )
+    assert recs[1]["project"] == "agents"
+
+
+# Test C — `git -C $R` (shell variable) does NOT set project (no mis-attribution)
+def test_git_dash_c_shell_var_ignored():
+    recs = _extract(
+        [
+            _asst(1, ts="t1", content=[_bash("git -C $R log --oneline")]),
+            _asst(2, ts="t2"),
+        ]
+    )
+    assert recs[1]["project"] is None
+
+
+# Test D — `git -C <path> checkout -b feat/issue-N-foo` sets BOTH project AND task
+def test_git_dash_c_checkout_sets_project_and_task():
+    recs = _extract(
+        [
+            _asst(
+                1,
+                ts="t1",
+                content=[
+                    _bash("git -C ~/agents checkout -b feat/issue-311-attr origin/main")
+                ],
+            ),
+            _asst(2, ts="t2"),
+        ]
+    )
+    assert recs[1]["project"] == "agents"
+    assert recs[1]["task"] == "issue:311"
+
+
+# Test E — conflicting --repo and git -C in same command → stays unattributed (precision over recall)
+def test_conflicting_signals_no_project():
+    recs = _extract(
+        [
+            _asst(
+                1,
+                ts="t1",
+                content=[_bash("git -C /path/to/repo-a status --repo owner/repo-b")],
+            ),
+            _asst(2, ts="t2"),
+        ]
+    )
+    # conflicting signals → project remains None (precision over recall)
+    assert recs[1]["project"] is None
+
+
+# Test F — no cross-repo signal → stays unattributed, never mis-attributed
+def test_no_cross_repo_signal_stays_unattributed():
+    recs = _extract(
+        [
+            _asst(1, ts="t1", content=[_bash("echo hello")]),
+            _asst(2, ts="t2"),
+        ]
+    )
+    assert recs[1]["task"] == "unattributed"
+    assert recs[1]["project"] is None
+
+
+# Test G — `cd` takes precedence over `--repo` flag on the same command
+def test_cd_takes_precedence_over_repo_flag():
+    # cd /Users/.../agents in command wins over a stray --repo flag
+    recs = _extract(
+        [
+            _asst(
+                1,
+                ts="t1",
+                content=[
+                    _bash("cd /Users/jjob/agents && gh pr create --title x --body y")
+                ],
+            ),
+            _asst(2, ts="t2"),
+        ]
+    )
+    assert recs[1]["project"] == "agents"
+
+
+# Test G2 — `--repo` pointing to a DIFFERENT repo does NOT override `cd`-established project
+def test_cd_beats_conflicting_repo_flag():
+    # cd sets agents; --repo points to maison-scaffold; cd wins (precision over recall)
+    recs = _extract(
+        [
+            _asst(
+                1,
+                ts="t1",
+                content=[
+                    _bash(
+                        "cd /Users/jjob/agents && gh pr create --repo jwj2002/maison-scaffold --title x"
+                    )
+                ],
+            ),
+            _asst(2, ts="t2"),
+        ]
+    )
+    # cd fires first → project = "agents"; --repo block is skipped ("project" already in out)
+    assert recs[1]["project"] == "agents"
+
+
+# Test H — AC4: the feature REDUCES project-unattributed. Demonstrated by a counterfactual
+# (identical sessions WITH vs WITHOUT a `--repo` signal — the with-signal run has fewer
+# project=None records), plus an honest per-run outcome from collect() (attributed + unattributed
+# = written). We do NOT diff the append-only shard total, which only grows.
+def test_collect_repo_target_reduces_unattributed(tmp_path):
+    # Counterfactual. WITHOUT a repo signal: no cwd repo → every record stays project=None.
+    without = list(
+        U.extract_records([_asst(1, ts="t1"), _asst(2, ts="t2")], inference_host=HOST)
+    )
+    # WITH a `--repo` signal in msg1: the subsequent message gains project=agents.
+    with_signal = list(
+        U.extract_records(
+            [
+                _asst(
+                    1, ts="t1", content=[_bash("gh pr merge 1 --repo jwj2002/agents")]
+                ),
+                _asst(2, ts="t2"),
+            ],
+            inference_host=HOST,
+        )
+    )
+    none_without = sum(1 for r in without if r.get("project") is None)
+    none_with = sum(1 for r in with_signal if r.get("project") is None)
+    assert none_with < none_without  # the mined --repo rescued at least one record
+
+    # collect() reports the run's honest attribution outcome (no append-only shard diff).
+    proj = tmp_path / "projects" / "-proj-x"
+    proj.mkdir(parents=True)
+    shard = tmp_path / "telemetry" / HOST / "usage.jsonl"
+    (proj / "s1.jsonl").write_text(
+        "\n".join(
+            json.dumps(e)
+            for e in [
+                _asst(
+                    1, ts="t1", content=[_bash("gh pr merge 1 --repo jwj2002/agents")]
+                ),
+                _asst(2, ts="t2"),  # gets project=agents from the mined signal
+            ]
+        )
+    )
+    result = U.collect(tmp_path / "projects", shard, inference_host=HOST)
+    assert (
+        result["project_attributed"] + result["project_unattributed"]
+        == result["written"]
+    )
+    assert (
+        result["project_attributed"] >= 1
+    )  # the mined --repo attributed at least one record
+    # Also confirm msg3 is the attributed one: read the shard
+    records = [
+        json.loads(line) for line in shard.read_text().splitlines() if line.strip()
+    ]
+    new_records = [r for r in records if r.get("dedup_key", "").startswith("s1:")]
+    attributed = [r for r in new_records if r.get("project") == "agents"]
+    assert len(attributed) >= 1  # at least msg3 got project=agents
+
+
+# mine_command unit tests for AC compliance
+def test_mine_command_gh_repo():
+    assert (
+        U.mine_command("gh pr merge 99 --repo jwj2002/agents --squash")["project"]
+        == "agents"
+    )
+
+
+def test_mine_command_git_dash_c_abs():
+    assert U.mine_command("git -C /Users/jjob/agents status")["project"] == "agents"
+
+
+def test_mine_command_git_dash_c_shell_var():
+    assert "project" not in U.mine_command("git -C $R log")
+
+
+def test_mine_command_git_dash_c_checkout():
+    result = U.mine_command("git -C ~/agents checkout -b feat/issue-311-foo")
+    assert result["project"] == "agents"
+    assert result["task"] == "issue:311"
+
+
+def test_mine_command_conflicting_signals():
+    result = U.mine_command("git -C /path/to/repo-a status --repo owner/repo-b")
+    assert result.get("project") is None or "project" not in result
+
+
+# AC3 precision: per-message cwd-vs-mined precedence tests (issue #311 fix 2)
+
+
+# Test I — hijack prevention: cwd=agents + stray --repo in earlier message → later msgs stay project=agents
+def test_cwd_repo_beats_stray_mined_project():
+    """A real-cwd session (cwd=/Users/jjob/agents) must not be hijacked by a stray --repo flag.
+    After msg1 mines project=maison-scaffold, msg2 has cwd=agents → must get project=agents (cwd wins)."""
+    recs = _extract(
+        [
+            _asst(
+                1,
+                ts="t1",
+                cwd="/Users/jjob/agents",
+                content=[_bash("gh pr view 99 --repo jwj2002/maison-scaffold")],
+            ),
+            _asst(2, ts="t2", cwd="/Users/jjob/agents"),
+        ]
+    )
+    # msg1: pre-command, cwd=agents → project=agents (cwd wins over nothing mined yet)
+    assert recs[0]["project"] == "agents"
+    # msg2: active["project"] is now "maison-scaffold" from mining msg1, but cwd=agents → cwd wins
+    assert recs[1]["project"] == "agents"
+
+
+# Test J — #311 target: cwd=None (no repo) + --repo signal → project from mined signal
+def test_scratch_cwd_uses_mined_project():
+    """The primary #311 target: cwd is absent (simulates abs-path-outside-any-repo session).
+    cwd yields None → mined active["project"] fills the gap (the #311 win)."""
+    recs = _extract(
+        [
+            _asst(
+                1,
+                ts="t1",
+                cwd=None,
+                content=[_bash("gh pr merge 5 --repo jwj2002/agents --squash")],
+            ),
+            _asst(2, ts="t2", cwd=None),
+        ]
+    )
+    # msg1: no cwd → project=None (pre-command, nothing mined yet)
+    assert recs[0]["project"] is None
+    # msg2: no cwd → cwd_project=None → falls back to mined active["project"] = "agents"
+    assert recs[1]["project"] == "agents"
+
+
+# Test K — ssh-develop regression: ssh-derived project still wins when work_host != inference_host
+def test_ssh_develop_project_attribution_not_regressed():
+    """SSH-develop (§4.2): when ssh sets work_host to a remote, active["project"] (mined from ssh
+    'cd repo') must still win for subsequent messages — even though cwd is local."""
+    recs = _extract(
+        [
+            _asst(
+                1,
+                ts="t1",
+                cwd="/Users/jjob",  # local cwd — irrelevant under ssh-develop
+                content=[_bash("ssh jns 'cd ~/app-repos/app-buddy && git status'")],
+            ),
+            _asst(2, ts="t2", cwd="/Users/jjob"),  # still local cwd after ssh
+        ]
+    )
+    # msg1: pre-command, cwd=/Users/jjob → _project_from_path gives "jjob"; work_host still HOST
+    # so on_remote is False for msg1 → cwd wins → project="jjob"
+    assert recs[0]["project"] == "jjob"
+    # msg2: after ssh, work_host="jns" (≠ HOST) → on_remote=True → ssh-mined active["project"]
+    # wins. ssh 'cd ~/app-repos/app-buddy' → mine_command sets project="app-buddy" via cd.
+    assert recs[1]["work_host"] == "jns"
+    assert recs[1]["project"] == "app-buddy"

--- a/claude-config/tests/test_usage_collector_claude.py
+++ b/claude-config/tests/test_usage_collector_claude.py
@@ -329,8 +329,12 @@ def test_git_dash_c_checkout_sets_project_and_task():
     assert recs[1]["task"] == "issue:311"
 
 
-# Test E — conflicting --repo and git -C in same command → stays unattributed (precision over recall)
+# Test E — tokenized parsing: `--repo` in a `git` command is NOT a gh signal; only `-C` fires
 def test_conflicting_signals_no_project():
+    # With tokenized parsing: `git -C /path/to/repo-a status --repo owner/repo-b` is a `git`
+    # invocation.  Only `-C /path/to/repo-a` fires (tokenized git-C match requires toks[0]=="git").
+    # `--repo owner/repo-b` requires toks[0]=="gh" to fire → it doesn't.
+    # Result: project = "repo-a" (no conflict — the `--repo` is ignored in a git context).
     recs = _extract(
         [
             _asst(
@@ -341,8 +345,9 @@ def test_conflicting_signals_no_project():
             _asst(2, ts="t2"),
         ]
     )
-    # conflicting signals → project remains None (precision over recall)
-    assert recs[1]["project"] is None
+    assert (
+        recs[1]["project"] == "repo-a"
+    )  # only git -C fires; --repo in git context is ignored
 
 
 # Test F — no cross-repo signal → stays unattributed, never mis-attributed
@@ -476,74 +481,212 @@ def test_mine_command_git_dash_c_checkout():
 
 
 def test_mine_command_conflicting_signals():
+    # With tokenized parsing, `--repo` in a `git` command is NOT a gh signal.
+    # Only `git -C /path/to/repo-a` fires → project = "repo-a".
     result = U.mine_command("git -C /path/to/repo-a status --repo owner/repo-b")
-    assert result.get("project") is None or "project" not in result
+    assert result.get("project") == "repo-a"
 
 
 # AC3 precision: per-message cwd-vs-mined precedence tests (issue #311 fix 2)
 
 
-# Test I — hijack prevention: cwd=agents + stray --repo in earlier message → later msgs stay project=agents
+# Test I — hijack prevention: gitBranch present → real repo → stray --repo cannot override
 def test_cwd_repo_beats_stray_mined_project():
-    """A real-cwd session (cwd=/Users/jjob/agents) must not be hijacked by a stray --repo flag.
-    After msg1 mines project=maison-scaffold, msg2 has cwd=agents → must get project=agents (cwd wins)."""
+    """A real-cwd session must not be hijacked by a stray --repo flag.
+    gitBranch present confirms cwd IS a real git repo → cwd-derived project is authoritative.
+    A later message with gitBranch=feat/... must get project=agents (branch 2 wins), NOT
+    the mined project=maison-scaffold from mining the earlier --repo flag."""
     recs = _extract(
         [
             _asst(
                 1,
                 ts="t1",
-                cwd="/Users/jjob/agents",
+                cwd="/Users/x/agents",
+                gitBranch="feat/issue-9-x",
                 content=[_bash("gh pr view 99 --repo jwj2002/maison-scaffold")],
             ),
-            _asst(2, ts="t2", cwd="/Users/jjob/agents"),
+            _asst(2, ts="t2", cwd="/Users/x/agents", gitBranch="feat/issue-9-x"),
         ]
     )
-    # msg1: pre-command, cwd=agents → project=agents (cwd wins over nothing mined yet)
+    # msg1: gitBranch present → branch 2 → cwd-derived project wins → "agents"
     assert recs[0]["project"] == "agents"
-    # msg2: active["project"] is now "maison-scaffold" from mining msg1, but cwd=agents → cwd wins
+    # msg2: active["project"] is now "maison-scaffold" from mining msg1, but gitBranch present →
+    # branch 2 fires → cwd wins → project stays "agents" (hijack prevented)
     assert recs[1]["project"] == "agents"
 
 
-# Test J — #311 target: cwd=None (no repo) + --repo signal → project from mined signal
+# Test J — #311 TARGET: cwd=/Users/x/projects/scratch (non-repo), gitBranch absent → mined --repo wins
 def test_scratch_cwd_uses_mined_project():
-    """The primary #311 target: cwd is absent (simulates abs-path-outside-any-repo session).
-    cwd yields None → mined active["project"] fills the gap (the #311 win)."""
+    """THE #311 TARGET CASE — realistic non-repo cwd with a cross-repo --repo signal.
+    cwd=/Users/x/projects/scratch is a real path but NOT a git repo → gitBranch is absent/empty.
+    With the old code, _project_from_path("scratch") would fire branch 2 and return "scratch",
+    IGNORING the mined --repo agents signal entirely.
+    With the gitBranch discriminant: gitBranch absent → branch 3 → mined project wins."""
     recs = _extract(
         [
             _asst(
                 1,
                 ts="t1",
-                cwd=None,
-                content=[_bash("gh pr merge 5 --repo jwj2002/agents --squash")],
+                cwd="/Users/x/projects/scratch",
+                gitBranch=None,  # not in a git repo
+                content=[_bash("gh pr merge 1 --repo jwj2002/agents --squash")],
             ),
-            _asst(2, ts="t2", cwd=None),
+            _asst(2, ts="t2", cwd="/Users/x/projects/scratch", gitBranch=None),
         ]
     )
-    # msg1: no cwd → project=None (pre-command, nothing mined yet)
-    assert recs[0]["project"] is None
-    # msg2: no cwd → cwd_project=None → falls back to mined active["project"] = "agents"
+    # msg1: gitBranch absent, no mined project yet → branch 4 fallback → cwd basename "scratch"
+    assert recs[0]["project"] == "scratch"
+    # msg2: gitBranch absent, active["project"]="agents" (mined from msg1) → branch 3 → "agents"
+    # THIS IS THE #311 WIN: scratch-session gets attributed to agents, not "scratch".
     assert recs[1]["project"] == "agents"
 
 
 # Test K — ssh-develop regression: ssh-derived project still wins when work_host != inference_host
 def test_ssh_develop_project_attribution_not_regressed():
     """SSH-develop (§4.2): when ssh sets work_host to a remote, active["project"] (mined from ssh
-    'cd repo') must still win for subsequent messages — even though cwd is local."""
+    'cd repo') must still win for subsequent messages — even though cwd is local.
+    Uses realistic cwd (a real local dir, but not the remote repo) and gitBranch to confirm
+    branch 1 (on_remote) fires before branch 2 (gitBranch) and wins."""
     recs = _extract(
         [
             _asst(
                 1,
                 ts="t1",
-                cwd="/Users/jjob",  # local cwd — irrelevant under ssh-develop
+                cwd="/Users/x/projects/scratch",
+                gitBranch=None,  # local cwd is not a git repo; user is SSHing out
                 content=[_bash("ssh jns 'cd ~/app-repos/app-buddy && git status'")],
             ),
-            _asst(2, ts="t2", cwd="/Users/jjob"),  # still local cwd after ssh
+            _asst(
+                2, ts="t2", cwd="/Users/x/projects/scratch", gitBranch=None
+            ),  # still local after ssh
         ]
     )
-    # msg1: pre-command, cwd=/Users/jjob → _project_from_path gives "jjob"; work_host still HOST
-    # so on_remote is False for msg1 → cwd wins → project="jjob"
-    assert recs[0]["project"] == "jjob"
-    # msg2: after ssh, work_host="jns" (≠ HOST) → on_remote=True → ssh-mined active["project"]
-    # wins. ssh 'cd ~/app-repos/app-buddy' → mine_command sets project="app-buddy" via cd.
+    # msg1: on_remote=False (ssh fires but work_host still HOST until NEXT message), gitBranch absent,
+    # no mined project yet → branch 4 → cwd basename "scratch"
+    assert recs[0]["project"] == "scratch"
+    # msg2: after ssh cmd, work_host="jns" (≠ HOST) → on_remote=True → branch 1 → ssh-mined
+    # active["project"] wins. ssh 'cd ~/app-repos/app-buddy' → project="app-buddy" via cd.
     assert recs[1]["work_host"] == "jns"
     assert recs[1]["project"] == "app-buddy"
+
+
+# --- Finding 3: tokenization tests (no raw-string false positives) ---------------------------------
+
+
+def test_tokenization_echo_repo_not_matched():
+    """echo '--repo evil/repo' must NOT mine a project — it is not a real gh invocation."""
+    result = U.mine_command("echo '--repo evil/repo'")
+    assert "project" not in result or result.get("project") is None
+
+
+def test_tokenization_comment_not_matched():
+    """A comment containing --repo must NOT mine a project."""
+    result = U.mine_command("# gh pr view --repo jwj2002/agents")
+    assert "project" not in result or result.get("project") is None
+
+
+def test_tokenization_gh_inline_equals():
+    """gh --repo=owner/name (inline =) must mine the project."""
+    result = U.mine_command("gh pr create --repo=jwj2002/agents --title x")
+    assert result.get("project") == "agents"
+
+
+def test_tokenization_gh_no_slash_ignored():
+    """gh --repo noSlashHere must not produce a project (no owner/name separator)."""
+    result = U.mine_command("gh pr view --repo noSlashHere")
+    assert "project" not in result or result.get("project") is None
+
+
+# --- Finding 4: cross-command conflict guard --------------------------------------------------------
+
+
+def test_cross_command_conflict_clears_project():
+    """Two commands in the same message mining DIFFERENT projects → active["project"] cleared.
+    The conflicting mined signal must NOT determine subsequent attribution; cwd fallback applies.
+    Specifically: the project must NOT be "agents" or "maison-scaffold" (neither wins)."""
+    recs = _extract(
+        [
+            _asst(
+                1,
+                ts="t1",
+                cwd="/Users/x/projects/scratch",
+                gitBranch=None,
+                content=[
+                    _bash("gh pr view 1 --repo jwj2002/agents"),
+                    _bash("gh pr view 2 --repo jwj2002/maison-scaffold"),
+                ],
+            ),
+            _asst(2, ts="t2", cwd="/Users/x/projects/scratch", gitBranch=None),
+        ]
+    )
+    # Conflicting mines → active["project"] cleared → branch 3 doesn't fire.
+    # Branch 4 falls back to cwd basename "scratch" (the cwd itself is unambiguous).
+    # Neither "agents" nor "maison-scaffold" must win (last-write-win prevented).
+    assert recs[1]["project"] not in ("agents", "maison-scaffold"), (
+        f"conflict guard FAILED: a conflicted project leaked through as {recs[1]['project']!r}"
+    )
+
+
+def test_cross_command_same_project_not_cleared():
+    """Two commands mining the SAME project must NOT clear it (only conflict clears)."""
+    recs = _extract(
+        [
+            _asst(
+                1,
+                ts="t1",
+                cwd="/Users/x/projects/scratch",
+                gitBranch=None,
+                content=[
+                    _bash("gh pr view 1 --repo jwj2002/agents"),
+                    _bash("gh pr view 2 --repo jwj2002/agents"),
+                ],
+            ),
+            _asst(2, ts="t2", cwd="/Users/x/projects/scratch", gitBranch=None),
+        ]
+    )
+    # Same project from both commands → no conflict → project = "agents"
+    assert recs[1]["project"] == "agents"
+
+
+# --- AC4 counterfactual: #311 target vs old cwd-basename mis-attribution ---------------------------
+
+
+def test_311_target_vs_old_cwd_basename():
+    """Demonstrate the #311 win: with gitBranch discriminant, a scratch session with
+    gh --repo jwj2002/agents correctly attributes to agents, not to the cwd basename 'scratch'.
+    Also demonstrate that the hijack case (gitBranch present) correctly prevents override."""
+    # THE #311 TARGET: cwd=scratch (not a repo), gitBranch absent → mined --repo wins
+    target_recs = _extract(
+        [
+            _asst(
+                1,
+                ts="t1",
+                cwd="/Users/x/projects/scratch",
+                gitBranch=None,
+                content=[_bash("gh pr merge 1 --repo jwj2002/agents --squash")],
+            ),
+            _asst(2, ts="t2", cwd="/Users/x/projects/scratch", gitBranch=None),
+        ]
+    )
+    # msg2 must get project=agents (not "scratch", which the old code would return)
+    assert target_recs[1]["project"] == "agents", (
+        f"#311 target FAILED: expected 'agents', got {target_recs[1]['project']!r}"
+    )
+
+    # HIJACK-PREVENTED: cwd=agents with gitBranch present → cwd wins, stray --repo ignored
+    hijack_recs = _extract(
+        [
+            _asst(
+                1,
+                ts="t1",
+                cwd="/Users/x/agents",
+                gitBranch="feat/issue-9-x",
+                content=[_bash("gh pr view 99 --repo jwj2002/maison-scaffold")],
+            ),
+            _asst(2, ts="t2", cwd="/Users/x/agents", gitBranch="feat/issue-9-x"),
+        ]
+    )
+    # msg2 must get project=agents (not "maison-scaffold" — hijack prevented)
+    assert hijack_recs[1]["project"] == "agents", (
+        f"hijack FAILED: expected 'agents', got {hijack_recs[1]['project']!r}"
+    )


### PR DESCRIPTION
Reduces `task:unattributed` for sessions working on a repo from a cwd outside it (e.g. cwd `~/projects/scratch`, work via `gh --repo jwj2002/agents`). **Redesign** of the first attempt, which adversarial review found mis-attributed the target case and could be hijacked.

## Design — gitBranch-presence precedence
`gitBranch` (in the transcript) is Claude Code's proof that cwd is inside a git repo. Per-message PROJECT precedence:
1. on a remote host (ssh set `work_host != inference_host`) → ssh-mined project
2. **gitBranch present** (cwd IS a repo) → cwd-derived project — a stray `gh --repo other` can NOT hijack a session working in its own repo
3. **gitBranch absent + mined `--repo`/`git -C`** → mined target — the cross-repo-from-scratch case, finally rescued (not mis-attributed)
4. else → cwd basename / unattributed

Recognizers **tokenized**: `--repo` fires only when `argv[0]==gh`, `git -C` only when `argv[0]==git` → `echo "--repo evil/repo"` and comments never attribute. Conflicting projects mined within one message → cleared. Precision over recall.

## Validation
- Suite 252→**259**, ruff clean. Tests use REALISTIC cwd (the prior cwd=None blind spot that hid the bug is gone): target rescued, hijack prevented, ssh no-regression, tokenization, cross-command conflict.
- **PROVE: PASS** — all 4 ACs + 6 behaviors verified; E15 secrets PASS (token scan extracts only repo/path names).
- Review history: Codex R1 REQUEST_CHANGES (cwd-greediness + hijack + tokenization + conflict) → this redesign implements its prescribed fix. Codex re-review **hung** (3rd codex-exec stdin hang this session) → self-reviewed per protocol; all R1 findings confirmed resolved by PROVE's realistic-cwd tests + direct verification.

Closes #311
🤖 Generated with [Claude Code](https://claude.com/claude-code)