### PR TITLE
feat(usage): D6 — freshness watchdog (#323)

### DIFF
--- a/claude-config/scripts/cost_telemetry_freshness.py
+++ b/claude-config/scripts/cost_telemetry_freshness.py
@@ -1,0 +1,98 @@
+"""Cost-telemetry freshness watchdog (cost-telemetry-v0 §D6).
+
+The dead-man's-switch for the usage collector — deliberately ~tiny (NOT the elaborate watchdog.py).
+It keys off the collector's `last_success` in `cost-telemetry.state`, NOT shard mtime alone: a
+successful run that wrote zero new rows must NOT false-alarm (its `usage.jsonl` mtime is old but the
+collector is healthy). Missing shard or missing state is independently alarming.
+
+Meant to run from the SessionStart hook (so a stalled collector is noticed) AND as `--check`.
+NOTE: wiring it into SessionStart is part of the deferred activation/smoke test — this module only
+provides the check + CLI; it is not registered as a hook here.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+DEFAULT_BASE = Path.home() / ".claude" / "telemetry"
+DEFAULT_LOG = Path.home() / ".claude" / "logs" / "cost-telemetry.log"
+STATE_FILENAME = "cost-telemetry.state"
+SHARD_FILENAME = "usage.jsonl"
+FRESHNESS_SLA_DAYS = 3
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def check(
+    base_dir, *, sla_days: int = FRESHNESS_SLA_DAYS, now: datetime | None = None
+) -> tuple[bool, str]:
+    """Return (stale, reason). stale=True ⇒ a warning should fire. Never raises."""
+    now = now or _now()
+    base = Path(base_dir)
+    state_path = base / STATE_FILENAME
+    shard_path = base / SHARD_FILENAME
+
+    if not state_path.exists():
+        return True, "collector has never run (no cost-telemetry.state)"
+    try:
+        state = json.loads(state_path.read_text(encoding="utf-8"))
+        last_success = state.get("last_success") if isinstance(state, dict) else None
+    except (json.JSONDecodeError, OSError, ValueError):
+        return True, "cost-telemetry.state unreadable"
+    if not last_success:
+        return True, "no successful collection recorded (last_success missing)"
+    try:
+        ts = datetime.fromisoformat(str(last_success))
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=timezone.utc)
+    except ValueError:
+        return True, f"last_success unparseable: {last_success!r}"
+
+    age_days = (now - ts).total_seconds() / 86400.0
+    if age_days > sla_days:
+        return (
+            True,
+            f"stale: last successful collection {age_days:.1f}d ago (SLA {sla_days}d)",
+        )
+    # Healthy run, but the shard itself must exist (a missing shard after a 'success' is alarming).
+    if not shard_path.exists():
+        return True, "usage.jsonl missing despite a recent successful run"
+    return False, f"fresh: last success {age_days:.1f}d ago"
+
+
+def _log(log_path, msg: str) -> None:
+    try:
+        Path(log_path).parent.mkdir(parents=True, exist_ok=True)
+        with Path(log_path).open("a", encoding="utf-8") as fh:
+            fh.write(f"{_now().isoformat()} [freshness] {msg}\n")
+    except OSError:
+        pass  # logging must never break the hook
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description="Cost-telemetry freshness watchdog")
+    ap.add_argument("--base", default=str(DEFAULT_BASE))
+    ap.add_argument("--log", default=str(DEFAULT_LOG))
+    ap.add_argument("--sla-days", type=int, default=FRESHNESS_SLA_DAYS)
+    ap.add_argument(
+        "--check", action="store_true", help="print status regardless of freshness"
+    )
+    args = ap.parse_args(argv)
+
+    stale, reason = check(args.base, sla_days=args.sla_days)
+    if stale:
+        _log(args.log, reason)
+        print(f"⚠ cost-telemetry {reason}", file=sys.stderr)
+    elif args.check:
+        print(f"cost-telemetry {reason}")
+    return 1 if stale else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/claude-config/tests/test_cost_telemetry_freshness.py
+++ b/claude-config/tests/test_cost_telemetry_freshness.py
@@ -1,0 +1,88 @@
+"""Acceptance tests for issue #323 — cost-telemetry freshness watchdog (cost-telemetry-v0 §D6)."""
+
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+import cost_telemetry_freshness as F  # noqa: E402
+
+NOW = datetime(2026, 6, 8, 12, 0, tzinfo=timezone.utc)
+
+
+def _state(base: Path, last_success, extra=None):
+    base.mkdir(parents=True, exist_ok=True)
+    obj = {"last_success": last_success}
+    if extra:
+        obj.update(extra)
+    (base / F.STATE_FILENAME).write_text(json.dumps(obj), encoding="utf-8")
+
+
+def _shard(base: Path):
+    (base / F.SHARD_FILENAME).write_text('{"x":1}\n', encoding="utf-8")
+
+
+def test_stale_last_success_warns(tmp_path):
+    _state(tmp_path, (NOW - timedelta(days=4)).isoformat())
+    _shard(tmp_path)
+    stale, reason = F.check(tmp_path, now=NOW)
+    assert stale and "stale" in reason
+
+
+def test_fresh_is_silent(tmp_path):
+    _state(tmp_path, (NOW - timedelta(hours=1)).isoformat())
+    _shard(tmp_path)
+    stale, reason = F.check(tmp_path, now=NOW)
+    assert not stale and "fresh" in reason
+
+
+def test_successful_no_new_rows_does_not_false_alarm(tmp_path):
+    # collector ran 2h ago, wrote 0 rows — shard mtime is old but last_success is recent → NOT stale
+    _state(
+        tmp_path,
+        (NOW - timedelta(hours=2)).isoformat(),
+        extra={"last_run_stats": {"rows_known_written": 0}},
+    )
+    _shard(tmp_path)
+    stale, _ = F.check(tmp_path, now=NOW)
+    assert not stale
+
+
+def test_missing_shard_warns_even_if_recent(tmp_path):
+    _state(
+        tmp_path, (NOW - timedelta(hours=1)).isoformat()
+    )  # recent success, but no shard
+    stale, reason = F.check(tmp_path, now=NOW)
+    assert stale and "usage.jsonl missing" in reason
+
+
+def test_missing_state_warns(tmp_path):
+    stale, reason = F.check(tmp_path, now=NOW)  # collector never ran
+    assert stale and "never run" in reason
+
+
+def test_missing_last_success_warns(tmp_path):
+    _state(tmp_path, None)
+    _shard(tmp_path)
+    stale, reason = F.check(tmp_path, now=NOW)
+    assert stale and "last_success" in reason
+
+
+def test_malformed_state_warns(tmp_path):
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    (tmp_path / F.STATE_FILENAME).write_text("{bad json", encoding="utf-8")
+    stale, reason = F.check(tmp_path, now=NOW)
+    assert stale and "unreadable" in reason
+
+
+def test_main_exit_codes(tmp_path):
+    _state(tmp_path, (NOW - timedelta(hours=1)).isoformat())
+    _shard(tmp_path)
+    assert F.main(["--base", str(tmp_path)]) == 0  # fresh
+    _state(tmp_path, (NOW - timedelta(days=5)).isoformat())
+    assert (
+        F.main(["--base", str(tmp_path), "--log", str(tmp_path / "log")]) == 1
+    )  # stale
+    assert (tmp_path / "log").exists()  # stale wrote a durable log line


### PR DESCRIPTION
Tiny dead-man's-switch (§D6): keys off collector last_success (not shard mtime, so no-new-rows runs don't false-alarm); stale/missing/malformed → durable log + warning + exit 1. Code only; SessionStart wiring deferred to joint activation. +8 tests. Closes #323.