### PR TITLE
feat(telemetry): two quality KPIs in the weekly email — first-pass rate + gates-caught

### DIFF
--- a/claude-config/commands/metrics.md
+++ b/claude-config/commands/metrics.md
@@ -192,6 +192,42 @@ for WEEK in 1 2 3 4; do
 done
 ```
 
+### Step 5.5: Quality KPIs
+
+Display the 8-week first-pass-correct rate and gates-caught trend table.
+The module reads `~/.claude/memory/metrics.jsonl` and `~/.claude/memory/prove-log.jsonl`
+directly and degrades gracefully when either file is absent.
+
+```bash
+python3 ~/.claude/scripts/quality_kpis.py \
+  --metrics ~/.claude/memory/metrics.jsonl \
+  --prove-log ~/.claude/memory/prove-log.jsonl \
+  --overrides ~/.agents/outputs/prove-overrides.jsonl
+```
+
+Example output:
+
+```
+## Quality KPIs (8-week trend)
+
+_Data sparse while first_pass_correct field matures; n/a = no qualifying records that week._
+
+| Week    | First-pass rate | n  | Gates caught |
+| ------- | --------------- | -- | ------------ |
+| 2026-W17 | n/a            | 0  | 0            |
+| 2026-W18 | n/a            | 0  | 0            |
+| 2026-W19 | n/a            | 0  | 0            |
+| 2026-W20 | 100%           | 2  | 1            |
+| 2026-W21 | n/a            | 0  | 0            |
+| 2026-W22 | 67%            | 3  | 0            |
+| 2026-W23 | 100%           | 4  | 0            |
+| 2026-W24 | 100%           | 3  | 1            |
+| **Total** | **89%**       | **12** | **2**    |
+```
+
+The `first_pass_correct` field was added mid-stream; only records that explicitly
+carry the field count toward the denominator (n). Older records are silently excluded.
+
 ---
 
 ## JSON Output Mode

--- a/claude-config/scripts/cost_report_weekly.py
+++ b/claude-config/scripts/cost_report_weekly.py
@@ -20,6 +20,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
+import quality_kpis as KPI  # noqa: E402
 import usage_aggregator as A  # noqa: E402
 import usage_email as E  # noqa: E402
 import usage_report as R  # noqa: E402
@@ -62,6 +63,13 @@ def main() -> int:
     html_path = REPORTS_DIR / f"cost-report-{host}-{wk}.html"
     R.write_report(agg, html_path, records=records)          # writes .html + .md
     md = html_path.with_suffix(".md").read_text(encoding="utf-8")  # email body = the local .md
+    kpi_section = KPI.format_kpi_section(KPI.compute_kpis(
+        metrics_path=Path.home() / ".claude" / "memory" / "metrics.jsonl",
+        prove_log_path=Path.home() / ".claude" / "memory" / "prove-log.jsonl",
+        overrides_paths=[Path.home() / ".agents" / "outputs" / "prove-overrides.jsonl"],
+    ))
+    if kpi_section:
+        md = md + "\n\n" + kpi_section
     print(f"[{now.isoformat()}] local report: {html_path} ({len(records)} records)")
 
     state = _load_state()

--- a/claude-config/scripts/quality_kpis.py
+++ b/claude-config/scripts/quality_kpis.py
@@ -1,0 +1,340 @@
+#!/usr/bin/env python3
+"""Quality KPI module — first-pass-correct rate and gates-caught count.
+
+Pure function module: file paths in, dict/markdown out. No side effects
+except reading files passed as Path arguments. All reads are fail-open
+(missing or malformed file → empty list for that source; no exception raised).
+
+Public API:
+    compute_kpis(metrics_path, prove_log_path, overrides_paths, *, weeks, now)
+        → {"rows": [...], "totals": {...}}
+    format_kpi_section(kpis) → str (markdown table, or "" when no data)
+
+CLI:
+    python3 quality_kpis.py --report [--weeks N]
+        --metrics PATH --prove-log PATH --overrides PATH [PATH ...]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_jsonl(path: Path) -> list[dict[str, Any]]:
+    """Read and parse a JSONL file. Returns [] on any error (fail-open)."""
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return []
+    records: list[dict[str, Any]] = []
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except (ValueError, KeyError):
+            continue
+        if isinstance(obj, dict):
+            records.append(obj)
+    return records
+
+
+def _week_of(date_str: str) -> str | None:
+    """Return 'YYYY-Www' from a date string ('YYYY-MM-DD') or ISO timestamp.
+
+    Returns None if the string cannot be parsed.
+    """
+    if not date_str:
+        return None
+    try:
+        # Try plain date first: YYYY-MM-DD
+        d = date.fromisoformat(date_str[:10])
+        iso = d.isocalendar()
+        return f"{iso[0]}-W{iso[1]:02d}"
+    except (ValueError, AttributeError):
+        return None
+
+
+def _build_weeks(now: datetime, n: int) -> list[str]:
+    """Return n ISO week keys (oldest first), ending with the week containing *now*."""
+    result: list[str] = []
+    for i in range(n - 1, -1, -1):
+        d = (now - timedelta(weeks=i)).date()
+        iso = d.isocalendar()
+        key = f"{iso[0]}-W{iso[1]:02d}"
+        if key not in result:  # guard against duplicates at DST boundaries
+            result.append(key)
+    # Ensure exactly n entries; if we somehow got fewer, pad from the left
+    while len(result) < n:
+        result.insert(0, "n/a")
+    return result[-n:]
+
+
+def _fpc_rows(records: list[dict[str, Any]], week_keys: list[str]) -> dict[str, dict]:
+    """Bucket metrics records by week, computing first-pass-correct data.
+
+    Only records with a 'first_pass_correct' boolean field count toward
+    the denominator; records without the field are excluded (they predate
+    the schema).
+    """
+    buckets: dict[str, dict] = {k: {"fpc_true": 0, "fpc_false": 0} for k in week_keys}
+    for rec in records:
+        fpc = rec.get("first_pass_correct")
+        if fpc is None:
+            continue  # predates the field; excluded from rate
+        date_str = rec.get("date", "")
+        wk = _week_of(str(date_str)) if date_str else None
+        if wk not in buckets:
+            continue
+        if fpc is True:
+            buckets[wk]["fpc_true"] += 1
+        elif fpc is False:
+            buckets[wk]["fpc_false"] += 1
+    return buckets
+
+
+def _gate_rows(
+    prove_log: list[dict[str, Any]],
+    overrides: list[dict[str, Any]],
+    week_keys: list[str],
+) -> dict[str, int]:
+    """Bucket gate-caught events by week.
+
+    A gate-caught event is:
+    - A prove-log record with verdict == "FAIL" or "BLOCKED", OR
+    - A prove-log record where any eval_results value is "fail", OR
+    - An override record where gate_exit != 0.
+    """
+    buckets: dict[str, int] = {k: 0 for k in week_keys}
+
+    for rec in prove_log:
+        verdict = rec.get("verdict", "")
+        eval_results = rec.get("eval_results") or {}
+        ts = rec.get("ts", "")
+        caught = verdict in ("FAIL", "BLOCKED") or any(
+            v == "fail" for v in eval_results.values()
+        )
+        if not caught:
+            continue
+        wk = _week_of(str(ts)[:10]) if ts else None
+        if wk in buckets:
+            buckets[wk] += 1
+
+    for rec in overrides:
+        gate_exit = rec.get("gate_exit", 0)
+        if gate_exit == 0:
+            continue  # gate was not actually blocking
+        ts = rec.get("ts", "")
+        wk = _week_of(str(ts)[:10]) if ts else None
+        if wk in buckets:
+            buckets[wk] += 1
+
+    return buckets
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def compute_kpis(
+    metrics_path: Path,
+    prove_log_path: Path,
+    overrides_paths: list[Path],
+    *,
+    weeks: int = 8,
+    now: datetime | None = None,
+) -> dict:
+    """Compute quality KPIs from data files.
+
+    Returns a dict:
+        {
+            "rows": [
+                {
+                    "week": "2026-W23",
+                    "fpc_rate": 0.85,   # float or None when no qualifying records
+                    "fpc_n": 12,        # denominator (records with fpc field)
+                    "gates_caught": 3,
+                },
+                ...  # oldest week first, 'weeks' entries
+            ],
+            "totals": {
+                "fpc_rate": float | None,
+                "fpc_n": int,
+                "gates_caught": int,
+            }
+        }
+
+    Degrades gracefully: missing or malformed files → empty data for that source.
+    Never raises.
+    """
+    if now is None:
+        now = datetime.now(timezone.utc)
+
+    week_keys = _build_weeks(now, weeks)
+
+    metrics_records = _load_jsonl(metrics_path)
+    prove_records = _load_jsonl(prove_log_path)
+    override_records: list[dict] = []
+    for op in overrides_paths:
+        override_records.extend(_load_jsonl(op))
+
+    fpc_buckets = _fpc_rows(metrics_records, week_keys)
+    gate_buckets = _gate_rows(prove_records, override_records, week_keys)
+
+    rows = []
+    total_fpc_true = 0
+    total_fpc_false = 0
+    total_gates = 0
+
+    for wk in week_keys:
+        fpc_data = fpc_buckets.get(wk, {"fpc_true": 0, "fpc_false": 0})
+        fpc_true = fpc_data["fpc_true"]
+        fpc_false = fpc_data["fpc_false"]
+        fpc_n = fpc_true + fpc_false
+        fpc_rate = fpc_true / fpc_n if fpc_n > 0 else None
+
+        gates = gate_buckets.get(wk, 0)
+
+        total_fpc_true += fpc_true
+        total_fpc_false += fpc_false
+        total_gates += gates
+
+        rows.append(
+            {
+                "week": wk,
+                "fpc_rate": fpc_rate,
+                "fpc_n": fpc_n,
+                "gates_caught": gates,
+            }
+        )
+
+    total_fpc_n = total_fpc_true + total_fpc_false
+    totals = {
+        "fpc_rate": total_fpc_true / total_fpc_n if total_fpc_n > 0 else None,
+        "fpc_n": total_fpc_n,
+        "gates_caught": total_gates,
+    }
+
+    return {"rows": rows, "totals": totals}
+
+
+def format_kpi_section(kpis: dict) -> str:
+    """Render the KPI data as a markdown section.
+
+    Returns a markdown string containing the 8-week quality KPI table.
+    Returns empty string only when kpis is empty or has no rows — always
+    renders for well-formed (even all-zero) data.
+    """
+    rows = kpis.get("rows")
+    if not rows:
+        return ""
+
+    totals = kpis.get("totals", {})
+
+    lines = [
+        "## Quality KPIs (8-week trend)",
+        "",
+        "_Data sparse while first_pass_correct field matures; "
+        "n/a = no qualifying records that week._",
+        "",
+        "| Week | First-pass rate | n | Gates caught |",
+        "| ---- | --------------- | - | ------------ |",
+    ]
+
+    for row in rows:
+        fpc_rate = row.get("fpc_rate")
+        fpc_n = row.get("fpc_n", 0)
+        gates = row.get("gates_caught", 0)
+        week = row.get("week", "?")
+
+        if fpc_rate is None:
+            rate_str = "n/a"
+        else:
+            rate_str = f"{fpc_rate:.0%}"
+
+        lines.append(f"| {week} | {rate_str} | {fpc_n} | {gates} |")
+
+    # Totals row
+    total_rate = totals.get("fpc_rate")
+    total_n = totals.get("fpc_n", 0)
+    total_gates = totals.get("gates_caught", 0)
+    total_rate_str = f"{total_rate:.0%}" if total_rate is not None else "n/a"
+    lines.append(f"| **Total** | **{total_rate_str}** | **{total_n}** | **{total_gates}** |")
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+DEFAULT_METRICS = Path.home() / ".claude" / "memory" / "metrics.jsonl"
+DEFAULT_PROVE_LOG = Path.home() / ".claude" / "memory" / "prove-log.jsonl"
+DEFAULT_OVERRIDES = [Path.home() / ".agents" / "outputs" / "prove-overrides.jsonl"]
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        description="Compute and display quality KPIs (first-pass rate + gates-caught)."
+    )
+    ap.add_argument(
+        "--report",
+        action="store_true",
+        help="Print the rendered markdown table (default when no other flag given)",
+    )
+    ap.add_argument(
+        "--weeks",
+        type=int,
+        default=8,
+        help="Number of ISO weeks to include (default: 8)",
+    )
+    ap.add_argument(
+        "--metrics",
+        type=Path,
+        default=DEFAULT_METRICS,
+        help="Path to metrics.jsonl",
+    )
+    ap.add_argument(
+        "--prove-log",
+        type=Path,
+        default=DEFAULT_PROVE_LOG,
+        help="Path to prove-log.jsonl",
+    )
+    ap.add_argument(
+        "--overrides",
+        type=Path,
+        nargs="*",
+        default=DEFAULT_OVERRIDES,
+        help="Path(s) to prove-overrides.jsonl (may specify multiple)",
+    )
+
+    args = ap.parse_args(argv)
+    overrides = args.overrides or []
+
+    kpis = compute_kpis(
+        metrics_path=args.metrics,
+        prove_log_path=args.prove_log,
+        overrides_paths=overrides,
+        weeks=args.weeks,
+    )
+    section = format_kpi_section(kpis)
+    if section:
+        print(section)
+    else:
+        print("(no KPI data)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/claude-config/tests/test_quality_kpis.py
+++ b/claude-config/tests/test_quality_kpis.py
@@ -1,0 +1,348 @@
+"""Tests for quality_kpis.py — first-pass-correct rate + gates-caught KPIs.
+
+Issue #386. All tests use tmp_path; no real ~/.claude files are read.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+import quality_kpis as Q  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Fixed reference datetime: 2026-06-09 (Monday) = 2026-W24
+# ---------------------------------------------------------------------------
+NOW = datetime(2026, 6, 9, 12, 0, tzinfo=timezone.utc)
+
+# Weeks built from NOW (oldest first, 8 weeks):
+# 2026-W17, W18, W19, W20, W21, W22, W23, W24
+WEEK_24 = "2026-W24"  # current week (contains 2026-06-09)
+WEEK_23 = "2026-W23"  # one week ago
+WEEK_22 = "2026-W22"  # two weeks ago
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _write_jsonl(path: Path, records: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as fh:
+        for rec in records:
+            fh.write(json.dumps(rec) + "\n")
+
+
+def _metrics(tmp_path: Path, records: list[dict]) -> Path:
+    p = tmp_path / "metrics.jsonl"
+    _write_jsonl(p, records)
+    return p
+
+
+def _prove_log(tmp_path: Path, records: list[dict]) -> Path:
+    p = tmp_path / "prove-log.jsonl"
+    _write_jsonl(p, records)
+    return p
+
+
+def _overrides(tmp_path: Path, records: list[dict]) -> Path:
+    p = tmp_path / "prove-overrides.jsonl"
+    _write_jsonl(p, records)
+    return p
+
+
+def _absent(tmp_path: Path, name: str) -> Path:
+    return tmp_path / name  # does NOT exist
+
+
+# ---------------------------------------------------------------------------
+# Test 1: empty sources → 8 zero rows, no exception
+# ---------------------------------------------------------------------------
+
+def test_empty_sources_returns_zero_table(tmp_path):
+    kpis = Q.compute_kpis(
+        metrics_path=_absent(tmp_path, "metrics.jsonl"),
+        prove_log_path=_absent(tmp_path, "prove-log.jsonl"),
+        overrides_paths=[_absent(tmp_path, "overrides.jsonl")],
+        weeks=8,
+        now=NOW,
+    )
+    assert len(kpis["rows"]) == 8
+    for row in kpis["rows"]:
+        assert row["fpc_rate"] is None
+        assert row["fpc_n"] == 0
+        assert row["gates_caught"] == 0
+    assert kpis["totals"]["fpc_rate"] is None
+    assert kpis["totals"]["fpc_n"] == 0
+    assert kpis["totals"]["gates_caught"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Test 2: first-pass rate computed correctly
+# ---------------------------------------------------------------------------
+
+def test_first_pass_rate_computed_correctly(tmp_path):
+    # 3 true, 1 false in WEEK_24 → 75%
+    recs = [
+        {"issue": 1, "date": "2026-06-09", "first_pass_correct": True},
+        {"issue": 2, "date": "2026-06-09", "first_pass_correct": True},
+        {"issue": 3, "date": "2026-06-09", "first_pass_correct": True},
+        {"issue": 4, "date": "2026-06-09", "first_pass_correct": False},
+    ]
+    kpis = Q.compute_kpis(
+        metrics_path=_metrics(tmp_path, recs),
+        prove_log_path=_absent(tmp_path, "prove-log.jsonl"),
+        overrides_paths=[],
+        now=NOW,
+    )
+    # Find WEEK_24 row
+    row = next(r for r in kpis["rows"] if r["week"] == WEEK_24)
+    assert row["fpc_n"] == 4
+    assert abs(row["fpc_rate"] - 0.75) < 1e-9
+    assert row["gates_caught"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Test 3: records without first_pass_correct field excluded from denominator
+# ---------------------------------------------------------------------------
+
+def test_records_without_fpc_field_excluded_from_denominator(tmp_path):
+    recs = [
+        {"issue": 1, "date": "2026-06-09"},            # no fpc field — excluded
+        {"issue": 2, "date": "2026-06-09", "first_pass_correct": None},  # explicit None — excluded
+        {"issue": 3, "date": "2026-06-09", "first_pass_correct": True},  # counts
+    ]
+    kpis = Q.compute_kpis(
+        metrics_path=_metrics(tmp_path, recs),
+        prove_log_path=_absent(tmp_path, "prove-log.jsonl"),
+        overrides_paths=[],
+        now=NOW,
+    )
+    row = next(r for r in kpis["rows"] if r["week"] == WEEK_24)
+    assert row["fpc_n"] == 1   # only the explicit True counts
+    assert row["fpc_rate"] == 1.0
+
+
+# ---------------------------------------------------------------------------
+# Test 4: gates_caught counts FAIL verdicts
+# ---------------------------------------------------------------------------
+
+def test_gates_caught_counts_fail_verdicts(tmp_path):
+    recs = [
+        {"ts": "2026-06-09T10:00:00Z", "issue": 10, "verdict": "FAIL", "eval_results": {}},
+    ]
+    kpis = Q.compute_kpis(
+        metrics_path=_absent(tmp_path, "metrics.jsonl"),
+        prove_log_path=_prove_log(tmp_path, recs),
+        overrides_paths=[],
+        now=NOW,
+    )
+    row = next(r for r in kpis["rows"] if r["week"] == WEEK_24)
+    assert row["gates_caught"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Test 5: gates_caught counts eval_results failures
+# ---------------------------------------------------------------------------
+
+def test_gates_caught_counts_eval_failures(tmp_path):
+    recs = [
+        {
+            "ts": "2026-06-09T10:00:00Z",
+            "issue": 11,
+            "verdict": "PASS",  # verdict is PASS but eval failed
+            "eval_results": {"E01": "fail", "E04": "pass"},
+        },
+    ]
+    kpis = Q.compute_kpis(
+        metrics_path=_absent(tmp_path, "metrics.jsonl"),
+        prove_log_path=_prove_log(tmp_path, recs),
+        overrides_paths=[],
+        now=NOW,
+    )
+    row = next(r for r in kpis["rows"] if r["week"] == WEEK_24)
+    assert row["gates_caught"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Test 6: gates_caught counts overrides with non-zero gate_exit
+# ---------------------------------------------------------------------------
+
+def test_gates_caught_counts_overrides_with_nonzero_exit(tmp_path):
+    recs_pass = [
+        {"ts": "2026-06-09T10:00:00Z", "issue": 20, "verdict": "PASS", "eval_results": {}},
+    ]
+    recs_override = [
+        {"ts": "2026-06-09T11:00:00Z", "issue": 21, "gate_exit": 2, "gate_reason": "blocker"},
+        {"ts": "2026-06-09T12:00:00Z", "issue": 22, "gate_exit": 0, "gate_reason": "ok"},
+    ]
+    kpis = Q.compute_kpis(
+        metrics_path=_absent(tmp_path, "metrics.jsonl"),
+        prove_log_path=_prove_log(tmp_path, recs_pass),
+        overrides_paths=[_overrides(tmp_path, recs_override)],
+        now=NOW,
+    )
+    row = next(r for r in kpis["rows"] if r["week"] == WEEK_24)
+    # prove_log PASS with no eval failures = 0 gates from prove-log
+    # override gate_exit=2 → 1 gate; gate_exit=0 → 0 gates
+    assert row["gates_caught"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Test 7: format_kpi_section markdown structure
+# ---------------------------------------------------------------------------
+
+def test_format_kpi_section_markdown_structure(tmp_path):
+    recs = [{"issue": 1, "date": "2026-06-09", "first_pass_correct": True}]
+    kpis = Q.compute_kpis(
+        metrics_path=_metrics(tmp_path, recs),
+        prove_log_path=_absent(tmp_path, "prove-log.jsonl"),
+        overrides_paths=[],
+        now=NOW,
+    )
+    md = Q.format_kpi_section(kpis)
+    assert "## Quality KPIs" in md
+    assert "| Week |" in md
+    assert "First-pass rate" in md
+    assert "Gates caught" in md
+    assert "**Total**" in md
+
+
+# ---------------------------------------------------------------------------
+# Test 8: format_kpi_section renders (not empty) even on all-zero data
+# ---------------------------------------------------------------------------
+
+def test_format_kpi_section_not_empty_on_all_zero_data(tmp_path):
+    kpis = Q.compute_kpis(
+        metrics_path=_absent(tmp_path, "metrics.jsonl"),
+        prove_log_path=_absent(tmp_path, "prove-log.jsonl"),
+        overrides_paths=[],
+        now=NOW,
+    )
+    md = Q.format_kpi_section(kpis)
+    # All-zero data should still render the table (not return empty string)
+    assert md != ""
+    assert "n/a" in md  # all rates are n/a when no fpc data
+
+
+# ---------------------------------------------------------------------------
+# Test 9: week bucketing — record in week N does not bleed into week N+1
+# ---------------------------------------------------------------------------
+
+def test_week_bucketing_correct(tmp_path):
+    # 2026-06-01 is W23, 2026-06-08 is W24 (starts on Monday 2026-06-08)
+    recs = [
+        {"issue": 1, "date": "2026-06-01", "first_pass_correct": True},   # W23
+        {"issue": 2, "date": "2026-06-08", "first_pass_correct": False},  # W24
+    ]
+    kpis = Q.compute_kpis(
+        metrics_path=_metrics(tmp_path, recs),
+        prove_log_path=_absent(tmp_path, "prove-log.jsonl"),
+        overrides_paths=[],
+        now=NOW,
+    )
+    row_23 = next(r for r in kpis["rows"] if r["week"] == WEEK_23)
+    row_24 = next(r for r in kpis["rows"] if r["week"] == WEEK_24)
+
+    assert row_23["fpc_n"] == 1
+    assert row_23["fpc_rate"] == 1.0   # 1 true in W23
+    assert row_24["fpc_n"] == 1
+    assert row_24["fpc_rate"] == 0.0   # 1 false in W24 (no bleed from W23)
+
+
+# ---------------------------------------------------------------------------
+# Test 10: compute_kpis returns exactly `weeks` rows
+# ---------------------------------------------------------------------------
+
+def test_compute_kpis_week_count(tmp_path):
+    for n in (1, 4, 8, 12):
+        kpis = Q.compute_kpis(
+            metrics_path=_absent(tmp_path, "metrics.jsonl"),
+            prove_log_path=_absent(tmp_path, "prove-log.jsonl"),
+            overrides_paths=[],
+            weeks=n,
+            now=NOW,
+        )
+        assert len(kpis["rows"]) == n, f"expected {n} rows, got {len(kpis['rows'])}"
+
+
+# ---------------------------------------------------------------------------
+# Bonus: BLOCKED verdict also counts as gate-caught
+# ---------------------------------------------------------------------------
+
+def test_gates_caught_counts_blocked_verdicts(tmp_path):
+    recs = [
+        {"ts": "2026-06-09T10:00:00Z", "issue": 30, "verdict": "BLOCKED", "eval_results": {}},
+    ]
+    kpis = Q.compute_kpis(
+        metrics_path=_absent(tmp_path, "metrics.jsonl"),
+        prove_log_path=_prove_log(tmp_path, recs),
+        overrides_paths=[],
+        now=NOW,
+    )
+    row = next(r for r in kpis["rows"] if r["week"] == WEEK_24)
+    assert row["gates_caught"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Bonus: multiple overrides paths (aggregated)
+# ---------------------------------------------------------------------------
+
+def test_multiple_overrides_paths_aggregated(tmp_path):
+    ov1 = tmp_path / "ov1.jsonl"
+    ov2 = tmp_path / "ov2.jsonl"
+    _write_jsonl(ov1, [{"ts": "2026-06-09T10:00:00Z", "gate_exit": 1}])
+    _write_jsonl(ov2, [{"ts": "2026-06-09T11:00:00Z", "gate_exit": 2}])
+    kpis = Q.compute_kpis(
+        metrics_path=_absent(tmp_path, "metrics.jsonl"),
+        prove_log_path=_absent(tmp_path, "prove-log.jsonl"),
+        overrides_paths=[ov1, ov2],
+        now=NOW,
+    )
+    row = next(r for r in kpis["rows"] if r["week"] == WEEK_24)
+    assert row["gates_caught"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Bonus: totals aggregate across all weeks
+# ---------------------------------------------------------------------------
+
+def test_totals_aggregate_across_all_weeks(tmp_path):
+    recs = [
+        {"issue": 1, "date": "2026-06-01", "first_pass_correct": True},   # W23
+        {"issue": 2, "date": "2026-06-09", "first_pass_correct": False},  # W24
+    ]
+    kpis = Q.compute_kpis(
+        metrics_path=_metrics(tmp_path, recs),
+        prove_log_path=_absent(tmp_path, "prove-log.jsonl"),
+        overrides_paths=[],
+        now=NOW,
+    )
+    assert kpis["totals"]["fpc_n"] == 2
+    assert abs(kpis["totals"]["fpc_rate"] - 0.5) < 1e-9
+
+
+# ---------------------------------------------------------------------------
+# Bonus: malformed JSONL lines are skipped gracefully
+# ---------------------------------------------------------------------------
+
+def test_malformed_jsonl_skipped_gracefully(tmp_path):
+    p = tmp_path / "metrics.jsonl"
+    p.write_text(
+        '{"issue": 1, "date": "2026-06-09", "first_pass_correct": true}\n'
+        "not-json-at-all\n"
+        '{"issue": 2, "date": "2026-06-09", "first_pass_correct": false}\n',
+        encoding="utf-8",
+    )
+    kpis = Q.compute_kpis(
+        metrics_path=p,
+        prove_log_path=_absent(tmp_path, "prove-log.jsonl"),
+        overrides_paths=[],
+        now=NOW,
+    )
+    row = next(r for r in kpis["rows"] if r["week"] == WEEK_24)
+    assert row["fpc_n"] == 2  # malformed line skipped, 2 valid records parsed


### PR DESCRIPTION
## Summary
- New `claude-config/scripts/quality_kpis.py`: pure module computing first-pass-correct rate (metrics.jsonl) + gates-caught-before-merge (prove-log.jsonl FAIL/downgrades + eval failures + prove-overrides.jsonl), bucketed into an 8-week ISO trend table; fail-open on every read; `--report` CLI for on-demand use
- cost_report_weekly.py appends the KPI section to the email body before send (8-line seam; usage_email.py untouched — no new delivery infra)
- metrics.md Step 5.5 documents the same numbers on demand

## Test Plan
- [x] PROVE PASS — 4/4 ACs implemented (prove-386-060926.md): schemas cross-checked against state_manager.record_prove_audit + prove_gate.record_override; live smoke W22 = 92% (n=12) matches manual count; LR-001 clean (BLE001/E722); 457/457 tests
- [x] prove_gate exit 0

Closes #386

🤖 Generated with [Claude Code](https://claude.com/claude-code)