### PR TITLE
feat(usage): D7 — resolve_billing_type metered helper (#321)

### DIFF
--- a/claude-config/scripts/usage_billing.py
+++ b/claude-config/scripts/usage_billing.py
@@ -1,0 +1,47 @@
+"""Billing-type detection (cost-telemetry-v0 §D7).
+
+Decides whether a session is `metered` (real $, API-key) or `subscription` (notional, projected $),
+which is the ONLY signal separating real-vs-projected cost in the report. The hard part is that an
+**API key in the environment beats a stale OAuth login** — a session run with `ANTHROPIC_API_KEY` set
+is billed to the key regardless of any `oauthAccount` left in `~/.claude.json`.
+
+This is a PURE helper (inject `env` + path) so it's testable. It is meant to be called by the
+SessionStart account-capture hook (where `env` is the session's own environment) so each session is
+tagged at capture time. ⚠ launchd does NOT inherit a shell's env — under launchd the API-key keys are
+absent unless explicitly added to the plist `EnvironmentVariables`, so the env-key branch only fires in
+the hook context, not in a launchd-run collector. (Wiring this into the live hook is part of the
+deferred activation / smoke test, not this change.)
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+# oauthAccount.billingType values that mean real metered billing despite being an OAuth login.
+_METERED_PLANS = frozenset(
+    {"console", "api", "metered", "usage_based", "pay_as_you_go"}
+)
+
+
+def resolve_billing_type(env: dict, claude_json_path) -> str:
+    """`metered` | `subscription` | `unknown`. Precedence (cost-telemetry-v0 §D7):
+    1. `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` present in `env` → `metered` (env key beats OAuth).
+    2. valid `oauthAccount` and no env key → `subscription` (or `metered` if its plan is console/api).
+    3. `~/.claude.json` absent / malformed / no oauthAccount → `unknown` (never silently mislabel)."""
+    env = env or {}
+    if env.get("ANTHROPIC_API_KEY") or env.get("OPENAI_API_KEY"):
+        return "metered"
+    try:
+        data = json.loads(Path(claude_json_path).read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError, OSError, ValueError):
+        return "unknown"
+    if not isinstance(data, dict):
+        return "unknown"
+    oa = data.get("oauthAccount")
+    if not isinstance(oa, dict) or not oa:
+        return "unknown"
+    plan = str(oa.get("billingType") or "").lower()
+    if plan in _METERED_PLANS:
+        return "metered"
+    return "subscription"  # an OAuth login that isn't a console/api plan = subscription

--- a/claude-config/tests/test_usage_billing.py
+++ b/claude-config/tests/test_usage_billing.py
@@ -1,0 +1,63 @@
+"""Acceptance tests for issue #321 — metered billing-type helper (cost-telemetry-v0 §D7)."""
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+import usage_billing as B  # noqa: E402
+
+
+def _claude_json(tmp_path, obj) -> Path:
+    p = tmp_path / ".claude.json"
+    p.write_text(json.dumps(obj), encoding="utf-8")
+    return p
+
+
+def test_env_anthropic_key_beats_oauth(tmp_path):
+    # an API key in env → metered even when a subscription oauthAccount exists
+    cj = _claude_json(tmp_path, {"oauthAccount": {"billingType": "max"}})
+    assert B.resolve_billing_type({"ANTHROPIC_API_KEY": "sk-x"}, cj) == "metered"
+
+
+def test_env_openai_key_metered(tmp_path):
+    cj = _claude_json(tmp_path, {"oauthAccount": {"billingType": "pro"}})
+    assert B.resolve_billing_type({"OPENAI_API_KEY": "sk-o"}, cj) == "metered"
+
+
+def test_subscription_oauth_no_key(tmp_path):
+    cj = _claude_json(tmp_path, {"oauthAccount": {"billingType": "max"}})
+    assert B.resolve_billing_type({}, cj) == "subscription"
+
+
+def test_oauth_no_billingtype_is_subscription(tmp_path):
+    # an OAuth login without an explicit metered plan → subscription
+    cj = _claude_json(tmp_path, {"oauthAccount": {"emailAddress": "x@y.com"}})
+    assert B.resolve_billing_type({}, cj) == "subscription"
+
+
+def test_console_oauth_is_metered(tmp_path):
+    cj = _claude_json(tmp_path, {"oauthAccount": {"billingType": "console"}})
+    assert B.resolve_billing_type({}, cj) == "metered"
+
+
+def test_malformed_json_unknown(tmp_path):
+    p = tmp_path / ".claude.json"
+    p.write_text("{not valid json", encoding="utf-8")
+    assert B.resolve_billing_type({}, p) == "unknown"
+
+
+def test_missing_file_unknown(tmp_path):
+    assert B.resolve_billing_type({}, tmp_path / "nope.json") == "unknown"
+
+
+def test_no_oauth_account_unknown(tmp_path):
+    cj = _claude_json(tmp_path, {"someOtherKey": 1})
+    assert B.resolve_billing_type({}, cj) == "unknown"
+
+
+def test_non_dict_json_unknown(tmp_path):
+    p = tmp_path / ".claude.json"
+    p.write_text('"a string"', encoding="utf-8")
+    assert B.resolve_billing_type({}, p) == "unknown"


### PR DESCRIPTION
Tested pure helper (§D7): metered/subscription/unknown with env-key precedence (API key beats stale OAuth). NOT wired into the live hook (deferred to joint activation). +9 tests, ruff clean. Closes #321.