### PR TITLE
docs(usage): drop Stop-hook plan; correct hook semantics

### DIFF
--- a/claude-config/hooks/cost_collect_request.py
+++ b/claude-config/hooks/cost_collect_request.py
@@ -1,11 +1,15 @@
 #!/usr/bin/env python3
-"""Stop-hook marker (cost-telemetry-v0 §D2): touch `.collect-requested` so the launchd collector
-knows a session just ended and a scan is wanted. The work is trivial (a single touch); end to end as
-a spawned command hook it measures ~20ms (process startup dominates), and it NEVER raises — a telemetry
-marker must not affect session exit. The full scan runs under launchd, not here.
+"""Collection-request marker (cost-telemetry-v0 §D2): touch `.collect-requested`. The work is trivial
+(a single touch); end to end as a spawned command hook it measures ~20ms (process startup dominates),
+and it NEVER raises — a telemetry marker must not affect session exit.
 
-NOT wired into settings.json by this change — registering it as a Stop hook is part of the deferred
-cost-telemetry activation / joint smoke test.
+⚠ NOT WIRED, and intentionally so. This was conceived as a `Stop` hook, but `Stop` fires at the end of
+every assistant TURN (not at session end), and — more importantly — nothing consumes this marker: the
+launchd collector runs on its own 6h timer and mines the transcript JSONLs by mtime, which already
+captures resumed and multi-day sessions (a still-open session's transcript keeps a fresh mtime, so its
+running cost is picked up every cycle). So the timer + transcript is the reliable source; this marker
+adds nothing and is left dormant. If event-driven collection is ever wanted, wire a `SessionEnd` hook
+(the correct "session ended" event) to kickstart the launchd job — do NOT use `Stop`.
 """
 
 from __future__ import annotations

--- a/specs/cost-telemetry-activation-runbook.md
+++ b/specs/cost-telemetry-activation-runbook.md
@@ -82,16 +82,17 @@ launchctl list | grep cost-telemetry            # confirm loaded
 
 ---
 
-## Step 5 — Enable the Stop hook (marker on session end)
-Edit `~/.claude/settings.json` → `hooks.Stop[0].hooks` array, **append**:
-```json
-{ "type": "command", "command": "python3 ~/.claude/hooks/cost_collect_request.py" }
-```
-**Verify:** `python3 -c "import json;json.load(open('$HOME/.claude/settings.json'))"` parses OK; start
-and end a throwaway session; confirm `~/.claude/telemetry/.collect-requested` is touched and the session
-exited normally (no error, no delay).
-**Rollback:** delete that one array entry from `settings.json`.
-**Reversible:** yes (config-only; the hook never raises and only touches a marker).
+## Step 5 — SKIP (superseded by the timer + transcript-mtime)
+**Decided 2026-06-08: do not wire the Stop hook.** It was conceived as a "session ended" marker, but the
+Claude Code `Stop` hook fires at the end of **every turn** (not at session end), and nothing consumes
+the marker — the launchd collector (Step 4) runs on its own 6h timer and mines transcript JSONLs by
+**mtime**, which already captures **resumed** sessions (transcript keeps appending) and **multi-day**
+sessions (a still-open transcript keeps a fresh mtime → its running cost is collected every cycle, not
+only when it ends). So the timer + transcript is strictly more reliable than any hook here.
+
+If lower-than-6h latency is ever wanted, wire a **`SessionEnd`** hook (the correct "ended" event) to
+`launchctl kickstart` the job — **not** the per-turn `Stop` hook. `cost_collect_request.py` is left in
+the repo, dormant, with a docstring documenting this.
 
 ---
 


### PR DESCRIPTION
Stop fires per-turn (not session-end) and the marker is unconsumed; timer+transcript-mtime already captures resumed/multi-day sessions more reliably. Runbook Step 5 → SKIP; dormant hook documented (use SessionEnd if event-driven ever needed). Doc-only.