### PR TITLE
feat(usage): D2 — launchd/install/Stop-hook artifacts (code only, NOT activated) (#324)

### DIFF
--- a/claude-config/hooks/cost_collect_request.py
+++ b/claude-config/hooks/cost_collect_request.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+"""Stop-hook marker (cost-telemetry-v0 §D2): touch `.collect-requested` so the launchd collector
+knows a session just ended and a scan is wanted. Deliberately trivial (<5ms) and it NEVER raises —
+a telemetry marker must not affect session exit. The full scan runs under launchd, not here.
+
+NOT wired into settings.json by this change — registering it as a Stop hook is part of the deferred
+cost-telemetry activation / joint smoke test.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def request(base_dir=None) -> int:
+    try:
+        base = Path(base_dir) if base_dir else Path.home() / ".claude" / "telemetry"
+        base.mkdir(parents=True, exist_ok=True)
+        (base / ".collect-requested").touch()
+    except Exception:
+        pass  # never break session exit
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(request())

--- a/claude-config/launchd/com.cost-telemetry-collect.plist
+++ b/claude-config/launchd/com.cost-telemetry-collect.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- cost-telemetry-v0 §D2 — runs usage_collect.py every 6h. NOT loaded automatically; activate via
+     scripts/install_cost_telemetry.sh (the deferred activation / joint smoke-test step). No API-key
+     env vars by default (launchd env ≠ hook env; adding a key would force every row to 'metered'). -->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.cost-telemetry-collect</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/usr/bin/python3</string>
+    <string>/Users/jasonjob/agents/claude-config/scripts/usage_collect.py</string>
+  </array>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PYTHONPATH</key>
+    <string>/Users/jasonjob/agents/claude-config/scripts</string>
+  </dict>
+  <key>StartInterval</key>
+  <integer>21600</integer>
+  <key>RunAtLoad</key>
+  <false/>
+  <key>StandardOutPath</key>
+  <string>/Users/jasonjob/.claude/logs/cost-telemetry.log</string>
+  <key>StandardErrorPath</key>
+  <string>/Users/jasonjob/.claude/logs/cost-telemetry.log</string>
+</dict>
+</plist>

--- a/claude-config/scripts/install_cost_telemetry.sh
+++ b/claude-config/scripts/install_cost_telemetry.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Activate / deactivate the cost-telemetry collector launchd job (cost-telemetry-v0 §D2).
+# NOT run automatically — this is the DEFERRED activation step (joint review + smoke test).
+# After `load`, also wire the Stop hook (hooks/cost_collect_request.py) and SessionStart freshness
+# (scripts/cost_telemetry_freshness.py) into ~/.claude/settings.json — also deferred.
+set -euo pipefail
+
+PLIST_SRC="$(cd "$(dirname "$0")/../launchd" && pwd)/com.cost-telemetry-collect.plist"
+DEST="$HOME/Library/LaunchAgents/com.cost-telemetry-collect.plist"
+LOG="$HOME/.claude/logs/cost-telemetry.log"
+
+case "${1:-help}" in
+  load)
+    mkdir -p "$HOME/.claude/logs" "$(dirname "$DEST")"
+    cp "$PLIST_SRC" "$DEST"
+    launchctl unload "$DEST" 2>/dev/null || true   # idempotent: unload before load
+    launchctl load "$DEST"
+    echo "✓ loaded com.cost-telemetry-collect (every 6h). Logs: $LOG"
+    echo "  Next (also deferred): add cost_collect_request.py to Stop hooks +"
+    echo "  cost_telemetry_freshness.py to SessionStart in ~/.claude/settings.json."
+    ;;
+  unload|--uninstall)
+    launchctl unload "$DEST" 2>/dev/null || true
+    rm -f "$DEST"
+    echo "✓ unloaded + removed com.cost-telemetry-collect."
+    ;;
+  status)
+    launchctl list | grep cost-telemetry || echo "(not loaded)"
+    ;;
+  *)
+    echo "usage: $0 [load|unload|status]"
+    echo "  load    — copy plist to LaunchAgents + launchctl load (idempotent)"
+    echo "  unload  — launchctl unload + remove plist"
+    echo "  status  — show whether the job is loaded"
+    ;;
+esac

--- a/claude-config/tests/test_cost_telemetry_install.py
+++ b/claude-config/tests/test_cost_telemetry_install.py
@@ -1,0 +1,53 @@
+"""Acceptance tests for issue #324 — launchd plist + Stop-hook touch script (cost-telemetry-v0 §D2).
+
+These verify the ARTIFACTS are valid; they do NOT activate anything (no launchctl, no settings.json edit).
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "hooks"))
+
+import cost_collect_request as R  # noqa: E402
+
+_REPO = Path(__file__).resolve().parents[2]
+PLIST = _REPO / "claude-config" / "launchd" / "com.cost-telemetry-collect.plist"
+
+
+def test_plist_exists_and_lints():
+    assert PLIST.exists()
+    if not (Path("/usr/bin/plutil").exists()):
+        pytest.skip("plutil not available (non-macOS)")
+    r = subprocess.run(
+        ["/usr/bin/plutil", "-lint", str(PLIST)], capture_output=True, text=True
+    )
+    assert r.returncode == 0, r.stdout + r.stderr
+
+
+def test_plist_schedule_and_no_api_keys():
+    text = PLIST.read_text(encoding="utf-8")
+    assert "<integer>21600</integer>" in text  # 6h StartInterval
+    assert "PYTHONPATH" in text
+    assert "<false/>" in text  # RunAtLoad false
+    # must NOT bake an API key into launchd env (would force every row to 'metered')
+    assert "ANTHROPIC_API_KEY" not in text and "OPENAI_API_KEY" not in text
+
+
+def test_install_script_present_and_syntax_ok():
+    sh = _REPO / "claude-config" / "scripts" / "install_cost_telemetry.sh"
+    assert sh.exists()
+    r = subprocess.run(["bash", "-n", str(sh)], capture_output=True, text=True)
+    assert r.returncode == 0, r.stderr
+
+
+def test_collect_request_touches_flag(tmp_path):
+    assert R.request(tmp_path) == 0
+    assert (tmp_path / ".collect-requested").exists()
+
+
+def test_collect_request_never_raises_on_bad_dir():
+    # a non-writable / bogus base must not raise (session-exit safety)
+    assert R.request("/proc/nonexistent/cannot/create") == 0


### PR DESCRIPTION
§D2 artifacts, inert until joint activation: plist (6h, no api-key env, RunAtLoad false), install_cost_telemetry.sh (load/unload), cost_collect_request.py (Stop-hook touch, never raises). NO launchctl load, NO settings.json edit. +5 tests (plutil lint etc). Closes #324.