### PR TITLE
chore(rules): de-buddy global rules, reconcile contradictions, fix frontmatter (#367)

### DIFF
--- a/claude-config/rules/git-workflow.md
+++ b/claude-config/rules/git-workflow.md
@@ -17,9 +17,14 @@ pausing to ask for merge approval.** The terminal state of a task is a merged
 PR, not an open one. The full default path:
 
 ```text
-commit → push → PR → validate/review → squash-merge → prune branch
-       → sync main → post-merge verify → close/update the issue
+commit → push → PR → validate/review → squash-merge → sync main
+       → post-merge verify → prune branch → close/update the issue
 ```
+
+Ordering matters (#367): post-merge verification runs BEFORE pruning. If
+verification fails, do NOT prune — the branch is your recovery path; create
+`fix/hotfix-<description>` from origin/main instead (see
+`post-merge-verification.md`, which this sequence now matches).
 
 **Stop before merge ONLY when:**
 

--- a/claude-config/rules/implementation-routing.md
+++ b/claude-config/rules/implementation-routing.md
@@ -54,70 +54,25 @@ Use the Codex plugin commands instead of inventing ad-hoc prompts:
 /codex:rescue               # delegate implementation when Claude is stuck
 ```
 
-### AC-FORBIDS-APPROVE + scope-freeze clauses
+### Per-AC audit + project review gates
 
-When invoking Codex for any **CODE review** (post-PATCH) or **SPEC review** that
-the prompt arguments allow you to extend, **append the per-AC audit + scope-
-freeze clauses** from the buddy-managed prompt fragment:
+Two generic principles apply to every MODERATE+ Codex review (skip both on
+TRIVIAL):
 
-```
-specs/../prompts/codex-review-clauses.md      (buddy repo)
-```
+1. **Per-AC audit**: extend the review prompt so the verdict must include an
+   `ac_audit` array (`implemented|partial|missing|deferred|n/a` per AC) and a
+   scope-freeze escape hatch (`new_concerns` instead of REQUEST_CHANGES
+   drift). A reviewer that can APPROVE on partial AC coverage will — the
+   per-AC shape forbids it.
+2. **Use the repo's review-gate wrapper when it ships one**: if the project
+   has a chokepoint that runs mechanical gates before `codex exec` (and logs
+   bypass telemetry), route the review through it rather than calling
+   `codex exec` directly.
 
-The fragment contains three sections to append to your Codex prompt:
-1. Per-AC audit (`ac_audit` array with `implemented|partial|missing|deferred|n/a` statuses)
-2. Scope-freeze (`new_concerns` escape hatch instead of REQUEST_CHANGES drift)
-3. Output JSON schema additions
-
-**Why:** issue #1609 (Harold-borrowed loop-closer). Without these clauses,
-Codex can return APPROVE on partial AC coverage — the Mavis Surface spec
-review hit this 4 rounds in a row. Companion: PROVE-side enforcement of the
-same `ac_audit` shape lives in issue #1612.
-
-**Mechanics:** for the spec-review workflow's R1-R4 `/tmp/codex-spec-r*.md`
-prompt files, append the three sections at the end before passing to
-`codex review`. For `/codex:review` plugin invocations, include the
-sections as the `[PROMPT]` positional or via stdin where the plugin allows.
-
-**When to skip:** TRIVIAL changes (one-file typo, copy edit) — the per-AC
-overhead isn't worth it. For everything MODERATE+, include the fragment.
-
-### Chokepoint wrapper (buddy#1613)
-
-Buddy ships a Python chokepoint at `scripts/codex_review_gate/main.py` that
-every Codex review for buddy work flows through. It runs configured
-mechanical gates BEFORE invoking `codex exec`; a gate exit code in `2-8`
-synthesizes a `REQUEST_CHANGES` verdict locally without calling Codex.
-Other non-zero exits (or crashes) fail-OPEN so Codex still runs.
-
-```bash
-python3 -m scripts.codex_review_gate.main \
-    --branch-sha $(git rev-parse HEAD) \
-    --plan /tmp/codex-1610-review.md \
-    --verdict-out /tmp/verdict-1610.json \
-    [--gates name="argv ..." ...] \
-    --codex-args -- --skip-git-repo-check --sandbox read-only "$(cat /tmp/codex-1610-review.md)"
-```
-
-The wrapper writes one row per invocation to
-`<store>/codex-gate-log.jsonl` (path resolved with test-isolation
-honoring `BUDDY_CODEX_GATE_LOG_PATH` → `BUDDY_TEST_STORE_DIR` →
-`PYTEST_CURRENT_TEST` → `BUDDY_HOME` → default). Critically: every row
-carries `gatesPassed = passed AND NOT bypassed`. Emergency bypass via
-`BUDDY_CODEX_GATE_ENFORCE=0` is allowed but the resulting verdict
-carries `bypassed=true, gatesPassed=false`. The pre-push hook at
-`buddy/scripts/pre-push` (and equivalent CI check) refuses any branch
-SHA whose latest log row lacks `gatesPassed=true`.
-
-**Why** (#1613 Harold loop-closer 5 of 5): the "305 reviews logged, 0
-gates ran" + "bypassed bypass" classes are unrecoverable without
-structural enforcement. The chokepoint is the structural answer.
-
-**When to skip:** TRIVIAL changes still skip Codex entirely; nothing to
-gate. For COMPLEX+ Codex reviews on buddy, prefer the chokepoint over
-calling `codex exec` directly. For now, `--gates` may be empty — the
-gate scripts are a separate follow-up — but the telemetry + bypass
-plumbing already enforces gatesPassed semantics.
+Project-specific mechanics (prompt fragments, wrapper CLIs, env vars,
+telemetry paths) live in that project's memory, not here — e.g. buddy's
+clauses + `codex_review_gate` chokepoint:
+`~/.claude/projects/-Users-jasonjob-projects-buddy/memory/codex_review_gates_buddy.md`.
 
 ## Step 2: Announce Routing Briefly
 

--- a/claude-config/rules/no-app-layer-ddl.md
+++ b/claude-config/rules/no-app-layer-ddl.md
@@ -39,17 +39,11 @@ Even if the pattern looks defensive and idempotent, **remove it**. The migration
 
 ## Why this is a distinct failure class
 
-This rule generalizes a 2026-06-05 buddy incident (#1766). Person Consolidation V1 (5-PR migration wave 2026-05-22 → 2026-05-25) correctly dropped `contact_notes.relationship_id` via migration `20260524180200_pr8_drop_relationship_id_columns.sql`. But `src/buddy/knowledge/postgres_store.py:_ensure_schema()` ran:
-
-```python
-# (in application code, on every pool acquire)
-CREATE TABLE IF NOT EXISTS contact_notes (... relationship_id TEXT ...)
-DO $$ BEGIN ALTER TABLE contact_notes ADD COLUMN relationship_id TEXT;
-     EXCEPTION WHEN duplicate_column THEN NULL; END $$
-CREATE INDEX IF NOT EXISTS idx_contact_notes_rel ON contact_notes(relationship_id)
-```
-
-Result: migration dropped the column at 2026-05-24; every subsequent server boot (every pool acquire, really) immediately re-created it as TEXT, no FK. A schema audit on 2026-06-05 found the column "still there" — leading initially to a (wrong) hypothesis that the migration audit missed the table. Closer investigation showed the migration WAS complete; the in-code DDL was the resurrection vector.
+This rule generalizes a 2026-06-05 buddy incident (#1766): a migration
+correctly dropped a column, but an `_ensure_schema()` block in application
+code re-created it on every pool acquire — the subsequent schema audit
+"found" the dropped column and wrongly blamed the migration. Incident
+detail lives in buddy's project memory, not here.
 
 This failure class is **invisible to schema-audit tooling**:
 - `grep` for the dropped column in migration files — finds the DROP migration. Pattern looks complete.
@@ -100,14 +94,6 @@ The existing `~/.claude/rules/spec-schema-collision-check.md` Part 1 (SQL-site g
 - `CREATE INDEX IF NOT EXISTS` outside migrations
 - `DROP TABLE/COLUMN/INDEX` from application code
 - "Idempotent migration shims" embedded in service code (e.g., `_ensure_schema()` methods)
-
----
-
-## When the rule was born
-
-**2026-06-05 buddy #1766 (smoke sweep #1758).** Person Consolidation V1 migration correctly dropped `contact_notes.relationship_id` on 2026-05-24. `src/buddy/knowledge/postgres_store.py:_ensure_schema()` resurrected it on every pool acquire. Discovered during a smoke audit that looked like the migration had failed but actually the application was undoing it.
-
-The fix (PR #1774) removed the in-code DDL block and added a comment pointing future developers at the migration as the source of truth. This rule was promoted to global because the failure pattern is generic — any project with both a migration system and "defensive" application-layer DDL will eventually hit it.
 
 ---
 

--- a/claude-config/rules/orchestrate-workflow.md
+++ b/claude-config/rules/orchestrate-workflow.md
@@ -1,5 +1,5 @@
 ---
-paths: ".agents/**/*.md"
+paths: ["**/.agents/**/*.md"]
 ---
 
 # Orchestrate Workflow & Agent Efficiency Guidelines

--- a/claude-config/rules/spec-review-workflow.md
+++ b/claude-config/rules/spec-review-workflow.md
@@ -76,7 +76,7 @@ For every claim in the spec of the form "operation X happens via path Y":
 
 - [ ] I read 50+ lines around Y in the actual source.
 - [ ] I confirmed that no pre-write guard / early return / conditional branch can prevent X from reaching the cited line.
-- [ ] If guards exist, the spec either (a) explicitly notes they apply, or (b) explains why the spec's call path bypasses them.
+- [ ] If guards exist, the spec either (a) explicitly notes they apply, or (b) demonstrates — by tracing the actual call path in source, not by assertion — that the spec's path exercises the bypass branch. "The spec's path bypasses the guard" without a traced line-level path is exactly the claim shape that produced the V1.7 round-8 finding (#367).
 
 This is the discipline that would have caught the V1.6 `add_edge() SUPERSESSION` claim: the function exists, the SUPERSESSION code at `:1211` exists, but `find_relationship_conflict()` at `:1090` returns None first for the romantic conflict group.
 


### PR DESCRIPTION
implementation-routing.md: the 60-line buddy-specific block (AC clauses
fragment paths, codex_review_gate CLI, BUDDY_* env vars, issues
#1609/#1612/#1613) compresses to two generic principles (per-AC audit
shape on MODERATE+ reviews; use the repo's review-gate wrapper when one
ships) + a pointer; full mechanics moved to buddy's project memory
(codex_review_gates_buddy.md, indexed). no-app-layer-ddl.md incident
post-mortem compressed to 2 sentences + pointer (rule body stays
generic). git-workflow.md default path reordered: post-merge verify
BEFORE prune (was prune-then-verify, contradicting
post-merge-verification.md). spec-review-workflow.md execution-trace
clause (b) tightened: a guard bypass must be TRACED in source, not
asserted (the V1.7 round-8 shape). orchestrate-workflow.md frontmatter
fixed to array form (glob validator: 18 rules clean).

Always-loaded reduction: implementation-routing 155->110 lines;
no-app-layer-ddl 118->104. Net -54 lines.

Closes #367

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
