### PR TITLE
chore(regression-set): wire the regression set into the ship flow (Option A)

### DIFF
--- a/claude-config/commands/ship.md
+++ b/claude-config/commands/ship.md
@@ -306,6 +306,7 @@ Shipped  PR #N  {pr_url}
 | HEAD parity | Step 7 | Always |
 | Kill switch (`y/N`) | Step 7 | Plain `/ship` only |
 | PROVE gate | Step 7.5 | Always (override only via `--override-prove`, recorded) |
+| Regression-set gate | Step 7.6 — diff touches `claude-config/agents/` or `claude-config/commands/` | Always (REGRESSED verdict blocks merge) |
 | Post-merge test failure | Step 9 | Always (blocks prune) |
 
 `--auto` bypasses only the kill switch (the `y/N` prompt). All other guards

--- a/claude-config/commands/ship.md
+++ b/claude-config/commands/ship.md
@@ -186,6 +186,28 @@ bypass silently; never bypass without a reason the user gave.
 
 No issue number in the branch name → the gate is skipped (nothing to gate).
 
+### Step 7.6 — Regression Set Gate (agent/command prompt changes)
+
+If the diff touches any file under `claude-config/agents/` or
+`claude-config/commands/`, run the regression set before merging:
+
+```bash
+bash claude-config/scripts/run_regression_set.sh
+```
+
+If the script exits non-zero (prompt files changed), complete a regression
+run, save a dated result file to `claude-config/regression-set/results/`,
+and verify CRITICAL recall has not regressed vs. the baseline:
+
+```bash
+python3 claude-config/regression-set/score.py \
+  claude-config/regression-set/results/2026-06-09-baseline.md \
+  claude-config/regression-set/results/<new-run>.md
+```
+
+A "REGRESSED" verdict from score.py blocks the merge — fix the prompt
+change until CRITICAL recall is at least as good as baseline.
+
 ### Step 8 — Merge
 
 ```bash

--- a/claude-config/regression-set/results/2026-06-09-baseline.md
+++ b/claude-config/regression-set/results/2026-06-09-baseline.md
@@ -1,0 +1,36 @@
+---
+run_name: baseline
+date: 2026-06-09
+config_version: 72b0c7bfc22f74845208954d86715026b1b5df8e
+notes: "Initial baseline — stubs not yet run through live reviewer; caught=0 by design."
+---
+
+# 001 enum-mismatch
+
+- critical_expected: 1
+- critical_caught: 0
+- warning_expected: 1
+- warning_caught: 0
+- false_positives: 0
+- false_positives_known: 0
+- reviewer_output_lines: 0
+
+# 002 clean-refactor
+
+- critical_expected: 0
+- critical_caught: 0
+- warning_expected: 0
+- warning_caught: 0
+- false_positives: 0
+- false_positives_known: 0
+- reviewer_output_lines: 0
+
+# 003 missing-migration
+
+- critical_expected: 1
+- critical_caught: 0
+- warning_expected: 2
+- warning_caught: 0
+- false_positives: 0
+- false_positives_known: 0
+- reviewer_output_lines: 0

--- a/claude-config/scripts/run_regression_set.sh
+++ b/claude-config/scripts/run_regression_set.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# run_regression_set.sh — detect agent/command prompt changes and guide a
+# regression-set run.
+#
+# Usage:
+#   bash run_regression_set.sh [--diff-range <range>]
+#
+# Exit 0 = no prompt files changed (regression set not required).
+# Exit 1 = prompt files changed (action required — complete a regression run).
+
+set -euo pipefail
+
+DIFF_RANGE="origin/main...HEAD"
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --diff-range)
+            DIFF_RANGE="$2"
+            shift 2
+            ;;
+        *)
+            echo "Unknown argument: $1" >&2
+            exit 2
+            ;;
+    esac
+done
+
+CHANGED=$(git diff --name-only "$DIFF_RANGE" 2>/dev/null || true)
+
+PROMPT_FILES=$(echo "$CHANGED" | grep -E '^claude-config/(agents|commands)/.*\.md$' || true)
+
+if [[ -z "$PROMPT_FILES" ]]; then
+    echo "No agent/command prompt files changed — regression set not required."
+    exit 0
+fi
+
+echo "Prompt files changed in $DIFF_RANGE:"
+echo "$PROMPT_FILES" | sed 's/^/  /'
+echo ""
+echo "ACTION REQUIRED — complete a regression run before merging:"
+echo ""
+echo "  1. For each case in claude-config/regression-set/cases/, run the"
+echo "     case diff through the reviewer agent (or live /codex:review)."
+echo "     Record findings in a dated result file:"
+echo ""
+echo "       claude-config/regression-set/results/$(date +%Y-%m-%d)-<run-name>.md"
+echo ""
+echo "     Use claude-config/regression-set/results/template.md as your template."
+echo ""
+echo "  2. Score the new run against the baseline:"
+echo ""
+echo "       python3 claude-config/regression-set/score.py \\"
+echo "         claude-config/regression-set/results/2026-06-09-baseline.md \\"
+echo "         claude-config/regression-set/results/$(date +%Y-%m-%d)-<run-name>.md"
+echo ""
+echo "  3. A 'REGRESSED' verdict blocks the merge — fix the prompt change until"
+echo "     CRITICAL recall is at least as good as the baseline."
+exit 1

--- a/claude-config/tests/test_score.py
+++ b/claude-config/tests/test_score.py
@@ -1,0 +1,107 @@
+"""Tests for regression-set score.py parse and regression-detection logic."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "regression-set"))
+
+import score  # noqa: E402
+
+BASELINE = (
+    Path(__file__).resolve().parents[1]
+    / "regression-set"
+    / "results"
+    / "2026-06-09-baseline.md"
+)
+
+
+def test_parse_baseline():
+    """Baseline file: 3 cases, correct recall values, zero noise."""
+    r = score.parse_results(BASELINE)
+    assert r["n_cases"] == 3
+    # CRITICAL recall: 0/2 caught → 0.0%
+    assert r["critical_recall"] == 0.0
+    # WARNING recall: 0/3 caught → 0.0%
+    assert r["warning_recall"] == 0.0
+    # No false positives in baseline
+    assert r["noise_rate"] == 0.0
+
+
+def test_score_regression_detected(tmp_path):
+    """A new run with lower CRITICAL recall than baseline is flagged REGRESSED."""
+    baseline_text = (
+        "---\nrun_name: base\ndate: 2026-01-01\nconfig_version: abc\n---\n\n"
+        "# 001 case-a\n"
+        "- critical_expected: 1\n"
+        "- critical_caught: 1\n"
+        "- warning_expected: 0\n"
+        "- warning_caught: 0\n"
+        "- false_positives: 0\n"
+        "- false_positives_known: 0\n"
+        "- reviewer_output_lines: 5\n"
+    )
+    new_run_text = (
+        "---\nrun_name: new\ndate: 2026-02-01\nconfig_version: def\n---\n\n"
+        "# 001 case-a\n"
+        "- critical_expected: 1\n"
+        "- critical_caught: 0\n"
+        "- warning_expected: 0\n"
+        "- warning_caught: 0\n"
+        "- false_positives: 0\n"
+        "- false_positives_known: 0\n"
+        "- reviewer_output_lines: 2\n"
+    )
+    baseline_path = tmp_path / "base.md"
+    new_run_path = tmp_path / "new.md"
+    baseline_path.write_text(baseline_text, encoding="utf-8")
+    new_run_path.write_text(new_run_text, encoding="utf-8")
+
+    a = score.parse_results(baseline_path)
+    b = score.parse_results(new_run_path)
+
+    regressed = b["critical_recall"] < a["critical_recall"] or (
+        b["warning_recall"] < a["warning_recall"] - 0.05
+        and b["noise_rate"] >= a["noise_rate"]
+    )
+    assert regressed is True
+
+
+def test_score_ok_to_ship(tmp_path):
+    """A new run with equal CRITICAL recall and lower noise is OK to ship."""
+    baseline_text = (
+        "---\nrun_name: base\ndate: 2026-01-01\nconfig_version: abc\n---\n\n"
+        "# 001 case-a\n"
+        "- critical_expected: 1\n"
+        "- critical_caught: 1\n"
+        "- warning_expected: 1\n"
+        "- warning_caught: 1\n"
+        "- false_positives: 2\n"
+        "- false_positives_known: 0\n"
+        "- reviewer_output_lines: 10\n"
+    )
+    new_run_text = (
+        "---\nrun_name: new\ndate: 2026-02-01\nconfig_version: def\n---\n\n"
+        "# 001 case-a\n"
+        "- critical_expected: 1\n"
+        "- critical_caught: 1\n"
+        "- warning_expected: 1\n"
+        "- warning_caught: 1\n"
+        "- false_positives: 0\n"
+        "- false_positives_known: 0\n"
+        "- reviewer_output_lines: 8\n"
+    )
+    baseline_path = tmp_path / "base.md"
+    new_run_path = tmp_path / "new.md"
+    baseline_path.write_text(baseline_text, encoding="utf-8")
+    new_run_path.write_text(new_run_text, encoding="utf-8")
+
+    a = score.parse_results(baseline_path)
+    b = score.parse_results(new_run_path)
+
+    regressed = b["critical_recall"] < a["critical_recall"] or (
+        b["warning_recall"] < a["warning_recall"] - 0.05
+        and b["noise_rate"] >= a["noise_rate"]
+    )
+    assert regressed is False


### PR DESCRIPTION
## Summary
Decision point resolved as **Option A — wire it** (8+ agent-prompt edits shipped 2026-06-09 with zero behavioral harness; deleting the only candidate harness contradicts the quality goal).

- `regression-set/results/2026-06-09-baseline.md` — first recorded baseline (expected counts parsed from the 3 real cases; `caught=0` documented: stubs not yet run through a live reviewer)
- `scripts/run_regression_set.sh` — trigger driver: detects `claude-config/{agents,commands}/*.md` changes in a diff range; exit 1 with a per-case run guide + score.py invocation
- `ship.md` Step 7.6 + Guard Summary row — REGRESSED verdict blocks merge
- `tests/test_score.py` — 3 unit tests over score.py parse/regression semantics
- **Deliberately no CI job**: live case runs need claude auth unavailable in GitHub Actions (verified — score.py itself is pure-static); the gate lives in the local ship flow

## Step 7.6 self-application note
The new gate fires on this very branch (it touches `commands/ship.md`). Disposition: the only prompt file changed is the gate's own procedural text — it does not alter reviewer behavior — and the baseline carries no live-run data yet, so a score comparison is vacuous (any run ≥ zero-baseline). First live regression run is owed at the first substantive agent-prompt change.

## Test Plan
- [x] PROVE PASS — 3/3 ACs implemented (prove-382-060926.md); non-blocking Guard-Summary gap fixed in addendum `21824ec`
- [x] Live: score.py runs end-to-end on the baseline (`cases: 3`); trigger exits 1 on this branch, 0 on clean range; 474/474 tests; evals runner clean; prove_gate exit 0

Closes #382

🤖 Generated with [Claude Code](https://claude.com/claude-code)