### PR TITLE
feat(hooks): edit-time quality feedback — file-scoped ruff + secrets on PostToolUse

### DIFF
--- a/.agents/outputs/patch-381-060926.md
+++ b/.agents/outputs/patch-381-060926.md
@@ -1,0 +1,131 @@
+---
+issue: 381
+agent: PATCH
+date: 2026-06-09
+status: Complete
+files_modified: 1
+files_created: 2
+tests_added: 9
+coverage_before: null
+coverage_after: null
+coverage_note: "No pytest-cov infra in this repo; no coverage tooling added (per code-quality-standards.md)"
+---
+
+# PATCH - Issue #381
+
+## Summary
+
+Implemented `edit_quality_feedback.py` — a PostToolUse hook that fires after
+Edit, Write, and MultiEdit on `*.py` files. It runs `ruff check --no-fix
+--output-format=concise` scoped to the single edited file path and applies the
+E15 secrets regexes from `evals/e15_secrets.py` against the added/new content
+only. Findings print to stdout; the hook always exits 0 (non-blocking). The
+hook is registered as a second entry in the `PostToolUse` hooks array in
+`settings.json`. Nine tests cover all acceptance criteria.
+
+## Pre-Flight
+
+- [x] Read MAP-PLAN artifact
+- [x] Read rules.md
+- [x] Branch: feature/issue-381-edit-time-eval-hook (not main)
+
+## Requirements Checklist
+
+### From MAP-PLAN
+- [x] PostToolUse fires on Edit/Write/MultiEdit for `*.py` only
+- [x] ruff check runs on the edited file path (--no-fix, 5s timeout)
+- [x] E15 secrets regex runs on added content only
+- [x] `# eval-ok: E15` allowlist honored
+- [x] Hook exits 0 in all cases (non-blocking)
+- [x] ruff absent → silent skip
+- [x] ruff timeout/OSError → silent skip, E15 still runs
+- [x] MultiEdit: added content = all new_string fields joined; ruff on disk file
+- [x] All 9 test cases pass
+- [x] ruff check clean on both new files
+
+## Files Changed
+
+### `claude-config/hooks/edit_quality_feedback.py` (NEW)
+- Main hook: reads PostToolUse JSON from stdin, guards on tool name and `.py` suffix
+- `_ruff_check(file_path)`: runs ruff with `--output-format=concise`, filters output
+  with `_RUFF_FINDING_RE` regex to exclude summary lines ("All checks passed!", "Found N errors.")
+- `_e15_check(content, file_path)`: lazy-imports E15 regex objects from `evals/e15_secrets.py`
+  via `sys.path.insert` for `_SCRIPTS_DIR`; scans content line-by-line; honors `allowlisted()`
+- `main()`: outer try/except catches JSON parse errors → exit 0; inner try/except swallows
+  any unexpected failure → exit 0 (fail-open by design, BLE001 ignored for hooks/)
+
+### `claude-config/settings.json` (MODIFIED)
+- Added second entry in `hooks.PostToolUse[0].hooks` array:
+  `python3 ~/.claude/hooks/edit_quality_feedback.py`
+- Existing `context_monitor.py` entry untouched
+
+### `claude-config/tests/test_edit_quality_feedback.py` (NEW)
+- 9 tests covering: non-py skip, unknown tool skip, ruff-absent silent skip,
+  ruff finding surfaces, ruff timeout silent skip, E15 secret found,
+  E15 allowlisted line skipped, MultiEdit joins new_strings, clean edit no output
+
+## Verification
+
+- `ruff check claude-config/hooks/edit_quality_feedback.py`: PASS
+- `ruff check claude-config/tests/test_edit_quality_feedback.py`: PASS
+- `pytest claude-config/tests/test_edit_quality_feedback.py -v`: 9/9 PASS
+- `pytest claude-config/tests/ -q`: 452/452 PASS (443 pre-existing + 9 new)
+- `python3 -c "import json; json.load(open('claude-config/settings.json'))"`: valid JSON
+
+## Live Smoke Evidence
+
+```
+# Clean edit on existing file → no output, exit 0
+$ echo '{"tool_name":"Edit","tool_input":{"file_path":"claude-config/hooks/context_monitor.py","new_string":"x=1\n"}}' | python3 ...edit_quality_feedback.py
+(no output)
+
+# Edit with hardcoded secret → E15 fires, exit 0
+$ payload with api_key = "sk-abc123verylongvalue99"
+[edit_quality_feedback] 2 finding(s) in script.py:
+  [ruff] script.py:1:1: E902 No such file or directory (os error 2)
+  [E15] script.py:1: high-confidence credential pattern in added content
+
+# Non-py file → no output, exit 0
+(no output)
+```
+
+## Issues Encountered
+
+One minor issue found during smoke testing: `ruff --output-format=concise` emits
+summary lines ("All checks passed!", "Found N error(s).", "[*] N fixable with --fix")
+in addition to actual finding lines. Initial implementation passed all non-finding
+lines through. Fixed by adding `_RUFF_FINDING_RE = re.compile(r".+:\d+:\d+: [A-Z]\d+")`
+and filtering with `_RUFF_FINDING_RE.match(ln)`. All 9 tests still pass after fix.
+
+## Deviations from PLAN
+
+None. Implementation follows MAP-PLAN exactly. The `_RUFF_FINDING_RE` filter is
+a TRIVIAL addition not mentioned explicitly in the plan but required for correctness
+(ruff output format behavior discovered during smoke testing).
+
+---
+
+## Fix Re-run (2026-06-09, PROVE FAIL → PASS)
+
+**Root cause:** PATCH applied `# eval-ok: E15 test fixture` only to the
+`test_e15_allowlisted_line_skipped` test (line 132 — demonstrating the
+allowlist mechanism), but not to the other three test fixture lines that also
+contain fake credential patterns. The evals runner operates on git diff added
+lines, so every line in the new-file diff was inspected, including lines 58,
+121, and 147.
+
+**Fix:** Added `# eval-ok: E15 test fixture` inline comment to the three
+offending lines:
+- Line 58: `_write_payload("file.js", "api_key = 'sk-abc123longvalue'")` call
+- Line 121: `secret_content = 'api_key = "sk-abc123xyz789longvalue"'` assignment
+- Line 147: `{"new_string": 'api_key = "sk-secretlong99value"'}` dict literal
+
+**Commit:** `fix(#381): allowlist E15 test fixtures`
+
+**Post-fix verification:**
+- `python3 ~/agents/claude-config/scripts/evals/run_evals.py --diff-range origin/main...HEAD`: EXIT 0 (CLEAN)
+- `python3 -m pytest claude-config/tests/ -q`: 452/452 PASS
+- `ruff check claude-config/tests/test_edit_quality_feedback.py`: PASS
+
+---
+AGENT_RETURN: patch-381-060926.md

