### PR TITLE
feat(orchestrate): tier-aware model routing + four-tier classification (#387)

### DIFF
--- a/claude-config/agents/map.md
+++ b/claude-config/agents/map.md
@@ -2,7 +2,7 @@
 name: orchestrate-map
 description: Read-only investigator for COMPLEX orchestrate workflow phase 1. Maps current code state before planning. Use only when dispatched by /orchestrate; do not auto-invoke.
 tools: Read, Grep, Glob, Bash, Write
-model: haiku
+model: sonnet
 agent: "MAP"
 version: 1.2
 phase: 1

--- a/claude-config/agents/pr-fresh-reviewer.md
+++ b/claude-config/agents/pr-fresh-reviewer.md
@@ -2,7 +2,7 @@
 name: pr-fresh-reviewer
 description: Fresh-context PR reviewer for the /pr workflow. Reviews staged diff against the issue with no inheritance from implementation discussion. Use only when explicitly invoked by /pr; do not auto-fire on every code change (the pr-review-toolkit:code-reviewer plugin agent fills that role).
 tools: Read, Grep, Glob, Bash
-model: haiku
+model: sonnet
 memory: project
 ---
 

--- a/claude-config/commands/orchestrate.md
+++ b/claude-config/commands/orchestrate.md
@@ -142,13 +142,20 @@ If seeds match, report before proceeding. If no `.planning/seeds/`, skip silentl
 
 ### Step 1: Classify Complexity
 
-| Level | Criteria | Workflow |
-|-------|----------|----------|
-| SIMPLE | 1-3 files | MAP-PLAN |
-| COMPLEX | Endpoints, migrations | MAP + PLAN |
+Four tiers (#387). Estimate the file count from the issue body + a quick grep;
+when two tiers both fit, the RISK signals (migrations, endpoints, fullstack,
+cross-cutting) win over the file count.
 
-TRIVIAL work (typo, single-config-line fix, obvious one-file change) is **not**
-handled by `/orchestrate` — see the routing gate below.
+| Tier | Criteria | Pipeline | Notes |
+|------|----------|----------|-------|
+| TRIVIAL | Typo, single-config-line, obvious one-file fix | — | Rejected below → `/quick` |
+| SIMPLE | 1–3 files, one subsystem, clear behavior | MAP-PLAN | Default cheap path |
+| MODERATE | 4–5 files, single subsystem, clear pattern | MAP-PLAN | Same pipeline as SIMPLE, but Codex review per Step 1.1 and record `complexity: MODERATE` |
+| COMPLEX | 6+ files, OR any migration / new-changed endpoint / cross-cutting refactor / FULLSTACK | MAP → PLAN → PLAN-CHECK | Strong-model overrides at dispatch (Step 3) |
+
+**Canonical complexity enum for telemetry**: `TRIVIAL | SIMPLE | MODERATE |
+COMPLEX` — never `MEDIUM`, never `SUCCESS` for status (it's `PASS`). The
+telemetry already contains drifted labels from older runs; do not add more.
 
 Report:
 
@@ -329,13 +336,47 @@ Task(
     description='<phase> for issue <N>',
     subagent_type='orchestrate-<phase>',  # registered name
     prompt=AGENT_PROMPT,                   # context only — no instructions
+    # model=...  ← ONLY per the routing table below; omit otherwise
 )
 ```
 
 Claude Code auto-loads the agent body, applies the agent's `tools:` restriction,
-and uses the agent's `model:` (Haiku for read-only phases, Sonnet otherwise).
+and uses the agent's `model:` frontmatter unless the dispatch overrides it.
 Do NOT include "read your instructions from agents/X.md" in the prompt — the
 agent body is loaded automatically.
+
+#### Model Routing (#387) — right model for the right step
+
+Frontmatter defaults serve SIMPLE/MODERATE (65%+ of runs — the cheap path).
+On COMPLEX and FULLSTACK, override at dispatch: plan errors cascade into
+PATCH+PROVE recycles (the most expensive place to be wrong), implementation
+correctness is the historical failure bottleneck, and verification rigor
+must scale with blast radius (50/50 COMPLEX PASS with 3 lifetime PROVE
+blocks is a leniency smell, not a quality proof).
+
+| Phase | SIMPLE / MODERATE | COMPLEX / FULLSTACK |
+|-------|-------------------|---------------------|
+| MAP-PLAN | sonnet (frontmatter) | — |
+| MAP | — | sonnet (frontmatter) |
+| PLAN | — | **`model="opus"`** at dispatch |
+| PLAN-CHECK | haiku (frontmatter) | haiku (frontmatter) |
+| CONTRACT | sonnet (frontmatter) | **`model="opus"`** when FULLSTACK |
+| TEST-PLANNER | sonnet (frontmatter) | sonnet (frontmatter) |
+| PATCH | sonnet (frontmatter) | **`model="opus"`** at dispatch |
+| PROVE | sonnet (frontmatter) | **`model="opus"`** at dispatch |
+| DISCUSS | sonnet (frontmatter) | sonnet (frontmatter) |
+
+- "opus" means the strongest model tier available to the session — if the
+  main loop is running a stronger model (e.g. Fable), pass that instead
+  (`model="fable"`); never dispatch a COMPLEX PLAN/PATCH/PROVE on a model
+  weaker than sonnet.
+- Do NOT override upward on SIMPLE/MODERATE "just to be safe" — the tiering
+  IS the safety design; upgrading everything reintroduces the cost of having
+  no tiers.
+- PRIOR-FAIL retries (same issue, second attempt after a PROVE FAIL):
+  upgrade PATCH one tier (sonnet → opus-class) regardless of complexity —
+  failed work gets a different (stronger) model, per
+  `implementation-routing.md`.
 
 For per-agent dispatch tables, validation gates, and failure-context injection,
 **read `templates/orchestrate-pipeline.md`**.

--- a/claude-config/templates/orchestrate-pipeline.md
+++ b/claude-config/templates/orchestrate-pipeline.md
@@ -20,9 +20,12 @@ Task(
 ```
 
 Claude Code auto-loads the agent body, applies its `tools:` restriction, and
-honours its `model:` (Haiku for MAP / PLAN-CHECK / DISCUSS; Sonnet
-otherwise). The prompt should contain context only — never repeat the
-agent's own instructions.
+honours its `model:` frontmatter (haiku only for PLAN-CHECK; sonnet
+otherwise) unless the dispatch overrides it — COMPLEX/FULLSTACK dispatches
+override PLAN/PATCH/PROVE (+CONTRACT when fullstack) to the opus-class
+model per the Model Routing table in `commands/orchestrate.md` Step 3
+(#387). The prompt should contain context only — never repeat the agent's
+own instructions.
 
 For per-invocation prompt content, see `templates/agent-prompt.md`.
 


### PR DESCRIPTION
Model assignment was static and tier-blind: a COMPLEX migration PATCH and
a 2-file SIMPLE PATCH both ran sonnet, the COMPLEX pipeline's only
investigator (MAP) ran haiku, and pr-fresh-reviewer — a CRITICAL-blocking
/ship gate — reviewed on haiku. Step 3 now carries an explicit Model
Routing table: frontmatter defaults serve SIMPLE/MODERATE (the 65% cheap
path, unchanged cost); COMPLEX/FULLSTACK dispatches override PLAN/PATCH/
PROVE (+CONTRACT when fullstack) to the opus-class model via the Task
model parameter; PRIOR-FAIL retries upgrade PATCH one tier. map.md and
pr-fresh-reviewer.md bump haiku->sonnet; plan-checker stays haiku.

Step 1 classification grows from two tiers to the canonical four
(TRIVIAL reject; SIMPLE 1-3 files; MODERATE 4-5 single-subsystem on the
SIMPLE pipeline + Codex review; COMPLEX 6+/migrations/endpoints/
fullstack) with risk signals outranking file count, and pins the
telemetry enum (MODERATE not MEDIUM, PASS not SUCCESS — both drifted in
the corpus). orchestrate-pipeline.md model note de-drifted (it claimed
DISCUSS=haiku; discuss.md says sonnet).

Closes #387

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
