### PR TITLE
fix(scripts): validate-hooks resolves absolute in-repo claude-config paths

### DIFF
--- a/claude-config/scripts/validate-hooks.py
+++ b/claude-config/scripts/validate-hooks.py
@@ -61,24 +61,40 @@ def _resolve_settings_path() -> Path:
 
 
 def _resolve_to_repo_source(script: str, settings_path: Path) -> Path | None:
-    """Map a deployed-symlink path to the source-of-truth file in the repo.
+    """Map a deployed or machine-specific path to the repo source-of-truth file.
 
-    install.sh symlinks claude-config/<dir>/<file> into ~/.claude/<dir>/<file>.
-    When install.sh hasn't run (e.g. CI), the deployed path doesn't resolve
-    but the source path under claude-config/ does. This lets the validator
-    pass in both pre- and post-install environments.
+    Two shapes resolve to the same source under claude-config/, so the
+    validator passes in both pre- and post-install environments (incl. CI):
 
-    Returns None if the script doesn't look like a deployed claude-config
-    path (in which case only the deployed-path check applies).
+      1. Deployed-symlink path — install.sh symlinks claude-config/<dir>/<file>
+         into ~/.claude/<dir>/<file>. When install.sh hasn't run, the deployed
+         path doesn't exist but the repo source does.
+      2. Absolute in-repo path — a hardcoded /Users/<me>/agents/claude-config/…
+         path (used for scripts that install.sh does NOT symlink). The leading
+         dirs are machine-specific, so remap onto this checkout's claude-config.
+
+    Returns None if the script matches neither shape (only the literal-path
+    check then applies).
     """
-    home_prefix = "~/.claude/"
-    if not script.startswith(home_prefix):
-        return None
-    rel = script[len(home_prefix):]
     # settings.json lives at <repo>/claude-config/settings.json
     repo_claude_config = settings_path.parent
-    candidate = repo_claude_config / rel
-    return candidate
+
+    # Case 1: deployed-symlink path (~/.claude/<dir>/<file>) → repo source.
+    home_prefix = "~/.claude/"
+    if script.startswith(home_prefix):
+        return repo_claude_config / script[len(home_prefix):]
+
+    # Case 2: an absolute, machine-specific path that points into the repo's
+    # claude-config/ tree — e.g. a hook authored with a hardcoded
+    # /Users/<me>/agents/claude-config/scripts/foo.py path (the convention for
+    # scripts that install.sh does NOT symlink into ~/.claude/). Remap the part
+    # after the last "/claude-config/" segment onto this checkout's
+    # claude-config root so it resolves on any machine / in CI.
+    marker = "/claude-config/"
+    if marker in script:
+        return repo_claude_config / script.rsplit(marker, 1)[1]
+
+    return None
 
 
 def _extract_script(cmd: str) -> str | None:


### PR DESCRIPTION
## Summary

`main`'s PR-only `validate` check has been **red since #344**. That PR activated the freshness-watchdog SessionStart hook with a hardcoded absolute path (`/Users/jasonjob/agents/claude-config/scripts/cost_telemetry_freshness.py`) — necessary because `scripts/` is **not** symlinked into `~/.claude/` like `hooks/` is. The validator only knew how to remap the `~/.claude/...` symlink convention back to repo source, so the absolute path resolved on the authoring laptop but **never on CI**. Because `validate` runs on `pull_request` only, #344 was merged while red and every subsequent branch inherits the failure.

## Fix

Extend `_resolve_to_repo_source`: when a hook's script path embeds `/claude-config/`, remap the segment after it onto the current checkout's `claude-config` root. Machine-specific leading directories (`/Users/...` vs `/home/runner/...`) stop mattering, so absolute in-repo hook paths resolve everywhere. **No change to runtime hook wiring** — the hook keeps its absolute path; only the validator got smarter. In-spirit with #106 ("accept repo source paths when symlinks unavailable").

## Test Plan
- `py_compile` passes.
- Validator against the real `settings.json`: `✓ All hook script paths resolve (11 checked)`, exit 0.
- Unit-tested `_resolve_to_repo_source` with a CI-style path (`/home/runner/.../claude-config/scripts/cost_telemetry_freshness.py`) not existing literally → remaps to repo source and resolves; unrelated `/tmp/...` path → `None` (no false positives).

🤖 Generated with [Claude Code](https://claude.com/claude-code)