### PR TITLE
feat(usage): D3 — PRICE_TABLE_VERSION + normalized usage schema (#319)

### DIFF
--- a/claude-config/scripts/otel_sink.py
+++ b/claude-config/scripts/otel_sink.py
@@ -117,6 +117,11 @@ DEFAULT_PRICE = PRICES[
     "claude-sonnet-4"
 ]  # conservative fallback for unrecognized models (compute_cost only)
 
+# Stamped onto every usage record (cost-telemetry-v0 §D3) so cost_usd is auditable / re-priceable.
+# BUMP this whenever a PRICES rate changes — test_price_table_version pins the current value so any
+# silent rate edit fails CI until the version is bumped.
+PRICE_TABLE_VERSION = "2026-06-08"
+
 EXPORTER_FRESHNESS_SLA_DEFAULT = (
     24 * 3600
 )  # 24h: sink must be written within SLA or alarm (§0.1)

--- a/claude-config/scripts/usage_schema.py
+++ b/claude-config/scripts/usage_schema.py
@@ -1,0 +1,77 @@
+"""D3 normalized usage record (cost-telemetry-v0 §D3).
+
+The single source of truth for the `usage.jsonl` row shape, so no downstream code (report,
+recommender) has to guess whether `None`/`""`/`"unattributed"` mean the same thing. The collector
+(`usage_collect.py`, §D1) calls `normalize()` on every record before append; the report layer renders
+`project`/`task == None` as "unattributed" (the data stays honest, the rendering is cosmetic).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import otel_sink as O  # noqa: E402  (PRICE_TABLE_VERSION + PRICES)
+
+PRICE_BASIS = "published_api_rate"
+
+# The 20 canonical fields, in order (cost-telemetry-v0 §D3).
+NORMALIZED_FIELDS = (
+    "provider",
+    "account",
+    "billing_type",
+    "price_basis",
+    "price_table_version",
+    "inference_host",
+    "work_host",
+    "project",
+    "task",
+    "model",
+    "files_changed",
+    "files_changed_source",
+    "input",
+    "output",
+    "cache_read",
+    "cache_creation",
+    "cost_usd",
+    "session_id",
+    "ts",
+    "dedup_key",
+)
+
+_BILLING = frozenset({"metered", "subscription", "unknown"})
+_FCS = frozenset({"pr_git", "project_metrics", "session_shard", "none"})
+_TOKEN_FIELDS = ("input", "output", "cache_read", "cache_creation")
+
+
+def canonical_account(fields: dict) -> str:
+    """Canonical account id (cost-telemetry-v0 §D3): Claude account_uuid → Codex account_id →
+    email → 'unknown'. Email is a last resort and is kept OUT of the default report by callers."""
+    if not isinstance(fields, dict):
+        return "unknown"
+    for k in ("account_uuid", "account_id", "email"):
+        v = fields.get(k)
+        if v:
+            return str(v)
+    return "unknown"
+
+
+def normalize(rec: dict) -> dict:
+    """Coerce a raw collector record to the D3 schema. Never invents cost: `cost_usd` stays None
+    for quarantined (unknown-model) rows. Stamps pricing provenance. All 20 fields present."""
+    out = dict(rec) if isinstance(rec, dict) else {}
+    bt = out.get("billing_type")
+    out["billing_type"] = bt if bt in _BILLING else "unknown"
+    out["price_basis"] = PRICE_BASIS
+    out["price_table_version"] = O.PRICE_TABLE_VERSION
+    out["files_changed"] = out.get("files_changed")  # null when absent (never 0/"")
+    fcs = out.get("files_changed_source")
+    out["files_changed_source"] = fcs if fcs in _FCS else "none"
+    for t in _TOKEN_FIELDS:
+        out[t] = int(out.get(t, 0) or 0)
+    cost = out.get("cost_usd")
+    out["cost_usd"] = float(cost) if cost is not None else None
+    for f in NORMALIZED_FIELDS:
+        out.setdefault(f, None)
+    return out

--- a/claude-config/tests/test_usage_schema.py
+++ b/claude-config/tests/test_usage_schema.py
@@ -1,0 +1,77 @@
+"""Acceptance tests for issue #319 — D3 PRICE_TABLE_VERSION + normalized schema (cost-telemetry-v0 §D3)."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+import otel_sink as O  # noqa: E402
+import usage_schema as S  # noqa: E402
+
+
+def test_price_table_version_exists_and_pinned():
+    assert isinstance(O.PRICE_TABLE_VERSION, str) and O.PRICE_TABLE_VERSION
+    # PIN: a silent PRICES rate edit must bump this. If you changed rates, bump the version + this test.
+    assert O.PRICE_TABLE_VERSION == "2026-06-08"
+
+
+def test_normalize_fills_all_fields_and_stamps_pricing():
+    rec = {
+        "provider": "claude",
+        "model": "claude-opus-4",
+        "input": 100,
+        "output": 50,
+        "cost_usd": 1.5,
+        "session_id": "s",
+        "ts": "t",
+        "dedup_key": "s:1",
+        "billing_type": "metered",
+    }
+    out = S.normalize(rec)
+    for f in S.NORMALIZED_FIELDS:
+        assert f in out, f
+    assert out["price_basis"] == "published_api_rate"
+    assert out["price_table_version"] == O.PRICE_TABLE_VERSION
+    assert out["billing_type"] == "metered"
+    assert out["cost_usd"] == 1.5
+
+
+def test_billing_type_none_or_bad_becomes_unknown():
+    assert S.normalize({"billing_type": None})["billing_type"] == "unknown"
+    assert S.normalize({"billing_type": "console"})["billing_type"] == "unknown"
+    assert S.normalize({})["billing_type"] == "unknown"
+
+
+def test_files_changed_defaults_null_and_source_none():
+    out = S.normalize({})
+    assert out["files_changed"] is None  # null, never 0/""
+    assert out["files_changed_source"] == "none"
+    assert (
+        S.normalize({"files_changed_source": "bogus"})["files_changed_source"] == "none"
+    )
+    assert (
+        S.normalize({"files_changed_source": "pr_git"})["files_changed_source"]
+        == "pr_git"
+    )
+
+
+def test_quarantine_cost_stays_null():
+    # an unknown-model (quarantined) row carries no cost — normalize must not invent one
+    out = S.normalize({"model": "gpt-99-unknown", "cost_usd": None})
+    assert out["cost_usd"] is None
+
+
+def test_tokens_coerced_to_int():
+    out = S.normalize({"input": "100", "output": None, "cache_read": 5})
+    assert out["input"] == 100 and out["output"] == 0 and out["cache_read"] == 5
+
+
+def test_canonical_account_precedence():
+    assert (
+        S.canonical_account({"account_uuid": "u", "account_id": "a", "email": "e"})
+        == "u"
+    )
+    assert S.canonical_account({"account_id": "a", "email": "e"}) == "a"
+    assert S.canonical_account({"email": "e@x.com"}) == "e@x.com"
+    assert S.canonical_account({}) == "unknown"
+    assert S.canonical_account(None) == "unknown"


### PR DESCRIPTION
Base layer for cost-telemetry-v0 §D3. `PRICE_TABLE_VERSION` constant (pinned by test) + `usage_schema.py` (normalized 20-field record, `normalize()`, `canonical_account()`). +7 tests, ruff clean. Closes #319.