### PR TITLE
feat(usage): D4 — report billing-split/coverage/quarantine (#322)

### DIFF
--- a/claude-config/scripts/usage_report.py
+++ b/claude-config/scripts/usage_report.py
@@ -173,17 +173,189 @@ def _table(headers: list, rows: list) -> str:
     return f"<table><thead><tr>{th}</tr></thead><tbody>{trs}</tbody></table>"
 
 
+def _billing_headline_html(totals: dict) -> str:
+    """Three labeled billing-headline lines (D4 AC): Metered (real $), Subscription (projected $,
+    notional *), Unknown. NEVER renders a single summed total when metered+subscription both present.
+    When only one bucket exists the single line is still rendered under its label (not the old flat
+    total) so the label is always explicit."""
+    cbb = totals.get("cost_by_billing") or {}
+    if not cbb:
+        # fall back gracefully — should not normally happen
+        return f"<p>Total: {html.escape(_fmt_cost(totals))} &middot; {html.escape(str(totals.get('records', 0)))} records</p>"
+    lines = []
+    metered = cbb.get("metered")
+    subscription = cbb.get("subscription")
+    unknown = cbb.get("unknown")
+    if metered is not None:
+        lines.append(f"Metered (real $): {html.escape(_money(metered))}")
+    if subscription is not None:
+        lines.append(
+            f"Subscription (projected $, notional) *: {html.escape(_money(subscription))}"
+        )
+    if unknown is not None:
+        lines.append(f"Unknown: {html.escape(_money(unknown))}")
+    if not lines:
+        lines.append(f"Total: {html.escape(_fmt_cost(totals))}")
+    record_count = html.escape(str(totals.get("records", 0)))
+    joined = " &middot; ".join(lines)
+    return f"<p>{joined} &middot; {record_count} records</p>"
+
+
+def _build_tier_approx_index(records: list | None) -> dict:
+    """Build a (project, tier, model) → bool(is_approximate) lookup from raw records.
+    A group is NOT approximate only if ALL its records have files_changed_source == 'pr_git'.
+    Records absent or with missing/non-pr_git files_changed_source → approximate."""
+    from collections import defaultdict
+    from importlib import import_module
+
+    agg_mod = import_module("usage_aggregator")
+    # Track whether any non-pr_git record exists per key
+    has_non_pr_git: dict = defaultdict(bool)
+    group_seen: set = set()
+    for r in records or []:
+        proj = r.get("project")
+        tier = agg_mod.task_tier(r.get("files_changed"))
+        model = r.get("model")
+        key = (proj, tier, model)
+        group_seen.add(key)
+        fcs = r.get("files_changed_source")
+        if fcs != "pr_git":
+            has_non_pr_git[key] = True
+    # A group is approximate if any record is NOT pr_git (or no records seen → approximate)
+    return {key: has_non_pr_git.get(key, False) for key in group_seen}
+
+
+def _model_tier_html(agg: dict, records: list | None = None) -> str:
+    """By model × tier table (D4 AC). Each cell is marked '(tier approximate)' unless ALL
+    records in that group carry files_changed_source == 'pr_git'."""
+    cmt = agg.get("cost_by_model_tier") or {}
+    approx_index = _build_tier_approx_index(records)
+    rows = []
+    for proj, tiers in sorted(cmt.items(), key=lambda kv: str(kv[0])):
+        for tier, models in sorted(tiers.items(), key=lambda kv: str(kv[0])):
+            for model, grp in sorted(models.items(), key=lambda kv: str(kv[0])):
+                key = (proj, tier, model)
+                approx = approx_index.get(key, True)
+                tier_label = f"{tier} (tier approximate)" if approx else tier
+                proj_label = proj if proj is not None else "unattributed"
+                rows.append([proj_label, tier_label, model, _fmt_cost(grp)])
+    return _table(["Project", "Tier", "Model", "Cost"], rows)
+
+
+def _by_project_task_html(records: list | None) -> str:
+    """By project/task table (D4 AC). project/task == None → 'unattributed' row (not hidden)."""
+    from collections import defaultdict
+    from importlib import import_module
+
+    agg_mod = import_module("usage_aggregator")
+    groups: dict = defaultdict(list)
+    for r in records or []:
+        key = (r.get("project"), r.get("task"))
+        groups[key].append(r)
+    rows = []
+    for (proj, task), rs in sorted(
+        groups.items(), key=lambda kv: (str(kv[0][0]), str(kv[0][1]))
+    ):
+        proj_label = proj if proj is not None else "unattributed"
+        task_label = task if task is not None else "unattributed"
+        rows.append([proj_label, task_label, _fmt_cost(agg_mod._cost_group(rs))])
+    return _table(["Project", "Task", "Cost"], rows)
+
+
+def _attribution_coverage_html(records: list | None) -> str:
+    """Attribution coverage per billing bucket (D4 AC): % of cost with project AND task present;
+    unattributed $ shown explicitly."""
+    from collections import defaultdict
+
+    recs = records or []
+    if not recs:
+        return '<p class="nodata">No records — attribution coverage unavailable.</p>'
+
+    from importlib import import_module
+
+    agg_mod = import_module("usage_aggregator")
+
+    # Build per-billing-bucket totals and attributed totals
+    bucket_total: dict = defaultdict(float)
+    bucket_attributed: dict = defaultdict(float)
+    bucket_unattributed: dict = defaultdict(float)
+    for r in recs:
+        bt = r.get("billing_type") or "unknown"
+        c = agg_mod._f(r.get("cost_usd", 0))
+        bucket_total[bt] += c
+        has_proj = r.get("project") is not None
+        has_task = r.get("task") is not None
+        if has_proj and has_task:
+            bucket_attributed[bt] += c
+        else:
+            bucket_unattributed[bt] += c
+
+    all_buckets = sorted(set(bucket_total) | set(bucket_attributed))
+    rows = []
+    for bt in all_buckets:
+        total = bucket_total[bt]
+        attributed = bucket_attributed[bt]
+        unattributed = bucket_unattributed[bt]
+        pct = (attributed / total * 100) if total > 0 else 0.0
+        label = bt.capitalize()
+        rows.append(
+            [
+                label,
+                f"{pct:.1f}%",
+                _money(attributed),
+                _money(unattributed),
+            ]
+        )
+    return _table(
+        ["Billing Bucket", "Attribution Coverage", "Attributed $", "Unattributed $"],
+        rows,
+    )
+
+
+def _quarantine_html(quarantine) -> str:
+    """Quarantine summary (D4 AC). quarantine may be:
+    - None / empty → return '' (section omitted)
+    - dict with keys 'count' (int) and 'models' (list[str])
+    - int → treat as count with no model names
+    """
+    if quarantine is None:
+        return ""
+    count = 0
+    models: list = []
+    if isinstance(quarantine, dict):
+        count = int(quarantine.get("count") or 0)
+        models = list(quarantine.get("models") or [])
+    elif isinstance(quarantine, int):
+        count = quarantine
+    elif hasattr(quarantine, "__len__"):
+        count = len(quarantine)
+        models = [str(x) for x in quarantine]
+    if count == 0 and not models:
+        return ""
+    model_part = ""
+    if models:
+        escaped_models = ", ".join(html.escape(str(m)) for m in models)
+        model_part = f" &mdash; models needing pricing: {escaped_models}"
+    return (
+        f"<p class='callout'><strong>Quarantine: {count} rows</strong>{model_part}</p>"
+    )
+
+
 def render_html(
     agg: dict,
     *,
     records: list | None = None,
     period: str = "week",
     title: str = "Fleet Usage Report",
+    quarantine=None,
 ) -> str:
     agg = agg or {}
     tr = trends(records or [], period=period)
     totals = agg.get("totals") or {}
     has_subscription = "subscription" in json.dumps(agg)
+
+    # Billing headline: three labeled lines (D4 AC) — never a single summed total
+    headline = _billing_headline_html(totals)
 
     # Section 1: cost by project (table) — $/PR trend chart fed by `tr`. _table escapes cells (raw in).
     proj_rows = [[p, _fmt_cost(_proj_group(agg, p))] for p in _projects(agg)]
@@ -192,15 +364,22 @@ def render_html(
         + _table(["Project", "Cost"], proj_rows)
         + "<canvas id='c_pr_trend'></canvas>"
     )
-    # Section 2: model mix
+    # Section 2: model mix + by model × tier (D4 AC)
     mm_rows = [
         [p, m, _fmt_cost(g)]
         for p, models in (agg.get("model_mix") or {}).items()
         for m, g in models.items()
     ]
-    s2 = f"<h2 id='model_mix'>{SECTIONS[1][1]}</h2>" + _table(
-        ["Project", "Model", "Cost"], mm_rows
+    s2 = (
+        f"<h2 id='model_mix'>{SECTIONS[1][1]}</h2>"
+        + _table(["Project", "Model", "Cost"], mm_rows)
+        + "<h3>By Model &times; Tier</h3>"
+        + _model_tier_html(agg, records)
     )
+    # Section 2b: by project / task (D4 AC) — unattributed row shown explicitly
+    s2b = "<h3>By Project / Task</h3>" + _by_project_task_html(records)
+    # Section 2c: attribution coverage (D4 AC)
+    s2c = "<h3>Attribution Coverage</h3>" + _attribution_coverage_html(records)
     # Section 3: cache efficiency (table + trend chart). _pct/_money are crash-safe on malformed data.
     cache_rows = [
         [
@@ -246,9 +425,12 @@ def render_html(
         + _table(["Host", "peak concurrent", "burn $/hr"], conc_rows)
         + "<canvas id='c_conc'></canvas>"
     )
-    # Section 7: right-sizing recommendations (usage_recommend loaded lazily)
-    s7 = f"<h2 id='recommendations'>{SECTIONS[6][1]}</h2>" + _render_recommendations(
-        agg, records
+    # Quarantine summary (D4 AC) — rendered before recommendations; omitted when empty/None
+    s_quarantine = _quarantine_html(quarantine)
+    # Section 7: right-sizing recommendations with [diagnostic] badge (D4 AC)
+    s7 = (
+        f"<h2 id='recommendations'>{SECTIONS[6][1]} <span class='badge-diagnostic'>[diagnostic]</span></h2>"
+        + _render_recommendations(agg, records)
     )
 
     footnote = (
@@ -267,11 +449,12 @@ def render_html(
 <style>body{{font-family:system-ui,sans-serif;margin:2rem;max-width:1100px}}
 table{{border-collapse:collapse;margin:.5rem 0}}th,td{{border:1px solid #ccc;padding:.3rem .6rem}}
 .nodata{{color:#999;font-style:italic}}.footnote{{color:#666;font-size:.85rem;margin-top:2rem}}
-.callout{{background:#f5f7ff;padding:.6rem;border-left:3px solid #36c}}canvas{{max-height:320px}}</style>
+.callout{{background:#f5f7ff;padding:.6rem;border-left:3px solid #36c}}canvas{{max-height:320px}}
+.badge-diagnostic{{background:#e8f4f8;color:#0366d6;font-size:.75rem;padding:.1rem .4rem;border-radius:3px;border:1px solid #b0d4e8}}</style>
 </head><body>
 <h1>{html.escape(title)}</h1>
-<p>Total: {html.escape(_fmt_cost(totals))} &middot; {html.escape(str(totals.get("records", 0)))} records</p>
-{s1}{s2}{s3}{s4}{s5}{s6}{s7}
+{headline}
+{s1}{s2}{s2b}{s2c}{s3}{s4}{s5}{s6}{s_quarantine}{s7}
 {footnote}
 <!-- Chart labels are data-derived strings, but Chart.js renders them on the CANVAS as text (no
      innerHTML / DOM-injection path; no HTML-tooltip plugin is used), and the embedded blob is
@@ -320,13 +503,105 @@ def _dim_rows(records: list | None, field: str) -> list:
     return rows
 
 
+def _md_summary(agg: dict, records: list | None, quarantine) -> str:
+    """Plain-text Markdown summary for the D5 email body: billing split + coverage + quarantine."""
+    totals = agg.get("totals") or {}
+    cbb = totals.get("cost_by_billing") or {}
+    lines = ["# Usage Report Summary", ""]
+
+    # Billing split
+    lines.append("## Billing")
+    if cbb:
+        for bt, cost in sorted(cbb.items()):
+            label_map = {
+                "metered": "Metered (real $)",
+                "subscription": "Subscription (projected $, notional) *",
+                "unknown": "Unknown",
+            }
+            label = label_map.get(bt, bt.capitalize())
+            lines.append(f"- {label}: {_money(cost)}")
+    else:
+        lines.append(f"- Total: {_fmt_cost(totals)}")
+    lines.append(f"- Records: {totals.get('records', 0)}")
+    lines.append("")
+
+    # Attribution coverage
+    recs = records or []
+    lines.append("## Attribution Coverage")
+    if recs:
+        from collections import defaultdict
+        from importlib import import_module
+
+        agg_mod = import_module("usage_aggregator")
+        bucket_total: dict = defaultdict(float)
+        bucket_attributed: dict = defaultdict(float)
+        bucket_unattributed: dict = defaultdict(float)
+        for r in recs:
+            bt = r.get("billing_type") or "unknown"
+            c = agg_mod._f(r.get("cost_usd", 0))
+            bucket_total[bt] += c
+            has_proj = r.get("project") is not None
+            has_task = r.get("task") is not None
+            if has_proj and has_task:
+                bucket_attributed[bt] += c
+            else:
+                bucket_unattributed[bt] += c
+        for bt in sorted(bucket_total):
+            total = bucket_total[bt]
+            attributed = bucket_attributed[bt]
+            unattributed = bucket_unattributed[bt]
+            pct = (attributed / total * 100) if total > 0 else 0.0
+            lines.append(
+                f"- {bt.capitalize()}: {pct:.1f}% attributed"
+                f" | attributed {_money(attributed)}"
+                f" | unattributed {_money(unattributed)}"
+            )
+    else:
+        lines.append("- No records")
+    lines.append("")
+
+    # Quarantine
+    lines.append("## Quarantine")
+    if quarantine is None:
+        lines.append("- None")
+    else:
+        count = 0
+        models: list = []
+        if isinstance(quarantine, dict):
+            count = int(quarantine.get("count") or 0)
+            models = list(quarantine.get("models") or [])
+        elif isinstance(quarantine, int):
+            count = quarantine
+        elif hasattr(quarantine, "__len__"):
+            count = len(quarantine)
+            models = [str(x) for x in quarantine]
+        if count == 0 and not models:
+            lines.append("- None")
+        else:
+            lines.append(f"- {count} rows quarantined")
+            if models:
+                lines.append(
+                    f"- Models needing pricing: {', '.join(str(m) for m in models)}"
+                )
+    lines.append("")
+    return "\n".join(lines)
+
+
 def write_report(
-    agg: dict, out_path, *, records: list | None = None, period: str = "week"
+    agg: dict,
+    out_path,
+    *,
+    records: list | None = None,
+    period: str = "week",
+    quarantine=None,
 ) -> str:
     from pathlib import Path
 
-    html_str = render_html(agg, records=records, period=period)
+    html_str = render_html(agg, records=records, period=period, quarantine=quarantine)
     p = Path(out_path)
     p.parent.mkdir(parents=True, exist_ok=True)
     p.write_text(html_str, encoding="utf-8")
+    # Also write .md summary (D4 AC: same basename, .md extension)
+    md_path = p.with_suffix(".md")
+    md_path.write_text(_md_summary(agg, records, quarantine), encoding="utf-8")
     return str(p)

--- a/claude-config/tests/test_usage_report_d4.py
+++ b/claude-config/tests/test_usage_report_d4.py
@@ -1,0 +1,529 @@
+"""Acceptance tests for issue #322 — D4 report enhancements.
+
+Tests:
+- mixed-billing fixture → three separate buckets, never summed; subscription has `*`
+- all-unattributed fixture → renders, coverage 0%, no crash, "unattributed" row present
+- quarantine non-empty → "Quarantine: N rows" + model names; empty/None → section absent
+- diagnostic badge present in recommendations heading
+- write_report → .md file created with billing split + coverage text
+- tier_approximate logic: pr_git → not approximate; absent/other → approximate
+"""
+
+import sys
+from html.parser import HTMLParser
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+import usage_report as R  # noqa: E402
+import usage_aggregator as A  # noqa: E402
+
+
+def _rec(**kw):
+    base = {
+        "provider": "claude",
+        "model": "claude-opus-4",
+        "project": "agents",
+        "task": "issue:42",
+        "input": 900_000,
+        "output": 1000,
+        "cache_read": 100_000,
+        "cache_creation": 0,
+        "cost_usd": 2.0,
+        "inference_host": "mac",
+        "work_host": "mac",
+        "session_id": "s1",
+        "ts": "2026-06-01T00:00:00Z",
+        "billing_type": "subscription",
+        "files_changed": 3,
+        "files_changed_source": "none",
+    }
+    base.update(kw)
+    return base
+
+
+def _parses(html_str: str) -> bool:
+    HTMLParser().feed(html_str)
+    return (
+        "<!DOCTYPE html>" in html_str
+        and html_str.count("<body>") == 1
+        and html_str.count("</body>") == 1
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC: mixed-billing fixture → three separate buckets, NEVER one summed total
+# ---------------------------------------------------------------------------
+
+
+def test_billing_headline_three_buckets():
+    """Mixed metered+subscription → three labeled lines, never a single summed total (D4 AC)."""
+    recs = [
+        _rec(billing_type="metered", cost_usd=1.50, session_id="m1"),
+        _rec(billing_type="subscription", cost_usd=3.00, session_id="s1"),
+        _rec(billing_type="unknown", cost_usd=0.50, session_id="u1"),
+    ]
+    agg = A.aggregate(recs)
+    h = R.render_html(agg, records=recs)
+    assert _parses(h)
+    # Each bucket must appear as a labeled line
+    assert "Metered (real $):" in h
+    assert "Subscription (projected $, notional) *:" in h
+    assert "Unknown:" in h
+    # Subscription must carry * marker
+    assert "notional) *:" in h
+    # Must NOT contain a single unlabeled total — "Total:" outside of fallback must not appear
+    # The old single-line "Total: $X.XX" should be gone from the headline paragraph
+    assert "Metered (real $): $1.50" in h
+    assert "Subscription (projected $, notional) *: $3.00" in h
+    assert "Unknown: $0.50" in h
+
+
+def test_billing_headline_subscription_only():
+    """Subscription-only data → single labeled subscription line (not old flat total)."""
+    recs = [_rec(billing_type="subscription", cost_usd=5.0, session_id="s1")]
+    agg = A.aggregate(recs)
+    h = R.render_html(agg, records=recs)
+    assert "Subscription (projected $, notional) *:" in h
+    assert "Metered (real $)" not in h
+    assert "Unknown:" not in h
+
+
+def test_billing_headline_metered_only():
+    """Metered-only data → single labeled metered line with no subscription star."""
+    recs = [_rec(billing_type="metered", cost_usd=2.0, session_id="m1")]
+    agg = A.aggregate(recs)
+    h = R.render_html(agg, records=recs)
+    assert "Metered (real $): $2.00" in h
+    assert "Subscription" not in h or "Subscription (projected" not in h
+
+
+def test_billing_headline_no_single_summed_total_when_mixed():
+    """When metered + subscription are both present, there MUST be NO single summed total line
+    in the billing headline (D4 AC: 'never a single summed total')."""
+    recs = [
+        _rec(billing_type="metered", cost_usd=1.0, session_id="m1"),
+        _rec(billing_type="subscription", cost_usd=2.0, session_id="s1"),
+    ]
+    agg = A.aggregate(recs)
+    h = R.render_html(agg, records=recs)
+    # The old pattern "Total: $X.XX" must not appear in the headline paragraph
+    # (it would be a single summed total)
+    assert "Metered (real $):" in h and "Subscription (projected $, notional) *:" in h
+    # Confirm NO raw summation: $3.00 is the sum — if it appears, it should only be in
+    # billing-aware contexts (e.g., a table cell), not as a standalone "Total:" headline
+    # We check the headline paragraph specifically
+    import re
+
+    headline_match = re.search(r"<p>(.*?)</p>", h, re.DOTALL)
+    assert headline_match is not None
+    first_p = headline_match.group(1)
+    assert "Total:" not in first_p
+
+
+# ---------------------------------------------------------------------------
+# AC: all-unattributed fixture → renders, coverage 0%, no crash, "unattributed" row
+# ---------------------------------------------------------------------------
+
+
+def test_all_unattributed_no_crash():
+    """All records with project=None AND task=None → renders without crash (D4 AC)."""
+    recs = [
+        _rec(
+            project=None,
+            task=None,
+            billing_type="metered",
+            cost_usd=1.0,
+            session_id="u1",
+        ),
+        _rec(
+            project=None,
+            task=None,
+            billing_type="metered",
+            cost_usd=2.0,
+            session_id="u2",
+        ),
+    ]
+    agg = A.aggregate(recs)
+    h = R.render_html(agg, records=recs)
+    assert _parses(h)
+
+
+def test_all_unattributed_coverage_zero():
+    """All records unattributed → attribution coverage shows 0% (D4 AC)."""
+    recs = [
+        _rec(
+            project=None,
+            task=None,
+            billing_type="metered",
+            cost_usd=1.0,
+            session_id="u1",
+        ),
+    ]
+    agg = A.aggregate(recs)
+    h = R.render_html(agg, records=recs)
+    # Coverage section should show 0%
+    assert "0.0%" in h
+
+
+def test_all_unattributed_row_present():
+    """project/task == None → 'unattributed' row present in By Project/Task table (D4 AC)."""
+    recs = [
+        _rec(
+            project=None,
+            task=None,
+            billing_type="metered",
+            cost_usd=1.0,
+            session_id="u1",
+        ),
+    ]
+    agg = A.aggregate(recs)
+    h = R.render_html(agg, records=recs)
+    assert "unattributed" in h
+
+
+def test_partial_attribution_unattributed_row():
+    """Some records attributed, some not → unattributed row present and coverage < 100%."""
+    recs = [
+        _rec(
+            project="proj-a",
+            task="issue:1",
+            billing_type="metered",
+            cost_usd=3.0,
+            session_id="a1",
+        ),
+        _rec(
+            project=None,
+            task=None,
+            billing_type="metered",
+            cost_usd=1.0,
+            session_id="u1",
+        ),
+    ]
+    agg = A.aggregate(recs)
+    h = R.render_html(agg, records=recs)
+    assert "unattributed" in h
+    # Coverage is 3.0/4.0 = 75%
+    assert "75.0%" in h
+
+
+# ---------------------------------------------------------------------------
+# AC: quarantine non-empty → "Quarantine: N rows" + model names; empty → absent
+# ---------------------------------------------------------------------------
+
+
+def test_quarantine_non_empty_renders():
+    """Non-empty quarantine → 'Quarantine: N rows' + model names (D4 AC)."""
+    recs = [_rec(billing_type="metered", cost_usd=1.0)]
+    agg = A.aggregate(recs)
+    q = {"count": 3, "models": ["claude-new-x", "gpt-6"]}
+    h = R.render_html(agg, records=recs, quarantine=q)
+    assert "Quarantine: 3 rows" in h
+    assert "claude-new-x" in h
+    assert "gpt-6" in h
+
+
+def test_quarantine_none_omitted():
+    """quarantine=None → quarantine section absent (D4 AC)."""
+    recs = [_rec(billing_type="metered", cost_usd=1.0)]
+    agg = A.aggregate(recs)
+    h = R.render_html(agg, records=recs, quarantine=None)
+    assert "Quarantine:" not in h
+
+
+def test_quarantine_empty_dict_omitted():
+    """quarantine with count=0 and no models → section absent (D4 AC)."""
+    recs = [_rec(billing_type="metered", cost_usd=1.0)]
+    agg = A.aggregate(recs)
+    h = R.render_html(agg, records=recs, quarantine={"count": 0, "models": []})
+    assert "Quarantine:" not in h
+
+
+def test_quarantine_int_form():
+    """quarantine as plain int → 'Quarantine: N rows' (alternate call form)."""
+    recs = [_rec(billing_type="metered", cost_usd=1.0)]
+    agg = A.aggregate(recs)
+    h = R.render_html(agg, records=recs, quarantine=5)
+    assert "Quarantine: 5 rows" in h
+
+
+def test_quarantine_model_name_escaped():
+    """Model names in quarantine are HTML-escaped (no XSS)."""
+    recs = [_rec(billing_type="metered", cost_usd=1.0)]
+    agg = A.aggregate(recs)
+    q = {"count": 1, "models": ["<script>alert(1)</script>"]}
+    h = R.render_html(agg, records=recs, quarantine=q)
+    assert "<script>alert(1)</script>" not in h
+    assert "&lt;script&gt;" in h
+
+
+# ---------------------------------------------------------------------------
+# AC: [diagnostic] badge present in recommendations heading
+# ---------------------------------------------------------------------------
+
+
+def test_diagnostic_badge_in_recommendations_heading():
+    """Recommendations section heading must contain '[diagnostic]' badge (D4 AC)."""
+    recs = [_rec(billing_type="metered", cost_usd=1.0)]
+    agg = A.aggregate(recs)
+    h = R.render_html(agg, records=recs)
+    assert "[diagnostic]" in h
+    # Badge must be inside the recommendations heading element
+    assert "id='recommendations'" in h
+    idx = h.index("id='recommendations'")
+    # Find the heading tag containing "recommendations"
+    heading_chunk = h[idx : idx + 200]
+    assert "[diagnostic]" in heading_chunk
+
+
+# ---------------------------------------------------------------------------
+# AC: write_report → .md file created alongside .html
+# ---------------------------------------------------------------------------
+
+
+def test_write_report_creates_md_file(tmp_path):
+    """write_report must produce a .md file alongside the .html (D4 AC)."""
+    recs = [
+        _rec(billing_type="metered", cost_usd=2.0, session_id="m1"),
+        _rec(billing_type="subscription", cost_usd=3.0, session_id="s1"),
+    ]
+    agg = A.aggregate(recs)
+    out_html = tmp_path / "reports" / "usage.html"
+    R.write_report(agg, out_html, records=recs)
+    md_path = tmp_path / "reports" / "usage.md"
+    assert md_path.exists(), ".md summary file must be created alongside .html"
+
+
+def test_write_report_md_contains_billing_split(tmp_path):
+    """The .md summary must contain billing split lines (D4 AC)."""
+    recs = [
+        _rec(billing_type="metered", cost_usd=2.0, session_id="m1"),
+        _rec(billing_type="subscription", cost_usd=3.0, session_id="s1"),
+    ]
+    agg = A.aggregate(recs)
+    out_html = tmp_path / "report.html"
+    R.write_report(agg, out_html, records=recs)
+    md = (tmp_path / "report.md").read_text()
+    assert "Metered" in md
+    assert "Subscription" in md
+    assert "$2.00" in md
+    assert "$3.00" in md
+
+
+def test_write_report_md_contains_coverage(tmp_path):
+    """The .md summary must contain attribution coverage text (D4 AC)."""
+    recs = [
+        _rec(
+            billing_type="metered",
+            cost_usd=1.0,
+            project="proj",
+            task="issue:1",
+            session_id="a1",
+        ),
+        _rec(
+            billing_type="metered",
+            cost_usd=1.0,
+            project=None,
+            task=None,
+            session_id="u1",
+        ),
+    ]
+    agg = A.aggregate(recs)
+    out_html = tmp_path / "report.html"
+    R.write_report(agg, out_html, records=recs)
+    md = (tmp_path / "report.md").read_text()
+    assert "Attribution Coverage" in md
+    assert "50.0%" in md
+
+
+def test_write_report_md_contains_quarantine(tmp_path):
+    """The .md summary must include quarantine info when non-empty (D4 AC)."""
+    recs = [_rec(billing_type="metered", cost_usd=1.0)]
+    agg = A.aggregate(recs)
+    out_html = tmp_path / "report.html"
+    R.write_report(
+        agg, out_html, records=recs, quarantine={"count": 2, "models": ["model-xyz"]}
+    )
+    md = (tmp_path / "report.md").read_text()
+    assert "2 rows quarantined" in md
+    assert "model-xyz" in md
+
+
+def test_write_report_md_quarantine_none_when_absent(tmp_path):
+    """The .md summary shows 'None' for quarantine when not passed (D4 AC)."""
+    recs = [_rec(billing_type="metered", cost_usd=1.0)]
+    agg = A.aggregate(recs)
+    out_html = tmp_path / "report.html"
+    R.write_report(agg, out_html, records=recs)
+    md = (tmp_path / "report.md").read_text()
+    assert "Quarantine" in md
+    assert "None" in md
+
+
+# ---------------------------------------------------------------------------
+# AC: tier_approximate logic
+# ---------------------------------------------------------------------------
+
+
+def test_model_tier_pr_git_not_approximate():
+    """Records with files_changed_source=pr_git → tier NOT marked approximate (D4 spec)."""
+    recs = [
+        _rec(
+            project="proj",
+            task="issue:1",
+            model="claude-opus-4",
+            files_changed=1,
+            files_changed_source="pr_git",
+            billing_type="metered",
+            cost_usd=1.0,
+            session_id="pg1",
+        ),
+    ]
+    agg = A.aggregate(recs)
+    h = R.render_html(agg, records=recs)
+    # TRIVIAL tier from files_changed=1 and all records are pr_git → should NOT have "(tier approximate)"
+    assert "tier approximate" not in h
+
+
+def test_model_tier_missing_source_is_approximate():
+    """Records with files_changed_source absent/none → tier marked approximate (D4 spec)."""
+    recs = [
+        _rec(
+            project="proj",
+            task="issue:1",
+            model="claude-opus-4",
+            files_changed=1,
+            files_changed_source="none",
+            billing_type="metered",
+            cost_usd=1.0,
+            session_id="ms1",
+        ),
+    ]
+    agg = A.aggregate(recs)
+    h = R.render_html(agg, records=recs)
+    assert "tier approximate" in h
+
+
+def test_model_tier_mixed_source_is_approximate():
+    """Group with one pr_git + one session_shard record → still approximate (all must be pr_git)."""
+    recs = [
+        _rec(
+            project="proj",
+            task="issue:1",
+            model="claude-opus-4",
+            files_changed=1,
+            files_changed_source="pr_git",
+            billing_type="metered",
+            cost_usd=1.0,
+            session_id="pg1",
+        ),
+        _rec(
+            project="proj",
+            task="issue:2",
+            model="claude-opus-4",
+            files_changed=1,
+            files_changed_source="session_shard",
+            billing_type="metered",
+            cost_usd=1.0,
+            session_id="ss1",
+        ),
+    ]
+    agg = A.aggregate(recs)
+    h = R.render_html(agg, records=recs)
+    # At least one non-pr_git record in the group → approximate
+    assert "tier approximate" in h
+
+
+# ---------------------------------------------------------------------------
+# AC: by project/task table shows unattributed row explicitly
+# ---------------------------------------------------------------------------
+
+
+def test_by_project_task_unattributed_row_explicit():
+    """project=None and task=None → 'unattributed' row appears (not hidden) in the table (D4 AC)."""
+    recs = [
+        _rec(
+            project="proj-a",
+            task="issue:1",
+            billing_type="metered",
+            cost_usd=3.0,
+            session_id="a1",
+        ),
+        _rec(
+            project=None,
+            task=None,
+            billing_type="metered",
+            cost_usd=1.0,
+            session_id="u1",
+        ),
+    ]
+    h = R._by_project_task_html(recs)
+    assert "unattributed" in h
+    assert "proj-a" in h
+
+
+def test_by_project_task_only_unattributed():
+    """All records unattributed → table still renders with unattributed row (D4 AC)."""
+    recs = [
+        _rec(
+            project=None,
+            task=None,
+            billing_type="metered",
+            cost_usd=1.0,
+            session_id="u1",
+        ),
+    ]
+    h = R._by_project_task_html(recs)
+    assert "unattributed" in h
+    assert "no data" not in h
+
+
+def test_by_project_task_empty_records():
+    """Empty records → no-data state (no crash) (D4 AC)."""
+    h = R._by_project_task_html([])
+    assert "no data" in h
+
+
+# ---------------------------------------------------------------------------
+# Integration: full render with all D4 features together
+# ---------------------------------------------------------------------------
+
+
+def test_d4_full_integration():
+    """Full integration test: mixed billing, unattributed records, quarantine, all sections render."""
+    recs = [
+        _rec(
+            billing_type="metered",
+            cost_usd=2.0,
+            project="proj-a",
+            task="issue:1",
+            session_id="m1",
+            files_changed=3,
+            files_changed_source="pr_git",
+        ),
+        _rec(
+            billing_type="subscription",
+            cost_usd=3.0,
+            project=None,
+            task=None,
+            session_id="s1",
+            files_changed=1,
+            files_changed_source="none",
+        ),
+    ]
+    agg = A.aggregate(recs)
+    q = {"count": 2, "models": ["new-model-x"]}
+    h = R.render_html(agg, records=recs, quarantine=q)
+    assert _parses(h)
+    # Billing split
+    assert "Metered (real $):" in h
+    assert "Subscription (projected $, notional) *:" in h
+    # Unattributed
+    assert "unattributed" in h
+    # Quarantine
+    assert "Quarantine: 2 rows" in h
+    assert "new-model-x" in h
+    # Diagnostic badge
+    assert "[diagnostic]" in h
+    # Attribution coverage present
+    assert "Attribution Coverage" in h


### PR DESCRIPTION
Additive report (§D4): billing 3-way split (never summed), by model×tier (approximate unless pr_git), unattributed row, coverage-per-bucket, quarantine summary, [diagnostic] badge, .md summary for email. Reuses aggregator billing calc. +26 tests, suite 315 green. Closes #322.