### PR TITLE
feat(telemetry): per-machine email config for the weekly cost report

### DIFF
--- a/claude-config/cost-telemetry-email.example.json
+++ b/claude-config/cost-telemetry-email.example.json
@@ -1,0 +1,12 @@
+{
+  "_comment": "Per-machine cost-telemetry email config. Copy to ~/.claude/cost-telemetry/email.json (chmod 600) and edit, OR run `usage_email.py --configure`. NOT committed — each machine has its own. Validate with `usage_email.py --check-config`; test with `--test-send`.",
+  "_account_types": "gmail (creds = a google token.json; sender = that account) | m365 (creds = a ~/.claude/m365/*.json; sender = its sender_upn) | none (no email — weekly job writes a local report only)",
+
+  "enabled": true,
+  "account": {
+    "type": "gmail",
+    "sender": "you@gmail.com",
+    "creds": "~/agents/google/token.json"
+  },
+  "recipient": "you@gmail.com"
+}

--- a/claude-config/launchd/README.md
+++ b/claude-config/launchd/README.md
@@ -105,3 +105,50 @@ Run once on demand:
 python3 ~/agents/claude-config/scripts/memory_audit_metrics.py --days 7   # weekly metrics row
 claude --print "$(cat ~/agents/docs/memory-audit.md)"                      # full audit (writes a report)
 ```
+
+---
+
+## Cost-telemetry weekly report (`com.cost-telemetry-report-weekly`)
+
+**Weekly** (Mondays 09:05, aligned with the memory jobs). Builds the cost report
+locally (`~/.claude/cost-reports/cost-report-<host>-<week>.{html,md}`) via
+`scripts/cost_report_weekly.py`, then **emails it per this machine's config**.
+
+Email is **per-machine** — set the account to send from + recipient on each
+computer (the repo is shared, so this config is machine-local, never committed):
+
+```bash
+python3 ~/agents/claude-config/scripts/usage_email.py --configure      # guided: type + sender + recipient
+python3 ~/agents/claude-config/scripts/usage_email.py --check-config    # show resolved transport + creds
+python3 ~/agents/claude-config/scripts/usage_email.py --test-send       # send a one-off test now
+```
+
+Config lives at `~/.claude/cost-telemetry/email.json` (chmod 600; template:
+`claude-config/cost-telemetry-email.example.json`). Account types:
+
+| type | sends as | creds (default) |
+|---|---|---|
+| `gmail` | the token's Google account (e.g. `jasonwadejob@gmail.com`) | `~/agents/google/token.json` |
+| `m365` | the creds' `sender_upn` (e.g. `jjob@vital-enterprises.com`) | `~/.claude/m365/agent.json` |
+| `none` | — (no email; **local report still written**) | — |
+
+If email is `none`/disabled/unconfigured, the weekly job still writes the local
+report and exits 0 — it never blocks.
+
+### Deploy / reload
+
+```bash
+p=com.cost-telemetry-report-weekly
+cp "claude-config/launchd/$p.plist" ~/Library/LaunchAgents/
+launchctl unload "$HOME/Library/LaunchAgents/$p.plist" 2>/dev/null || true
+launchctl load   "$HOME/Library/LaunchAgents/$p.plist"
+```
+
+### Observe
+
+```bash
+launchctl list | grep cost-telemetry-report
+tail -f ~/Library/Logs/claude-learn/cost-report.log
+ls ~/.claude/cost-reports/                     # the local report archive
+python3 ~/agents/claude-config/scripts/cost_report_weekly.py   # run once on demand
+```

--- a/claude-config/launchd/com.cost-telemetry-report-weekly.plist
+++ b/claude-config/launchd/com.cost-telemetry-report-weekly.plist
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.cost-telemetry-report-weekly</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>-lc</string>
+        <string>
+          LOG="$HOME/Library/Logs/claude-learn/cost-report.log"
+          mkdir -p "$(dirname "$LOG")"
+          echo "[$(date -Iseconds)] weekly cost report" &gt;&gt;"$LOG"
+          PY="$HOME/agents/.venv/bin/python"; [ -x "$PY" ] || PY=python3
+          cd "$HOME/agents" \
+          &amp;&amp; git pull --ff-only --quiet 2&gt;&gt;"$LOG" ;
+          "$PY" claude-config/scripts/cost_report_weekly.py &gt;&gt;"$LOG" 2&gt;&amp;1
+        </string>
+    </array>
+    <key>WorkingDirectory</key>
+    <string>/Users/jasonjob/agents</string>
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Weekday</key>
+        <integer>1</integer>
+        <key>Hour</key>
+        <integer>9</integer>
+        <key>Minute</key>
+        <integer>5</integer>
+    </dict>
+    <key>StandardOutPath</key>
+    <string>/Users/jasonjob/Library/Logs/claude-learn/cost-report.out</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/jasonjob/Library/Logs/claude-learn/cost-report.err</string>
+    <key>RunAtLoad</key>
+    <false/>
+</dict>
+</plist>

--- a/claude-config/scripts/cost_report_weekly.py
+++ b/claude-config/scripts/cost_report_weekly.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Weekly cost-telemetry report — build locally, then email per machine config.
+
+Run by `com.cost-telemetry-report-weekly` (Mondays). It ALWAYS writes a local
+report to ~/.claude/cost-reports/ (the archive/fallback); email delivery is on
+top of that and only happens when ~/.claude/cost-telemetry/email.json is
+configured + enabled (see usage_email). Never blocks; logs + exits 0.
+
+Pipeline reuses the existing modules:
+  usage_aggregator.read_shards + aggregate  ->  usage_report.write_report (html+md)
+  ->  usage_email.send_weekly (transport selected by the machine-local config)
+"""
+
+from __future__ import annotations
+
+import json
+import socket
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import usage_aggregator as A  # noqa: E402
+import usage_email as E  # noqa: E402
+import usage_report as R  # noqa: E402
+
+TELEMETRY_DIR = Path.home() / ".claude" / "telemetry"          # read_shards globs */usage.jsonl under here
+REPORTS_DIR = Path.home() / ".claude" / "cost-reports"
+EMAIL_STATE = Path.home() / ".claude" / "cost-telemetry" / "email-state.json"  # email-only state (no collector races)
+
+
+def _host() -> str:
+    try:
+        sys.path.insert(0, str(Path.home() / "agents" / "lib"))
+        from project_resolver import get_host_name
+        return get_host_name()
+    except Exception:
+        return socket.gethostname().split(".")[0] or "unknown"
+
+
+def _load_state() -> dict:
+    try:
+        return json.loads(EMAIL_STATE.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+
+
+def _save_state(state: dict) -> None:
+    EMAIL_STATE.parent.mkdir(parents=True, exist_ok=True)
+    EMAIL_STATE.write_text(json.dumps(state, indent=2) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    now = datetime.now(timezone.utc)
+    host = _host()
+    iso = now.isocalendar()
+    wk = f"{iso[0]}-W{iso[1]:02d}"
+
+    records = A.read_shards(TELEMETRY_DIR)
+    agg = A.aggregate(records)
+    REPORTS_DIR.mkdir(parents=True, exist_ok=True)
+    html_path = REPORTS_DIR / f"cost-report-{host}-{wk}.html"
+    R.write_report(agg, html_path, records=records)          # writes .html + .md
+    md = html_path.with_suffix(".md").read_text(encoding="utf-8")  # email body = the local .md
+    print(f"[{now.isoformat()}] local report: {html_path} ({len(records)} records)")
+
+    state = _load_state()
+    code, new_state = E.send_weekly(
+        md_summary=md, html_path=str(html_path), state=state, host=host, now=now,
+    )
+    if code == E.SENT_OR_SKIP and new_state != state:
+        _save_state(new_state)
+    status = {
+        E.SENT_OR_SKIP: "emailed (or already sent this week)",
+        E.DISABLED: "email disabled — local report only",
+        E.SEND_FAILED: "email FAILED (local report written)",
+    }.get(code, str(code))
+    print(f"[{now.isoformat()}] email: {status} (exit {code})")
+    return 0  # never block the cadence
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/claude-config/scripts/cost_report_weekly.py
+++ b/claude-config/scripts/cost_report_weekly.py
@@ -69,7 +69,10 @@ def main() -> int:
         md_summary=md, html_path=str(html_path), state=state, host=host, now=now,
     )
     if code == E.SENT_OR_SKIP and new_state != state:
-        _save_state(new_state)
+        try:
+            _save_state(new_state)
+        except OSError as e:
+            print(f"[{now.isoformat()}] warn: could not persist email state: {e}")
     status = {
         E.SENT_OR_SKIP: "emailed (or already sent this week)",
         E.DISABLED: "email disabled — local report only",

--- a/claude-config/scripts/usage_email.py
+++ b/claude-config/scripts/usage_email.py
@@ -1,24 +1,51 @@
-"""Weekly cost-report email delivery (cost-telemetry-v0 §D5) — FAST-FOLLOW / cut-able.
+"""Weekly cost-report email delivery — per-machine configurable account + transport.
 
-The LOCAL report is the v0 gate; this only adds delivery. It is NOT triggered live by this module —
-wiring the weekly job + the first real send is part of the deferred activation / joint smoke test.
+The account to send FROM (type + sender + creds) and the recipient are read from
+a machine-local config so each computer mails the right place:
+  - personal laptop  -> gmail  / jasonwadejob@gmail.com
+  - work laptop      -> m365   / jjob@vital-enterprises.com
 
-`send_fn` is injectable so the real M365 send (`~/agents/m365/send_mail.py`) is decoupled and testable.
-Idempotent (one send per ISO week, tracked in the collector state); a send failure logs + returns exit 4
-and NEVER blocks collection. Always sends as jjob@vital-enterprises.com (never overrides the sender).
+Config (machine-local, NOT committed): ~/.claude/cost-telemetry/email.json
+  {
+    "enabled": true,
+    "account": { "type": "gmail", "sender": "...", "creds": "~/agents/google/token.json" },
+    "recipient": "..."
+  }
+JSON (stdlib) — also valid YAML — so it parses under launchd's /usr/bin/python3.
+A committed `cost-telemetry-email.yaml.example` documents the shape.
+
+Transports shell out to the existing send helpers (selected by `account.type`):
+  gmail -> ~/agents/google/send_mail.py  (--token <creds>; sender = token account)
+  m365  -> ~/agents/m365/send_mail.py    (--creds <creds>; sender = creds sender_upn)
+  none  -> no send (caller writes a local report instead)
+
+Each transport helper enforces its own recipient safety (e.g. m365 refuses
+gmail recipients unless explicitly unblocked). The machine-local config file is
+the authorization: send only when `enabled` is true and a recipient is set.
+A send failure logs + returns nonzero and NEVER blocks collection. Idempotent:
+one send per ISO week, tracked in the collector state. `send_fn` stays injectable
+for tests.
 """
 
 from __future__ import annotations
 
+import argparse
+import json
 import subprocess
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
-SENDER = "jjob@vital-enterprises.com"
-DEFAULT_SEND_MAIL = Path.home() / "agents" / "m365" / "send_mail.py"
-# Graph creds are NOT ambient under launchd — point at the token cache explicitly when activated.
-DEFAULT_TOKEN_CACHE = Path.home() / ".claude" / "m365" / "token-cache.bin"
+CONFIG_PATH = Path.home() / ".claude" / "cost-telemetry" / "email.json"
+VENV_PY = Path.home() / "agents" / ".venv" / "bin" / "python"
+GMAIL_HELPER = Path.home() / "agents" / "google" / "send_mail.py"
+M365_HELPER = Path.home() / "agents" / "m365" / "send_mail.py"
+VALID_TYPES = ("gmail", "m365", "none")
+
+# Exit codes (stable; used by the weekly job to decide local-report fallback):
+SENT_OR_SKIP = 0     # sent this week, or idempotent skip
+DISABLED = 3         # email not configured / disabled -> caller writes local report
+SEND_FAILED = 4      # transport raised (logged; collection never blocked)
 
 
 def _week_key(dt: datetime) -> str:
@@ -26,23 +53,60 @@ def _week_key(dt: datetime) -> str:
     return f"{iso[0]}-W{iso[1]:02d}"
 
 
-def _default_send(*, subject: str, body: str, html_path, recipient: str) -> None:
-    """Real send via the M365 helper. Raises on non-zero exit."""
-    cmd = [
-        sys.executable,
-        str(DEFAULT_SEND_MAIL),
-        "--to",
-        recipient,
-        "--subject",
-        subject,
-        "--body",
-        body,
-    ]
-    if html_path:
-        cmd += ["--attach", str(html_path)]
+def _python_bin() -> str:
+    """Helpers need third-party libs (googleapiclient / msal+requests) from the
+    repo venv; fall back to the current interpreter if the venv is absent."""
+    return str(VENV_PY) if VENV_PY.exists() else sys.executable
+
+
+def load_email_config(path: Path | None = None) -> dict:
+    """Read the machine-local email config. Fail-safe: any problem -> disabled.
+
+    Returns a dict with at least {"enabled": bool}. Never raises.
+    """
+    path = path or CONFIG_PATH
+    try:
+        cfg = json.loads(Path(path).read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {"enabled": False}
+    if not isinstance(cfg, dict):
+        return {"enabled": False}
+    cfg.setdefault("enabled", False)
+    cfg.setdefault("account", {})
+    return cfg
+
+
+def _helper_argv(account: dict, *, recipient: str, subject: str, body: str, html_path) -> list[str] | None:
+    """Build the send-helper argv for the account type, or None if unsendable."""
+    atype = (account or {}).get("type", "none")
+    creds = (account or {}).get("creds")
+    creds = str(Path(creds).expanduser()) if creds else None
+    if atype == "gmail":
+        cmd = [_python_bin(), str(GMAIL_HELPER), "--to", recipient, "--subject", subject, "--body", body]
+        if creds:
+            cmd += ["--token", creds]
+        if html_path:
+            cmd += ["--attach", str(html_path)]
+        return cmd
+    if atype == "m365":
+        cmd = [_python_bin(), str(M365_HELPER), "--to", recipient, "--subject", subject, "--body", body]
+        if creds:
+            cmd += ["--creds", creds]
+        if html_path:
+            cmd += ["--attach", str(html_path)]
+        return cmd
+    return None  # 'none' / unknown
+
+
+def _default_send(*, account: dict, recipient: str, subject: str, body: str, html_path) -> None:
+    """Real send via the configured transport helper. Raises on failure."""
+    cmd = _helper_argv(account, recipient=recipient, subject=subject, body=body, html_path=html_path)
+    if cmd is None:
+        raise RuntimeError(f"no transport for account type {account.get('type')!r}")
     r = subprocess.run(cmd, capture_output=True, text=True)
     if r.returncode != 0:
-        raise RuntimeError(f"send_mail failed ({r.returncode}): {r.stderr.strip()}")
+        # Do not echo the helper's stdout (may contain addresses); type + code only.
+        raise RuntimeError(f"send helper failed (exit {r.returncode})")
 
 
 def send_weekly(
@@ -51,26 +115,108 @@ def send_weekly(
     html_path,
     state: dict,
     host: str,
-    recipient: str = SENDER,
-    allow_nonstandard_recipient: bool = False,
+    config: dict | None = None,
     now: datetime | None = None,
     send_fn=None,
 ) -> tuple[int, dict]:
-    """Send the weekly report if not already sent this ISO week.
-    Returns (exit_code, updated_state): 0 = sent OR idempotent-skip; 4 = send failure / refused
-    recipient (caller logs; collection is never blocked). State is only advanced on a successful send."""
+    """Send the weekly report per the machine-local config, if not already sent
+    this ISO week. Returns (exit_code, updated_state). State advances only on a
+    successful send. Never raises (collection is never blocked)."""
     now = now or datetime.now(timezone.utc)
-    # The report carries internal cost data — refuse any recipient other than the fixed sender unless a
-    # caller EXPLICITLY opts in (a dev-only escape hatch). Never silently send elsewhere (#339).
-    if recipient != SENDER and not allow_nonstandard_recipient:
-        return 4, state
+    config = config if config is not None else load_email_config()
+
+    recipient = (config.get("recipient") or "").strip()
+    account = config.get("account") or {}
+    if not config.get("enabled") or not recipient or account.get("type") in (None, "none"):
+        return DISABLED, state  # caller writes a local report instead
+
     wk = _week_key(now)
     if state.get("last_email_sent_week") == wk:
-        return 0, state  # idempotent — already sent this week
-    send = send_fn or _default_send
+        return SENT_OR_SKIP, state  # idempotent — already sent this week
+
     subject = f"[cost-telemetry] {host} — week {wk}"
+    send = send_fn or _default_send
     try:
-        send(subject=subject, body=md_summary, html_path=html_path, recipient=recipient)
+        send(account=account, recipient=recipient, subject=subject, body=md_summary, html_path=html_path)
     except Exception:
-        return 4, state  # never block collection; caller logs the failure
-    return 0, {**state, "last_email_sent_week": wk}
+        return SEND_FAILED, state  # caller logs; collection never blocked
+    return SENT_OR_SKIP, {**state, "last_email_sent_week": wk}
+
+
+# ----------------------------------------------------------------- CLI
+
+def _creds_default(atype: str) -> str:
+    return {
+        "gmail": "~/agents/google/token.json",
+        "m365": "~/.claude/m365/agent.json",
+    }.get(atype, "")
+
+
+def cmd_configure() -> int:
+    print("Configure the cost-telemetry weekly email for THIS machine.\n")
+    atype = input(f"Account type {VALID_TYPES}: ").strip() or "none"
+    if atype not in VALID_TYPES:
+        print(f"invalid type {atype!r}; must be one of {VALID_TYPES}", file=sys.stderr)
+        return 2
+    cfg: dict = {"enabled": atype != "none", "account": {"type": atype}, "recipient": ""}
+    if atype != "none":
+        cfg["account"]["sender"] = input("Sender account (from address): ").strip()
+        creds = input(f"Creds path [{_creds_default(atype)}]: ").strip() or _creds_default(atype)
+        cfg["account"]["creds"] = creds
+        cfg["recipient"] = input("Recipient address: ").strip()
+        cp = Path(creds).expanduser()
+        if not cp.exists():
+            print(f"  ! warning: creds not found at {cp} — set them up before the first send.")
+    CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    CONFIG_PATH.write_text(json.dumps(cfg, indent=2) + "\n", encoding="utf-8")
+    CONFIG_PATH.chmod(0o600)
+    print(f"\nWrote {CONFIG_PATH}\nRun `usage_email.py --check-config` to validate, "
+          "or `--test-send` to send a test now.")
+    return 0
+
+
+def cmd_check_config() -> int:
+    cfg = load_email_config()
+    print(json.dumps(cfg, indent=2))
+    if not cfg.get("enabled"):
+        print(f"\nstatus: DISABLED (no/invalid {CONFIG_PATH}) — weekly job writes a local report only.")
+        return 0
+    account = cfg.get("account") or {}
+    creds = account.get("creds")
+    cp = Path(creds).expanduser() if creds else None
+    print(f"\ntransport: {account.get('type')}  sender: {account.get('sender')}")
+    print(f"recipient: {cfg.get('recipient')}")
+    print(f"creds:     {cp} {'(present)' if cp and cp.exists() else '(MISSING)'}")
+    print(f"python:    {_python_bin()}")
+    return 0
+
+
+def cmd_test_send() -> int:
+    cfg = load_email_config()
+    now = datetime.now(timezone.utc)
+    code, _ = send_weekly(
+        md_summary=f"cost-telemetry test send at {now.isoformat()}",
+        html_path=None, state={}, host="test", config=cfg, now=now,
+    )
+    msg = {SENT_OR_SKIP: "sent (or already sent this week)", DISABLED: "disabled/not configured",
+           SEND_FAILED: "send FAILED"}.get(code, str(code))
+    print(f"test-send: {msg} (exit {code})")
+    return 0 if code == SENT_OR_SKIP else code
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(prog="usage_email", description=__doc__.splitlines()[0])
+    g = ap.add_mutually_exclusive_group(required=True)
+    g.add_argument("--configure", action="store_true", help="interactively write this machine's email config")
+    g.add_argument("--check-config", action="store_true", help="print the resolved config + transport (no send)")
+    g.add_argument("--test-send", action="store_true", help="send a one-off test email via the configured transport")
+    args = ap.parse_args(argv)
+    if args.configure:
+        return cmd_configure()
+    if args.check_config:
+        return cmd_check_config()
+    return cmd_test_send()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/claude-config/scripts/usage_email.py
+++ b/claude-config/scripts/usage_email.py
@@ -31,12 +31,15 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import subprocess
 import sys
+import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
 
 CONFIG_PATH = Path.home() / ".claude" / "cost-telemetry" / "email.json"
+SEND_TIMEOUT = 120  # seconds — a hung helper must never block the weekly cadence
 VENV_PY = Path.home() / "agents" / ".venv" / "bin" / "python"
 GMAIL_HELPER = Path.home() / "agents" / "google" / "send_mail.py"
 M365_HELPER = Path.home() / "agents" / "m365" / "send_mail.py"
@@ -76,37 +79,63 @@ def load_email_config(path: Path | None = None) -> dict:
     return cfg
 
 
-def _helper_argv(account: dict, *, recipient: str, subject: str, body: str, html_path) -> list[str] | None:
-    """Build the send-helper argv for the account type, or None if unsendable."""
+def _helper_argv(account: dict, *, recipient: str, subject: str, html_path, body_file=None) -> list[str] | None:
+    """Build the send-helper argv for the account type, or None if unsendable.
+
+    The report body is delivered out-of-band — gmail via stdin (`--body -`),
+    m365 via `--body-file` — so the cost report never appears in process argv
+    (visible to `ps`). Recipient/subject are non-sensitive metadata.
+    """
     atype = (account or {}).get("type", "none")
     creds = (account or {}).get("creds")
     creds = str(Path(creds).expanduser()) if creds else None
     if atype == "gmail":
-        cmd = [_python_bin(), str(GMAIL_HELPER), "--to", recipient, "--subject", subject, "--body", body]
+        cmd = [_python_bin(), str(GMAIL_HELPER), "--to", recipient, "--subject", subject, "--body", "-"]
         if creds:
             cmd += ["--token", creds]
-        if html_path:
-            cmd += ["--attach", str(html_path)]
-        return cmd
-    if atype == "m365":
-        cmd = [_python_bin(), str(M365_HELPER), "--to", recipient, "--subject", subject, "--body", body]
+    elif atype == "m365":
+        cmd = [_python_bin(), str(M365_HELPER), "--to", recipient, "--subject", subject,
+               "--body-file", body_file or "-"]
         if creds:
             cmd += ["--creds", creds]
-        if html_path:
-            cmd += ["--attach", str(html_path)]
-        return cmd
-    return None  # 'none' / unknown
+    else:
+        return None  # 'none' / unknown
+    if html_path:
+        cmd += ["--attach", str(html_path)]
+    return cmd
+
+
+def _run(cmd: list[str], *, input_text: str | None = None) -> None:
+    """Run a send helper with a timeout; raise on non-zero (type+code only, no stdout)."""
+    r = subprocess.run(cmd, capture_output=True, text=True, input=input_text, timeout=SEND_TIMEOUT)
+    if r.returncode != 0:
+        raise RuntimeError(f"send helper failed (exit {r.returncode})")
 
 
 def _default_send(*, account: dict, recipient: str, subject: str, body: str, html_path) -> None:
-    """Real send via the configured transport helper. Raises on failure."""
-    cmd = _helper_argv(account, recipient=recipient, subject=subject, body=body, html_path=html_path)
-    if cmd is None:
-        raise RuntimeError(f"no transport for account type {account.get('type')!r}")
-    r = subprocess.run(cmd, capture_output=True, text=True)
-    if r.returncode != 0:
-        # Do not echo the helper's stdout (may contain addresses); type + code only.
-        raise RuntimeError(f"send helper failed (exit {r.returncode})")
+    """Real send via the configured transport. Body goes via stdin (gmail) or a
+    chmod-600 temp file (m365) — never argv. Raises on failure/timeout."""
+    atype = (account or {}).get("type", "none")
+    if atype == "gmail":
+        cmd = _helper_argv(account, recipient=recipient, subject=subject, html_path=html_path)
+        _run(cmd, input_text=body)
+        return
+    if atype == "m365":
+        fd, body_file = tempfile.mkstemp(suffix=".md")
+        try:
+            os.fchmod(fd, 0o600)
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                fh.write(body)
+            cmd = _helper_argv(account, recipient=recipient, subject=subject,
+                               html_path=html_path, body_file=body_file)
+            _run(cmd)
+        finally:
+            try:
+                os.unlink(body_file)
+            except OSError:
+                pass
+        return
+    raise RuntimeError(f"no transport for account type {atype!r}")
 
 
 def send_weekly(

--- a/claude-config/tests/test_usage_email.py
+++ b/claude-config/tests/test_usage_email.py
@@ -114,26 +114,28 @@ def test_load_config_valid(tmp_path):
 
 # ---- transport argv resolution -------------------------------------------
 
-def test_helper_argv_gmail_uses_token_flag():
+def test_helper_argv_gmail_uses_token_and_stdin_body():
     cmd = E._helper_argv(
         {"type": "gmail", "creds": "~/agents/google/token.json"},
-        recipient="me@gmail.com", subject="s", body="b", html_path="/tmp/r.html",
+        recipient="me@gmail.com", subject="s", html_path="/tmp/r.html",
     )
     assert str(E.GMAIL_HELPER) in cmd
     assert "--token" in cmd and "--to" in cmd and "--attach" in cmd
     assert "--creds" not in cmd
+    assert cmd[cmd.index("--body") + 1] == "-"      # body via stdin, not argv
 
 
-def test_helper_argv_m365_uses_creds_flag():
+def test_helper_argv_m365_uses_creds_and_bodyfile():
     cmd = E._helper_argv(
         {"type": "m365", "creds": "~/.claude/m365/agent.json"},
-        recipient="x@vital.com", subject="s", body="b", html_path=None,
+        recipient="x@vital.com", subject="s", html_path=None, body_file="/tmp/body.md",
     )
     assert str(E.M365_HELPER) in cmd
     assert "--creds" in cmd and "--token" not in cmd
-    assert "--attach" not in cmd  # no html → no attach
+    assert "--attach" not in cmd                     # no html → no attach
+    assert cmd[cmd.index("--body-file") + 1] == "/tmp/body.md"  # body via file, not argv
 
 
 def test_helper_argv_none_is_unsendable():
-    assert E._helper_argv({"type": "none"}, recipient="x", subject="s", body="b", html_path=None) is None
-    assert E._helper_argv({}, recipient="x", subject="s", body="b", html_path=None) is None
+    assert E._helper_argv({"type": "none"}, recipient="x", subject="s", html_path=None) is None
+    assert E._helper_argv({}, recipient="x", subject="s", html_path=None) is None

--- a/claude-config/tests/test_usage_email.py
+++ b/claude-config/tests/test_usage_email.py
@@ -1,8 +1,10 @@
-"""Acceptance tests for issue #326 — weekly email delivery (cost-telemetry-v0 §D5).
+"""Tests for the per-machine email config + transport layer (usage_email).
 
-No live send: the M365 helper is mocked via the injectable send_fn. Activation/first real send is deferred.
+No live send: the transport is mocked via the injectable send_fn. Config is
+passed explicitly (or via a temp file) so tests never touch the real machine config.
 """
 
+import json
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -12,6 +14,11 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
 import usage_email as E  # noqa: E402
 
 NOW = datetime(2026, 6, 8, 12, 0, tzinfo=timezone.utc)
+GMAIL_CFG = {
+    "enabled": True,
+    "account": {"type": "gmail", "sender": "me@gmail.com", "creds": "~/agents/google/token.json"},
+    "recipient": "me@gmail.com",
+}
 
 
 def _recorder():
@@ -23,19 +30,18 @@ def _recorder():
     return calls, send_fn
 
 
-def test_first_send_of_week_calls_sender_and_updates_state():
+# ---- send_weekly contract -------------------------------------------------
+
+def test_first_send_of_week_calls_transport_and_updates_state():
     calls, send_fn = _recorder()
     code, state = E.send_weekly(
-        md_summary="# report",
-        html_path="/tmp/r.html",
-        state={},
-        host="jns-mac",
-        now=NOW,
-        send_fn=send_fn,
+        md_summary="# report", html_path="/tmp/r.html", state={}, host="jns-mac",
+        config=GMAIL_CFG, now=NOW, send_fn=send_fn,
     )
-    assert code == 0
+    assert code == E.SENT_OR_SKIP
     assert len(calls) == 1
-    assert calls[0]["recipient"] == E.SENDER  # never overrides sender
+    assert calls[0]["recipient"] == "me@gmail.com"        # from config
+    assert calls[0]["account"]["type"] == "gmail"          # transport passed through
     assert calls[0]["html_path"] == "/tmp/r.html"
     assert calls[0]["body"] == "# report"
     assert "jns-mac" in calls[0]["subject"]
@@ -46,60 +52,88 @@ def test_idempotent_no_double_send_same_week():
     calls, send_fn = _recorder()
     prior = {"last_email_sent_week": E._week_key(NOW)}
     code, state = E.send_weekly(
-        md_summary="x",
-        html_path=None,
-        state=prior,
-        host="h",
-        now=NOW,
-        send_fn=send_fn,
+        md_summary="x", html_path=None, state=prior, host="h",
+        config=GMAIL_CFG, now=NOW, send_fn=send_fn,
     )
-    assert code == 0
-    assert calls == []  # NOT called — already sent this week
-    assert state == prior
-
-
-def test_send_failure_returns_4_and_does_not_advance_state():
-    def boom(**kw):
-        raise RuntimeError("graph down")
-
-    code, state = E.send_weekly(
-        md_summary="x",
-        html_path=None,
-        state={},
-        host="h",
-        now=NOW,
-        send_fn=boom,
-    )
-    assert code == 4
-    assert "last_email_sent_week" not in state  # not advanced → retried next run
+    assert code == E.SENT_OR_SKIP and calls == [] and state == prior
 
 
 def test_next_week_sends_again():
     calls, send_fn = _recorder()
-    later = datetime(2026, 6, 16, 12, 0, tzinfo=timezone.utc)  # a different ISO week
+    later = datetime(2026, 6, 16, 12, 0, tzinfo=timezone.utc)
     prior = {"last_email_sent_week": E._week_key(NOW)}
     code, state = E.send_weekly(
-        md_summary="x",
-        html_path=None,
-        state=prior,
-        host="h",
-        now=later,
-        send_fn=send_fn,
+        md_summary="x", html_path=None, state=prior, host="h",
+        config=GMAIL_CFG, now=later, send_fn=send_fn,
     )
-    assert code == 0 and len(calls) == 1
+    assert code == E.SENT_OR_SKIP and len(calls) == 1
     assert state["last_email_sent_week"] == E._week_key(later)
 
 
-def test_refuses_nonstandard_recipient_unless_opted_in():
-    # #339: the report carries internal cost data — refuse any non-SENDER recipient by default.
+def test_send_failure_returns_4_and_does_not_advance_state():
+    def boom(**kw):
+        raise RuntimeError("transport down")
+    code, state = E.send_weekly(
+        md_summary="x", html_path=None, state={}, host="h",
+        config=GMAIL_CFG, now=NOW, send_fn=boom,
+    )
+    assert code == E.SEND_FAILED and "last_email_sent_week" not in state
+
+
+def test_disabled_config_does_not_send():
     calls, send_fn = _recorder()
-    code, _ = E.send_weekly(
-        md_summary="x", html_path=None, state={}, host="h",
-        recipient="evil@example.com", now=NOW, send_fn=send_fn,
+    for cfg in ({"enabled": False}, {"enabled": True, "recipient": "", "account": {"type": "gmail"}},
+                {"enabled": True, "recipient": "x@y.z", "account": {"type": "none"}}):
+        code, state = E.send_weekly(
+            md_summary="x", html_path=None, state={}, host="h",
+            config=cfg, now=NOW, send_fn=send_fn,
+        )
+        assert code == E.DISABLED, cfg
+    assert calls == []  # nothing sent in any disabled shape
+
+
+# ---- config loader --------------------------------------------------------
+
+def test_load_config_absent_is_disabled(tmp_path):
+    assert E.load_email_config(tmp_path / "nope.json") == {"enabled": False}
+
+
+def test_load_config_malformed_is_disabled(tmp_path):
+    p = tmp_path / "email.json"
+    p.write_text("{not json")
+    assert E.load_email_config(p) == {"enabled": False}
+
+
+def test_load_config_valid(tmp_path):
+    p = tmp_path / "email.json"
+    p.write_text(json.dumps(GMAIL_CFG))
+    cfg = E.load_email_config(p)
+    assert cfg["enabled"] and cfg["recipient"] == "me@gmail.com"
+    assert cfg["account"]["type"] == "gmail"
+
+
+# ---- transport argv resolution -------------------------------------------
+
+def test_helper_argv_gmail_uses_token_flag():
+    cmd = E._helper_argv(
+        {"type": "gmail", "creds": "~/agents/google/token.json"},
+        recipient="me@gmail.com", subject="s", body="b", html_path="/tmp/r.html",
     )
-    assert code == 4 and calls == []  # refused, nothing sent
-    code2, _ = E.send_weekly(
-        md_summary="x", html_path=None, state={}, host="h",
-        recipient="evil@example.com", allow_nonstandard_recipient=True, now=NOW, send_fn=send_fn,
+    assert str(E.GMAIL_HELPER) in cmd
+    assert "--token" in cmd and "--to" in cmd and "--attach" in cmd
+    assert "--creds" not in cmd
+
+
+def test_helper_argv_m365_uses_creds_flag():
+    cmd = E._helper_argv(
+        {"type": "m365", "creds": "~/.claude/m365/agent.json"},
+        recipient="x@vital.com", subject="s", body="b", html_path=None,
     )
-    assert code2 == 0 and len(calls) == 1  # explicit dev opt-in allows it
+    assert str(E.M365_HELPER) in cmd
+    assert "--creds" in cmd and "--token" not in cmd
+    assert "--attach" not in cmd  # no html → no attach
+
+
+def test_helper_argv_none_is_unsendable():
+    assert E._helper_argv({"type": "none"}, recipient="x", subject="s", body="b", html_path=None) is None
+    assert E._helper_argv({}, recipient="x", subject="s", body="b", html_path=None) is None

--- a/google/send_mail.py
+++ b/google/send_mail.py
@@ -26,11 +26,15 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 from auth import load_credentials  # noqa: E402
 
 
-def send_mail(to, subject, body, attach=None, cc=None, bcc=None):
-    """Send one email; returns (sender_address, message_id)."""
+def send_mail(to, subject, body, attach=None, cc=None, bcc=None, token_path=None):
+    """Send one email; returns (sender_address, message_id).
+
+    token_path selects which Google account to send as (default: the shared
+    google/token.json). Lets callers pick a specific account per machine.
+    """
     from googleapiclient.discovery import build
 
-    creds = load_credentials()
+    creds = load_credentials(token_path) if token_path else load_credentials()
     svc = build("gmail", "v1", credentials=creds)
 
     msg = EmailMessage()
@@ -74,10 +78,14 @@ def main() -> None:
     ap.add_argument(
         "--attach", action="append", default=[], help="file path (repeatable)"
     )
+    ap.add_argument(
+        "--token",
+        help="path to a Google token.json (default: shared google/token.json) — selects the send account",
+    )
     a = ap.parse_args()
 
     body = sys.stdin.read() if a.body == "-" else a.body
-    sender, mid = send_mail(a.to, a.subject, body, a.attach, a.cc, a.bcc)
+    sender, mid = send_mail(a.to, a.subject, body, a.attach, a.cc, a.bcc, token_path=a.token)
     print(f"SENT from {sender} -> {', '.join(a.to)} (id {mid})")
 
 

--- a/m365/send_mail.py
+++ b/m365/send_mail.py
@@ -63,7 +63,7 @@ def load_creds(creds_path: Path = CREDS_PATH) -> dict:
     required = {"tenant_id", "client_id", "client_secret", "sender_upn"}
     missing = required - creds.keys()
     if missing:
-        raise SendMailError(f"{CREDS_PATH} missing fields: {sorted(missing)}")
+        raise SendMailError(f"{creds_path} missing fields: {sorted(missing)}")
     return creds
 
 

--- a/m365/send_mail.py
+++ b/m365/send_mail.py
@@ -46,18 +46,19 @@ class SendMailError(Exception):
     """Raised when Graph rejects the send."""
 
 
-def load_creds() -> dict:
-    if not CREDS_PATH.exists():
+def load_creds(creds_path: Path = CREDS_PATH) -> dict:
+    creds_path = Path(creds_path).expanduser()
+    if not creds_path.exists():
         raise SendMailError(
-            f"Missing credentials at {CREDS_PATH}. Drop the JSON with "
+            f"Missing credentials at {creds_path}. Drop the JSON with "
             "tenant_id / client_id / client_secret / sender_upn fields "
             "and chmod 600. See ~/.claude/CLAUDE.md for the M365 section."
         )
-    if (CREDS_PATH.stat().st_mode & 0o077) != 0:
+    if (creds_path.stat().st_mode & 0o077) != 0:
         raise SendMailError(
-            f"{CREDS_PATH} has loose permissions; run `chmod 600 {CREDS_PATH}`."
+            f"{creds_path} has loose permissions; run `chmod 600 {creds_path}`."
         )
-    with CREDS_PATH.open() as f:
+    with creds_path.open() as f:
         creds = json.load(f)
     required = {"tenant_id", "client_id", "client_secret", "sender_upn"}
     missing = required - creds.keys()
@@ -162,9 +163,10 @@ def send_mail(
     content_type: str = "Text",
     attach: list[Path] | None = None,
     unblock_recipient: list[str] | None = None,
+    creds_path: Path = CREDS_PATH,
 ) -> None:
     check_blocked_recipients(to=to, cc=cc or [], unblocked=unblock_recipient or [])
-    creds = load_creds()
+    creds = load_creds(creds_path)
     token = get_token(creds)
     attachments = build_attachments(attach or [])
     payload = build_message(
@@ -192,6 +194,10 @@ def parse_args() -> argparse.Namespace:
     p = argparse.ArgumentParser(description=__doc__)
     p.add_argument("--to", required=True, help="Comma-separated recipients")
     p.add_argument("--cc", default="", help="Comma-separated cc addresses")
+    p.add_argument(
+        "--creds",
+        help=f"path to M365 creds JSON (default: {CREDS_PATH}) — selects the send account",
+    )
     p.add_argument("--subject", required=True)
     body_group = p.add_mutually_exclusive_group(required=True)
     body_group.add_argument("--body", help="Inline body text")
@@ -236,6 +242,7 @@ def main() -> int:
             content_type=args.content_type,
             attach=attach,
             unblock_recipient=args.unblock_recipient,
+            creds_path=Path(args.creds) if args.creds else CREDS_PATH,
         )
     except SendMailError as e:
         print(f"send_mail: {e}", file=sys.stderr)


### PR DESCRIPTION
## Summary

The weekly cost-report email was hardcoded to `jjob@vital-enterprises.com` via M365 only — it couldn't work across machines (this personal laptop sends as `jasonwadejob@gmail.com`; the work laptop as `jjob@vital-enterprises.com`). This makes the **send account configurable per computer**: account **type** (`gmail` | `m365` | `none`) + **sender** + **recipient**, from a machine-local config the repo never commits.

## Changes
- **`usage_email.py`** — config-driven. `load_email_config()` reads `~/.claude/cost-telemetry/email.json` (fail-safe: absent/disabled → no send). Transport registry selects the helper by `account.type`; recipient + creds come from config. New CLI: **`--configure`** (guided), **`--check-config`**, **`--test-send`**. The machine-local (gitignored) config is the authorization; each transport helper still enforces its own recipient safety (M365 keeps its gmail block as a backstop).
- **`google/send_mail.py` (`--token`)** + **`m365/send_mail.py` (`--creds`)** — optional creds path so the config selects which account to send from. Backward-compatible (defaults unchanged).
- **`cost_report_weekly.py`** — weekly glue: `read_shards → aggregate → write_report` (local html+md) → `send_weekly`. **Always** writes the local report; emails on top only if configured. Never blocks.
- **`com.cost-telemetry-report-weekly.plist`** — Mon 09:05, aligned with the memory launchd jobs.
- **`cost-telemetry-email.example.json`** + `launchd/README.md` — per-machine setup docs.
- **`test_usage_email.py`** — rewritten for the config/transport contract.

## Account types
| type | sends as | creds (default, configurable) |
|---|---|---|
| `gmail` | the token's Google account | `~/agents/google/token.json` |
| `m365` | the creds' `sender_upn` | `~/.claude/m365/agent.json` |
| `none` | — (local report only) | — |

## Test Plan
- **62 tests green** (`test_usage_email` rewritten to 11 + report/aggregator unaffected); `py_compile` + `plutil -lint` pass.
- **End-to-end on this laptop:** wrote gmail config → `--check-config` resolves (transport gmail, creds present) → `--test-send` **delivered** to `jasonwadejob@gmail.com`.
- **Weekly glue:** built a local report from 66k records → `~/.claude/cost-reports/cost-report-jns-mac-2026-W24.{html,md}`; with no email config it correctly fell back to **local-only, exit 0**.

## Per-machine setup (each computer)
```bash
python3 ~/agents/claude-config/scripts/usage_email.py --configure   # type + sender + recipient
python3 ~/agents/claude-config/scripts/usage_email.py --check-config
```
Then load `com.cost-telemetry-report-weekly.plist` (see `launchd/README.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)