--- a/claude-config/hooks/edit_quality_feedback.py
+++ b/claude-config/hooks/edit_quality_feedback.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""
+PostToolUse hook: edit-time quality feedback.
+
+Fires after Edit, Write, and MultiEdit on *.py files. Runs:
+  1. ruff check --no-fix on the edited file path
+  2. E15 secrets regex on the added/new content only
+
+Findings are printed to stdout so Claude Code surfaces them as inline
+feedback. The hook is non-blocking — always exits 0. Any internal error
+is silently swallowed (fail-open by design; BLE001 already ignored for
+hooks/ in ruff.toml).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+_SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
+
+_WATCHED_TOOLS = {"Edit", "Write", "MultiEdit"}
+
+# Ruff concise-format finding lines look like: path:line:col: CODE message
+_RUFF_FINDING_RE = re.compile(r".+:\d+:\d+: [A-Z]\d+")
+
+
+def _ruff_check(file_path: str) -> list[str]:
+    """Return ruff finding lines for file_path, or [] on any failure."""
+    if shutil.which("ruff") is None:
+        return []
+    try:
+        result = subprocess.run(
+            ["ruff", "check", "--no-fix", "--output-format=concise", file_path],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        lines = result.stdout.strip().splitlines()
+        # Only keep lines that match path:line:col: CODE format — filter
+        # out summary lines ("All checks passed!", "Found N error(s).", etc.)
+        return [
+            f"[ruff] {ln}"
+            for ln in lines
+            if _RUFF_FINDING_RE.match(ln)
+        ]
+    except (OSError, subprocess.TimeoutExpired):
+        return []
+
+
+def _e15_check(content: str, file_path: str) -> list[str]:
+    """Return E15 finding lines for the added content, or [] on any failure."""
+    scripts_str = str(_SCRIPTS_DIR)
+    if scripts_str not in sys.path:
+        sys.path.insert(0, scripts_str)
+
+    try:
+        from evals.e15_secrets import (  # type: ignore[import]
+            _ASSIGN_RE,
+            _ENV_LOOKUP_RE,
+            _PLACEHOLDER_RE,
+            _TOKEN_RES,
+        )
+        from evals.common import allowlisted  # type: ignore[import]
+    except ImportError:
+        return []
+
+    findings: list[str] = []
+    for lineno, line in enumerate(content.splitlines(), 1):
+        if allowlisted(line, "E15"):
+            continue
+        matched = False
+        for rx in _TOKEN_RES:
+            if rx.search(line):
+                findings.append(
+                    f"[E15] {file_path}:{lineno}: "
+                    "high-confidence credential pattern in added content"
+                )
+                matched = True
+                break
+        if not matched:
+            m = _ASSIGN_RE.search(line)
+            if m and not _PLACEHOLDER_RE.search(line) and not _ENV_LOOKUP_RE.search(line):
+                findings.append(
+                    f"[E15] {file_path}:{lineno}: "
+                    f"hardcoded {m.group(1)} literal — load from env/config instead"
+                )
+    return findings
+
+
+def main() -> None:
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        sys.exit(0)
+
+    try:
+        tool_name = payload.get("tool_name", "")
+        if tool_name not in _WATCHED_TOOLS:
+            sys.exit(0)
+
+        tool_input = payload.get("tool_input", {})
+        file_path = tool_input.get("file_path", "")
+        if not file_path.endswith(".py"):
+            sys.exit(0)
+
+        # Extract added content for E15 scan
+        if tool_name == "Edit":
+            added_content = tool_input.get("new_string", "")
+        elif tool_name == "Write":
+            added_content = tool_input.get("content", "")
+        else:  # MultiEdit
+            edits = tool_input.get("edits", [])
+            added_content = "\n".join(e.get("new_string", "") for e in edits)
+
+        ruff_findings = _ruff_check(file_path)
+        e15_findings = _e15_check(added_content, file_path)
+
+        all_findings = ruff_findings + e15_findings
+        if all_findings:
+            count = len(all_findings)
+            print(f"[edit_quality_feedback] {count} finding(s) in {file_path}:")
+            for finding in all_findings:
+                print(f"  {finding}")
+
+    except Exception:
+        pass
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/claude-config/settings.json
+++ b/claude-config/settings.json
@@ -125,6 +125,10 @@
           {
             "type": "command",
             "command": "python3 ~/.claude/hooks/context_monitor.py"
+          },
+          {
+            "type": "command",
+            "command": "python3 ~/.claude/hooks/edit_quality_feedback.py"
           }
         ]
       }

