### PR TITLE
chore(rules): one routing table for the four overlapping review surfaces

### DIFF
--- a/claude-config/commands/ship.md
+++ b/claude-config/commands/ship.md
@@ -93,16 +93,18 @@ the push if the remote has diverged beyond our rebase base.
 
 ### Step 5 — PR + Review Gates
 
-If no open PR exists for this branch, create one per `pr.md §Create PR`. Then:
+If no open PR exists for this branch, create one per `pr.md §Create PR`. Then
+run the review gates per `implementation-routing.md §Review Surface Routing`:
 
-1. **Fresh-context review**: Run `pr-fresh-reviewer` per `pr.md §Pre-PR Fresh-Context Review`.
+1. **Fresh-context review** (`pr-fresh-reviewer`) fires automatically via
+   `pr.md §Pre-PR Fresh-Context Review`.
    - **Gate**: CRITICAL findings → STOP. Do NOT proceed until fixed.
    - WARNING findings: include in PR body; continue.
 
-2. **COMPLEX-signal check**: Run the signal detection block per `pr.md §Pre-merge Codex review for COMPLEX changes`.
-   - If COMPLEX signals fire, recommend `/codex:adversarial-review` before proceeding.
-   - This is advisory — the user decides whether to run it. `/ship` pauses and
-     prompts: "COMPLEX signals detected. Run /codex:adversarial-review? [y/N to skip]"
+2. **Tier/risk-class escalation**: consult the routing table in
+   `implementation-routing.md §Review Surface Routing` to determine whether
+   `/codex:adversarial-review` applies. `/ship` prompts when COMPLEX signals
+   fire (see `pr.md §Pre-merge Codex review for COMPLEX changes`).
 
 ### Step 6 — CI Watch
 

--- a/claude-config/rules/implementation-routing.md
+++ b/claude-config/rules/implementation-routing.md
@@ -74,6 +74,25 @@ telemetry paths) live in that project's memory, not here — e.g. buddy's
 clauses + `codex_review_gate` chokepoint:
 `~/.claude/projects/-Users-jasonjob-projects-buddy/memory/codex_review_gates_buddy.md`.
 
+## Review Surface Routing
+
+One table; pick the row that matches your situation. Surfaces are additive —
+`pr-fresh-reviewer` always runs in `/pr`/`/ship`; Codex is layered on top for
+higher tiers.
+
+| When | Surface | How invoked |
+|------|---------|-------------|
+| Any PR (always) | `pr-fresh-reviewer` | Automatic — `/pr` and `/ship` Step 5 |
+| After every change (continuous) | `pr-review-toolkit:code-reviewer` | Automatic — plugin auto-fires |
+| SIMPLE diff, optional spot check | `/codex:review` | Manual — user invokes |
+| MODERATE+ or risk-class (auth, payments, migrations, contracts) | `/codex:adversarial-review` | Manual — user invokes; `/ship` prompts |
+| Architectural / deep quality review of a path | `/deep-review <path>` | Manual — user invokes outside PR workflow |
+| Quick interactive inline review | `/code-review` (harness built-in) | Manual — outside PR workflow |
+
+**Risk-class overrides tier**: SIMPLE diffs that touch auth, payments,
+migrations, data loss, or secrets → treat as MODERATE+ for review surface
+selection.
+
 ## Step 2: Announce Routing Briefly
 
 Examples:

--- a/claude-config/skills/deep-review/SKILL.md
+++ b/claude-config/skills/deep-review/SKILL.md
@@ -7,6 +7,8 @@ argument-hint: [path-or-scope]
 
 # Deep Code Review (v1.0)
 
+**Use when**: architectural or quality deep-dive on a path/scope outside the PR gate workflow. Not a PR pre-commit check — use `pr-fresh-reviewer` (automatic) or `/codex:adversarial-review` (MODERATE+) for PR gating instead.
+
 Comprehensive, critical code review. Not a pre-commit check — a thorough architectural and quality review.
 
 ## Usage


### PR DESCRIPTION
## Summary
- New `## Review Surface Routing` table in implementation-routing.md: six surfaces (pr-fresh-reviewer, pr-review-toolkit:code-reviewer, /codex:review, /codex:adversarial-review, /deep-review, /code-review) mapped to tiers with one-line use-whens + risk-class override
- ship.md Step 5 delegates to the table (CRITICAL-gate semantics preserved verbatim)
- deep-review SKILL.md gains a 'Use when' scope line (it is an architectural review, not a PR gate — not redundant, now routed)

## Test Plan
- [x] PROVE PASS — 3/3 ACs implemented (prove-385-060926.md); evals runner clean; validate-paths-globs 18 rules clean; 443/443 tests
- [x] prove_gate exit 0

Closes #385

🤖 Generated with [Claude Code](https://claude.com/claude-code)