### PR TITLE
chore(usage): wire billing resolver into live capture hook (Step 7)

### DIFF
--- a/claude-config/hooks/usage_account_capture.py
+++ b/claude-config/hooks/usage_account_capture.py
@@ -23,6 +23,14 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
+# The env-aware billing resolver lives in scripts/ (sibling of hooks/). Import best-effort so the hook
+# still works if it's missing — billing then falls back to the OAuth-only classifier (#337/#339).
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+try:
+    from usage_billing import resolve_billing_type
+except Exception:  # pragma: no cover - defensive
+    resolve_billing_type = None
+
 # Identity fields copied from oauthAccount — explicitly NO token/key fields.
 _OAUTH_FIELDS = {
     "accountUuid": "account_uuid",
@@ -48,8 +56,11 @@ def classify_billing(raw) -> str | None:
     return raw  # unknown enum → passthrough (don't silently mislabel)
 
 
-def build_entry(claude_json_path, session_id, *, now_ts: str) -> dict:
-    """Build the sidecar entry from ~/.claude.json's oauthAccount. Never includes any secret."""
+def build_entry(claude_json_path, session_id, *, now_ts: str, env: dict | None = None) -> dict:
+    """Build the sidecar entry from ~/.claude.json's oauthAccount. Never includes any secret.
+    `env` (defaults to the session's os.environ) lets the billing resolver see an API key — injectable
+    for tests so billing detection is deterministic."""
+    env = env if env is not None else os.environ
     entry = {"session_id": session_id, "ts": now_ts}
     try:
         data = json.loads(Path(claude_json_path).read_text(encoding="utf-8"))
@@ -63,7 +74,16 @@ def build_entry(claude_json_path, session_id, *, now_ts: str) -> dict:
         entry[dst] = oa.get(src)
     raw = oa.get("billingType")
     entry["billing_type_raw"] = raw
-    entry["billing_type"] = classify_billing(raw)
+    # Env API key beats a stale OAuth login (an API-key session is 'metered' even if oauthAccount says
+    # subscription; #337/#339). Fall back to the OAuth-only classifier if the resolver is unavailable so
+    # the hook never breaks.
+    if resolve_billing_type is not None:
+        try:
+            entry["billing_type"] = resolve_billing_type(env, claude_json_path)
+        except Exception:
+            entry["billing_type"] = classify_billing(raw)
+    else:
+        entry["billing_type"] = classify_billing(raw)
     return entry
 
 

--- a/claude-config/scripts/usage_billing.py
+++ b/claude-config/scripts/usage_billing.py
@@ -9,8 +9,8 @@ This is a PURE helper (inject `env` + path) so it's testable. It is meant to be 
 SessionStart account-capture hook (where `env` is the session's own environment) so each session is
 tagged at capture time. ⚠ launchd does NOT inherit a shell's env — under launchd the API-key keys are
 absent unless explicitly added to the plist `EnvironmentVariables`, so the env-key branch only fires in
-the hook context, not in a launchd-run collector. (Wiring this into the live hook is part of the
-deferred activation / smoke test, not this change.)
+the hook context, not in a launchd-run collector. (Wired into the live SessionStart account-capture
+hook via runbook Step 7 — #337/#339 review.)
 """
 
 from __future__ import annotations

--- a/claude-config/tests/test_account_capture.py
+++ b/claude-config/tests/test_account_capture.py
@@ -35,7 +35,7 @@ def _claude_json(tmp_path, oauth=OAUTH, secret=True):
 # Hook: build_entry copies the identity fields, classifies billing, and leaks NO secret --------------
 def test_hook_build_entry(tmp_path):
     entry = H.build_entry(
-        _claude_json(tmp_path), "sess-1", now_ts="2026-06-06T00:00:00Z"
+        _claude_json(tmp_path), "sess-1", now_ts="2026-06-06T00:00:00Z", env={}
     )
     assert entry["session_id"] == "sess-1"
     assert entry["account_uuid"] == "87a-uuid"
@@ -43,6 +43,18 @@ def test_hook_build_entry(tmp_path):
     assert entry["email"] == "jas@example.com"
     assert entry["billing_type"] == "subscription"
     assert SECRET not in json.dumps(entry)  # the auth token never reaches the sidecar
+
+
+def test_build_entry_env_api_key_is_metered(tmp_path):
+    # #337/#339: an env API key beats a stale OAuth 'subscription' login → metered (else subscription).
+    cj = _claude_json(tmp_path)  # OAUTH billingType = subscription
+    assert (
+        H.build_entry(cj, "s", now_ts="t", env={"ANTHROPIC_API_KEY": "sk-x"})[
+            "billing_type"
+        ]
+        == "metered"
+    )
+    assert H.build_entry(cj, "s", now_ts="t", env={})["billing_type"] == "subscription"
 
 
 def test_hook_classify_billing():
@@ -148,7 +160,9 @@ def test_codex_billing_classification(tmp_path):
 def test_integration_hook_then_collect(tmp_path):
     # capture
     sidecar = tmp_path / "telemetry" / "account-map.jsonl"
-    H.append_entry(sidecar, H.build_entry(_claude_json(tmp_path), "sessZ", now_ts="t0"))
+    H.append_entry(
+        sidecar, H.build_entry(_claude_json(tmp_path), "sessZ", now_ts="t0", env={})
+    )
     # a transcript for that session
     proj = tmp_path / "projects" / "-p"
     proj.mkdir(parents=True)


### PR DESCRIPTION
build_entry uses resolve_billing_type(env, ~/.claude.json) → env API key beats stale OAuth subscription (metered). Injectable env for tests; best-effort import + wrapped call so the live hook never breaks. Verified live. 369 tests green. Last correctness gap closed.