### PR TITLE
chore(settings): persist Fable 5 as default model (/model drift)

### DIFF
--- a/claude-config/settings.json
+++ b/claude-config/settings.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "permissions": {
-    "defaultMode": "auto",
     "allow": [
       "Bash(clawdbot --help:*)",
       "Bash(clawdbot config:*)",
@@ -54,8 +53,10 @@
       "Write(./**/secrets/**)",
       "Write(./**/*.pem)",
       "Write(./**/*.key)"
-    ]
+    ],
+    "defaultMode": "auto"
   },
+  "model": "claude-fable-5[1m]",
   "hooks": {
     "PreCompact": [
       {
@@ -156,8 +157,8 @@
       }
     }
   },
+  "tui": "fullscreen",
   "skipDangerousModePermissionPrompt": true,
   "skipWorkflowUsageWarning": true,
-  "theme": "dark",
-  "tui": "fullscreen"
+  "theme": "dark"
 }


### PR DESCRIPTION
Captures the user's /model selection (claude-fable-5[1m]) plus the
harness's cosmetic key reorder; ends the perpetually-dirty tracked file.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
