### PR TITLE
chore(learn): advance watermark to seed the loop (closes #177)

### DIFF
--- a/telemetry/_state.json
+++ b/telemetry/_state.json
@@ -1,5 +1,5 @@
 {
-  "last_learn_at": "2000-01-01T00:00:00Z",
-  "last_learn_host": "",
+  "last_learn_at": "2026-06-07T17:06:38.450621Z",
+  "last_learn_host": "jns-mac",
   "version": 1
 }


### PR DESCRIPTION
## Summary

Ran `/learn --cross-project --apply --validate` to seed the learning loop (#177; the gate was tripped — 41 failures since the 2000-epoch watermark).

**Result:** the 90-day window held **6 failures, all distinct root causes** (asyncpg pool/conn, pipecat deadlock, missing service wiring, conn-id scope, missing interface methods, AC4-metric) — none reached the ≥2-occurrence threshold, so **no new patterns were extracted and no agent files changed**. The recurring history already shaped the existing patterns.

The substantive effect is **consuming those 6 and advancing the gate watermark** → the tripped `/learn` gate resets (0 new since `consumed_max` = `2026-06-07T17:06:38Z`).

## Test Plan
- `telemetry_gate.py --count-only` → 0 new (was 41).
- `telemetry_gate.py --verbose` → "gate not tripped".
- Only `telemetry/_state.json` (the tracked watermark) changed.

Closes #177.

🤖 Generated with [Claude Code](https://claude.com/claude-code)