### PR TITLE
feat(memory): auto-inject recall bodies in SessionStart (#365)

### DIFF
--- a/claude-config/hooks/sessionstart_restore_state.py
+++ b/claude-config/hooks/sessionstart_restore_state.py
@@ -74,6 +74,117 @@ def get_active_work(yaml_content: str) -> dict:
         return {}
 
 
+# ---------------------------------------------------------------- auto-recall
+
+# Injection budget (#365): keep the whole section ~1–1.5k tokens so sessions
+# don't bloat. Chars ≈ 4 × tokens.
+AUTORECALL_TOTAL_CHARS = 6000
+AUTORECALL_PER_FACT_CHARS = 1200
+_TYPE_PRIORITY = {"feedback": 0, "user": 1, "reference": 2, "project": 3}
+
+
+def _fact_meta(path: Path) -> dict | None:
+    """Parse name/type/expires/body from a fact file. None on unreadable.
+
+    Minimal line-based frontmatter parse — works without PyYAML and tolerates
+    the nested `metadata:`/flat variants in the wild.
+    """
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None
+    meta = {"name": path.stem, "type": "project", "expires": None, "body": text}
+    if text.startswith("---\n"):
+        end = text.find("\n---", 4)
+        if end != -1:
+            for line in text[4:end].splitlines():
+                stripped = line.strip()
+                for key in ("type", "expires", "name"):
+                    if stripped.startswith(f"{key}:"):
+                        meta[key] = stripped.split(":", 1)[1].strip().strip("'\"") or meta[key]
+            meta["body"] = text[end + 4:].lstrip("-").lstrip("\n")
+    return meta
+
+
+def _expired(expires: str | None, today: str) -> bool:
+    return bool(expires) and str(expires)[:10] < today
+
+
+def render_project_memory(fact_dir: Path, *, today: str | None = None) -> str:
+    """Build the auto-recalled Project Memory section (empty string if none).
+
+    Selection: non-expired facts ranked by type priority (feedback > user >
+    reference > project) then mtime (newest first), injected until the char
+    budget runs out. Remaining facts are listed as topics with the recall CTA.
+    """
+    from datetime import date
+    today = today or date.today().isoformat()
+
+    paths = [p for p in sorted(fact_dir.glob("*.md")) if p.name != "MEMORY.md"]
+    facts = []
+    for p in paths:
+        meta = _fact_meta(p)
+        if meta is None or _expired(meta["expires"], today):
+            continue
+        meta["path"] = p
+        facts.append(meta)
+    if not facts:
+        return ""
+
+    facts.sort(key=lambda f: (_TYPE_PRIORITY.get(f["type"], 9),
+                              -f["path"].stat().st_mtime))
+    injected, leftover, used = [], [], 0
+    for f in facts:
+        body = f["body"].strip()
+        if len(body) > AUTORECALL_PER_FACT_CHARS:
+            body = (body[:AUTORECALL_PER_FACT_CHARS]
+                    + f"\n… *(truncated — full fact: `{f['path']}`)*")
+        cost = len(body) + len(f["name"]) + 40
+        if used + cost > AUTORECALL_TOTAL_CHARS:
+            leftover.append(f)
+            continue
+        injected.append((f, body))
+        used += cost
+
+    lines = ["### Project Memory (auto-recalled)\n"]
+    lines.append(
+        f"{len(injected)} of {len(facts)} fact bodies injected "
+        "(highest-value first, budget-capped). Verify against current code "
+        "before acting — facts reflect what was true when written.\n"
+    )
+    for f, body in injected:
+        lines.append(f"**{f['name']}** ({f['type']}):\n{body}\n")
+    if leftover:
+        topics = ", ".join(f["name"].replace("_", " ").replace("-", " ")
+                           for f in leftover[:8])
+        lines.append(
+            f"Not injected ({len(leftover)}): {topics}. "
+            "→ `~/agents/bin/memory recall <topic>` to pull these.\n"
+        )
+
+    _log_autorecall(fact_dir, len(injected), len(facts), used)
+    return "\n".join(lines)
+
+
+def _log_autorecall(fact_dir: Path, injected: int, total: int, chars: int) -> None:
+    """Append an auto-injection record so memory_audit_metrics can report
+    auto-recall separately from manual recall. Best-effort."""
+    try:
+        from datetime import datetime, timezone
+        rec = {
+            "ts": datetime.now(timezone.utc).isoformat(),
+            "project": fact_dir.parent.name,
+            "facts_injected": injected,
+            "facts_total": total,
+            "chars": chars,
+        }
+        log = Path.home() / ".claude" / "memory-autoinject.jsonl"
+        with log.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(rec) + "\n")
+    except Exception:
+        logging.warning("autorecall metrics append failed", exc_info=True)
+
+
 def main() -> int:
     _hook_in = json.load(sys.stdin)
 
