### PR TITLE
feat(learn): track generated patterns in claude-config so learning propagates across machines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,7 @@ google/*.bin
 telemetry/*/sessions.jsonl
 telemetry/*/capture_heartbeat.json
 telemetry/*/failures.jsonl
+
+# Safety: these local-only files must never appear in the tracked memory dir
+claude-config/memory/failures.jsonl
+claude-config/memory/metrics.jsonl

--- a/claude-config/commands/learn.md
+++ b/claude-config/commands/learn.md
@@ -445,8 +445,11 @@ After all pattern updates are written in Steps 6.5.  This step uses the
 4. **Stage and commit** telemetry shard(s), watermark, and any agent file changes:
    ```bash
    git add telemetry/ claude-config/agents/ \
-       .claude/memory/patterns-full.md \
+       claude-config/memory/patterns-full.md \
+       claude-config/memory/patterns-critical.md \
        .claude/memory/pattern-events.jsonl 2>/dev/null || true
+   # Note: patterns-*.md live at claude-config/memory/ (repo path, symlinked to
+   # ~/.claude/memory/ by install.sh). Stage the repo path, not the symlink.
    git commit -m "learn: apply patterns + advance watermark to $CONSUMED_MAX"
    ```
 

--- a/claude-config/install.sh
+++ b/claude-config/install.sh
@@ -102,6 +102,7 @@ link_item() {
 
 echo "Phase 1: Symlinks"
 mkdir -p "$CLAUDE_DIR"
+mkdir -p "$CLAUDE_DIR/memory"
 
 link_item "$SCRIPT_DIR/settings.json"       "$CLAUDE_DIR/settings.json"       "settings.json"
 link_item "$SCRIPT_DIR/CLAUDE.md"           "$CLAUDE_DIR/CLAUDE.md"           "CLAUDE.md"
@@ -112,6 +113,12 @@ link_item "$SCRIPT_DIR/rules"               "$CLAUDE_DIR/rules"              "ru
 link_item "$SCRIPT_DIR/skills"              "$CLAUDE_DIR/skills"              "skills/"
 link_item "$SCRIPT_DIR/templates"           "$CLAUDE_DIR/templates"           "templates/"
 link_item "$SCRIPT_DIR/statusline.py"       "$CLAUDE_DIR/statusline.py"       "statusline.py"
+link_item "$SCRIPT_DIR/memory/patterns-critical.md" \
+    "$CLAUDE_DIR/memory/patterns-critical.md" \
+    "memory/patterns-critical.md"
+link_item "$SCRIPT_DIR/memory/patterns-full.md" \
+    "$CLAUDE_DIR/memory/patterns-full.md" \
+    "memory/patterns-full.md"
 
 echo ""
 
@@ -522,7 +529,8 @@ echo "Phase 4: Verify"
 ERRORS=0
 
 # Verify symlinks resolve
-for link in settings.json hooks commands agents rules skills templates statusline.py; do
+for link in settings.json hooks commands agents rules skills templates statusline.py \
+            memory/patterns-critical.md memory/patterns-full.md; do
     target="$CLAUDE_DIR/$link"
     if [ -L "$target" ] && [ -e "$target" ]; then
         : # OK

--- a/claude-config/memory/patterns-critical.md
+++ b/claude-config/memory/patterns-critical.md
@@ -1,0 +1,80 @@
+# Critical Patterns
+
+**Provenance**: regenerated 2026-06-09 (#366) from the FULL deduped 2026
+failure corpus — N=40 records, 2026-01-06 → 2026-06-07, union of
+`~/agents/telemetry/*/failures.jsonl` + `~/.claude/memory/failures.jsonl`,
+classified by `map_freetext_root_causes.py`. Percentages are real counts
+against that N, not carried-forward claims.
+
+**Load this file ALWAYS. patterns-full.md has per-cluster evidence.**
+
+---
+
+## 1. VERIFICATION_GAP — 11/40 (27.5%), the dominant cluster
+
+**Trigger**: any assumption about code structure, spec content, data shape,
+or dependency behavior.
+
+**2026 evidence shapes** (from the corpus): "stated dependency resolved but
+didn't verify implementation", "added new field without checking ALL
+formulas using it", "assumed consecutive year data", "didn't verify column
+dependencies and execution order", "documented expected data shapes but
+didn't add validation".
+
+**Prevention**:
+- Read the spec file FIRST if referenced; read the actual code before
+  asserting anything about it
+- "Resolved/exists/unchanged" claims require a fresh read, not memory
+- New field/parameter → grep EVERY consumer (formulas, serializers, tests)
+- Data-shape assumptions get validation code, not comments
+
+---
+
+## 2. AMBIGUITY_UNRESOLVED — 3/40 (7.5%)
+
+**Trigger**: two valid interpretations of a spec/issue; a contradiction you
+noticed.
+
+**2026 evidence shapes**: "identified contradiction but failed to resolve it
+definitively", "discussed both interpretations but didn't pick one".
+
+**Prevention**: pick ONE interpretation, write it down (artifact/PR body),
+and flag the alternative explicitly. Noticing ambiguity without resolving
+it is the failure — resolution is cheap, rework is not.
+
+---
+
+## 3. Long tail — 26/40 (65%): one-off infra/SQL/integration causes
+
+No other cluster reaches 3 (SCOPE_CREEP 2, DOCUMENTATION 2, rest
+singletons: SQL reserved words, asyncpg pool misuse, blocking
+fire-and-forget, stub handlers, …). The lesson is the loop, not a pattern:
+record root causes precisely so /learn can cluster them.
+
+---
+
+## Status of the legacy headline patterns
+
+| Pattern | Old claim | 2026 corpus | Now |
+|---|---|---|---|
+| VERIFICATION_GAP | 63% | **27.5%** | still #1 — apply above |
+| ENUM_VALUE | 26% | **0 occurrences** | mechanically gated (E01, evals runner #361); still read enum VALUEs on fullstack work |
+| COMPONENT_API | 17% | **0 occurrences** | prose eval E02 + /quick gate; still read component source before reuse |
+
+The old percentages came from an earlier (pre-2026-telemetry) corpus and
+must not be quoted as current. ENUM_VALUE/COMPONENT_API remain real
+fullstack risks — their absence in 2026 partly reflects less fullstack
+work — but their enforcement is now mechanical, not statistical.
+
+---
+
+## Decision Matrix
+
+| Situation | Action |
+|-----------|--------|
+| Issue references spec | Read spec FIRST |
+| Claiming "X is handled/unchanged" | Re-read X now |
+| New field/param | Grep every consumer |
+| Two valid interpretations | Pick ONE, document why |
+| Fullstack with enums | Check VALUE vs NAME (E01 runner) |
+| Reusing component | Read PropTypes/source |

--- a/claude-config/memory/patterns-full.md
+++ b/claude-config/memory/patterns-full.md
@@ -1,0 +1,137 @@
+# Full Patterns — per-cluster evidence
+
+**Provenance**: generated 2026-06-09 (#366) from the deduped 2026 failure
+corpus (N=40, 2026-01-06 → 2026-06-07; telemetry shards + global
+failures.jsonl, classified by map_freetext_root_causes.py).
+Load on COMPLEX issues; patterns-critical.md is the always-on summary.
+
+## VERIFICATION_GAP (11)
+
+- **#78** (buddy): VERIFICATION_GAP
+  - prevention: PLAN should specify data flow between sequential processing steps; MAP-PLAN acceptance criteria should include explicit verification of data handoff between met
+- **#157** (mymoney-dev): Agent stated dependency resolved but didn't verify exact implementation details
+- **#156** (mymoney-dev): Agent used outdated pattern without checking if spec was updated
+- **#156** (mymoney-dev): Agent wrote defensive comment without checking database constraints
+- **#157** (mymoney-dev): Agent added new field without checking ALL formulas that might need it
+- **#157** (mymoney-dev): Agent didn't verify column dependencies and execution order
+- **#160** (mymoney-dev): Agent didn't validate label semantics match data field semantics
+- **#160** (mymoney-dev): Agent listed field in dependencies but didn't verify it's used in implementation
+- **#160** (mymoney-dev): Agent assumed consecutive year data, filtered by modulo instead of deriving from actual rows
+- **#160** (mymoney-dev): Agent assumed projectionMode is always numeric string when not 'current', didn't add validation
+- **#160** (mymoney-dev): Agent documented expected data shapes but didn't add validation before processing
+
+## AMBIGUITY_UNRESOLVED (3)
+
+- **#156** (mymoney-dev): Agent identified contradiction but failed to resolve it definitively
+- **#156** (mymoney-dev): Agent discussed both interpretations but didn't pick one definitively
+- **#157** (mymoney-dev): Agent didn't call out naming inconsistency risk explicitly
+
+## UNMAPPED (3)
+
+- **#156** (mymoney-dev): Agent copied pattern verbatim without understanding which variables are needed
+- **#157** (mymoney-dev): Agent copied acceptance criteria from issue description without aligning to implementation approach
+- **#311** (): AC4 metric measured task-unattributed (unchanged by feature) instead of project-unattributed (the actual win);
+  - prevention: before/after metrics must measure the dimension the feature changes; per-message precedence must prevent a one-off mined signal from overriding the physical cwd
+
+## SCOPE_CREEP (2)
+
+- **#156** (mymoney-dev): Agent planned tests for explicit spec cases but missed implicit filter validation
+- **#160** (mymoney-dev): Agent only implemented primary warning scenario, didn't consider secondary deficit type
+
+## DOCUMENTATION (2)
+
+- **#160** (mymoney-dev): Agent wrote functionally correct logic but didn't document state handling priority explicitly
+- **#157** (mymoney-dev): Agent didn't specify test precision requirements in plan
+
+## LLM_OUTPUT_SCHEMA (1)
+
+- **#learning-dashboard** (buddy): LLM_OUTPUT_SCHEMA
+  - prevention: When consuming LLM-generated JSON, handle multiple plausible keys. Or constrain the output schema in the analysis prompt.
+
+## SERVER_DEP_MANAGEMENT (1)
+
+- **#431** (buddy): SERVER_DEP_MANAGEMENT
+  - prevention: NEVER use 'uv sync' on the server. Always use 'uv pip install <package>' for adding new dependencies. Server dep management is pip-based, not lockfile-based.
+
+## BLOCKING_FIRE_AND_FORGET (1)
+
+- **#phase2-live-test** (buddy): BLOCKING_FIRE_AND_FORGET
+  - prevention: Background tasks that don't affect the response should use asyncio.create_task(), not await. Review all callers of slow background operations.
+
+## ASYNCPG_POOL_VS_CONNECTION (1)
+
+- **#sprint4-audit-logger** (buddy): ASYNCPG_POOL_VS_CONNECTION
+  - prevention: When writing DB code that requires transactions in this codebase, remember: get_pool() returns a Pool, not a Connection. Transactions require pool.acquire() fir
+
+## PIPECAT_PIPELINE_DEADLOCK (1)
+
+- **#sprint4-ui-state-query** (buddy): PIPECAT_PIPELINE_DEADLOCK
+  - prevention: Never await a response from the same WebSocket pipeline that your handler is blocking. Pipecat's transport serializes frame processing — if a tool handler block
+
+## MISSING_TEST (1)
+
+- **#211** (mymoney-dev): MISSING_TEST
+  - prevention: Read acceptance criteria literally - if tests required in phase, create tests in that phase
+
+## LINT_ERROR (1)
+
+- **#235** (mymoney-dev): LINT_ERROR
+  - prevention: Run ruff check on all changed files before committing
+
+## NO_ROOT_CAUSE (1)
+
+- (mymoney-dev): 
+
+## PATH_EXPANSION (1)
+
+- **#learning-dashboard** (buddy): PATH_EXPANSION
+  - prevention: Always use Path(...).expanduser() when path comes from config. PROVE should verify file exists at expected absolute path after write operations.
+
+## SQL_RESERVED_WORD (1)
+
+- **#phase2-live-test** (buddy): SQL_RESERVED_WORD
+  - prevention: Always check column names against PostgreSQL reserved word list. Quote identifiers that match reserved words.
+
+## WRONG_TABLE_NAME (1)
+
+- **#phase2-live-test** (buddy): WRONG_TABLE_NAME
+  - prevention: Always verify table names by reading init-db.sql or running \dt before writing queries. Never trust spec table names without verification.
+
+## INVALID_SQL_CONSTRUCT (1)
+
+- **#phase2-live-test** (buddy): INVALID_SQL_CONSTRUCT
+  - prevention: Test complex SQL against actual PostgreSQL before shipping. DISTINCT + ORDER BY in aggregates is a known PostgreSQL limitation.
+
+## OPENAI_STRICT_SCHEMA (1)
+
+- **#phase2-live-test** (buddy): OPENAI_STRICT_SCHEMA
+  - prevention: When building OpenAI JSON schemas with strict=True: every object needs additionalProperties: false and every property in required. Test schema with a real API c
+
+## SEQUENTIAL_IO (1)
+
+- **#phase2-live-test** (buddy): SEQUENTIAL_IO
+  - prevention: When multiple async DB/IO calls are independent, always use asyncio.gather(). Review extraction pipeline for parallelization opportunities.
+
+## MISSING_SERVICE_WIRING (1)
+
+- **#sprint4-ui-state-query** (buddy): MISSING_SERVICE_WIRING
+  - prevention: When a new capability needs a service, verify that service is actually in ServiceContainer before writing self.deps.get() calls. If not, check whether the servi
+
+## WRONG_CONN_ID_SCOPE (1)
+
+- **#sprint4-ui-state-query** (buddy): WRONG_CONN_ID_SCOPE
+  - prevention: ContextVars set in the voice pipeline represent Pipecat transport connections, NOT browser UI connections. Never use voice pipeline conn_id to target web UI Web
+
+## MISSING_INTERFACE_METHODS (1)
+
+- **#sprint4-ui-state-query** (buddy): MISSING_INTERFACE_METHODS
+  - prevention: When writing code that depends on duck-typed methods, read the actual target class and verify method signatures exist before writing the calling code. No interf
+
+## MULTI_MODEL (1)
+
+- **#211** (mymoney-dev): MULTI_MODEL
+  - prevention: Always import relationship target classes at module level, not in TYPE_CHECKING blocks
+
+## STUB_HANDLERS (1)
+
+- **#582** (mymoney-dev): stub_handlers


### PR DESCRIPTION
## Summary
- patterns-critical.md + patterns-full.md now live in `claude-config/memory/` (tracked), seeded from the 2026-06-09 regenerated copies with provenance headers
- install.sh symlinks them into `~/.claude/memory/` per-file (link_item idiom: existing regular files are backed up and replaced; idempotent on re-run)
- learn.md Step 6.6 stages the repo paths so /learn commits regenerated patterns alongside the watermark
- .gitignore guards prevent failures.jsonl/metrics.jsonl from ever entering claude-config/memory/ (telemetry stays machine-local per #350)

## Post-merge step (other machines)
`ssh jbox06 'cd ~/agents && git pull --ff-only && ./claude-config/install.sh'` — same for the work laptop on next pull.

## Test Plan
- [x] PROVE PASS — 5/5 ACs implemented (prove-383-060926.md): live install run verified migration (regular file → backup → symlink) + idempotency; consumers read through symlinks unchanged; git check-ignore confirms guards; 443/443 tests; bash -n clean
- [x] prove_gate exit 0

Closes #383

🤖 Generated with [Claude Code](https://claude.com/claude-code)