### PR TITLE
chore(regression-set): fix case-001 answer leak; recalibrate case-003 expected findings

### DIFF
--- a/claude-config/regression-set/README.md
+++ b/claude-config/regression-set/README.md
@@ -30,6 +30,13 @@ regression-set/
 └── score.py                   ← simple scorer (see below)
 ```
 
+## Case authoring rules
+
+**Answer-leak rule**: The `## Diff` section must contain only the patch under
+review. Expected findings, bug labels, and corrective hints must never appear
+inside a diff hunk or code block in that section. Place explanatory notes in
+`## Notes`, `## Expected Findings`, or `## Known False-Positives` only.
+
 ## Case file format
 
 Each case captures a real past PR/diff and the findings a *good* reviewer

--- a/claude-config/regression-set/cases/001-example-enum-mismatch.md
+++ b/claude-config/regression-set/cases/001-example-enum-mismatch.md
@@ -39,7 +39,7 @@ class AccountMemberRole(StrEnum):
 # frontend/src/components/RolePicker.jsx
  const ROLE_OPTIONS = [
    { value: "OWNER", label: "Owner" },
-+  { value: "CO_OWNER", label: "Co-owner" },     // BUG: uses Python NAME
++  { value: "CO_OWNER", label: "Co-owner" },
    { value: "VIEWER", label: "Viewer" },
  ];
 ```

--- a/claude-config/regression-set/cases/003-example-missing-migration.md
+++ b/claude-config/regression-set/cases/003-example-missing-migration.md
@@ -55,6 +55,8 @@ No file added under `backend/alembic/versions/`.
   - Why CRITICAL: dev works (auto_create_tables); staging/prod will fail because schema doesn't match
   - Where: `backend/backend/accounts/models.py` (column add); `backend/alembic/versions/` (missing file)
   - Fix: `alembic revision --autogenerate -m "add account archived_at"` and commit the resulting file
+- [ ] **None-check missing**: `repo.get(account_id)` returns `None` for unknown IDs; the next line dereferences unconditionally → `AttributeError` at runtime
+  - Where: `backend/backend/accounts/services.py` `archive()` line 3
 
 ### WARNING
 
@@ -62,6 +64,10 @@ No file added under `backend/alembic/versions/`.
   - Where: `backend/tests/accounts_tests/test_services.py`
 - [ ] `archive()` does not check whether account is already archived (idempotency)
   - Where: `backend/backend/accounts/services.py`
+- [ ] **E09 SERVICE_BYPASSES_REPO**: `self.repo.commit()` called directly from service layer — service should not own commit boundaries
+  - Where: `backend/backend/accounts/services.py` `archive()` line 4
+- [ ] **E12 AUDIT_LOG_MISSING**: `archive()` is a write operation but makes no AuditService call
+  - Where: `backend/backend/accounts/services.py` `archive()`
 
 ### SUGGESTION
 

--- a/claude-config/regression-set/results/2026-06-10-384-context-budgets-rescored.md
+++ b/claude-config/regression-set/results/2026-06-10-384-context-budgets-rescored.md
@@ -1,0 +1,39 @@
+---
+run_name: 384-context-budgets-rescored
+date: 2026-06-10
+config_version: 7646e1f6c4da4ad759bd3badf3fd76a911800653
+notes: "Rescored against corrected keys (issue #400): case-001 leak comment removed,
+  case-003 expected lists updated (+1 CRITICAL None-check, +2 WARNING E09/E12).
+  Reviewer outputs identical to 2026-06-10-384-context-budgets.md — reviews not re-run.
+  Original file preserved as historical record."
+---
+
+# 001 enum-mismatch
+
+- critical_expected: 1
+- critical_caught: 1
+- warning_expected: 1
+- warning_caught: 0
+- false_positives: 0
+- false_positives_known: 0
+- reviewer_output_lines: 1
+
+# 002 clean-refactor
+
+- critical_expected: 0
+- critical_caught: 0
+- warning_expected: 0
+- warning_caught: 0
+- false_positives: 0
+- false_positives_known: 0
+- reviewer_output_lines: 1
+
+# 003 missing-migration
+
+- critical_expected: 2
+- critical_caught: 2
+- warning_expected: 4
+- warning_caught: 2
+- false_positives: 0
+- false_positives_known: 0
+- reviewer_output_lines: 4


### PR DESCRIPTION
## Summary
- Case 001: `// BUG: uses Python NAME` stripped from the reviewable diff (the 2026-06-10 live run had to hand-sanitize it)
- Case 003: the three findings the live reviewers surfaced are now dispositioned with rationale — None-check on `repo.get()` → **CRITICAL** (visible AttributeError in the diff); E09 commit-in-service and E12 missing-audit → **WARNING** (both in this config's own eval catalog); none belong in Known-False-Positives
- New rescored result (`2026-06-10-384-context-budgets-rescored.md`): CRITICAL recall **3/3 (100%)**, WARNING 2/5 (40%), noise 0.00, verdict OK to ship — original file preserved as historical record
- README gains the authoring rule: expected findings must never leak into the reviewable section

## Test Plan
- [x] PROVE PASS 4/4 ACs (prove-400-061026.md): score.py run independently matches plan exactly; explicit apples-to-apples judgment (per-file denominators are intentional — the comparison measures key calibration, not the reviewer); 483/483 tests; evals clean; prove_gate exit 0

Closes #400

🤖 Generated with [Claude Code](https://claude.com/claude-code)