### PR TITLE
chore(usage): activate freshness watchdog as SessionStart hook (Step 6)

### DIFF
--- a/claude-config/settings.json
+++ b/claude-config/settings.json
@@ -83,6 +83,10 @@
           {
             "type": "command",
             "command": "python3 ~/.claude/hooks/usage_account_capture.py"
+          },
+          {
+            "type": "command",
+            "command": "python3 /Users/jasonjob/agents/claude-config/scripts/cost_telemetry_freshness.py --hook"
           }
         ]
       }


### PR DESCRIPTION
Wires cost_telemetry_freshness.py --hook into SessionStart. Always exits 0 (never blocks a session), ~42ms, reads state only. Surfaces a warning if the collector stalls >3 days. JSON validated, command verified exit 0, live via symlink. Backup retained.