--- a/claude-config/tests/test_edit_quality_feedback.py
+++ b/claude-config/tests/test_edit_quality_feedback.py
@@ -55,7 +55,7 @@ def test_non_py_file_skipped(monkeypatch, capsys):
     """Write to a non-.py file produces no output."""
     # Mock ruff to ensure it is never called
     monkeypatch.setattr(EQF, "_ruff_check", lambda fp: (_ for _ in ()).throw(AssertionError("ruff called")))
-    out = _run_main(_write_payload("file.js", "api_key = 'sk-abc123longvalue'"), monkeypatch, capsys)
+    out = _run_main(_write_payload("file.js", "api_key = 'sk-abc123longvalue'"), monkeypatch, capsys)  # eval-ok: E15 test fixture
     assert out == ""
 
 
@@ -118,7 +118,7 @@ def test_e15_secret_found(monkeypatch, capsys):
     # Silence ruff so only E15 fires
     monkeypatch.setattr(EQF, "_ruff_check", lambda fp: [])
 
-    secret_content = 'api_key = "sk-abc123xyz789longvalue"'
+    secret_content = 'api_key = "sk-abc123xyz789longvalue"'  # eval-ok: E15 test fixture
     out = _run_main(_edit_payload("script.py", secret_content), monkeypatch, capsys)
     assert "[E15]" in out
     assert "[edit_quality_feedback]" in out
