### PR TITLE
feat(orchestrate): inject recalled project memory into every phase prompt

### DIFF
--- a/bin/memory
+++ b/bin/memory
@@ -117,6 +117,17 @@ def cmd_recall(args) -> int:
     hits.sort(key=lambda h: (h[0], h[1]), reverse=True)
     shown = hits[: args.limit]
 
+    if args.compact:
+        # One line per hit: path + label/type + name + description. No bodies —
+        # for injecting a bounded index into another prompt (e.g. /orchestrate).
+        # The reader Reads the path for the full body on demand.
+        for score, _mtime, label, path, meta, _body in shown:
+            typ = f" · {meta['type']}" if meta["type"] else ""
+            name = meta["name"] or path.stem
+            desc = (" — " + meta["description"]) if meta["description"] else ""
+            print(f"- {path}  [{label}{typ}] {name}{desc}")
+        return 0
+
     print(f"# {len(hits)} fact(s) match {args.query!r} — showing {len(shown)}\n")
     for score, _mtime, label, path, meta, body in shown:
         title = meta["name"] or path.stem
@@ -187,6 +198,7 @@ def main(argv=None) -> int:
     p_recall.add_argument("query", help="search terms (space-separated)")
     p_recall.add_argument("--project", help="limit to projects whose label contains this substring")
     p_recall.add_argument("--limit", type=int, default=5, help="max facts to print (default 5)")
+    p_recall.add_argument("--compact", action="store_true", help="one-line index per hit (path + name + description), no bodies")
     p_recall.set_defaults(func=cmd_recall)
 
     p_doctor = sub.add_parser("doctor", help="reconcile MEMORY.md indexes against fact files")

--- a/claude-config/commands/orchestrate.md
+++ b/claude-config/commands/orchestrate.md
@@ -296,6 +296,27 @@ the in-flight task documents where the run halted.
 Skip this step entirely on `--resume` runs unless the resumed phase has no
 existing task (re-create only the missing tail of the chain).
 
+### Step 2.8: Recall Project Memory (once per workflow)
+
+Project-memory fact *bodies* are not auto-loaded into subagents. Recall the
+relevant ones **once** here and inject them into every phase prompt via the
+`{PROJECT_MEMORY_BLOCK}` variable (see `templates/agent-prompt.md`), so MAP /
+PLAN / PATCH / PROVE all inherit the same curated context without each running
+the CLI:
+
+```bash
+~/agents/bin/memory recall "<issue title + key entities/subsystem terms>" --compact --limit 8
+```
+
+- Use the issue title plus any distinctive nouns (entity, feature, file/module
+  names) as the query.
+- Capture the output verbatim as `{PROJECT_MEMORY_BLOCK}`. If it's empty, set
+  the block to `(no project-memory facts matched this issue)`.
+- The block is a compact index (paths + descriptions), not bodies — agents
+  Read the full body of any fact that bears on their work (honors the
+  Context-Isolation rule in `templates/agent-prompt.md`).
+- On `--resume`, reuse the block if already captured; otherwise re-recall.
+
 ### Step 3: Spawn Agents (Task Tool)
 
 **CRITICAL**: Use the Task tool to spawn each phase agent via **native subagent

--- a/claude-config/templates/agent-prompt.md
+++ b/claude-config/templates/agent-prompt.md
@@ -40,6 +40,7 @@ that as the system prompt. Pass *only* per-invocation context.
 | `{COMPLEXITY}` | Issue complexity | TRIVIAL, SIMPLE, COMPLEX |
 | `{ARTIFACT_NAME}` | Output artifact filename | map-plan-184-032526.md |
 | `{ARTIFACT_LIST}` | Prior artifacts (markdown list of paths only) | - MAP-PLAN: .agents/outputs/... |
