### PR TITLE
fix(learn): resolve claude CLI explicitly + dead-man's-switch alert

### DIFF
--- a/claude-config/scripts/learn-gate-poller.sh
+++ b/claude-config/scripts/learn-gate-poller.sh
@@ -8,6 +8,10 @@
 # Responsibilities (each best-effort, none aborts the others):
 #   1. Sync the agents repo — ff-only pull of code/config updates.
 #   2. Run the learn gate; if it trips, apply cross-project patterns via /learn.
+#   3. Dead-man's switch (#359): every outcome arms or clears
+#      learn_deadman.py, which emails an alert if the gate stays tripped
+#      >7 days without a successful /learn run. The loop must never fail
+#      silently again.
 #
 # Win C (the perpetually-dirty tree caused by telemetry/<host>/*.jsonl shards)
 # is RESOLVED: shards are gitignored and local-only (REC 0.1's OTEL hub, the
@@ -23,6 +27,31 @@ mkdir -p "$(dirname "$LOG")"
 ts()  { date -Iseconds; }
 log() { echo "[$(ts)] $*" >>"$LOG"; }
 
+deadman() {  # trip|clear — best-effort, never blocks the poller
+    python3 "$REPO/claude-config/scripts/learn_deadman.py" "$1" >>"$LOG" 2>&1 \
+        || log "deadman $1 failed (non-fatal)"
+}
+
+# Resolve the claude CLI explicitly: launchd's PATH (even via `bash -lc`) does
+# not reliably include user install dirs — the loop was dead for months on
+# `claude: command not found` (#359). Never invoke bare `claude` here.
+resolve_claude() {
+    local candidate
+    if candidate="$(command -v claude 2>/dev/null)"; then
+        echo "$candidate"; return 0
+    fi
+    for candidate in \
+        "$HOME/.local/bin/claude" \
+        "$HOME/.claude/local/claude" \
+        /opt/homebrew/bin/claude \
+        /usr/local/bin/claude; do
+        if [ -x "$candidate" ]; then
+            echo "$candidate"; return 0
+        fi
+    done
+    return 1
+}
+
 cd "$REPO" || { log "FATAL: $REPO missing — aborting poller run"; exit 0; }
 
 # 1. Sync. ff-only preserves the existing safe semantics and tolerates a dirty
@@ -31,10 +60,21 @@ git pull --ff-only --quiet 2>>"$LOG" || log "pull --ff-only failed (non-fatal)"
 
 # 2. Gate, then learn only if the gate trips (matches the former inline behaviour).
 if python3 claude-config/scripts/telemetry_gate.py --verbose >>"$LOG" 2>&1; then
-    claude --print "/learn --apply --cross-project --validate" >>"$LOG" 2>&1 \
-        || log "/learn run failed (non-fatal)"
+    if CLAUDE_BIN="$(resolve_claude)"; then
+        if "$CLAUDE_BIN" --print "/learn --apply --cross-project --validate" >>"$LOG" 2>&1; then
+            log "/learn run succeeded"
+            deadman clear
+        else
+            log "/learn invocation FAILED (exit $?) — gate remains tripped"
+            deadman trip
+        fi
+    else
+        log "FATAL: claude CLI not found (checked PATH, ~/.local/bin, ~/.claude/local, /opt/homebrew/bin, /usr/local/bin)"
+        deadman trip
+    fi
 else
     log "learn gate not tripped — skip /learn"
+    deadman clear
 fi
 
 log "poller run complete"

