### PR TITLE
chore(config): commit fullscreen TUI + skip workflow-usage warning prefs

### DIFF
--- a/claude-config/settings.json
+++ b/claude-config/settings.json
@@ -153,5 +153,7 @@
     }
   },
   "skipDangerousModePermissionPrompt": true,
-  "theme": "dark"
+  "skipWorkflowUsageWarning": true,
+  "theme": "dark",
+  "tui": "fullscreen"
 }


### PR DESCRIPTION
## Summary

Two settings were carried as a **local-only uncommitted diff** on the WSL machine:

- `tui: "fullscreen"`
- `skipWorkflowUsageWarning: true`

Because they lived only in the working tree, every `git pull` that touched `settings.json` aborted with a merge conflict and needed manual reconciliation. Committing them removes that recurring friction and applies them on all machines.

## Test Plan

- `python3 -c "import json; json.load(open('claude-config/settings.json'))"` → JSON valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)