### PR TITLE
feat(ship): enforce PROVE verdict as a merge gate

### DIFF
--- a/claude-config/commands/orchestrate.md
+++ b/claude-config/commands/orchestrate.md
@@ -505,6 +505,14 @@ out later) rather than a hardcoded but plausible default that would lie
 about what actually ran. The helpers fail open on IOError; losing one
 metric line never fails the orchestrate run.
 
+**FAIL halts the workflow (#360).** A recorded verdict of `FAIL` or `BLOCKED`
+(including a PASS downgraded by AC-FORBIDS-APPROVE) means the workflow STOPS
+here: report the verdict and the failing ACs, do NOT hand off to `/ship`, do
+NOT merge. The same verdict is independently enforced at merge time by
+`scripts/prove_gate.py` (ship.md Step 7.5), so a FAIL that slips past this
+step is still caught — but the orchestrator should never rely on that
+backstop deliberately. Fix, re-run PATCH/PROVE, and only then ship.
+
 ### Step 5: Report Status
 
 ```

--- a/claude-config/commands/ship.md
+++ b/claude-config/commands/ship.md
@@ -15,6 +15,7 @@ guards that prevent dropped commits, red CI, and broken main.
 ```bash
 /ship           # Full sequence; pauses before merge for confirmation (kill switch)
 /ship --auto    # Same guards; skips confirmation prompt at step 7 (merge tail runs unattended)
+/ship --override-prove "<reason>"   # Bypass a blocking PROVE verdict (recorded, never silent)
 ```
 
 `--auto` is safe only because every prior guard must already have passed. The
@@ -153,6 +154,36 @@ Proceed with squash-merge? [y/N]
 Only continue on explicit `y`. Any other input aborts. With `--auto`, skip
 this prompt — the guards above are the contract that makes auto safe.
 
+### Step 7.5 — PROVE Gate (#360)
+
+A PROVE verdict is enforced, not advisory. Derive the issue number from the
+branch name (`issue-{N}` pattern) and run the mechanical gate:
+
+```bash
+ISSUE=$(git branch --show-current | grep -oE 'issue-[0-9]+' | grep -oE '[0-9]+')
+if [ -n "$ISSUE" ]; then
+  python3 ~/agents/claude-config/scripts/prove_gate.py --issue "$ISSUE"   # exit 0 = proceed
+fi
+```
+
+Exit-code contract (from `prove_gate.py`):
+
+| Exit | Meaning | Action |
+|------|---------|--------|
+| 0 | PASS + clean ac_audit, or issue never orchestrate-tracked | Proceed |
+| 2 | PROVE says FAIL/BLOCKED | **STOP** — fix and re-run PROVE |
+| 3 | PASS but ac_audit has missing/partial (AC-FORBIDS-APPROVE) | **STOP** |
+| 4 | Orchestrate-tracked but PROVE never ran | **STOP** — run PROVE first |
+| 5 | Verdict unreadable (fail-closed) | **STOP** — fix the artifact |
+
+On any non-zero exit: STOP, print the gate's reason line, do NOT merge.
+The only bypass is explicit: `--override-prove "<reason>"` reruns the gate
+with `--override "<reason>"`, which records the bypass to
+`.agents/outputs/prove-overrides.jsonl` and then allows the merge. Never
+bypass silently; never bypass without a reason the user gave.
+
+No issue number in the branch name → the gate is skipped (nothing to gate).
+
 ### Step 8 — Merge
 
 ```bash
@@ -250,6 +281,7 @@ Shipped  PR #N  {pr_url}
 | Red CI | Step 6 | Always |
 | HEAD parity | Step 7 | Always |
 | Kill switch (`y/N`) | Step 7 | Plain `/ship` only |
+| PROVE gate | Step 7.5 | Always (override only via `--override-prove`, recorded) |
 | Post-merge test failure | Step 9 | Always (blocks prune) |
 
 `--auto` bypasses only the kill switch (the `y/N` prompt). All other guards

--- a/claude-config/scripts/prove_gate.py
+++ b/claude-config/scripts/prove_gate.py
@@ -1,0 +1,182 @@
+"""PROVE verdict merge gate (issue #360).
+
+PROVE emits rich verdict artifacts (status + ac_audit frontmatter) but until
+this gate nothing ENFORCED them at ship time — a FAIL verdict was purely
+diagnostic and `/ship` merged anyway. This script is the mechanical check
+`/ship` runs before the merge step:
+
+  python3 ~/.claude/scripts/prove_gate.py --issue 320 [--outputs-dir .agents/outputs]
+
+Exit codes (stable contract for ship.md):
+  0  GATE_PASS         PASS verdict + ac_audit clean — merge may proceed.
+                       Also: issue was never orchestrate-tracked (no PROVE
+                       expected — /quick and ad-hoc work is not falsely gated).
+  2  GATE_FAIL         latest PROVE artifact says FAIL or BLOCKED.
+  3  GATE_AC_VIOLATION status says PASS but ac_audit has missing/partial
+                       entries (AC-FORBIDS-APPROVE, #1609/#1612) — the PASS
+                       is downgraded, merge is blocked.
+  4  GATE_NO_ARTIFACT  issue has orchestrate artifacts (map/plan/patch) but
+                       no PROVE artifact — verification was skipped.
+  5  GATE_PARSE_ERROR  artifact exists but frontmatter is unreadable.
+                       Fail-CLOSED: an unverifiable verdict blocks the merge.
+
+Override: `--override "<reason>"` records the bypass to
+`<outputs-dir>/prove-overrides.jsonl` (who/when/why/what-the-gate-said) and
+exits 0. The override is allowed but never silent — same philosophy as the
+buddy chokepoint's bypassed=true telemetry (#1613).
+
+AC-audit semantics are NOT reimplemented here: the gate imports
+state_manager.validate_ac_audit so ship-time and record-time enforcement can
+never drift.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+# state_manager lives in the deployed hooks dir; fall back to the repo copy
+# so the gate also works from a fresh checkout.
+for _hooks in (Path.home() / ".claude" / "hooks",
+               Path(__file__).resolve().parent.parent / "hooks"):
+    if (_hooks / "state_manager.py").exists():
+        sys.path.insert(0, str(_hooks))
+        break
+
+from state_manager import validate_ac_audit  # noqa: E402
+
+GATE_PASS = 0
+GATE_FAIL = 2
+GATE_AC_VIOLATION = 3
+GATE_NO_ARTIFACT = 4
+GATE_PARSE_ERROR = 5
+
+# Orchestrate phase artifacts that mark an issue as pipeline-tracked (and
+# therefore REQUIRED to have a PROVE artifact before shipping).
+TRACKED_PHASES = ("map", "map-plan", "plan", "patch", "contract", "test-plan")
+
+
+class ArtifactParseError(Exception):
+    """PROVE artifact exists but its frontmatter cannot be parsed."""
+
+
+def _frontmatter(text: str) -> dict:
+    """Parse the YAML frontmatter block of an artifact. Raises
+    ArtifactParseError on any shape problem — the gate fails closed."""
+    match = re.match(r"\A---\n(.*?)\n---\n", text, re.DOTALL)
+    if not match:
+        raise ArtifactParseError("no frontmatter block found")
+    try:
+        import yaml
+    except ImportError as exc:
+        raise ArtifactParseError("PyYAML unavailable — cannot parse verdict") from exc
+    try:
+        data = yaml.safe_load(match.group(1))
+    except yaml.YAMLError as exc:
+        raise ArtifactParseError(f"frontmatter is not valid YAML: {exc}") from exc
+    if not isinstance(data, dict):
+        raise ArtifactParseError("frontmatter is not a mapping")
+    return data
+
+
+def latest_artifact(outputs_dir: Path, issue: int, phase: str = "prove") -> Path | None:
+    candidates = sorted(
+        outputs_dir.glob(f"{phase}-{issue}-*.md"),
+        key=lambda p: p.stat().st_mtime,
+    )
+    return candidates[-1] if candidates else None
+
+
+def is_orchestrate_tracked(outputs_dir: Path, issue: int) -> bool:
+    return any(
+        latest_artifact(outputs_dir, issue, phase) is not None
+        for phase in TRACKED_PHASES
+    )
+
+
+def check_gate(outputs_dir: Path, issue: int) -> tuple[int, str]:
+    """Pure decision: (exit_code, human-readable reason)."""
+    artifact = latest_artifact(outputs_dir, issue)
+    if artifact is None:
+        if is_orchestrate_tracked(outputs_dir, issue):
+            return GATE_NO_ARTIFACT, (
+                f"issue #{issue} has orchestrate artifacts but NO PROVE artifact — "
+                "verification was skipped. Run PROVE before shipping."
+            )
+        return GATE_PASS, (
+            f"issue #{issue} is not orchestrate-tracked (no phase artifacts) — "
+            "no PROVE verdict expected; gate passes."
+        )
+
+    try:
+        fm = _frontmatter(artifact.read_text(encoding="utf-8"))
+    except (OSError, ArtifactParseError) as exc:
+        return GATE_PARSE_ERROR, (
+            f"{artifact.name}: cannot read verdict ({exc}) — failing CLOSED."
+        )
+
+    status = str(fm.get("status", "")).upper()
+    if status in ("FAIL", "BLOCKED"):
+        return GATE_FAIL, f"{artifact.name}: status={status} — merge blocked."
+    if status != "PASS":
+        return GATE_PARSE_ERROR, (
+            f"{artifact.name}: status={status or '(absent)'} is not "
+            "PASS/FAIL/BLOCKED — failing CLOSED."
+        )
+
+    audit = validate_ac_audit(fm.get("ac_audit"))
+    if audit.get("downgrade_to") == "FAIL":
+        offenders = "; ".join(
+            f"{m.get('status', '?')}: {str(m.get('ac', ''))[:80]}"
+            for m in audit.get("missing", [])
+        )
+        return GATE_AC_VIOLATION, (
+            f"{artifact.name}: status=PASS but ac_audit forbids approval "
+            f"(AC-FORBIDS-APPROVE) — {offenders}"
+        )
+
+    return GATE_PASS, f"{artifact.name}: status=PASS, ac_audit clean — merge may proceed."
+
+
+def record_override(outputs_dir: Path, issue: int, reason: str,
+                    gate_code: int, gate_reason: str) -> Path:
+    log = outputs_dir / "prove-overrides.jsonl"
+    log.parent.mkdir(parents=True, exist_ok=True)
+    entry = {
+        "ts": datetime.now(timezone.utc).isoformat(),
+        "issue": issue,
+        "override_reason": reason,
+        "gate_exit": gate_code,
+        "gate_reason": gate_reason,
+    }
+    with log.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(entry) + "\n")
+    return log
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(prog="prove_gate", description=__doc__.splitlines()[0])
+    ap.add_argument("--issue", type=int, required=True)
+    ap.add_argument("--outputs-dir", type=Path, default=Path(".agents/outputs"))
+    ap.add_argument(
+        "--override", metavar="REASON",
+        help="bypass a blocking verdict; the bypass is recorded to "
+             "prove-overrides.jsonl (never silent)",
+    )
+    args = ap.parse_args(argv)
+
+    code, reason = check_gate(args.outputs_dir, args.issue)
+    print(f"prove-gate: {reason}")
+    if code != GATE_PASS and args.override:
+        log = record_override(args.outputs_dir, args.issue, args.override, code, reason)
+        print(f"prove-gate: OVERRIDDEN ({args.override!r}) — recorded to {log}")
+        return GATE_PASS
+    return code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/claude-config/tests/test_prove_gate.py
+++ b/claude-config/tests/test_prove_gate.py
@@ -1,0 +1,128 @@
+"""Tests for the PROVE verdict merge gate (issue #360)."""
+
+import json
+import sys
+
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+import prove_gate as G  # noqa: E402
+
+
+def _artifact(tmp_path, name, status="PASS", ac_audit=None, raw=None):
+    outputs = tmp_path / ".agents" / "outputs"
+    outputs.mkdir(parents=True, exist_ok=True)
+    if raw is None:
+        audit_lines = ""
+        if ac_audit is not None:
+            audit_lines = "ac_audit:\n" + "".join(
+                f'  - ac: "{a["ac"]}"\n    status: {a["status"]}\n'
+                f'    evidence: "{a.get("evidence", "x")}"\n'
+                for a in ac_audit
+            )
+        raw = (
+            f"---\nissue: 42\nagent: PROVE\nstatus: {status}\n"
+            f"{audit_lines}---\n\n# body\n"
+        )
+    (outputs / name).write_text(raw, encoding="utf-8")
+    return outputs
+
+
+OK_AUDIT = [{"ac": "does the thing", "status": "implemented", "evidence": "file.py:1"}]
+
+
+def test_pass_with_clean_audit(tmp_path):
+    outputs = _artifact(tmp_path, "prove-42-060926.md", "PASS", OK_AUDIT)
+    code, reason = G.check_gate(outputs, 42)
+    assert code == G.GATE_PASS
+    assert "merge may proceed" in reason
+
+
+def test_fail_blocks(tmp_path):
+    outputs = _artifact(tmp_path, "prove-42-060926.md", "FAIL", OK_AUDIT)
+    code, reason = G.check_gate(outputs, 42)
+    assert code == G.GATE_FAIL
+    assert "blocked" in reason
+
+
+def test_blocked_blocks(tmp_path):
+    outputs = _artifact(tmp_path, "prove-42-060926.md", "BLOCKED", OK_AUDIT)
+    assert G.check_gate(outputs, 42)[0] == G.GATE_FAIL
+
+
+def test_pass_with_partial_audit_is_violation(tmp_path):
+    audit = OK_AUDIT + [{"ac": "second thing", "status": "partial", "evidence": "meh"}]
+    outputs = _artifact(tmp_path, "prove-42-060926.md", "PASS", audit)
+    code, reason = G.check_gate(outputs, 42)
+    assert code == G.GATE_AC_VIOLATION
+    assert "AC-FORBIDS-APPROVE" in reason
+
+
+def test_pass_with_no_audit_is_violation(tmp_path):
+    outputs = _artifact(tmp_path, "prove-42-060926.md", "PASS", ac_audit=None)
+    assert G.check_gate(outputs, 42)[0] == G.GATE_AC_VIOLATION
+
+
+def test_no_artifact_but_tracked_blocks(tmp_path):
+    outputs = _artifact(tmp_path, "map-plan-42-060926.md", raw="---\nissue: 42\n---\nbody\n")
+    code, reason = G.check_gate(outputs, 42)
+    assert code == G.GATE_NO_ARTIFACT
+    assert "verification was skipped" in reason
+
+
+def test_no_artifact_untracked_passes(tmp_path):
+    outputs = tmp_path / ".agents" / "outputs"
+    outputs.mkdir(parents=True)
+    code, reason = G.check_gate(outputs, 42)
+    assert code == G.GATE_PASS
+    assert "not orchestrate-tracked" in reason
+
+
+def test_unparseable_artifact_fails_closed(tmp_path):
+    outputs = _artifact(tmp_path, "prove-42-060926.md", raw="no frontmatter here\n")
+    assert G.check_gate(outputs, 42)[0] == G.GATE_PARSE_ERROR
+
+
+def test_unknown_status_fails_closed(tmp_path):
+    outputs = _artifact(tmp_path, "prove-42-060926.md", "MAYBE", OK_AUDIT)
+    assert G.check_gate(outputs, 42)[0] == G.GATE_PARSE_ERROR
+
+
+def test_latest_artifact_wins(tmp_path):
+    import os
+    outputs = _artifact(tmp_path, "prove-42-060826.md", "FAIL", OK_AUDIT)
+    _artifact(tmp_path, "prove-42-060926.md", "PASS", OK_AUDIT)
+    os.utime(outputs / "prove-42-060826.md", (1, 1))  # force older mtime
+    assert G.check_gate(outputs, 42)[0] == G.GATE_PASS
+
+
+def test_other_issues_artifacts_ignored(tmp_path):
+    outputs = _artifact(tmp_path, "prove-99-060926.md", "FAIL", OK_AUDIT)
+    code, _ = G.check_gate(outputs, 42)
+    assert code == G.GATE_PASS  # issue 42 untracked; 99's FAIL is irrelevant
+
+
+def test_override_records_and_passes(tmp_path):
+    outputs = _artifact(tmp_path, "prove-42-060926.md", "FAIL", OK_AUDIT)
+    rc = G.main(["--issue", "42", "--outputs-dir", str(outputs),
+                 "--override", "hotfix: prod down, verified manually"])
+    assert rc == G.GATE_PASS
+    rows = [json.loads(line) for line in
+            (outputs / "prove-overrides.jsonl").read_text().splitlines()]
+    assert rows[0]["issue"] == 42
+    assert rows[0]["gate_exit"] == G.GATE_FAIL
+    assert "hotfix" in rows[0]["override_reason"]
+
+
+def test_override_not_recorded_when_gate_passes(tmp_path):
+    outputs = _artifact(tmp_path, "prove-42-060926.md", "PASS", OK_AUDIT)
+    rc = G.main(["--issue", "42", "--outputs-dir", str(outputs),
+                 "--override", "unnecessary"])
+    assert rc == G.GATE_PASS
+    assert not (outputs / "prove-overrides.jsonl").exists()
+
+
+def test_cli_exit_codes(tmp_path):
+    outputs = _artifact(tmp_path, "prove-42-060926.md", "FAIL", OK_AUDIT)
+    assert G.main(["--issue", "42", "--outputs-dir", str(outputs)]) == G.GATE_FAIL


### PR DESCRIPTION
## Summary
- New `claude-config/scripts/prove_gate.py` — mechanical merge gate over PROVE artifact frontmatter with a stable exit-code contract (0 proceed / 2 FAIL / 3 AC-violation / 4 missing-PROVE / 5 fail-closed parse error)
- Reuses `state_manager.validate_ac_audit` (no drift between ship-time and record-time AC-FORBIDS-APPROVE)
- `/ship` Step 7.5 runs the gate before merge; only bypass is `--override-prove "<reason>"`, recorded to `prove-overrides.jsonl`
- `orchestrate.md` Step 4 now states FAIL halts the workflow before any /ship handoff

## Test Plan
- [x] 14 new tests in `test_prove_gate.py` — 399 total pass; ruff clean
- [x] Live run: catches the real `prove-320-060826.md` violation (status PASS, one `partial` AC → exit 3); clean `prove-311` passes (exit 0); untracked issue passes (exit 0)

Closes #360

🤖 Generated with [Claude Code](https://claude.com/claude-code)