### PR TITLE
fix(rules): correct jjob-spec git identity to jjob@vital-enterprises.com

### DIFF
--- a/claude-config/rules/github-accounts.md
+++ b/claude-config/rules/github-accounts.md
@@ -8,10 +8,16 @@ This machine has two GitHub accounts configured via `gh auth`. Always ensure the
 
 ## Account Mapping
 
-| GitHub Account | Used For | Git Email |
-|---------------|----------|-----------|
-| `jwj2002` | Personal projects | jasonwadejob@gmail.com |
-| `jjob-spec` | Maison Financial projects | jason@maisonfinancial.com |
+| GitHub Account | Used For | Git Author Name | Git Email |
+|---------------|----------|-----------------|-----------|
+| `jwj2002` | Personal projects | `jwj2002` | jasonwadejob@gmail.com |
+| `jjob-spec` | Maison Financial / VitalAI work | `jjob-spec` | jjob@vital-enterprises.com |
+
+> Verified from commit history (2026-06-09): jjob-spec commits as
+> `jjob-spec <jjob@vital-enterprises.com>` and jwj2002 as
+> `jwj2002 <jasonwadejob@gmail.com>`. The author NAME is the literal login,
+> not "Jason Job". (Earlier versions of this file wrongly listed
+> `jason@maisonfinancial.com` for jjob-spec.)
 
 ## Project → Account Mapping
 
@@ -24,18 +30,25 @@ This machine has two GitHub accounts configured via `gh auth`. Always ensure the
 | `~/projects/temper` | `jwj2002` | jwj2002/temper |
 | `~/projects/fastapi-architect-agent` | `jwj2002` | jwj2002/fastapi-architect-agent |
 | `~/projects/social_media_poster` | `jjob-spec` | jjob-spec/social-media-poster |
+| `~/projects/ai-channels` | `jjob-spec` (this laptop, collaborator) | jwj2002/ai-channels |
 | `~/agents` | `jwj2002` | jwj2002/agents |
+
+> `ai-channels` is cross-account: repo is **owned by jwj2002**, but the personal
+> laptop commits as jwj2002 while this (work) laptop commits as a **jjob-spec
+> collaborator**. The work-laptop clone uses a username-qualified remote
+> (`https://jjob-spec@github.com/jwj2002/ai-channels.git`) so the credential
+> store resolves the jjob-spec token regardless of the active gh account.
 
 ## Required Steps
 
 1. **Before any git/gh operation**, run `gh auth status` to check the active account
 2. **If wrong account is active**, run `gh auth switch -u <correct_account>`
-3. **After cloning a jjob-spec repo**, always set:
+3. **After cloning a jjob-spec repo**, always set (per-repo, not global):
    ```bash
-   git config user.name "Jason Job"
-   git config user.email "jason@maisonfinancial.com"
+   git config user.name "jjob-spec"
+   git config user.email "jjob@vital-enterprises.com"
    ```
-4. **For jwj2002 repos**, git email should be `jasonwadejob@gmail.com`
+4. **For jwj2002 repos**, set `user.name "jwj2002"` and `user.email "jasonwadejob@gmail.com"`
 
 ## Never
 


### PR DESCRIPTION
## Summary
`github-accounts.md` listed jjob-spec's git email as `jason@maisonfinancial.com`, but commit history (jjob-spec/vitalai-channels, jwj2002/ai-channels) shows jjob-spec commits as `jjob-spec <jjob@vital-enterprises.com>`. The author *name* is the literal login, not "Jason Job".

Changes:
- Fix jjob-spec email → `jjob@vital-enterprises.com`; add Git Author Name column.
- Correct the post-clone config snippet (name `jjob-spec`, vital-enterprises email).
- Add cross-account `ai-channels` row: repo owned by jwj2002, jjob-spec collaborator from the work laptop, username-qualified remote for deterministic auth.
- Add a verification note dated 2026-06-09.

## Test Plan
Docs/config only — no code. Verified `~/.claude/rules/github-accounts.md` is a symlink to the edited source (same inode), so the correction is live for future sessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)