@@ -188,30 +299,17 @@ def main() -> int:
         print("If the phase was completed, proceed to the next phase in the workflow.")
         print()
 
-    # 3.5 Project-memory recall CTA. Claude Code natively injects the MEMORY.md
-    #     index (titles), but nothing auto-loads the fact BODIES — where the
-    #     "why" lives. Point at the recall CLI so the index becomes an active
-    #     prompt rather than a passive list. Facts live under
-    #     ~/.claude/projects/<encoded-cwd>/memory/, not in the repo.
+    # 3.5 Project-memory auto-recall (#365). The CTA-only approach measured
+    #     0.9% adoption (13 recalls / 328 sessions) — facts were written and
+    #     never read. Inject the high-value fact BODIES directly, within a
+    #     hard budget, instead of asking the session to go fetch them. Facts
+    #     live under ~/.claude/projects/<encoded-cwd>/memory/.
     encoded = str(project_dir).replace("/", "-")
     fact_dir = Path.home() / ".claude" / "projects" / encoded / "memory"
     if fact_dir.is_dir():
-        facts = sorted(p for p in fact_dir.glob("*.md") if p.name != "MEMORY.md")
-        if facts:
-            topics = ", ".join(
-                p.stem.replace("_", " ").replace("-", " ") for p in facts[:6]
-            )
-            more = " …" if len(facts) > 6 else ""
-            print("### Project Memory\n")
-            print(
-                f"{len(facts)} memory fact(s) on file. The index above lists titles; "
-                "the *why* lives in the bodies, which are NOT auto-loaded."
-            )
-            print(f"Topics: {topics}{more}")
-            print(
-                "→ Run `~/agents/bin/memory recall <topic>` before non-trivial work "
-                "to pull the relevant fact bodies into context.\n"
-            )
+        section = render_project_memory(fact_dir)
+        if section:
+            print(section)
 
     # 4. Hint about full patterns location — only if the file actually exists.
     #    patterns-full.md is produced by `/learn`; advertising it before that

--- a/claude-config/scripts/memory_audit_metrics.py
+++ b/claude-config/scripts/memory_audit_metrics.py
@@ -138,6 +138,28 @@ def store_stats():
     return total, cold
 
 
+def autoinject_stats(cutoff: float) -> tuple[int, int]:
+    """(sessions auto-injected, facts injected) within the window, from the
+    SessionStart hook's sidecar log (#365). Auto-recall is counted separately
+    from manual recall so the trend can tell push from pull."""
+    log = Path.home() / ".claude" / "memory-autoinject.jsonl"
+    injections = facts = 0
+    try:
+        with log.open(encoding="utf-8") as fh:
+            for line in fh:
+                try:
+                    rec = json.loads(line)
+                    ts = datetime.fromisoformat(rec["ts"]).timestamp()
+                except (ValueError, KeyError, TypeError):
+                    continue
+                if ts >= cutoff:
+                    injections += 1
+                    facts += int(rec.get("facts_injected", 0))
+    except OSError:
+        pass
+    return injections, facts
+
+
 def main(argv=None) -> int:
     ap = argparse.ArgumentParser(prog="memory_audit_metrics")
     ap.add_argument("--days", type=int, default=7, help="rolling window in days (default 7)")
@@ -165,6 +187,9 @@ def main(argv=None) -> int:
         "sessions_with_recall": sessions_with_recall,
         "active_recall_pct": round(100 * sessions_with_recall / sessions, 1) if sessions else 0.0,
     }
+    auto_sessions, auto_facts = autoinject_stats(cutoff)
+    row["auto_inject_sessions"] = auto_sessions
+    row["auto_inject_facts"] = auto_facts
 
     print(json.dumps(row))
     if not args.print_only:

