### PR TITLE
refactor(hooks): dedupe shared helpers; add missing tests for actions_md + memory (#369)

### DIFF
--- a/claude-config/hooks/aggregate_metrics_to_global.py
+++ b/claude-config/hooks/aggregate_metrics_to_global.py
@@ -31,6 +31,8 @@ import sys
 from datetime import datetime
 from pathlib import Path
 
+from hook_common import get_host_name as _get_host_name  # shared (#369)
+
 
 def log(msg: str) -> None:
     """Append a timestamped line to ~/.claude/hooks.log."""
@@ -317,21 +319,6 @@ def aggregate(kind: str, source_dirs: list, global_dir: Path) -> int:
     return len(records)
 
 
-def _get_host_name() -> str:
-    """Read the canonical host name for this machine.
-
-    Mirrors lib/project_resolver.get_host_name() — duplicated here to keep
-    this hook stdlib-only (no sys.path manipulation required).
-    """
-    host_name_path = Path.home() / ".claude" / "host-name"
-    try:
-        text = host_name_path.read_text().strip()
-        if text:
-            return text
-    except FileNotFoundError:
-        pass
-    import socket
-    return (socket.gethostname() or "unknown").split(".")[0].lower()
 
 
 def write_host_shard(failures: list, agents_root: Path) -> int:

--- a/claude-config/hooks/capture_session_telemetry.py
+++ b/claude-config/hooks/capture_session_telemetry.py
@@ -17,8 +17,14 @@ import os
 import re
 import subprocess
 import sys
-from datetime import datetime, timezone
+from datetime import datetime
 from pathlib import Path
+
+from hook_common import (  # shared (#369)
+    append_jsonl_fsync as _append_jsonl_fsync,
+    get_host_name as _get_host_name,
+    utc_now_iso as _utc_now_iso,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -38,39 +44,6 @@ def log(msg: str) -> None:
         pass
 
 
-def _utc_now_iso() -> str:
-    """ISO-8601 UTC timestamp with microsecond precision (mirrors state_manager)."""
-    return (
-        datetime.now(timezone.utc)
-        .isoformat()
-        .replace("+00:00", "Z")
-    )
-
-
-def _get_host_name() -> str:
-    """Read canonical host name (mirrors aggregate_metrics_to_global.py)."""
-    host_name_path = Path.home() / ".claude" / "host-name"
-    try:
-        text = host_name_path.read_text(encoding="utf-8").strip()
-        if text:
-            return text
-    except FileNotFoundError:
-        pass
-    import socket
-    return (socket.gethostname() or "unknown").split(".")[0].lower()
-
-
-def _append_jsonl_fsync(target: Path, record: dict) -> None:
-    """Append one JSON line to target; fsync for durability (mirrors state_manager)."""
-    target.parent.mkdir(parents=True, exist_ok=True)
-    line = json.dumps(record, separators=(",", ":")) + "\n"
-    with open(target, "a", encoding="utf-8") as fh:
-        fh.write(line)
-        fh.flush()
-        try:
-            os.fsync(fh.fileno())
-        except OSError:
-            pass
 
 
 # ---------------------------------------------------------------------------

--- a/claude-config/hooks/hook_common.py
+++ b/claude-config/hooks/hook_common.py
@@ -1,0 +1,71 @@
+"""Shared stdlib-only helpers for the hook scripts (#369).
+
+These were copy-pasted across state_manager.py, capture_session_telemetry.py
+and aggregate_metrics_to_global.py; a drift in timestamp precision between
+copies would corrupt the /learn watermark invariant. One definition, three
+importers — hooks in this directory import siblings without sys.path work
+(the script's own dir is always on sys.path), and external callers already
+insert ~/.claude/hooks.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def utc_now_iso() -> str:
+    """ISO-8601 UTC timestamp with **microsecond** precision.
+
+    Returns strings like ``"2026-05-29T14:23:45.123456Z"``.  Used as
+    ``recorded_at`` on every new metrics/failure record so the telemetry
+    gate can compare records across machines using a sortable timestamp.
+
+    Watermark invariant (strict ``>``)
+    ----------------------------------
+    The /learn watermark is advanced to the **max consumed ``recorded_at``**
+    in the snapshot — never to wall-clock ``now()``.  After that advance,
+    any record whose ``recorded_at`` equals the watermark was, by definition,
+    already consumed and is correctly excluded by the ``> watermark`` filter.
+    Any record stamped *after* the snapshot (``recorded_at > consumed_max``)
+    is still counted on the next run.  Microsecond precision makes collisions
+    between concurrent records on the same machine extremely unlikely, and the
+    strict ``>`` gate handles any equality case correctly.
+    """
+    return (
+        datetime.now(timezone.utc)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def get_host_name() -> str:
+    """Read the canonical host name for this machine.
+
+    Mirrors lib/project_resolver.get_host_name() — duplicated at the hooks
+    layer (once, here) to keep hooks stdlib-only.
+    """
+    host_name_path = Path.home() / ".claude" / "host-name"
+    try:
+        text = host_name_path.read_text(encoding="utf-8").strip()
+        if text:
+            return text
+    except FileNotFoundError:
+        pass
+    import socket
+    return (socket.gethostname() or "unknown").split(".")[0].lower()
+
+
+def append_jsonl_fsync(target: Path, record: dict) -> None:
+    """Append one JSON line to target; fsync for durability."""
+    target.parent.mkdir(parents=True, exist_ok=True)
+    line = json.dumps(record, separators=(",", ":")) + "\n"
+    with open(target, "a", encoding="utf-8") as fh:
+        fh.write(line)
+        fh.flush()
+        try:
+            os.fsync(fh.fileno())
+        except OSError:
+            pass

--- a/claude-config/hooks/state_manager.py
+++ b/claude-config/hooks/state_manager.py
@@ -18,8 +18,10 @@ import json
 import logging
 import os
 import re
-from datetime import datetime, timezone
+from datetime import datetime
 from pathlib import Path
+
+from hook_common import utc_now_iso as _utc_now_iso  # shared (#369)
 
 _log_file = Path.home() / ".claude" / "hooks.log"
 logging.basicConfig(
@@ -36,29 +38,6 @@ except ImportError:
     HAS_YAML = False
 
 
-def _utc_now_iso() -> str:
-    """ISO-8601 UTC timestamp with **microsecond** precision.
-
-    Returns strings like ``"2026-05-29T14:23:45.123456Z"``.  Used as
-    ``recorded_at`` on every new metrics/failure record so the telemetry
-    gate can compare records across machines using a sortable timestamp.
-
-    Watermark invariant (strict ``>``)
-    ----------------------------------
-    The /learn watermark is advanced to the **max consumed ``recorded_at``**
-    in the snapshot — never to wall-clock ``now()``.  After that advance,
-    any record whose ``recorded_at`` equals the watermark was, by definition,
-    already consumed and is correctly excluded by the ``> watermark`` filter.
-    Any record stamped *after* the snapshot (``recorded_at > consumed_max``)
-    is still counted on the next run.  Microsecond precision makes collisions
-    between concurrent records on the same machine extremely unlikely, and the
-    strict ``>`` gate handles any equality case correctly.
-    """
-    return (
-        datetime.now(timezone.utc)
-        .isoformat()
-        .replace("+00:00", "Z")
-    )
 
 
 def _event_id(issue: int, date: str, project: str, root_cause: str, details: str) -> str:

--- a/claude-config/tests/test_hook_common.py
+++ b/claude-config/tests/test_hook_common.py
@@ -1,0 +1,48 @@
+"""Tests for the shared hook helpers (issue #369)."""
+
+import json
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "hooks"))
+
+import hook_common as HC  # noqa: E402
+
+
+def test_utc_now_iso_format():
+    ts = HC.utc_now_iso()
+    # microsecond precision + Z suffix — the watermark invariant depends on this
+    assert re.fullmatch(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6}Z", ts), ts
+
+
+def test_consumers_share_one_definition():
+    """Drift-proofing: the hook scripts must alias hook_common's functions,
+    not carry their own copies."""
+    import capture_session_telemetry as CT
+    import state_manager as SM
+    assert SM._utc_now_iso is HC.utc_now_iso
+    assert CT._utc_now_iso is HC.utc_now_iso
+    assert CT._get_host_name is HC.get_host_name
+    assert CT._append_jsonl_fsync is HC.append_jsonl_fsync
+
+
+def test_get_host_name_reads_file(tmp_path, monkeypatch):
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    (tmp_path / ".claude").mkdir()
+    (tmp_path / ".claude" / "host-name").write_text("my-box\n")
+    assert HC.get_host_name() == "my-box"
+
+
+def test_get_host_name_falls_back_to_hostname(tmp_path, monkeypatch):
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    name = HC.get_host_name()
+    assert name and "." not in name and name == name.lower()
+
+
+def test_append_jsonl_fsync_roundtrip(tmp_path):
+    target = tmp_path / "sub" / "log.jsonl"
+    HC.append_jsonl_fsync(target, {"a": 1})
+    HC.append_jsonl_fsync(target, {"b": 2})
+    rows = [json.loads(line) for line in target.read_text().splitlines()]
+    assert rows == [{"a": 1}, {"b": 2}]

--- a/lib/tests/test_actions_md.py
+++ b/lib/tests/test_actions_md.py
@@ -1,0 +1,176 @@
+"""Unit tests for lib/actions_md.py (issue #369).
+
+The schema-migration paths (v1/v2 → current) and _row_cells branching were
+previously covered only indirectly through the action CLI integration tests.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
+
+from lib.actions_md import (  # noqa: E402
+    CLOSED_COLS,
+    CLOSED_COLS_V1,
+    CLOSED_COLS_V2,
+    OPEN_COLS,
+    OPEN_COLS_V1,
+    MarkdownParseError,
+    _row_cells,
+    escape_pipes,
+    parse_file,
+    parse_files_cell,
+    parse_next_id_from_data,
+    render_files_cell,
+    render_row,
+)
+
+
+def _doc(open_rows: list[str], closed_rows: list[str], *,
+         open_cols=OPEN_COLS, closed_cols=CLOSED_COLS, next_id: str | None = "A-010") -> str:
+    def table(cols, rows):
+        head = render_row(cols, {c: c for c in cols})
+        sep = "|" + "|".join(["----"] * len(cols)) + "|"
+        return "\n".join([head, sep, *rows])
+
+    parts = [
+        "# Actions",
+        "",
+        "## Open",
+        "",
+        table(open_cols, open_rows),
+        "",
+        "## Recently Closed",
+        "",
+        table(closed_cols, closed_rows),
+        "",
+    ]
+    if next_id:
+        parts.append(f"Next ID: {next_id}")
+    return "\n".join(parts)
+
+
+CUR_OPEN = "| A-001 | #5 | Do thing | Jason | open | 2026-06-01 | gh | a.py | note |"
+V1_OPEN = "| A-002 | #6 | Old thing | Jason | open | 2026-05-01 | gh | old note |"
+CUR_CLOSED = "| A-003 | #7 | Done | Jason | 2026-05-01 | 2026-06-01 | b.py | done |"
+V2_CLOSED = "| A-004 | #8 | Done v2 | Jason | 2026-06-02 | c.py | n |"
+V1_CLOSED = "| A-005 | #9 | Done v1 | Jason | 2026-06-03 | n |"
+
+
+# ---------- _row_cells schema branching ----------
+
+def test_row_cells_current_schema():
+    cells = _row_cells(CUR_OPEN, OPEN_COLS, OPEN_COLS_V1)
+    assert cells["ID"] == "A-001"
+    assert cells["Files"] == "a.py"
+
+
+def test_row_cells_legacy_synthesizes_missing_fields():
+    cells = _row_cells(V1_OPEN, OPEN_COLS, OPEN_COLS_V1)
+    assert cells["ID"] == "A-002"
+    assert cells["Notes"] == "old note"
+    assert cells["Files"] == ""  # synthesized — every current key present
+
+
+def test_row_cells_malformed_returns_empty():
+    assert _row_cells("| only | three | cells |", OPEN_COLS, OPEN_COLS_V1) == {}
+
+
+def test_row_cells_tries_multiple_legacies():
+    v2 = _row_cells(V2_CLOSED, CLOSED_COLS, CLOSED_COLS_V2, CLOSED_COLS_V1)
+    assert v2["Files"] == "c.py" and v2["Opened"] == ""
+    v1 = _row_cells(V1_CLOSED, CLOSED_COLS, CLOSED_COLS_V2, CLOSED_COLS_V1)
+    assert v1["Closed"] == "2026-06-03" and v1["Files"] == "" and v1["Opened"] == ""
+
+
+# ---------- parse_file ----------
+
+def test_parse_file_reads_rows_and_next_id(tmp_path):
+    p = tmp_path / "ACTIONS.md"
+    p.write_text(_doc([CUR_OPEN], [CUR_CLOSED]))
+    m = parse_file(p)
+    assert [r["ID"] for r in m.open_rows()] == ["A-001"]
+    assert [r["ID"] for r in m.closed_rows()] == ["A-003"]
+    assert m.next_id_num == 10
+
+
+def test_parse_file_derives_next_id_from_data_when_marker_missing(tmp_path):
+    p = tmp_path / "ACTIONS.md"
+    p.write_text(_doc([CUR_OPEN], [CUR_CLOSED], next_id=None))
+    m = parse_file(p)
+    assert m.next_id_num == 4  # max(A-001, A-003) + 1
+
+
+def test_parse_file_missing_section_raises(tmp_path):
+    p = tmp_path / "ACTIONS.md"
+    p.write_text("# Actions\n\n## Open\n\n| ID |\n|----|\n")
+    with pytest.raises(MarkdownParseError):
+        parse_file(p)
+
+
+def test_parse_file_missing_file_raises(tmp_path):
+    with pytest.raises(MarkdownParseError):
+        parse_file(tmp_path / "nope.md")
+
+
+def test_find_row_and_missing_id(tmp_path):
+    p = tmp_path / "ACTIONS.md"
+    p.write_text(_doc([CUR_OPEN], [CUR_CLOSED]))
+    m = parse_file(p)
+    assert m.find_row("A-001")[0] == "open"
+    assert m.find_row("A-003")[0] == "closed"
+    with pytest.raises(MarkdownParseError):
+        m.find_row("A-999")
+
+
+# ---------- migration ----------
+
+def test_migrate_v1_open_table_gains_files_column(tmp_path):
+    p = tmp_path / "ACTIONS.md"
+    p.write_text(_doc([V1_OPEN], [V1_CLOSED],
+                      open_cols=OPEN_COLS_V1, closed_cols=CLOSED_COLS_V1))
+    m = parse_file(p)
+    m.write()
+    m2 = parse_file(p)
+    header = m2.lines[m2.open_sep_idx - 1]
+    assert "Files" in header
+    row = m2.open_rows()[0]
+    assert row["ID"] == "A-002" and row["Files"] == ""
+    closed = m2.closed_rows()[0]
+    assert closed["ID"] == "A-005" and closed["Files"] == ""
+
+
+def test_migrate_is_idempotent(tmp_path):
+    p = tmp_path / "ACTIONS.md"
+    p.write_text(_doc([CUR_OPEN], [CUR_CLOSED]))
+    m = parse_file(p)
+    m.write()
+    first = p.read_text()
+    parse_file(p).write()
+    assert p.read_text() == first
+
+
+def test_write_roundtrip_preserves_data(tmp_path):
+    p = tmp_path / "ACTIONS.md"
+    p.write_text(_doc([CUR_OPEN], [CUR_CLOSED]))
+    before = parse_file(p)
+    rows_before = (before.open_rows(), before.closed_rows())
+    before.write()
+    after = parse_file(p)
+    assert (after.open_rows(), after.closed_rows()) == rows_before
+
+
+# ---------- small helpers ----------
+
+def test_parse_next_id_from_data_prefers_data_over_marker():
+    content = _doc([CUR_OPEN], [CUR_CLOSED], next_id="A-002")  # marker LIES (data has A-003)
+    assert parse_next_id_from_data(content) == 4
+
+
+def test_escape_pipes_and_files_cells():
+    assert "\\|" in escape_pipes("a|b")
+    assert parse_files_cell("a.py, b.py") == ["a.py", "b.py"]
+    assert parse_files_cell("") == []
+    assert render_files_cell(["a.py", "b.py"]) == "a.py, b.py"

--- a/lib/tests/test_bin_memory.py
+++ b/lib/tests/test_bin_memory.py
@@ -1,0 +1,165 @@
+"""Tests for bin/memory core logic (issue #369): recall ranking, TTL expiry,
+stale-perishable heuristic, archive selection helpers.
+
+bin/memory has no .py extension; load it via SourceFileLoader.
+"""
+
+import datetime
+import importlib.util
+import time
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+_BIN = Path(__file__).resolve().parent.parent.parent / "bin" / "memory"
+_loader = SourceFileLoader("bin_memory", str(_BIN))
+_spec = importlib.util.spec_from_loader("bin_memory", _loader)
+M = importlib.util.module_from_spec(_spec)
+_loader.exec_module(M)
+
+TODAY = datetime.date(2026, 6, 9)
+
+
+def _fact(memdir, name, *, ftype="project", expires="", desc="", body="body text"):
+    memdir.mkdir(parents=True, exist_ok=True)
+    fm = f"---\nname: {name}\ndescription: {desc}\ntype: {ftype}\n"
+    if expires:
+        fm += f"expires: {expires}\n"
+    fm += "---\n\n"
+    p = memdir / f"{name}.md"
+    p.write_text(fm + body, encoding="utf-8")
+    return p
+
+
+def _store(tmp_path, monkeypatch):
+    root = tmp_path / "projects"
+    monkeypatch.setattr(M, "PROJECTS_ROOT", root)
+    return root
+
+
+# ---------- frontmatter parsing ----------
+
+def test_split_frontmatter_flat_and_nested():
+    flat, body = M._split_frontmatter("---\nname: a\ntype: feedback\n---\nB")
+    assert flat["type"] == "feedback" and body == "B"
+    nested, _ = M._split_frontmatter(
+        "---\nname: a\nmetadata:\n  type: user\n---\nB")
+    assert nested["type"] == "user"
+
+
+def test_split_frontmatter_absent():
+    meta, body = M._split_frontmatter("no frontmatter")
+    assert meta["name"] == "" and body == "no frontmatter"
+
+
+# ---------- TTL ----------
+
+def test_is_expired():
+    assert M._is_expired({"expires": "2026-01-01"}, TODAY)
+    assert not M._is_expired({"expires": "2027-01-01"}, TODAY)
+    assert not M._is_expired({"expires": ""}, TODAY)
+    assert not M._is_expired({"expires": "not-a-date"}, TODAY)
+
+
+def test_stale_perishable_heuristic(tmp_path):
+    now = time.time()
+    old = now - 100 * 86400
+    p = tmp_path / "resume_session_plan.md"
+    p.write_text("x")
+    # type=project + perishable name + old → candidate
+    assert M._is_stale_perishable(p, {"type": "project"}, old, now, 90)
+    # durable types never stale
+    assert not M._is_stale_perishable(p, {"type": "feedback"}, old, now, 90)
+    # non-perishable name → not a candidate
+    q = tmp_path / "architecture_decision.md"
+    q.write_text("x")
+    assert not M._is_stale_perishable(q, {"type": "project"}, old, now, 90)
+    # recent → not a candidate
+    assert not M._is_stale_perishable(p, {"type": "project"}, now - 86400, now, 90)
+
+
+def test_ttl_reason_strings(tmp_path):
+    p = tmp_path / "resume_notes.md"
+    p.write_text("x")
+    now = time.time()
+    assert "expired" in M._ttl_reason(p, {"expires": "2026-01-01", "type": ""}, now, TODAY, now, 90)
+    assert "stale perishable" in M._ttl_reason(
+        p, {"expires": "", "type": "project"}, now - 100 * 86400, TODAY, now, 90)
+    assert M._ttl_reason(p, {"expires": "", "type": "feedback"}, now, TODAY, now, 90) is None
+
+
+# ---------- recall ranking ----------
+
+class _Args:
+    def __init__(self, query, project=None, limit=5, compact=True, all=False):
+        self.query = query
+        self.project = project
+        self.limit = limit
+        self.compact = compact
+        self.all = all
+
+
+def test_recall_title_match_outranks_body_match(tmp_path, monkeypatch, capsys):
+    root = _store(tmp_path, monkeypatch)
+    _fact(root / "-p-alpha" / "memory", "telemetry-design",
+          desc="telemetry hub design", body="unrelated")
+    _fact(root / "-p-beta" / "memory", "other-fact",
+          desc="", body="telemetry mentioned once")
+    rc = M.cmd_recall(_Args("telemetry"))
+    assert rc == 0
+    lines = [line for line in capsys.readouterr().out.splitlines() if line.startswith("- ")]
+    assert "telemetry-design" in lines[0]
+    assert "other-fact" in lines[1]
+
+
+def test_recall_hides_expired_by_default(tmp_path, monkeypatch, capsys):
+    root = _store(tmp_path, monkeypatch)
+    _fact(root / "-p-a" / "memory", "dead-fact", expires="2026-01-01",
+          body="needle content")
+    rc = M.cmd_recall(_Args("needle"))
+    assert rc == 0
+    assert "No facts match" in capsys.readouterr().out
+
+    rc = M.cmd_recall(_Args("needle", all=True))
+    assert "dead-fact" in capsys.readouterr().out and rc == 0
+
+
+def test_recall_project_filter(tmp_path, monkeypatch, capsys):
+    root = _store(tmp_path, monkeypatch)
+    _fact(root / "-Users-jasonjob-projects-alpha" / "memory", "fact-a", body="needle")
+    _fact(root / "-Users-jasonjob-projects-beta" / "memory", "fact-b", body="needle")
+    M.cmd_recall(_Args("needle", project="alpha"))
+    out = capsys.readouterr().out
+    assert "fact-a" in out and "fact-b" not in out
+
+
+def test_recall_skips_archive_subdir(tmp_path, monkeypatch, capsys):
+    root = _store(tmp_path, monkeypatch)
+    mem = root / "-p-a" / "memory"
+    _fact(mem, "live-fact", body="needle")
+    _fact(mem / "archive", "buried-fact", body="needle")
+    M.cmd_recall(_Args("needle"))
+    out = capsys.readouterr().out
+    assert "live-fact" in out and "buried-fact" not in out
+
+
+def test_recall_limit(tmp_path, monkeypatch, capsys):
+    root = _store(tmp_path, monkeypatch)
+    for i in range(8):
+        _fact(root / f"-p-{i}" / "memory", f"fact-{i}", body="needle")
+    M.cmd_recall(_Args("needle", limit=3))
+    lines = [line for line in capsys.readouterr().out.splitlines() if line.startswith("- ")]
+    assert len(lines) == 3
+
+
+def test_recall_empty_query_errors():
+    assert M.cmd_recall(_Args("   ")) == 2
+
+
+# ---------- index hygiene ----------
+
+def test_deindex_removes_pointer(tmp_path):
+    idx = tmp_path / "MEMORY.md"
+    idx.write_text("# Memory\n- [A](a.md) — hook\n- [B](b.md) — hook\n")
+    M._deindex(idx, "a.md")
+    text = idx.read_text()
+    assert "a.md" not in text and "b.md" in text


### PR DESCRIPTION
hooks/hook_common.py now owns _utc_now_iso/_get_host_name/
_append_jsonl_fsync (previously copy-pasted across state_manager,
capture_session_telemetry, aggregate_metrics_to_global — a precision
drift between copies would corrupt the /learn watermark invariant).
The three hooks import-alias the shared definitions; a drift-proofing
test asserts function identity across modules.

New unit suites for the two zero-coverage load-bearing modules:
lib/tests/test_actions_md.py (14 tests — v1/v2->current schema
migration, _row_cells legacy branching + malformed rows, marker-vs-data
next-ID, idempotent migrate, write round-trip) and
lib/tests/test_bin_memory.py (12 tests via SourceFileLoader — recall
ranking incl. title-weighting, TTL expiry, stale-perishable heuristic,
archive-subdir exclusion, project filter, deindex hygiene).

Test evidence: ruff clean; 573+69+233 pass across all suites; live
sessionstart hook run OK through the deduped path.

Closes #369

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
