### PR TITLE
fix(ship): wait for CI checks to exist before gh pr checks --watch

### DIFF
--- a/claude-config/commands/learn.md
+++ b/claude-config/commands/learn.md
@@ -463,8 +463,16 @@ After all pattern updates are written in Steps 6.5.  This step uses the
    Gate: $NEW_COUNT new failures since $LAST_LEARN_AT.
    Watermark advanced to: $CONSUMED_MAX (max consumed recorded_at — not wall-clock now).
    Host: $HOST"
-   # Wait for CI, verify HEAD parity, squash merge (per ship.md §4-8)
-   gh pr checks --watch
+   # Wait for CI checks to be registered, then watch (per ship.md §6)
+   LEARN_PR=$(gh pr view --json number -q .number)
+   echo "Waiting for CI checks to appear..."
+   for i in $(seq 1 24); do
+     N=$(gh pr checks $LEARN_PR 2>/dev/null | grep -c '.')
+     [ "$N" -ge 1 ] && break
+     [ "$i" -eq 24 ] && { echo "BLOCKED: no CI checks appeared after 120s — investigate before merging"; exit 1; }
+     sleep 5
+   done
+   gh pr checks $LEARN_PR --watch
    gh pr merge --squash --delete-branch
    ```
 

--- a/claude-config/commands/pr.md
+++ b/claude-config/commands/pr.md
@@ -295,7 +295,18 @@ cd frontend && npm run build
 1. Read the failing check output: `gh pr checks $PR_NUMBER`
 2. Fix issues on the feature branch
 3. Push fixes: `git push`
-4. Re-run checks: `gh pr checks $PR_NUMBER --watch`
+4. Wait for checks to be registered after the push, then watch:
+   ```bash
+   # Wait for CI checks to be registered (prevents race: push before workflow run exists)
+   echo "Waiting for CI checks to appear..."
+   for i in $(seq 1 24); do
+     N=$(gh pr checks $PR_NUMBER 2>/dev/null | grep -c '.')
+     [ "$N" -ge 1 ] && break
+     [ "$i" -eq 24 ] && { echo "BLOCKED: no CI checks appeared after 120s — investigate before merging"; exit 1; }
+     sleep 5
+   done
+   gh pr checks $PR_NUMBER --watch
+   ```
 
 ---
 

--- a/claude-config/commands/ship.md
+++ b/claude-config/commands/ship.md
@@ -109,7 +109,18 @@ run the review gates per `implementation-routing.md §Review Surface Routing`:
 ### Step 6 — CI Watch
 
 ```bash
-gh pr checks --watch
+PR_NUMBER=$(gh pr view --json number -q .number)
+
+# Wait for CI checks to be registered (prevents race: merge before workflow run exists)
+echo "Waiting for CI checks to appear..."
+for i in $(seq 1 24); do
+  N=$(gh pr checks $PR_NUMBER 2>/dev/null | grep -c '.')
+  [ "$N" -ge 1 ] && break
+  [ "$i" -eq 24 ] && { echo "BLOCKED: no CI checks appeared after 120s — investigate before merging"; exit 1; }
+  sleep 5
+done
+
+gh pr checks $PR_NUMBER --watch
 ```
 
 **Gate**: Any red or pending check → STOP. Print the failing check URL. Do NOT
@@ -122,7 +133,7 @@ a PR created before the last push can squash-merge an older snapshot, silently
 dropping commits.
 
 ```bash
-PR_NUMBER=$(gh pr view --json number -q .number)
+# PR_NUMBER derived in Step 6; reused here
 PR_HEAD=$(gh pr view --json headRefOid -q .headRefOid)
 LOCAL_HEAD=$(git rev-parse HEAD)
 
@@ -130,7 +141,15 @@ if [ "$PR_HEAD" != "$LOCAL_HEAD" ]; then
   echo "HEAD MISMATCH: PR HEAD $PR_HEAD != local HEAD $LOCAL_HEAD"
   echo "Pushing to sync and re-checking CI..."
   git push --force-with-lease origin HEAD
-  gh pr checks --watch
+  # Wait for CI checks to be registered after the new push
+  echo "Waiting for CI checks to appear..."
+  for i in $(seq 1 24); do
+    N=$(gh pr checks $PR_NUMBER 2>/dev/null | grep -c '.')
+    [ "$N" -ge 1 ] && break
+    [ "$i" -eq 24 ] && { echo "BLOCKED: no CI checks appeared after 120s — investigate before merging"; exit 1; }
+    sleep 5
+  done
+  gh pr checks $PR_NUMBER --watch
   PR_HEAD=$(gh pr view --json headRefOid -q .headRefOid)
   LOCAL_HEAD=$(git rev-parse HEAD)
   if [ "$PR_HEAD" != "$LOCAL_HEAD" ]; then
@@ -302,7 +321,8 @@ Shipped  PR #N  {pr_url}
 | Pre-commit hook | Step 2 | Always |
 | Rebase conflict | Step 3 | Always |
 | CRITICAL review | Step 5 | Always |
-| Red CI | Step 6 | Always |
+| Checks exist (≥1 check registered) | Step 6, Step 7 re-push | Always |
+| Red CI | Step 6, Step 7 re-push | Always |
 | HEAD parity | Step 7 | Always |
 | Kill switch (`y/N`) | Step 7 | Plain `/ship` only |
 | PROVE gate | Step 7.5 | Always (override only via `--override-prove`, recorded) |


### PR DESCRIPTION
## Summary
- `gh pr checks --watch` exits 0 with 'no checks reported' when the workflow run hasn't been created yet — PRs #389–#391 merged before CI ran. All four `--watch` sites now carry a canonical poll loop (24×5s; timeout → BLOCKED, never proceed on absent checks): ship.md Step 6, ship.md Step 7 re-push, pr.md §If-Checks-Fail, learn.md auto-apply. PR_NUMBER derived once in Step 6, reused in Step 7. Guard Summary row added.

## Step 7.6 disposition
The regression gate fires (commands/*.md touched). The change is procedural workflow text — poll loops around gh invocations — not reviewer-behavior prompts; per the #382 self-application precedent, no live reviewer run is owed. The corrected answer keys (#400, merged) remain the active baseline.

## Live demonstration (AC4)
This PR's own merge uses the poll-then-watch pattern — checks polled until present, then watched to green, then merged. PR #403 and #404 were also merged with the same loop.

## Test Plan
- [x] PROVE PASS 4/4 ACs (prove-397-061026.md): all four sites guarded (file:line evidence), read-only sites untouched, bash -n on every snippet, break-condition dry-run against a merged PR; 483/483 tests; prove_gate exit 0

Closes #397

🤖 Generated with [Claude Code](https://claude.com/claude-code)