### PR TITLE
fix(usage): Codex adversarial review — 5 number-correctness bugs (#337)

### DIFF
--- a/claude-config/scripts/otel_sink.py
+++ b/claude-config/scripts/otel_sink.py
@@ -28,85 +28,91 @@ TOKEN_FIELDS = ("input", "output", "cache_creation", "cache_read")
 # not 954M pure input — 954M is the token TOTAL across all types.) test_multiprovider_pricing enforces
 # this within 5%.
 PRICES = {
+    # Opus 4.5–4.8 published API rate: $5 in / $25 out; 5-min cache write 1.25x = $6.25; cache read 0.1x
+    # = $0.50. Was $15/$75 (the Opus 4.0/4.1 rate) — that overstated 4.6/4.7/4.8 by 3x (~$34k on the real
+    # dataset; Codex review #337). _matches_family matches every "claude-opus-*" via the "opus" alpha-
+    # substring, so per-version rows can't be distinguished here. Legacy Opus 4.0/4.1 ($15/$75) are
+    # deprecated and absent in real data; if they recur they'd be under-priced — acceptable vs the 3x
+    # over-price this removes.
     "claude-opus-4": {
-        "input": 15e-6,
-        "output": 75e-6,
-        "cache_creation": 18.75e-6,
-        "cache_read": 1.5e-6,
+        "input": 5e-6,
+        "output": 25e-6,
+        "cache_creation": 6.25e-6,
+        "cache_read": 0.50e-6,
     },
-    "claude-sonnet-4": {
+    "claude-sonnet-4": {  # Sonnet 4.5/4.6: $3 in / $15 out / $3.75 cache write / $0.30 cache read
         "input": 3e-6,
         "output": 15e-6,
         "cache_creation": 3.75e-6,
         "cache_read": 0.30e-6,
     },
-    "claude-haiku-4": {
-        "input": 0.80e-6,
-        "output": 4e-6,
-        "cache_creation": 1.0e-6,
-        "cache_read": 0.08e-6,
+    "claude-haiku-4": {  # Haiku 4.5 published API rate: $1 / $5 / $1.25 / $0.10 (Codex review #337)
+        "input": 1e-6,
+        "output": 5e-6,
+        "cache_creation": 1.25e-6,
+        "cache_read": 0.10e-6,
     },
     # OpenAI / Codex. OpenAI bills cached input at a discount and charges no separate cache-WRITE,
-    # so cache_creation = 0 for all GPT rows. Rates are representative (per-MTok / 1e6) —
-    # VERIFY against OpenAI published pricing before treating these as authoritative for billing.
+    # so cache_creation = 0 for all GPT rows. Rates per OpenAI API pricing + the Codex rate card
+    # (1 credit = $0.04, anchored on gpt-5.5 = 125cr = $5/MTok); confirmed in Codex review #337.
     #
     # INSERTION ORDER IS LOAD-BEARING: more-specific prefixes MUST precede any prefix they could
     # shadow (e.g. gpt-5.4-mini before gpt-5.4; gpt-5.2-codex before gpt-5-codex).
-    "gpt-5.2-codex": {  # real data: 2694 events in ~/.codex/sessions — VERIFY rates
+    "gpt-5.2-codex": {  # rate card: $1.75 in / $14 out / $0.175 cached (#337)
+        "input": 1.75e-6,
+        "output": 14e-6,
+        "cache_creation": 0.0,
+        "cache_read": 0.175e-6,
+    },
+    "gpt-5.3-codex": {  # rate card: $1.75 in / $14 out / $0.175 cached (#337)
+        "input": 1.75e-6,
+        "output": 14e-6,
+        "cache_creation": 0.0,
+        "cache_read": 0.175e-6,
+    },
+    "gpt-5-codex": {  # literal gpt-5-codex (prefix-match only); aligned to the codex rate card (#337)
+        "input": 1.75e-6,
+        "output": 14e-6,
+        "cache_creation": 0.0,
+        "cache_read": 0.175e-6,
+    },
+    "gpt-5.4-mini": {  # rate card: $0.75 in / $4.52 out / $0.075 cached (#337)
         "input": 0.75e-6,
-        "output": 6e-6,
+        "output": 4.52e-6,
         "cache_creation": 0.0,
         "cache_read": 0.075e-6,
     },
-    "gpt-5.3-codex": {  # real data: 704 events — VERIFY rates
-        "input": 1.0e-6,
-        "output": 8e-6,
-        "cache_creation": 0.0,
-        "cache_read": 0.10e-6,
-    },
-    "gpt-5-codex": {  # the literal gpt-5-codex model (prefix match only; a future gpt-5.N-codex with no row intentionally raises under strict, per #231) — VERIFY rates
-        "input": 0.75e-6,
-        "output": 6e-6,
-        "cache_creation": 0.0,
-        "cache_read": 0.075e-6,
-    },
-    "gpt-5.4-mini": {  # mini tier, cheaper than flagship — VERIFY rates
+    "gpt-5.2-mini": {  # mini tier — no rate-card entry; representative, VERIFY
         "input": 0.10e-6,
         "output": 0.40e-6,
         "cache_creation": 0.0,
         "cache_read": 0.025e-6,
     },
-    "gpt-5.2-mini": {  # mini tier — VERIFY rates
+    "gpt-5-mini": {  # literal gpt-5-mini (prefix-match only) — representative, VERIFY
         "input": 0.10e-6,
         "output": 0.40e-6,
         "cache_creation": 0.0,
         "cache_read": 0.025e-6,
     },
-    "gpt-5-mini": {  # the literal gpt-5-mini model (prefix match only; a future gpt-5.N-mini with no row intentionally raises under strict, per #231) — VERIFY rates
-        "input": 0.10e-6,
-        "output": 0.40e-6,
-        "cache_creation": 0.0,
-        "cache_read": 0.025e-6,
-    },
-    "gpt-4o-mini": {  # VERIFY rates
+    "gpt-4o-mini": {  # OpenAI: $0.15 in / $0.60 out / $0.075 cached
         "input": 0.15e-6,
         "output": 0.60e-6,
         "cache_creation": 0.0,
         "cache_read": 0.075e-6,
     },
-    "gpt-5.4": {  # real data: 354 events, flagship tier — VERIFY rates
-        "input": 1.25e-6,
-        "output": 10e-6,
+    "gpt-5.4": {  # rate card: $2.50 in / $15 out / $0.25 cached (#337)
+        "input": 2.50e-6,
+        "output": 15e-6,
         "cache_creation": 0.0,
-        "cache_read": 0.125e-6,
+        "cache_read": 0.25e-6,
     },
-    "gpt-5.5": {  # verified in use (Codex CLI, §2.2) — VERIFY rates
-        "input": 1.25e-6,
-        "output": 10e-6,
+    "gpt-5.5": {  # OpenAI API pricing: $5 in / $30 out / $0.50 cached (#337, web-verified)
+        "input": 5e-6,
+        "output": 30e-6,
         "cache_creation": 0.0,
-        "cache_read": 0.125e-6,
+        "cache_read": 0.50e-6,
     },
-    "gpt-4o": {  # VERIFY rates
+    "gpt-4o": {  # OpenAI: $2.50 in / $10 out / $1.25 cached
         "input": 2.50e-6,
         "output": 10e-6,
         "cache_creation": 0.0,
@@ -120,7 +126,7 @@ DEFAULT_PRICE = PRICES[
 # Stamped onto every usage record (cost-telemetry-v0 §D3) so cost_usd is auditable / re-priceable.
 # BUMP this whenever a PRICES rate changes — test_price_table_version pins the current value so any
 # silent rate edit fails CI until the version is bumped.
-PRICE_TABLE_VERSION = "2026-06-08"
+PRICE_TABLE_VERSION = "2026-06-08b"
 
 EXPORTER_FRESHNESS_SLA_DEFAULT = (
     24 * 3600

--- a/claude-config/scripts/usage_collect.py
+++ b/claude-config/scripts/usage_collect.py
@@ -749,19 +749,29 @@ def run_reprocess_quarantine(
     if new_usage_rows:
         _append_jsonl(usage_path, new_usage_rows)
 
-    # Rewrite quarantine file marking resolved rows
+    # Move resolved rows OUT of the active quarantine file into an audit trail. A resolved row's
+    # dedup_key now lives in usage.jsonl; leaving it in usage-quarantine.jsonl too would put the same
+    # key in both active files (Codex review #337 finding 4). Active quarantine = unresolved only.
     if resolved_keys:
-        new_qrows = []
+        active_qrows, resolved_qrows = [], []
         for qrow in qrows:
-            dk = qrow.get("dedup_key")
-            if dk in resolved_keys:
+            if qrow.get("dedup_key") in resolved_keys:
                 qrow = dict(qrow)
                 qrow["resolved"] = True
-            new_qrows.append(qrow)
+                resolved_qrows.append(qrow)
+            else:
+                active_qrows.append(qrow)
         quarantine_path.write_text(
-            "\n".join(json.dumps(r, ensure_ascii=False) for r in new_qrows) + "\n",
+            ("\n".join(json.dumps(r, ensure_ascii=False) for r in active_qrows) + "\n")
+            if active_qrows
+            else "",
             encoding="utf-8",
         )
+        if resolved_qrows:
+            _append_jsonl(
+                quarantine_path.parent / "usage-quarantine-resolved.jsonl",
+                resolved_qrows,
+            )
 
     stats = {
         "resolved": len(resolved_keys),

--- a/claude-config/scripts/usage_collector_claude.py
+++ b/claude-config/scripts/usage_collector_claude.py
@@ -380,6 +380,12 @@ def extract_records(
     active = {"task": "unattributed", "project": None, "work_host": inference_host}
     pending_compaction = False
     records = []
+    # Split-turn de-dup (Codex review #337 finding 2): Claude logs ONE API turn as adjacent assistant
+    # rows (a thinking block + a text block) sharing sessionId/timestamp/model and IDENTICAL usage, with
+    # DIFFERENT uuids. sessionId:uuid de-dup counts both → double-counts that turn's spend. Collapse them
+    # by an API-turn signature. Gated on uuid-present so the malformed-fallback path (#262) is untouched,
+    # and the full token tuple keeps legitimate retries (different ts/tokens) distinct.
+    seen_turn_sigs: set = set()
     for idx, entry in enumerate(entries):
         if _is_compaction(entry):
             pending_compaction = True
@@ -456,8 +462,23 @@ def extract_records(
                 "compaction": pending_compaction,
                 "dedup_key": dedup_key,
             }
-            records.append(_apply_account(rec, account_map, fallback_account))
-            pending_compaction = False
+            turn_sig = (
+                sid,
+                entry.get("timestamp"),
+                msg.get("model"),
+                tok["input"],
+                tok["output"],
+                tok["cache_read"],
+                tok["cache_creation"],
+            )
+            if uuid and turn_sig in seen_turn_sigs:
+                # Adjacent split-turn duplicate (thinking+text of one API turn) — already counted.
+                pending_compaction = False
+            else:
+                if uuid:
+                    seen_turn_sigs.add(turn_sig)
+                records.append(_apply_account(rec, account_map, fallback_account))
+                pending_compaction = False
         # mine this entry's commands → update active state for subsequent messages (segmentation)
         # Cross-command conflict guard (issue #311 Finding 4): if two commands in the SAME assistant
         # message mine DIFFERENT projects, last-write-win is a mis-attribution risk.  Detect conflict

--- a/claude-config/scripts/usage_report.py
+++ b/claude-config/scripts/usage_report.py
@@ -116,16 +116,23 @@ def trends(records: list, *, period: str = "week") -> dict:
             continue
         proj = r.get("project") or "unknown"
         cell = out.setdefault(proj, {}).setdefault(
-            bucket, {"cost": 0.0, "input": 0, "cache_read": 0}
+            bucket, {"cost_by_billing": {}, "input": 0, "cache_read": 0}
         )
-        cell["cost"] += _fnum(r.get("cost_usd"))
+        # Never sum across billing types (§6): keep metered/subscription/unknown as separate buckets so
+        # the trend chart plots them as distinct series, never one mixed dollar (Codex review #337 finding 3).
+        bt = r.get("billing_type") or "unknown"
+        cell["cost_by_billing"][bt] = cell["cost_by_billing"].get(bt, 0.0) + _fnum(
+            r.get("cost_usd")
+        )
         cell["input"] += int(_fnum(r.get("input")))
         cell["cache_read"] += int(_fnum(r.get("cache_read")))
     for proj, buckets in out.items():
         for b, c in buckets.items():
             denom = c["input"] + c["cache_read"]
             c["cache_pct"] = round(c["cache_read"] / denom, 4) if denom else 0.0
-            c["cost"] = round(c["cost"], 6)
+            c["cost_by_billing"] = {
+                k: round(v, 6) for k, v in c["cost_by_billing"].items()
+            }
     return out
 
 
@@ -466,7 +473,10 @@ function line(id,series,title){{const el=document.getElementById(id);if(!el)retu
  const labels=[...new Set([].concat(...Object.values(series).map(b=>Object.keys(b))))].sort();
  const ds=Object.entries(series).map(([k,b])=>({{label:k,data:labels.map(l=>(b[l]||{{}}).cost||0)}}));
  if(ds.length)new Chart(el,{{type:'line',data:{{labels,datasets:ds}},options:titleOpt(title)}});}}
-try{{line('c_pr_trend',D.trends,COST_T);
+try{{
+ // One line per project × billing-type — buckets are never summed into a single plotted dollar (#337).
+ const prT={{}};for(const[p,b]of Object.entries(D.trends)){{for(const[k,v]of Object.entries(b)){{const cbb=v.cost_by_billing||{{}};for(const[bt,c]of Object.entries(cbb)){{const key=p+' / '+bt;(prT[key]=prT[key]||{{}})[k]={{cost:c}};}}}}}}
+ line('c_pr_trend',prT,COST_T);
  const ct={{}};for(const[p,b]of Object.entries(D.trends)){{ct[p]={{}};for(const[k,v]of Object.entries(b))ct[p][k]={{cost:v.cache_pct}};}}
  line('c_cache_trend',ct,'cache read %');
  const te=document.getElementById('c_tier');if(te){{const t=D.by_tier;new Chart(te,{{type:'bar',

--- a/claude-config/scripts/usage_schema.py
+++ b/claude-config/scripts/usage_schema.py
@@ -65,6 +65,11 @@ def normalize(rec: dict) -> dict:
     out["billing_type"] = bt if bt in _BILLING else "unknown"
     out["price_basis"] = PRICE_BASIS
     out["price_table_version"] = O.PRICE_TABLE_VERSION
+    # Data layer uses None for "no attribution" — the collector's "unattributed" sentinel was being
+    # counted as attributed by the report's `task is not None` coverage check (Codex review #337
+    # finding 5: 100% vs the true ~88%). Normalize it to None; the report renders None as "unattributed".
+    if out.get("task") == "unattributed":
+        out["task"] = None
     out["files_changed"] = out.get("files_changed")  # null when absent (never 0/"")
     fcs = out.get("files_changed_source")
     out["files_changed_source"] = fcs if fcs in _FCS else "none"

--- a/claude-config/tests/test_multiprovider_pricing.py
+++ b/claude-config/tests/test_multiprovider_pricing.py
@@ -59,9 +59,10 @@ def test_unknown_model_compute_cost_falls_back():
     assert O.compute_cost({"model": "totally-unknown", "input": 1000}) > 0
 
 
-# Opus 4.8 sanity cross-check against the §2.1 real billing figure -----------------------------------
+# Opus sanity cross-check against the §2.1 real mix, at the CORRECTED rate ------------------------------
 def test_opus_rates_sanity_vs_real_session():
-    # the REAL measured mix (not 954M pure input) → ~$2,159 reference (§2.1)
+    # Same real measured mix as §2.1, but priced at the CORRECT Opus 4.5–4.8 rate ($5/$25/$6.25/$0.50).
+    # The old $2,159 reference used the wrong $15/$75 rate (Opus 4.0/4.1) and was ~3x too high (#337).
     real_mix = {
         "model": "claude-opus-4",
         "input": 657_029,
@@ -70,8 +71,8 @@ def test_opus_rates_sanity_vs_real_session():
         "cache_creation": 24_381_544,
     }
     cost = O.compute_cost(real_mix)
-    assert cost == pytest.approx(2159, rel=0.05), (
-        f"opus rates drifted: ${cost:,.2f} vs $2,159 ref"
+    assert cost == pytest.approx(720, rel=0.05), (
+        f"opus rates drifted: ${cost:,.2f} vs $720 ref"
     )
 
 
@@ -204,5 +205,52 @@ def test_matches_family_exported_and_consistent():
         assert known_via_collector is True, f"{m!r} should be a known model"
 
 
-# --- Unknown model still raises under strict (existing test_unknown_model_still_loud covers this) ---
-# gpt-99-unknown test is preserved above; no additional test needed here.
+# --- Official published rates (Codex review #337): assert the actual per-MTok numbers directly -------
+
+
+def test_opus_4x_official_rates():
+    for m in ("claude-opus-4-8", "claude-opus-4-7", "claude-opus-4-6"):
+        row = O._price_for(m)
+        assert row["input"] == 5e-6, m
+        assert row["output"] == 25e-6, m
+        assert row["cache_creation"] == 6.25e-6, m
+        assert row["cache_read"] == 0.50e-6, m
+
+
+def test_opus_hand_recompute_matches_published():
+    # A real smoke-test row, recomputed by hand at the official $5/$25/$6.25/$0.50 rate.
+    cost = O.compute_cost(
+        {
+            "model": "claude-opus-4-7",
+            "input": 6,
+            "output": 425,
+            "cache_creation": 46242,
+            "cache_read": 0,
+        }
+    )
+    assert cost == pytest.approx(0.2996675, abs=1e-7)
+
+
+def test_haiku_45_official_rates():
+    row = O._price_for("claude-haiku-4-5-20251001")
+    assert (row["input"], row["output"], row["cache_creation"], row["cache_read"]) == (
+        1e-6,
+        5e-6,
+        1.25e-6,
+        0.10e-6,
+    )
+
+
+def test_gpt55_official_rates():
+    row = O._price_for("gpt-5.5")
+    assert (row["input"], row["output"], row["cache_read"]) == (5e-6, 30e-6, 0.50e-6)
+
+
+def test_gpt_codex_official_rates():
+    for m in ("gpt-5.2-codex", "gpt-5.3-codex"):
+        row = O._price_for(m)
+        assert (row["input"], row["output"], row["cache_read"]) == (
+            1.75e-6,
+            14e-6,
+            0.175e-6,
+        ), m

--- a/claude-config/tests/test_usage_collect.py
+++ b/claude-config/tests/test_usage_collect.py
@@ -303,11 +303,22 @@ def test_reprocess_quarantine(tmp_path, monkeypatch):
     assert usage_rows[0]["dedup_key"] == "test:reprocess:1"
     assert usage_rows[0]["cost_usd"] is not None  # now priced
 
-    # Quarantine row marked resolved
-    q_rows = [
+    # Resolved row moved OUT of the active quarantine file into the audit trail (#337 finding 4) —
+    # the only row was resolved, so the active quarantine file is now empty.
+    active_q = [
         json.loads(line) for line in q_path.read_text().splitlines() if line.strip()
     ]
-    assert q_rows[0]["resolved"] is True
+    resolved_q = [
+        json.loads(line)
+        for line in (base / "usage-quarantine-resolved.jsonl").read_text().splitlines()
+        if line.strip()
+    ]
+    assert active_q == []
+    assert len(resolved_q) == 1 and resolved_q[0]["resolved"] is True
+    # INVARIANT: no dedup_key appears in BOTH usage.jsonl and the active quarantine file.
+    assert {r.get("dedup_key") for r in active_q} & {
+        r["dedup_key"] for r in usage_rows
+    } == set()
 
 
 # ---------------------------------------------------------------------------

--- a/claude-config/tests/test_usage_collector_claude.py
+++ b/claude-config/tests/test_usage_collector_claude.py
@@ -48,6 +48,37 @@ def _extract(entries):
     return U.extract_records(entries, inference_host=HOST)
 
 
+# Adversarial fixture from real Claude transcripts: one API turn can be logged as adjacent
+# thinking/text assistant rows with the same timestamp and identical usage counters.
+def test_split_assistant_usage_turn_is_not_double_counted():
+    usage = {
+        "input_tokens": 1,
+        "cache_creation_input_tokens": 2490,
+        "cache_read_input_tokens": 156954,
+        "output_tokens": 519,
+    }
+    recs = _extract(
+        [
+            _asst(
+                "thinking-part",
+                ts="2026-05-23T00:19:30.513Z",
+                sid="real-session",
+                usage=usage,
+                content=[{"type": "thinking", "thinking": "..."}],
+            ),
+            _asst(
+                "text-part",
+                ts="2026-05-23T00:19:30.513Z",
+                sid="real-session",
+                usage=usage,
+                content=[{"type": "text", "text": "done"}],
+            ),
+        ]
+    )
+
+    assert len(recs) == 1
+
+
 # 1. per-message timestamps, not one record at session start ----------------------------------------
 def test_per_message_records_and_timestamps():
     recs = _extract(

--- a/claude-config/tests/test_usage_recommend.py
+++ b/claude-config/tests/test_usage_recommend.py
@@ -120,7 +120,7 @@ def test_downshift_savings_math():
 
 
 def test_downshift_savings_opus_to_sonnet():
-    """1M input tokens opus→sonnet savings = 1M × (15e-6 - 3e-6) = 12.00."""
+    """1M input tokens opus→sonnet savings = 1M × (5e-6 - 3e-6) = 2.00 (corrected Opus rate, #337)."""
     rec = _r(
         model="claude-opus-4",
         input=1_000_000,
@@ -129,7 +129,7 @@ def test_downshift_savings_opus_to_sonnet():
         cache_creation=0,
     )
     savings = REC._downshift_savings([rec], "claude-sonnet-4")
-    assert abs(savings - 12.00) < 1e-6
+    assert abs(savings - 2.00) < 1e-6
 
 
 def test_downshift_savings_empty_records():

--- a/claude-config/tests/test_usage_report_d4.py
+++ b/claude-config/tests/test_usage_report_d4.py
@@ -79,6 +79,35 @@ def test_billing_headline_three_buckets():
     assert "Unknown: $0.50" in h
 
 
+def test_trends_do_not_sum_mixed_billing_buckets():
+    """Trend data must preserve billing buckets, not plot one mixed API-equivalent dollar."""
+    recs = [
+        _rec(
+            project="buddy",
+            billing_type="unknown",
+            cost_usd=7370.16,
+            session_id="u1",
+            ts="2026-06-03T00:00:00Z",
+        ),
+        _rec(
+            project="buddy",
+            billing_type="subscription",
+            cost_usd=5.11,
+            session_id="s1",
+            ts="2026-06-03T00:01:00Z",
+        ),
+    ]
+
+    tr = R.trends(recs, period="week")
+    bucket = tr["buddy"]["2026-W23"]
+
+    assert bucket["cost_by_billing"] == {
+        "unknown": 7370.16,
+        "subscription": 5.11,
+    }
+    assert "cost" not in bucket
+
+
 def test_billing_headline_subscription_only():
     """Subscription-only data → single labeled subscription line (not old flat total)."""
     recs = [_rec(billing_type="subscription", cost_usd=5.0, session_id="s1")]

--- a/claude-config/tests/test_usage_schema.py
+++ b/claude-config/tests/test_usage_schema.py
@@ -12,7 +12,7 @@ import usage_schema as S  # noqa: E402
 def test_price_table_version_exists_and_pinned():
     assert isinstance(O.PRICE_TABLE_VERSION, str) and O.PRICE_TABLE_VERSION
     # PIN: a silent PRICES rate edit must bump this. If you changed rates, bump the version + this test.
-    assert O.PRICE_TABLE_VERSION == "2026-06-08"
+    assert O.PRICE_TABLE_VERSION == "2026-06-08b"
 
 
 def test_normalize_fills_all_fields_and_stamps_pricing():
@@ -39,6 +39,13 @@ def test_normalize_fills_all_fields_and_stamps_pricing():
 def test_billing_type_none_or_bad_becomes_unknown():
     assert S.normalize({"billing_type": None})["billing_type"] == "unknown"
     assert S.normalize({"billing_type": "console"})["billing_type"] == "unknown"
+
+
+def test_unattributed_task_normalized_to_none():
+    # #337 finding 5: the collector's "unattributed" sentinel must become None at the data layer so the
+    # report's `task is not None` coverage check counts it as missing (it was inflating coverage to 100%).
+    assert S.normalize({"task": "unattributed"})["task"] is None
+    assert S.normalize({"task": "issue:42"})["task"] == "issue:42"  # real task untouched
     assert S.normalize({})["billing_type"] == "unknown"
 
 


### PR DESCRIPTION
Fixes all 5 wrong-number paths from the independent Codex review: (1) pricing 3x high → corrected Opus/Haiku/GPT rates (authoritative, +official-rate tests); (2) split-turn double-count → turn-signature dedup; (3) trends() billing-sum → per-bucket series; (4) quarantine reprocess dedup_key overlap → resolved rows moved to audit file; (5) attribution coverage 100%→true ~88% (normalize 'unattributed'→None). Kept Codex's 2 adversarial tests (now pass). Real re-run reconciles with Codex's estimate: $17,760 total (was $51,704). 363 tests green. Closes #337.