### PR TITLE
feat(quality): code-quality-standards rule + coverage-delta gate (#364)

### DIFF
--- a/claude-config/CLAUDE.md
+++ b/claude-config/CLAUDE.md
@@ -172,6 +172,7 @@ that the M365 capability isn't configured on that machine.
 | `git-workflow.md` | Any commit/branch/PR work |
 | `github-accounts.md` / `gitlab-access.md` | Before any push or auth-sensitive op |
 | `behavioral-evals.md` + `eval-file-mapping.md` | PROVE phase, code review |
+| `code-quality-standards.md` | Auto-loads on code paths — quantified, command-checkable standards (coverage delta, lint, LR-001, evals) |
 | `fastapi-layered-pattern.md` (in `templates/`, not `rules/`) | Read by `/scaffold-project` and `/scaffold-module` |
 | `rbac-pattern.md` | Auth/permissions code |
 | `orchestrate-workflow.md` | `/orchestrate` runs |

--- a/claude-config/agents/patch.md
+++ b/claude-config/agents/patch.md
@@ -156,6 +156,31 @@ fi
 
 See `~/.claude/snippets/verify-commands.md` (referenced from `_base.md`) for the canonical backend/frontend verification commands.
 
+### Coverage Delta (#364)
+
+When the repo has pytest + coverage infra (a `--cov` run works), capture a
+baseline BEFORE the first change:
+
+```bash
+pytest --cov --cov-report=json:/tmp/cov-before-${ISSUE}.json -q 2>/dev/null \
+  && python3 -c "import json; print(json.load(open('/tmp/cov-before-${ISSUE}.json'))['totals']['percent_covered'])"
+```
+
+At Pre-Submission Gates, re-run with `cov-after` and record both numbers in
+the artifact frontmatter:
+
+```yaml
+coverage_before: 84.2   # null when no coverage infra
+coverage_after: 84.9
+coverage_note: ""       # REQUIRED explanation when after < before
+```
+
+Rules (`rules/code-quality-standards.md`): coverage must not decrease;
+a decrease needs an explicit `coverage_note` explaining why (e.g. removed
+dead tested code) or PROVE will flag it. No coverage infra in the repo →
+record `coverage_before: null` and move on — do NOT bolt coverage tooling
+onto the repo as a side effect.
+
 ---
 
 ## Atomic Commits (MANDATORY)

--- a/claude-config/agents/prove.md
+++ b/claude-config/agents/prove.md
@@ -145,6 +145,13 @@ git log --oneline origin/main..HEAD
 | Backend tests | `pytest -q` | All pass |
 | Frontend lint | `npm run lint` | No errors |
 | Frontend build | `npm run build` | Success |
+| Coverage delta (#364) | read `coverage_before/after` from the PATCH artifact | `after >= before`, OR a non-empty `coverage_note` explains the decrease, OR `before: null` (no infra) |
+
+An unexplained coverage decrease is an Issues Found entry and an
+`ac_audit`-level problem — it makes the verdict FAIL-able (see
+`rules/code-quality-standards.md`). If PATCH recorded no coverage fields at
+all in a repo that HAS coverage infra, run the before/after comparison
+yourself (`git stash` ↔ working tree) or flag the omission.
 
 ### 2. Verification Levels
 

--- a/claude-config/rules/code-quality-standards.md
+++ b/claude-config/rules/code-quality-standards.md
@@ -1,0 +1,69 @@
+---
+paths: ["**/*.py", "**/*.ts", "**/*.tsx", "**/*.jsx", "**/backend/**", "**/frontend/**"]
+---
+
+# Code Quality Standards (#364)
+
+Quantified, command-checkable standards. Every standard names the exact
+command that verifies it — a standard that can't be checked by command is
+prose, and prose is not a gate. Aspirational language ("should", "prefer")
+is deliberately absent.
+
+## Coverage
+
+| Standard | Check |
+|---|---|
+| Changed-code coverage must not DECREASE vs the base branch | `pytest --cov --cov-report=json:cov.json` before and after; compare `totals.percent_covered` (PATCH records the delta; PROVE verdicts on it) |
+| New modules: ≥80% line coverage | `pytest --cov=<new_module> --cov-report=term-missing` |
+| No test infra in the repo | Standard does not apply — do NOT bolt coverage tooling onto a repo that has none as a side effect of a feature PR; note `coverage: n/a (no test infra)` in the artifact |
+
+An unexplained coverage decrease is a PROVE finding (FAIL-able). An
+*explained* decrease (e.g. deleting dead tested code) is recorded with the
+explanation and passes.
+
+## Lint & Format
+
+| Standard | Check |
+|---|---|
+| Lint clean using the project's own config | `ruff check .` (repo's ruff.toml/pyproject wins; no per-PR rule inventions) |
+| Format clean where the project enforces it | `ruff format --check <changed files>` — only in repos that already format |
+| Frontend | `npm run lint` with the project's config |
+
+## Exceptions (LR-001)
+
+| Standard | Check |
+|---|---|
+| No bare `except:` / blind `except Exception` in library/CLI code | `ruff check --select E722,BLE001 <changed files>` |
+| Fail-open surfaces (session hooks, statuslines, daemons that must never crash the host) may catch broadly ONLY at their top level | per-file-ignores in the repo's ruff config, with a comment saying why — never inline ad-hoc |
+
+## Types
+
+| Standard | Check |
+|---|---|
+| Repos that already run mypy/pyright: changed files pass at the repo's configured strictness | `mypy <changed files>` / `npx tsc --noEmit` |
+| Repos without type-checking | Do not retrofit silently; propose it as its own issue |
+
+## Behavioral evals
+
+| Standard | Check |
+|---|---|
+| Mechanical evals clean on the diff | `python3 ~/agents/claude-config/scripts/evals/run_evals.py --diff-range origin/main...HEAD` (E01/E04/E13/E14/E15; exit 0) |
+| Prose evals (E02/E03/E05–E12) | PROVE per `behavioral-evals.md` |
+
+## Secrets
+
+| Standard | Check |
+|---|---|
+| No credentials in the diff | E15 via the evals runner (part of the command above) |
+
+## How the pipeline applies this
+
+- **PATCH** captures the coverage baseline before changes and records the
+  delta in its artifact frontmatter (`coverage_before` / `coverage_after`,
+  see patch.md §Coverage Delta).
+- **PROVE** treats an unexplained coverage decrease, any lint failure on
+  changed files, or a mechanical-eval finding as an `ac_audit`-level issue —
+  which makes it FAIL-able via AC-FORBIDS-APPROVE and enforced at merge by
+  `prove_gate.py` (#360).
+- **/quick** applies the eval gate on risk triggers (quick.md §2.5); lint
+  on touched areas is already mandatory there.


### PR DESCRIPTION
New rules/code-quality-standards.md: quantified, command-checkable
standards (coverage may not decrease + >=80% for new modules; lint with
the project's own config; LR-001 via ruff E722/BLE001; mechanical evals;
no silent type-checker retrofits). PATCH captures coverage_before/after
in artifact frontmatter with a required coverage_note on decreases;
PROVE verdicts on the delta as an ac_audit-level issue, which makes it
enforceable at merge via prove_gate (#360). CLAUDE.md reference table
updated.

Closes #364

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