+| `{PROJECT_MEMORY_BLOCK}` | Relevant project-memory facts (compact index; built once by the orchestrator — see commands/orchestrate.md Step 2.8) | - /Users/.../memory/feedback_rbac_pattern.md [recall-ops · feedback] RBAC is the standard... |
 | `{PRIOR_FAILURE_BLOCK}` | Failure context or "First attempt" | ## Prior Failure ... |
 | `{AGENT_INSTRUCTIONS}` | Per-invocation extra instructions (1-2 sentences) | Read MAP-PLAN. Generate test matrix. |
 | `{SCOPE}` | Optional scope constraint | BACKEND ONLY, FRONTEND ONLY |
@@ -55,6 +56,9 @@ that as the system prompt. Pass *only* per-invocation context.
 
 ## Prior Artifacts
 {ARTIFACT_LIST}
+
+## Project Memory (relevant facts — Read the body of any that bear on your work)
+{PROJECT_MEMORY_BLOCK}
 
 {PRIOR_FAILURE_BLOCK}
 

--- a/claude-config/templates/orchestrate-pipeline.md
+++ b/claude-config/templates/orchestrate-pipeline.md
@@ -43,6 +43,9 @@ tables below specify just the variables that change.
 ## Prior Artifacts
 {ARTIFACT_LIST}
 
+## Project Memory (relevant facts — Read the body of any that bear on your work)
+{PROJECT_MEMORY_BLOCK}
+
 {PRIOR_FAILURE_BLOCK}
 
 ## Per-Run Instructions
@@ -55,6 +58,12 @@ End your response with `AGENT_RETURN: {ARTIFACT_NAME}`.
 > **Fresh Context Rule**: Each agent gets a clean context window. Pass file
 > PATHS in the artifact list, not file CONTENTS. Let agents use the Read tool
 > to load what they need.
+>
+> `{PROJECT_MEMORY_BLOCK}` is built **once** per workflow at `commands/orchestrate.md`
+> Step 2.8 (`memory recall … --compact`) and reused for every phase — a compact
+> index of paths + descriptions, so it honors the Fresh Context Rule (agents
+> Read the bodies on demand). New phase agents inherit it automatically; no
+> per-agent edit needed.
 
 ---
 


### PR DESCRIPTION
## Summary

Wire `memory recall` into `/orchestrate` (Phase 2 of the memory-recall plan) at the **single shared chokepoint** instead of per agent file.

**Why not per-agent:** `_base.md` is *not* auto-loaded at runtime — each orchestrate agent's own file body IS its system prompt, which is why the `## Pre-Flight (from _base.md)` blocks are already copy-pasted across 8 files. Adding a recall line to each would be unscalable and would worsen that duplication. Instead, the orchestrator already fills a shared prompt template (`templates/agent-prompt.md`) with dynamic blocks like `{PRIOR_FAILURE_BLOCK}`. Injecting memory there means **every phase agent (MAP/PLAN/PATCH/PROVE + any future one) inherits it automatically, and recall runs once per workflow.**

## Changes
- **`bin/memory`** — `recall --compact`: one-line index per hit (path + `[project · type]` name + description, no bodies). Bounded output for injecting into another prompt.
- **`templates/agent-prompt.md`** — new `{PROJECT_MEMORY_BLOCK}` variable + a `## Project Memory (relevant facts — Read the body of any that bear on your work)` section.
- **`commands/orchestrate.md`** — Step 2.8: orchestrator runs `~/agents/bin/memory recall "<issue keywords>" --compact --limit 8` once and fills the block for all phases (empty → `(no project-memory facts matched this issue)`).
- **`templates/orchestrate-pipeline.md`** — documents the variable and that it honors the Fresh Context Rule (compact index of paths; agents Read bodies on demand).

## Design notes
- Honors the template's own Context-Isolation rule: inject **paths + descriptions**, not file contents — agents Read full bodies on demand (unlike `{PRIOR_FAILURE_BLOCK}`, which injects full text).
- Recall happens once in orchestrator context, not N times across fresh-context subagents.

## Test Plan
- `py_compile bin/memory` — pass.
- `memory recall "<terms>" --compact --limit N` → one bounded line per hit with path + name + description. ✓
- `{PROJECT_MEMORY_BLOCK}` present in all three orchestrate template/command files. ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)