### PR TITLE
feat(usage): D5 — weekly email delivery (code only, no live send) (#326)

### DIFF
--- a/claude-config/scripts/usage_email.py
+++ b/claude-config/scripts/usage_email.py
@@ -1,0 +1,71 @@
+"""Weekly cost-report email delivery (cost-telemetry-v0 §D5) — FAST-FOLLOW / cut-able.
+
+The LOCAL report is the v0 gate; this only adds delivery. It is NOT triggered live by this module —
+wiring the weekly job + the first real send is part of the deferred activation / joint smoke test.
+
+`send_fn` is injectable so the real M365 send (`~/agents/m365/send_mail.py`) is decoupled and testable.
+Idempotent (one send per ISO week, tracked in the collector state); a send failure logs + returns exit 4
+and NEVER blocks collection. Always sends as jjob@vital-enterprises.com (never overrides the sender).
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+SENDER = "jjob@vital-enterprises.com"
+DEFAULT_SEND_MAIL = Path.home() / "agents" / "m365" / "send_mail.py"
+# Graph creds are NOT ambient under launchd — point at the token cache explicitly when activated.
+DEFAULT_TOKEN_CACHE = Path.home() / ".claude" / "m365" / "token-cache.bin"
+
+
+def _week_key(dt: datetime) -> str:
+    iso = dt.isocalendar()
+    return f"{iso[0]}-W{iso[1]:02d}"
+
+
+def _default_send(*, subject: str, body: str, html_path, recipient: str) -> None:
+    """Real send via the M365 helper. Raises on non-zero exit."""
+    cmd = [
+        sys.executable,
+        str(DEFAULT_SEND_MAIL),
+        "--to",
+        recipient,
+        "--subject",
+        subject,
+        "--body",
+        body,
+    ]
+    if html_path:
+        cmd += ["--attach", str(html_path)]
+    r = subprocess.run(cmd, capture_output=True, text=True)
+    if r.returncode != 0:
+        raise RuntimeError(f"send_mail failed ({r.returncode}): {r.stderr.strip()}")
+
+
+def send_weekly(
+    *,
+    md_summary: str,
+    html_path,
+    state: dict,
+    host: str,
+    recipient: str = SENDER,
+    now: datetime | None = None,
+    send_fn=None,
+) -> tuple[int, dict]:
+    """Send the weekly report if not already sent this ISO week.
+    Returns (exit_code, updated_state): 0 = sent OR idempotent-skip; 4 = send failure (caller logs;
+    collection is never blocked). State is only advanced on a successful send."""
+    now = now or datetime.now(timezone.utc)
+    wk = _week_key(now)
+    if state.get("last_email_sent_week") == wk:
+        return 0, state  # idempotent — already sent this week
+    send = send_fn or _default_send
+    subject = f"[cost-telemetry] {host} — week {wk}"
+    try:
+        send(subject=subject, body=md_summary, html_path=html_path, recipient=recipient)
+    except Exception:
+        return 4, state  # never block collection; caller logs the failure
+    return 0, {**state, "last_email_sent_week": wk}

--- a/claude-config/tests/test_usage_email.py
+++ b/claude-config/tests/test_usage_email.py
@@ -1,0 +1,90 @@
+"""Acceptance tests for issue #326 — weekly email delivery (cost-telemetry-v0 §D5).
+
+No live send: the M365 helper is mocked via the injectable send_fn. Activation/first real send is deferred.
+"""
+
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+import usage_email as E  # noqa: E402
+
+NOW = datetime(2026, 6, 8, 12, 0, tzinfo=timezone.utc)
+
+
+def _recorder():
+    calls = []
+
+    def send_fn(**kw):
+        calls.append(kw)
+
+    return calls, send_fn
+
+
+def test_first_send_of_week_calls_sender_and_updates_state():
+    calls, send_fn = _recorder()
+    code, state = E.send_weekly(
+        md_summary="# report",
+        html_path="/tmp/r.html",
+        state={},
+        host="jns-mac",
+        now=NOW,
+        send_fn=send_fn,
+    )
+    assert code == 0
+    assert len(calls) == 1
+    assert calls[0]["recipient"] == E.SENDER  # never overrides sender
+    assert calls[0]["html_path"] == "/tmp/r.html"
+    assert calls[0]["body"] == "# report"
+    assert "jns-mac" in calls[0]["subject"]
+    assert state["last_email_sent_week"] == E._week_key(NOW)
+
+
+def test_idempotent_no_double_send_same_week():
+    calls, send_fn = _recorder()
+    prior = {"last_email_sent_week": E._week_key(NOW)}
+    code, state = E.send_weekly(
+        md_summary="x",
+        html_path=None,
+        state=prior,
+        host="h",
+        now=NOW,
+        send_fn=send_fn,
+    )
+    assert code == 0
+    assert calls == []  # NOT called — already sent this week
+    assert state == prior
+
+
+def test_send_failure_returns_4_and_does_not_advance_state():
+    def boom(**kw):
+        raise RuntimeError("graph down")
+
+    code, state = E.send_weekly(
+        md_summary="x",
+        html_path=None,
+        state={},
+        host="h",
+        now=NOW,
+        send_fn=boom,
+    )
+    assert code == 4
+    assert "last_email_sent_week" not in state  # not advanced → retried next run
+
+
+def test_next_week_sends_again():
+    calls, send_fn = _recorder()
+    later = datetime(2026, 6, 16, 12, 0, tzinfo=timezone.utc)  # a different ISO week
+    prior = {"last_email_sent_week": E._week_key(NOW)}
+    code, state = E.send_weekly(
+        md_summary="x",
+        html_path=None,
+        state=prior,
+        host="h",
+        now=later,
+        send_fn=send_fn,
+    )
+    assert code == 0 and len(calls) == 1
+    assert state["last_email_sent_week"] == E._week_key(later)


### PR DESCRIPTION
§D5 fast-follow: send_weekly() idempotent (one/ISO-week), send-failure→exit 4 (never blocks), sender locked to jjob@vital-enterprises.com, injectable send_fn (real M365 helper decoupled). NOT triggered live — wiring + first send deferred to joint smoke test; tests mock the sender. +4 tests, suite 353. Closes #326.