@@ -144,7 +144,7 @@ def test_multiedit_joins_new_strings(monkeypatch, capsys):
 
     edits = [
         {"old_string": "foo", "new_string": "bar"},
-        {"old_string": "baz", "new_string": 'api_key = "sk-secretlong99value"'},
+        {"old_string": "baz", "new_string": 'api_key = "sk-secretlong99value"'},  # eval-ok: E15 test fixture
     ]
     payload = _multiedit_payload("script.py", edits)
     out = _run_main(payload, monkeypatch, capsys)

--- a/claude-config/tests/test_edit_quality_feedback.py
+++ b/claude-config/tests/test_edit_quality_feedback.py
@@ -1,0 +1,162 @@
+"""Tests for the edit_quality_feedback PostToolUse hook (issue #381)."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "hooks"))
+
+import edit_quality_feedback as EQF  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _run_main(payload: dict, monkeypatch, capsys):
+    """Pipe payload through main() and return captured stdout."""
+    monkeypatch.setattr("sys.stdin", __import__("io").StringIO(json.dumps(payload)))
+    try:
+        EQF.main()
+    except SystemExit:
+        pass
+    return capsys.readouterr().out
+
+
+def _edit_payload(file_path: str, new_string: str = "") -> dict:
+    return {
+        "tool_name": "Edit",
+        "tool_input": {"file_path": file_path, "new_string": new_string},
+    }
+
+
+def _write_payload(file_path: str, content: str = "") -> dict:
+    return {
+        "tool_name": "Write",
+        "tool_input": {"file_path": file_path, "content": content},
+    }
+
+
+def _multiedit_payload(file_path: str, edits: list[dict]) -> dict:
+    return {
+        "tool_name": "MultiEdit",
+        "tool_input": {"file_path": file_path, "edits": edits},
+    }
+
+
+# ---------------------------------------------------------------------------
+# Skip guards
+# ---------------------------------------------------------------------------
+
+def test_non_py_file_skipped(monkeypatch, capsys):
+    """Write to a non-.py file produces no output."""
+    # Mock ruff to ensure it is never called
+    monkeypatch.setattr(EQF, "_ruff_check", lambda fp: (_ for _ in ()).throw(AssertionError("ruff called")))
+    out = _run_main(_write_payload("file.js", "api_key = 'sk-abc123longvalue'"), monkeypatch, capsys)
+    assert out == ""
+
+
+def test_unknown_tool_skipped(monkeypatch, capsys):
+    """A non-Edit/Write/MultiEdit tool produces no output."""
+    payload = {"tool_name": "Read", "tool_input": {"file_path": "script.py"}}
+    out = _run_main(payload, monkeypatch, capsys)
+    assert out == ""
+
+
+# ---------------------------------------------------------------------------
+# ruff integration
+# ---------------------------------------------------------------------------
+
+def test_ruff_absent_skips_silently(monkeypatch, capsys):
+    """When ruff is absent, ruff check is skipped; E15 still runs."""
+    monkeypatch.setattr("shutil.which", lambda _: None)
+    # No secret in content — expect empty output even without ruff
+    out = _run_main(_edit_payload("script.py", "x = 1"), monkeypatch, capsys)
+    assert "[ruff]" not in out
+
+
+def test_ruff_finding_surfaces(monkeypatch, capsys):
+    """A ruff finding line appears prefixed with [ruff] in stdout."""
+    finding_line = "script.py:10:5: F841 Local variable `x` is assigned but never used"
+
+    def _mock_run(cmd, **_kwargs):
+        class R:
+            stdout = finding_line
+            returncode = 1
+        return R()
+
+    monkeypatch.setattr(subprocess, "run", _mock_run)
+    monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/ruff")
+
+    out = _run_main(_edit_payload("script.py", "x = 1"), monkeypatch, capsys)
+    assert "[ruff]" in out
+    assert "F841" in out
+    assert "[edit_quality_feedback]" in out
+
+
+def test_ruff_timeout_silently_skipped(monkeypatch, capsys):
+    """TimeoutExpired from subprocess does not crash the hook; exit 0."""
+    def _mock_run(*_args, **_kwargs):
+        raise subprocess.TimeoutExpired(cmd=["ruff"], timeout=5)
+
+    monkeypatch.setattr(subprocess, "run", _mock_run)
+    monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/ruff")
+
+    out = _run_main(_edit_payload("script.py", "x = 1"), monkeypatch, capsys)
+    assert "[ruff]" not in out  # no crash, just silence
+
+
+# ---------------------------------------------------------------------------
+# E15 secret detection
+# ---------------------------------------------------------------------------
+
+def test_e15_secret_found(monkeypatch, capsys):
+    """A hardcoded api_key literal triggers an E15 finding."""
+    # Silence ruff so only E15 fires
+    monkeypatch.setattr(EQF, "_ruff_check", lambda fp: [])
+
+    secret_content = 'api_key = "sk-abc123xyz789longvalue"'
+    out = _run_main(_edit_payload("script.py", secret_content), monkeypatch, capsys)
+    assert "[E15]" in out
+    assert "[edit_quality_feedback]" in out
+
+
+def test_e15_allowlisted_line_skipped(monkeypatch, capsys):
+    """A line with # eval-ok: E15 suppresses the E15 finding."""
+    monkeypatch.setattr(EQF, "_ruff_check", lambda fp: [])
+
+    # The allowlist comment is on the same line as the secret
+    secret_content = 'api_key = "sk-abc123xyz789longvalue"  # eval-ok: E15 test fixture'
+    out = _run_main(_edit_payload("script.py", secret_content), monkeypatch, capsys)
+    assert "[E15]" not in out
+
+
+# ---------------------------------------------------------------------------
+# MultiEdit
+# ---------------------------------------------------------------------------
+
+def test_multiedit_joins_new_strings(monkeypatch, capsys):
+    """MultiEdit joins all new_string values; a secret in any triggers E15."""
+    monkeypatch.setattr(EQF, "_ruff_check", lambda fp: [])
+
+    edits = [
+        {"old_string": "foo", "new_string": "bar"},
+        {"old_string": "baz", "new_string": 'api_key = "sk-secretlong99value"'},
+    ]
+    payload = _multiedit_payload("script.py", edits)
+    out = _run_main(payload, monkeypatch, capsys)
+    assert "[E15]" in out
+
+
+# ---------------------------------------------------------------------------
+# Clean path — no output
+# ---------------------------------------------------------------------------
+
+def test_clean_edit_no_output(monkeypatch, capsys):
+    """Clean ruff + no secrets → stdout is empty."""
+    monkeypatch.setattr(EQF, "_ruff_check", lambda fp: [])
+    out = _run_main(_edit_payload("script.py", "x = 1 + 2"), monkeypatch, capsys)
+    assert out == ""


### PR DESCRIPTION
## Summary
- New `claude-config/hooks/edit_quality_feedback.py` (PostToolUse on Edit/Write/MultiEdit, *.py only): file-scoped `ruff check` with the project's own config + E15 secrets regexes (imported from `evals/e15_secrets.py`, no duplication) on the added content; findings stream back into the session as non-blocking feedback; always exits 0; 5s ruff timeout, silent skip when ruff is absent
- settings.json gains the second PostToolUse entry (additive)
- 9 tests; `eval-ok: E15` allowlist honored

## PROVE evidence (re-run after initial FAIL)
- Initial PROVE FAILED: 3 secret-looking test fixtures lacked the `eval-ok` allowlist, making the evals runner exit 1 — the gate caught its own test file. Fixed in `041c931`; recorded as first_pass_correct=false
- Re-PROVE PASS, 5/5 ACs: evals runner exit 0; live probes — lint+secret edit → 3 findings, exit 0, **97ms**; clean .py and non-.py → silent exit 0; 452/452 tests; ruff clean

Closes #381

🤖 Generated with [Claude Code](https://claude.com/claude-code)