--- a/claude-config/tests/test_sessionstart_autorecall.py
+++ b/claude-config/tests/test_sessionstart_autorecall.py
@@ -1,0 +1,119 @@
+"""Tests for SessionStart project-memory auto-recall (issue #365)."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "hooks"))
+
+import sessionstart_restore_state as H  # noqa: E402
+
+TODAY = "2026-06-09"
+
+
+def _fact(d, name, *, ftype="project", expires=None, body="the why lives here",
+          mtime=None):
+    fm = f"---\nname: {name}\ntype: {ftype}\n"
+    if expires:
+        fm += f"expires: {expires}\n"
+    fm += "---\n\n"
+    p = d / f"{name}.md"
+    p.write_text(fm + body, encoding="utf-8")
+    if mtime:
+        import os
+        os.utime(p, (mtime, mtime))
+    return p
+
+
+def _memdir(tmp_path):
+    d = tmp_path / ".claude" / "projects" / "-Users-x-proj" / "memory"
+    d.mkdir(parents=True)
+    return d
+
+
+def test_injects_fact_bodies(tmp_path, monkeypatch):
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    d = _memdir(tmp_path)
+    _fact(d, "lesson-one", ftype="feedback", body="Always do X because Y.")
+    out = H.render_project_memory(d, today=TODAY)
+    assert "auto-recalled" in out
+    assert "Always do X because Y." in out
+    assert "lesson-one" in out
+
+
+def test_empty_dir_renders_nothing(tmp_path, monkeypatch):
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    d = _memdir(tmp_path)
+    assert H.render_project_memory(d, today=TODAY) == ""
+
+
+def test_expired_facts_skipped(tmp_path, monkeypatch):
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    d = _memdir(tmp_path)
+    _fact(d, "dead-handoff", expires="2026-01-01", body="stale resume doc")
+    assert H.render_project_memory(d, today=TODAY) == ""
+
+
+def test_unexpired_expires_included(tmp_path, monkeypatch):
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    d = _memdir(tmp_path)
+    _fact(d, "live-plan", expires="2027-01-01", body="still relevant plan")
+    assert "still relevant plan" in H.render_project_memory(d, today=TODAY)
+
+
+def test_memory_index_excluded(tmp_path, monkeypatch):
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    d = _memdir(tmp_path)
+    (d / "MEMORY.md").write_text("# index\n- [a](a.md)\n")
+    assert H.render_project_memory(d, today=TODAY) == ""
+
+
+def test_feedback_outranks_project(tmp_path, monkeypatch):
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    d = _memdir(tmp_path)
+    _fact(d, "zz-feedback", ftype="feedback", body="F" * 100, mtime=1000)
+    _fact(d, "aa-project", ftype="project", body="P" * 100, mtime=2000)
+    out = H.render_project_memory(d, today=TODAY)
+    assert out.index("zz-feedback") < out.index("aa-project")
+
+
+def test_budget_caps_injection_and_lists_leftovers(tmp_path, monkeypatch):
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    d = _memdir(tmp_path)
+    for i in range(12):
+        _fact(d, f"fact-{i:02d}", ftype="feedback", body="B" * 1100, mtime=1000 + i)
+    out = H.render_project_memory(d, today=TODAY)
+    assert "Not injected" in out
+    assert "memory recall" in out
+    # budget 6000 chars with ~1140-char facts → at most 5 injected
+    assert out.count("(feedback):") <= 5
+
+
+def test_long_body_truncated_with_pointer(tmp_path, monkeypatch):
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    d = _memdir(tmp_path)
+    _fact(d, "big-fact", ftype="feedback", body="X" * 5000)
+    out = H.render_project_memory(d, today=TODAY)
+    assert "truncated" in out
+    assert "big-fact.md" in out
+
+
+def test_autoinject_metrics_logged(tmp_path, monkeypatch):
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    d = _memdir(tmp_path)
+    _fact(d, "lesson", ftype="user", body="who jason is")
+    H.render_project_memory(d, today=TODAY)
+    log = tmp_path / ".claude" / "memory-autoinject.jsonl"
+    assert log.exists()
+    import json
+    rec = json.loads(log.read_text().splitlines()[0])
+    assert rec["facts_injected"] == 1
+    assert rec["project"] == "-Users-x-proj"
+
+
+def test_corrupt_fact_skipped_not_fatal(tmp_path, monkeypatch):
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    d = _memdir(tmp_path)
+    (d / "bad.md").write_bytes(b"\xff\xfe broken")
+    _fact(d, "good", ftype="feedback", body="fine")
+    out = H.render_project_memory(d, today=TODAY)
+    assert "fine" in out


### PR DESCRIPTION
The CTA-only read path measured 0.9-1.5% adoption — facts were written
and never read. The SessionStart hook now injects fact BODIES directly:
non-expired facts ranked feedback > user > reference > project then
mtime, injected under a 6k-char budget with per-fact truncation pointers;
leftovers listed with the recall CTA. TTL respected (expired facts never
injected). Each injection logs to ~/.claude/memory-autoinject.jsonl and
memory_audit_metrics reports auto_inject_sessions/facts separately from
manual recall so the trend can tell push from pull.

Test evidence: 10 new tests (542 claude-config tests pass); live hook
run on this repo injects 4/8 facts at 5621 chars with correct ranking.

Closes #365

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