--- a/claude-config/scripts/learn_deadman.py
+++ b/claude-config/scripts/learn_deadman.py
@@ -1,0 +1,186 @@
+"""Dead-man's switch for the learn loop (issue #359).
+
+The learn-gate poller silently failed for months (`claude: command not found`
+under launchd; before that, dirty-tree pull failures) while the gate sat
+tripped with 40+ unconsumed failures. Nothing alerted. This module makes that
+state loud: if the gate has been tripped for more than ALERT_AFTER_DAYS
+without a successful /learn run, send an email via the machine-local
+transport config (~/.claude/cost-telemetry/email.json, shared with the weekly
+cost report — #355). No config -> log-only, never raises, never blocks the
+poller.
+
+State (machine-local, not committed): ~/.claude/learn-gate-deadman.json
+  { "tripped_since": iso8601|null, "last_alert_at": iso8601|null }
+
+CLI (called from learn-gate-poller.sh):
+  learn_deadman.py trip    gate tripped but /learn did NOT complete this run
+  learn_deadman.py clear   /learn succeeded (or gate is no longer tripped)
+  learn_deadman.py status  print state as JSON
+
+Stdlib-only so it runs under launchd's /usr/bin/python3. Email transport is
+reused from usage_email (also stdlib-only).
+"""
+
+from __future__ import annotations
+
+import json
+import socket
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from usage_email import _default_send, load_email_config  # noqa: E402
+
+STATE_PATH = Path.home() / ".claude" / "learn-gate-deadman.json"
+ALERT_AFTER_DAYS = 7   # tripped this long without a successful learn -> alert
+RATE_LIMIT_DAYS = 3    # at most one email per this many days
+
+
+class DeadmanStateError(Exception):
+    """State file exists but cannot be parsed (corrupt JSON / wrong shape)."""
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _host() -> str:
+    name_file = Path.home() / ".claude" / "host-name"
+    try:
+        text = name_file.read_text(encoding="utf-8").strip()
+        if text:
+            return text
+    except OSError:
+        pass
+    return socket.gethostname()
+
+
+def load_state(path: Path | None = None) -> dict:
+    """Read deadman state. Missing file -> fresh state. Corrupt file -> fresh
+    state too (the deadman must never crash the poller), but the caller can
+    distinguish via DeadmanStateError if it asks."""
+    path = path or STATE_PATH
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError:
+        return {"tripped_since": None, "last_alert_at": None}
+    try:
+        state = json.loads(raw)
+        if not isinstance(state, dict):
+            raise DeadmanStateError(f"state is {type(state).__name__}, expected object")
+    except (ValueError, DeadmanStateError):
+        return {"tripped_since": None, "last_alert_at": None}
+    state.setdefault("tripped_since", None)
+    state.setdefault("last_alert_at", None)
+    return state
+
+
+def save_state(state: dict, path: Path | None = None) -> None:
+    path = path or STATE_PATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(state, indent=2) + "\n", encoding="utf-8")
+
+
+def _parse_iso(ts: str | None) -> datetime | None:
+    if not ts:
+        return None
+    try:
+        dt = datetime.fromisoformat(ts)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def _alert_body(tripped_since: datetime, now: datetime, host: str) -> str:
+    days = (now - tripped_since).days
+    return (
+        f"# Learn-loop dead-man alert — {host}\n\n"
+        f"The learn gate has been TRIPPED for **{days} days** "
+        f"(since {tripped_since.isoformat()}) without a successful /learn run.\n\n"
+        "The self-learning loop is not consuming failures. Likely causes:\n"
+        "- `claude` CLI not resolvable from the launchd environment\n"
+        "- repo pull failing (dirty tree / auth)\n"
+        "- /learn run crashing\n\n"
+        "Check: `tail -50 ~/Library/Logs/claude-learn/poller.log`\n"
+        "Then run manually: `claude --print '/learn --apply --cross-project --validate'`\n"
+    )
+
+
+def trip(
+    *,
+    now: datetime | None = None,
+    state_path: Path | None = None,
+    config: dict | None = None,
+    send_fn=None,
+) -> str:
+    """Record a tripped-but-unconsumed gate; alert if it has been stuck too
+    long. Returns a one-line status for the poller log. Never raises."""
+    now = now or _utc_now()
+    state = load_state(state_path)
+
+    tripped_since = _parse_iso(state["tripped_since"])
+    if tripped_since is None:
+        tripped_since = now
+        state["tripped_since"] = now.isoformat()
+        save_state(state, state_path)
+        return f"deadman: armed (tripped_since={now.isoformat()})"
+
+    stuck_for = now - tripped_since
+    if stuck_for < timedelta(days=ALERT_AFTER_DAYS):
+        return f"deadman: armed, stuck {stuck_for.days}d (<{ALERT_AFTER_DAYS}d, no alert)"
+
+    last_alert = _parse_iso(state["last_alert_at"])
+    if last_alert is not None and (now - last_alert) < timedelta(days=RATE_LIMIT_DAYS):
+        return f"deadman: stuck {stuck_for.days}d, alert rate-limited (last {last_alert.isoformat()})"
+
+    config = config if config is not None else load_email_config()
+    recipient = (config.get("recipient") or "").strip()
+    account = config.get("account") or {}
+    host = _host()
+    if not config.get("enabled") or not recipient or account.get("type") in (None, "none"):
+        return f"deadman: stuck {stuck_for.days}d, NO EMAIL CONFIG — alert is log-only"
+
+    subject = f"[learn-loop] DEAD-MAN ALERT: gate tripped {stuck_for.days}d on {host}"
+    body = _alert_body(tripped_since, now, host)
+    send = send_fn or _default_send
+    try:
+        send(account=account, recipient=recipient, subject=subject, body=body, html_path=None)
+    except (RuntimeError, OSError, ValueError, subprocess.TimeoutExpired) as exc:
+        return f"deadman: stuck {stuck_for.days}d, alert send FAILED ({type(exc).__name__})"
+    state["last_alert_at"] = now.isoformat()
+    save_state(state, state_path)
+    return f"deadman: stuck {stuck_for.days}d, alert EMAILED to {recipient}"
+
+
+def clear(*, state_path: Path | None = None) -> str:
+    """Learn succeeded (or gate untripped): disarm. Never raises."""
+    state = load_state(state_path)
+    was_armed = state["tripped_since"] is not None
+    if was_armed:
+        save_state({"tripped_since": None, "last_alert_at": None}, state_path)
+        return "deadman: cleared (learn loop healthy again)"
+    return "deadman: idle"
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = sys.argv[1:] if argv is None else argv
+    cmd = argv[0] if argv else "status"
+    if cmd == "trip":
+        print(trip())
+    elif cmd == "clear":
+        print(clear())
+    elif cmd == "status":
+        print(json.dumps(load_state(), indent=2))
+    else:
+        print(f"usage: learn_deadman.py trip|clear|status (got {cmd!r})", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/claude-config/tests/test_learn_deadman.py
+++ b/claude-config/tests/test_learn_deadman.py
@@ -1,0 +1,132 @@
+"""Tests for the learn-loop dead-man's switch (issue #359).
+
+No live sends: send_fn is injected. State path and clock are injected so tests
+never touch the real machine state.
+"""
+
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+import learn_deadman as D  # noqa: E402
+
+NOW = datetime(2026, 6, 9, 12, 0, tzinfo=timezone.utc)
+CFG = {
+    "enabled": True,
+    "account": {"type": "gmail", "sender": "me@gmail.com", "creds": "~/x/token.json"},
+    "recipient": "me@gmail.com",
+}
+NO_CFG = {"enabled": False}
+
+
+def _recorder():
+    calls = []
+
+    def send(**kwargs):
+        calls.append(kwargs)
+
+    return calls, send
+
+
+def _state(tmp_path, **kw):
+    p = tmp_path / "deadman.json"
+    if kw:
+        p.write_text(json.dumps(kw), encoding="utf-8")
+    return p
+
+
+def test_first_trip_arms_without_alert(tmp_path):
+    calls, send = _recorder()
+    p = _state(tmp_path)
+    msg = D.trip(now=NOW, state_path=p, config=CFG, send_fn=send)
+    assert "armed" in msg
+    assert calls == []
+    assert json.loads(p.read_text())["tripped_since"] == NOW.isoformat()
+
+
+def test_stuck_under_threshold_no_alert(tmp_path):
+    calls, send = _recorder()
+    p = _state(tmp_path, tripped_since=(NOW - timedelta(days=3)).isoformat())
+    msg = D.trip(now=NOW, state_path=p, config=CFG, send_fn=send)
+    assert "no alert" in msg
+    assert calls == []
+
+
+def test_stuck_past_threshold_sends_alert(tmp_path):
+    calls, send = _recorder()
+    p = _state(tmp_path, tripped_since=(NOW - timedelta(days=8)).isoformat())
+    msg = D.trip(now=NOW, state_path=p, config=CFG, send_fn=send)
+    assert "EMAILED" in msg
+    assert len(calls) == 1
+    assert "DEAD-MAN ALERT" in calls[0]["subject"]
+    assert "8 days" in calls[0]["body"]
+    assert json.loads(p.read_text())["last_alert_at"] == NOW.isoformat()
+
+
+def test_alert_rate_limited(tmp_path):
+    calls, send = _recorder()
+    p = _state(
+        tmp_path,
+        tripped_since=(NOW - timedelta(days=10)).isoformat(),
+        last_alert_at=(NOW - timedelta(days=1)).isoformat(),
+    )
+    msg = D.trip(now=NOW, state_path=p, config=CFG, send_fn=send)
+    assert "rate-limited" in msg
+    assert calls == []
+
+
+def test_alert_fires_again_after_rate_limit_window(tmp_path):
+    calls, send = _recorder()
+    p = _state(
+        tmp_path,
+        tripped_since=(NOW - timedelta(days=10)).isoformat(),
+        last_alert_at=(NOW - timedelta(days=4)).isoformat(),
+    )
+    msg = D.trip(now=NOW, state_path=p, config=CFG, send_fn=send)
+    assert "EMAILED" in msg
+    assert len(calls) == 1
+
+
+def test_no_email_config_is_log_only(tmp_path):
+    calls, send = _recorder()
+    p = _state(tmp_path, tripped_since=(NOW - timedelta(days=8)).isoformat())
+    msg = D.trip(now=NOW, state_path=p, config=NO_CFG, send_fn=send)
+    assert "NO EMAIL CONFIG" in msg
+    assert calls == []
+
+
+def test_send_failure_does_not_raise_or_advance_state(tmp_path):
+    def boom(**kwargs):
+        raise RuntimeError("send helper failed (exit 1)")
+
+    p = _state(tmp_path, tripped_since=(NOW - timedelta(days=8)).isoformat())
+    msg = D.trip(now=NOW, state_path=p, config=CFG, send_fn=boom)
+    assert "FAILED" in msg
+    assert json.loads(p.read_text()).get("last_alert_at") is None  # retry next run
+
+
+def test_clear_disarms(tmp_path):
+    p = _state(tmp_path, tripped_since=NOW.isoformat(), last_alert_at=NOW.isoformat())
+    msg = D.clear(state_path=p)
+    assert "cleared" in msg
+    state = json.loads(p.read_text())
+    assert state["tripped_since"] is None
+    assert state["last_alert_at"] is None
+
+
+def test_clear_when_idle_is_noop(tmp_path):
+    p = _state(tmp_path)
+    assert D.clear(state_path=p) == "deadman: idle"
+    assert not p.exists()  # never written for a no-op
+
+
+def test_corrupt_state_treated_as_fresh(tmp_path):
+    p = tmp_path / "deadman.json"
+    p.write_text("{not json", encoding="utf-8")
+    calls, send = _recorder()
+    msg = D.trip(now=NOW, state_path=p, config=CFG, send_fn=send)
+    assert "armed" in msg
+    assert calls == []


### PR DESCRIPTION
## Summary
- `resolve_claude()` in the poller: checks `command -v` then known install dirs (`~/.local/bin`, `~/.claude/local`, `/opt/homebrew/bin`, `/usr/local/bin`) — never invokes bare `claude` (the cause of months of silent `command not found` failures under launchd)
- New `claude-config/scripts/learn_deadman.py`: if the gate stays tripped >7 days without a successful /learn run, emails an alert via the machine-local transport config (shared with #355's cost report), rate-limited to 1 email per 3 days; log-only when no email is configured; never raises, never blocks the poller
- Poller wires every outcome: learn success / gate-untripped → `clear`; learn failure / claude missing → `trip` with distinct log lines

## Test Plan
- [x] 10 new tests in `test_learn_deadman.py` (arm, threshold, rate-limit, no-config, send-failure, clear, corrupt state) — 385 total pass
- [x] `bash -n` clean; `ruff check` clean
- [x] `resolve_claude` verified under `PATH=/usr/bin:/bin:/usr/sbin:/sbin` → resolves `~/.local/bin/claude`
- [x] Manual trip simulation with 9-day-stuck state → alert sent via injected transport

Closes #359

🤖 Generated with [Claude Code](https://claude.com/claude-code)