### PR TITLE
fix(telemetry): use portable path for cost-telemetry freshness hook

### DIFF
--- a/claude-config/settings.json
+++ b/claude-config/settings.json
@@ -86,7 +86,7 @@
           },
           {
             "type": "command",
-            "command": "python3 /Users/jasonjob/agents/claude-config/scripts/cost_telemetry_freshness.py --hook"
+            "command": "python3 ~/agents/claude-config/scripts/cost_telemetry_freshness.py --hook"
           }
         ]
       }


### PR DESCRIPTION
## Summary

The SessionStart `cost_telemetry_freshness.py` hook in `settings.json` hardcoded an absolute macOS path:

```
python3 /Users/jasonjob/agents/claude-config/scripts/cost_telemetry_freshness.py --hook
```

That path only exists on the macOS machine. On the WSL laptop (`/home/jjob`) and jbox06 the hook fails every SessionStart. Every other hook in this file uses a `~`-relative path; this one was missed. Switch to:

```
python3 ~/agents/claude-config/scripts/cost_telemetry_freshness.py --hook
```

`~` expands per-machine (`/home/jjob`, `/Users/jasonjob`, jbox06 `~/agents`), so it resolves everywhere. `scripts/` is not symlinked into `~/.claude`, so `~/agents/claude-config/scripts/...` is the correct portable reference (not `~/.claude/scripts`).

## Test Plan

- `python3 -c "import json; json.load(open('claude-config/settings.json'))"` → JSON valid
- Ran the exact hook command on the WSL machine → exit 0 (emits the expected "collector has never run" warning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)