### PR TITLE
fix(usage): smoke-test findings — billing back-fill + dormant tier enrichment (#335)

### DIFF
--- a/claude-config/scripts/files_changed_enrich.py
+++ b/claude-config/scripts/files_changed_enrich.py
@@ -80,9 +80,16 @@ def _git_files_for_issue(issue_number: int, repo_root: Path) -> int | None:
 # ---------------------------------------------------------------------------
 
 
+# metrics.jsonl records `complexity` (the tier), not a raw file count. Map it to a representative
+# files-band so the existing usage_aggregator.task_tier() (1→TRIVIAL, 2-3→SIMPLE, 4+→COMPLEX) yields
+# that same tier. This is a TIER PROXY, not a literal file count — the report marks project_metrics
+# rows "(tier approximate)" (only pr_git is authoritative), so it is honestly labelled.
+_COMPLEXITY_FILES = {"TRIVIAL": 1, "SIMPLE": 2, "COMPLEX": 4}
+
+
 def _project_metrics_files(issue_number: int, metrics_path: Path) -> int | None:
-    """Look up files_changed for issue_number in metrics.jsonl.
-    Returns the first match or None."""
+    """files_changed for issue_number from metrics.jsonl: a real `files_changed` int if present, else
+    a tier-band derived from `complexity` (metrics carries the tier, not a file count). First match wins."""
     if not metrics_path or not metrics_path.exists():
         return None
     try:
@@ -102,6 +109,9 @@ def _project_metrics_files(issue_number: int, metrics_path: Path) -> int | None:
                 fc = rec.get("files_changed")
                 if isinstance(fc, int) and fc >= 0:
                     return fc
+                band = _COMPLEXITY_FILES.get(str(rec.get("complexity") or "").upper())
+                if band is not None:
+                    return band
     except OSError:
         return None
     return None

--- a/claude-config/scripts/usage_collect.py
+++ b/claude-config/scripts/usage_collect.py
@@ -607,10 +607,14 @@ def run_collect(
             all_quarantine_rows.extend(result["quarantine_rows"])
 
     # --- enrich files_changed / files_changed_source ---
-    # Resolve the sessions shard for this host (best-effort; None if absent).
+    # Resolve enrichment inputs to their LIVE defaults (the bug behind "100% files_changed_source=none":
+    # run_collect was never handed these, so all tiers were inert). metrics.jsonl is the orchestrate
+    # outcome log; the sessions shard is the per-host capture stream (best-effort, None if absent).
     if enrich and all_usage_rows:
         _sessions_shard = tdir / "sessions.jsonl"
-        _resolved_metrics = metrics_path
+        _resolved_metrics = metrics_path or (
+            Path.home() / ".claude" / "memory" / "metrics.jsonl"
+        )
         _resolved_repo = repo_root
         _enrich_cache: dict = {}  # task -> (files_changed, source)
         for row in all_usage_rows:

--- a/claude-config/scripts/usage_collector_claude.py
+++ b/claude-config/scripts/usage_collector_claude.py
@@ -350,11 +350,15 @@ def _apply_account(rec: dict, account_map: dict | None, fallback: dict | None) -
             account_source="sidecar",
         )
     elif fallback:
+        # Identity (account/org/email) is stable across sessions → safe to back-fill from the current
+        # account. billing MODE is NOT: a historical session may have been on an API key. We did not
+        # capture it (the sidecar only began #265), so it is genuinely UNKNOWN — never assume the
+        # current account's mode (that falsely labels all history 'subscription'). Honest > convenient.
         rec.update(
             account=fallback.get("account_uuid"),
             org=fallback.get("org"),
             email=fallback.get("email"),
-            billing_type=fallback.get("billing_type"),
+            billing_type="unknown",
             account_source=fallback.get("account_source", "current_fallback"),
         )
     return rec

--- a/claude-config/tests/test_files_changed_enrich.py
+++ b/claude-config/tests/test_files_changed_enrich.py
@@ -512,3 +512,18 @@ def test_enrich_does_not_change_attribution_fields(tmp_path):
             )
         # enrichment fields differ (that's the point)
         assert re_.get("files_changed") is not None or re_.get("task") != "issue:42"
+
+
+# #335: metrics.jsonl has `complexity` (not a file count) → derive a tier-band so the tier is computable
+def test_project_metrics_uses_complexity_band(tmp_path):
+    m = tmp_path / "metrics.jsonl"
+    m.write_text(
+        '{"issue": 42, "complexity": "COMPLEX", "status": "PASS"}\n'
+        '{"issue": 7, "complexity": "TRIVIAL"}\n'
+        '{"issue": 9, "files_changed": 3}\n',
+        encoding="utf-8",
+    )
+    assert FCE._project_metrics_files(42, m) == 4  # COMPLEX → 4 (task_tier → COMPLEX)
+    assert FCE._project_metrics_files(7, m) == 1  # TRIVIAL → 1
+    assert FCE._project_metrics_files(9, m) == 3  # a real files_changed int still wins
+    assert FCE._project_metrics_files(999, m) is None  # no match

--- a/claude-config/tests/test_usage_collector_claude.py
+++ b/claude-config/tests/test_usage_collector_claude.py
@@ -690,3 +690,26 @@ def test_311_target_vs_old_cwd_basename():
     assert hijack_recs[1]["project"] == "agents", (
         f"hijack FAILED: expected 'agents', got {hijack_recs[1]['project']!r}"
     )
+
+
+# #335: fallback (no sidecar) must NOT inherit the current account's billing mode → 'unknown'
+def test_apply_account_fallback_billing_is_unknown():
+    fb = {
+        "account_uuid": "u-1",
+        "org": "Org",
+        "email": "x@y.com",
+        "billing_type": "subscription",
+    }
+    rec = U._apply_account({"session_id": "no-sidecar"}, account_map={}, fallback=fb)
+    assert (
+        rec["billing_type"] == "unknown"
+    )  # historical billing mode is unknown, never assumed
+    assert rec["account"] == "u-1"  # but stable identity still back-fills
+    # a sidecar match DOES use the captured per-session billing_type
+    amap = {"s1": {"account_uuid": "u-1", "billing_type": "metered"}}
+    assert (
+        U._apply_account({"session_id": "s1"}, account_map=amap, fallback=fb)[
+            "billing_type"
+        ]
+        == "metered"
+    )


### PR DESCRIPTION
Two bugs the real-data smoke run exposed: (1) billing back-filled current-account mode onto all history → now 'unknown' for un-sidecar'd rows (honest); (2) tier enrichment was inert (no metrics_path; metrics has complexity not file count) → default metrics path + map complexity→tier-band. Verified on re-run: billing now unknown-majority; files_changed_source project_metrics 9,470 rows. +2 regression tests. Closes #335.