### PR TITLE
fix(usage): freshness watchdog per-host shard path (Step-3 finding)

### DIFF
--- a/claude-config/scripts/cost_telemetry_freshness.py
+++ b/claude-config/scripts/cost_telemetry_freshness.py
@@ -36,7 +36,11 @@ def check(
     now = now or _now()
     base = Path(base_dir)
     state_path = base / STATE_FILENAME
-    shard_path = base / SHARD_FILENAME
+    # The collector writes the shard to a PER-HOST subdir (<base>/<host>/usage.jsonl) and the state to
+    # the root (<base>/cost-telemetry.state). Accept either the per-host subdir shard (real layout) or a
+    # base-level shard (flat/test layout) — checking only <base>/usage.jsonl false-alarms live (#339).
+    def _shard_exists() -> bool:
+        return (base / SHARD_FILENAME).exists() or any(base.glob(f"*/{SHARD_FILENAME}"))
 
     if not state_path.exists():
         return True, "collector has never run (no cost-telemetry.state)"
@@ -61,7 +65,7 @@ def check(
             f"stale: last successful collection {age_days:.1f}d ago (SLA {sla_days}d)",
         )
     # Healthy run, but the shard itself must exist (a missing shard after a 'success' is alarming).
-    if not shard_path.exists():
+    if not _shard_exists():
         return True, "usage.jsonl missing despite a recent successful run"
     return False, f"fresh: last success {age_days:.1f}d ago"
 

--- a/claude-config/tests/test_cost_telemetry_freshness.py
+++ b/claude-config/tests/test_cost_telemetry_freshness.py
@@ -94,3 +94,14 @@ def test_hook_mode_always_exits_zero_even_when_stale(tmp_path):
     log = tmp_path / "log"
     assert F.main(["--base", str(missing), "--log", str(log)]) == 1  # CLI: stale → nonzero
     assert F.main(["--base", str(missing), "--log", str(log), "--hook"]) == 0  # hook: always 0
+
+
+def test_fresh_when_shard_in_per_host_subdir(tmp_path):
+    """#339: real layout writes the shard to <base>/<host>/usage.jsonl, not <base>/usage.jsonl —
+    freshness must find it there and NOT false-alarm 'shard missing'."""
+    _state(tmp_path, (NOW - timedelta(days=1)).isoformat())
+    host = tmp_path / "jns-mac"
+    host.mkdir()
+    (host / F.SHARD_FILENAME).write_text("{}\n", encoding="utf-8")
+    stale, reason = F.check(tmp_path, now=NOW)
+    assert stale is False, reason


### PR DESCRIPTION
Runbook Step 3 exposed it: freshness checked <base>/usage.jsonl but the collector writes <base>/<host>/usage.jsonl → false 'shard missing' alarm on a healthy run. Now accepts the per-host subdir shard. +test. Verified live --check reports fresh.