### PR TITLE
feat(agent-parity): add Claude Codex drift checks

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -119,6 +119,9 @@ jobs:
           done
           [ "$fail" = "0" ] || exit 1
 
+      - name: Validate Claude/Codex parity report
+        run: bin/agent-parity check
+
       - name: Smoke test Codex install in temp HOME
         run: |
           set -e
@@ -126,8 +129,45 @@ jobs:
           HOME="$tmp" ./codex-config/install.sh
           test -L "$tmp/.codex/AGENTS.md"
           test -L "$tmp/.codex/rules/shared.rules"
-          test -L "$tmp/.codex/skills/technical-spec-review"
-          test -L "$tmp/.agents/skills/technical-spec-review"
+
+          assert_skill_link() {
+            name="$1"
+            expected="$2"
+            for root in "$tmp/.codex/skills" "$tmp/.agents/skills"; do
+              link="$root/$name"
+              if [ ! -L "$link" ]; then
+                echo "::error::missing skill symlink: $link"
+                exit 1
+              fi
+              actual="$(readlink "$link")"
+              if [ "$actual" != "$expected" ]; then
+                echo "::error::wrong skill symlink target: $link -> $actual (expected $expected)"
+                exit 1
+              fi
+            done
+          }
+
+          for skill_md in codex-config/skills/*/SKILL.md; do
+            [ -f "$skill_md" ] || continue
+            name="$(basename "$(dirname "$skill_md")")"
+            assert_skill_link "$name" "$PWD/codex-config/skills/$name"
+          done
+
+          for skill_md in claude-config/skills/*/SKILL.md; do
+            [ -f "$skill_md" ] || continue
+            name="$(basename "$(dirname "$skill_md")")"
+            if claude-config/scripts/check-skill-portability.sh "$skill_md" >/dev/null; then
+              assert_skill_link "$name" "$PWD/claude-config/skills/$name"
+            else
+              rc=$?
+              if [ "$rc" = "2" ]; then
+                echo "::error::invalid skill portability check for $name"
+                exit 1
+              fi
+            fi
+          done
+
+          bin/agent-parity check --home "$tmp"
 
       - name: Smoke test project bootstrap idempotency
         run: |

--- a/bin/agent-parity
+++ b/bin/agent-parity
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+"""Claude/Codex parity drift report."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from lib.agent_parity import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/codex-config/AGENTS.md
+++ b/codex-config/AGENTS.md
@@ -70,6 +70,18 @@ still ships, but runs adversarial review before merge.
 - Feed recurring Codex review findings back into shared instructions,
   project `AGENTS.md`, or Claude learning rules as appropriate.
 
+## Active Memory Recall
+
+Before non-trivial implementation, review, or orchestration-adjacent work in a
+project with memory, run:
+
+```bash
+~/agents/bin/memory recall "<issue title + subsystem terms>" --compact --limit 8
+```
+
+Treat recalled facts as prior context, not truth. Read any relevant fact body,
+then verify it against current source, specs, and tests before acting.
+
 ## Git Safety
 
 - Never use `git reset --hard`, `git checkout -- <file>`, force-push, or

--- a/docs/AGENT-CAPABILITIES.md
+++ b/docs/AGENT-CAPABILITIES.md
@@ -12,6 +12,7 @@ different runtime surfaces.
 - Shared project artifacts: `.agents/outputs/`
 - CLI-backed workflows: `action`, `project`, `decision`, `pulse`,
   `email-digest`, and related Python CLIs
+- Parity drift report: `bin/agent-parity check`
 - Validation scripts and CI in `.github/workflows/validate.yml`
 
 Shared rules belong in `AGENTS.md` or shared skills. Do not duplicate shared
@@ -116,6 +117,7 @@ bash -n claude-config/new-project-claude.sh
 python3 -c "import json; json.load(open('claude-config/settings.json'))"
 SETTINGS_PATH=$PWD/claude-config/settings.json python3 claude-config/scripts/validate-hooks.py
 codex execpolicy check --pretty --rules codex-config/rules/shared.rules -- git status
+bin/agent-parity check
 ```
 
 Installer smoke:

--- a/lib/agent_parity.py
+++ b/lib/agent_parity.py
@@ -1,0 +1,391 @@
+"""Mechanical Claude/Codex parity checks."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+CLAUDE_MD_BUDGET = 200
+RULES_BUDGET = 450
+
+
+@dataclass
+class CheckResult:
+    name: str
+    status: str
+    message: str
+    details: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "status": self.status,
+            "message": self.message,
+            "details": self.details,
+        }
+
+
+@dataclass
+class ParityReport:
+    repo: str
+    checks: list[CheckResult]
+
+    @property
+    def errors(self) -> list[str]:
+        return [check.message for check in self.checks if check.status == "fail"]
+
+    @property
+    def warnings(self) -> list[str]:
+        return [check.message for check in self.checks if check.status == "warn"]
+
+    @property
+    def ok(self) -> bool:
+        return not self.errors
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "ok": self.ok,
+            "repo": self.repo,
+            "checks": [check.to_dict() for check in self.checks],
+            "errors": self.errors,
+            "warnings": self.warnings,
+        }
+
+
+def _repo_root(path: Path) -> Path:
+    return path.resolve()
+
+
+def _line_count(path: Path) -> int:
+    return len(path.read_text(encoding="utf-8").splitlines())
+
+
+def _frontmatter(path: Path) -> dict[str, Any] | None:
+    text = path.read_text(encoding="utf-8")
+    if not text.startswith("---\n"):
+        return None
+    end = text.find("\n---\n", 4)
+    if end == -1:
+        return None
+    raw = text[4:end]
+    try:
+        import yaml
+    except ImportError:
+        return None
+    try:
+        parsed = yaml.safe_load(raw)
+    except yaml.YAMLError:
+        return None
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _is_always_load_rule(path: Path) -> bool:
+    fm = _frontmatter(path)
+    if fm is None:
+        return True
+    paths = fm.get("paths")
+    if paths is None:
+        return True
+    return paths == ["**"]
+
+
+def budget_check(repo: Path) -> CheckResult:
+    claude_md = repo / "claude-config" / "CLAUDE.md"
+    rules_dir = repo / "claude-config" / "rules"
+    details: dict[str, Any] = {
+        "claude_budget": CLAUDE_MD_BUDGET,
+        "rules_budget": RULES_BUDGET,
+    }
+    errors: list[str] = []
+
+    if not claude_md.is_file():
+        errors.append(f"missing {claude_md}")
+    else:
+        claude_lines = _line_count(claude_md)
+        details["claude_lines"] = claude_lines
+        details["claude_headroom"] = CLAUDE_MD_BUDGET - claude_lines
+        if claude_lines > CLAUDE_MD_BUDGET:
+            errors.append(
+                f"CLAUDE.md exceeds budget by {claude_lines - CLAUDE_MD_BUDGET} lines"
+            )
+
+    if not rules_dir.is_dir():
+        errors.append(f"missing {rules_dir}")
+    else:
+        counted: dict[str, int] = {}
+        total = 0
+        for rule in sorted(rules_dir.glob("*.md")):
+            if not _is_always_load_rule(rule):
+                continue
+            lines = _line_count(rule)
+            counted[rule.name] = lines
+            total += lines
+        details["always_load_rules"] = counted
+        details["rules_lines"] = total
+        details["rules_headroom"] = RULES_BUDGET - total
+        if total > RULES_BUDGET:
+            errors.append(f"always-load rules exceed budget by {total - RULES_BUDGET} lines")
+
+    if errors:
+        return CheckResult("budget_headroom", "fail", "; ".join(errors), details)
+    return CheckResult("budget_headroom", "pass", "context budgets within limits", details)
+
+
+def _skill_name(path: Path) -> str:
+    return path.parent.name
+
+
+def _run_portability_lint(repo: Path, skill_md: Path) -> int:
+    lint = repo / "claude-config" / "scripts" / "check-skill-portability.sh"
+    if not lint.is_file():
+        return 2
+    result = subprocess.run(
+        [str(lint), str(skill_md)],
+        cwd=repo,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+    return result.returncode
+
+
+def expected_portable_claude_skills(repo: Path) -> tuple[list[str], list[str]]:
+    portable: list[str] = []
+    skipped: list[str] = []
+    for skill_md in sorted((repo / "claude-config" / "skills").glob("*/SKILL.md")):
+        rc = _run_portability_lint(repo, skill_md)
+        name = _skill_name(skill_md)
+        if rc == 0:
+            portable.append(name)
+        elif rc == 1:
+            skipped.append(name)
+        else:
+            skipped.append(f"{name} (lint-error)")
+    return portable, skipped
+
+
+def codex_native_skills(repo: Path) -> list[str]:
+    return [
+        _skill_name(path)
+        for path in sorted((repo / "codex-config" / "skills").glob("*/SKILL.md"))
+    ]
+
+
+def _expected_link_target(repo: Path, skill: str) -> Path:
+    claude_skill = repo / "claude-config" / "skills" / skill
+    if claude_skill.is_dir():
+        return claude_skill
+    return repo / "codex-config" / "skills" / skill
+
+
+def skill_parity_check(repo: Path, home: Path | None = None) -> CheckResult:
+    portable, skipped = expected_portable_claude_skills(repo)
+    native = codex_native_skills(repo)
+    lint_errors = [name for name in skipped if name.endswith(" (lint-error)")]
+    details: dict[str, Any] = {
+        "portable_claude_skills": portable,
+        "claude_only_skills": skipped,
+        "codex_native_skills": native,
+    }
+    missing: list[str] = []
+
+    if home is not None:
+        link_checks: dict[str, dict[str, str]] = {}
+        for skill in sorted(set(portable + native)):
+            expected_target = _expected_link_target(repo, skill).resolve()
+            for root in (home / ".codex" / "skills", home / ".agents" / "skills"):
+                link = root / skill
+                label = str(link)
+                if not link.is_symlink():
+                    missing.append(f"{label} is not a symlink")
+                    continue
+                actual = link.resolve()
+                link_checks[label] = {
+                    "target": str(actual),
+                    "expected": str(expected_target),
+                }
+                if actual != expected_target:
+                    missing.append(f"{label} points to {actual}, expected {expected_target}")
+        details["installed_links"] = link_checks
+
+    if lint_errors:
+        return CheckResult(
+            "skill_parity",
+            "fail",
+            "skill portability lint failed",
+            {**details, "lint_errors": lint_errors},
+        )
+    if missing:
+        return CheckResult("skill_parity", "fail", "Codex skill links are incomplete", details)
+
+    message = "portable skills enumerated"
+    if home is not None:
+        message = "portable and native Codex skills are linked"
+    return CheckResult("skill_parity", "pass", message, details)
+
+
+CAPABILITY_PATHS = {
+    "claude_install": "claude-config/install.sh",
+    "claude_guidance": "claude-config/CLAUDE.md",
+    "claude_commands": "claude-config/commands",
+    "claude_agents": "claude-config/agents",
+    "claude_hooks": "claude-config/hooks",
+    "claude_settings": "claude-config/settings.json",
+    "codex_install": "codex-config/install.sh",
+    "codex_guidance": "codex-config/AGENTS.md",
+    "codex_config_template": "codex-config/config.toml.example",
+    "codex_rules": "codex-config/rules",
+    "codex_skills": "codex-config/skills",
+    "project_bootstrap": "new-project-agents.sh",
+    "parity_cli": "bin/agent-parity",
+    "validate_workflow": ".github/workflows/validate.yml",
+}
+
+
+def capability_docs_check(repo: Path) -> CheckResult:
+    doc = repo / "docs" / "AGENT-CAPABILITIES.md"
+    missing = [
+        f"{key}: {rel}"
+        for key, rel in CAPABILITY_PATHS.items()
+        if not (repo / rel).exists()
+    ]
+    details = {"checked_paths": CAPABILITY_PATHS}
+    if not doc.is_file():
+        missing.append("docs/AGENT-CAPABILITIES.md")
+    if missing:
+        return CheckResult(
+            "capability_docs",
+            "fail",
+            "documented capability paths are missing",
+            {**details, "missing": missing},
+        )
+    return CheckResult(
+        "capability_docs",
+        "pass",
+        "documented capability paths exist",
+        details,
+    )
+
+
+def workflow_tree_check(repo: Path) -> CheckResult:
+    active_legacy = repo / "orchestrate-workflow"
+    archived_legacy = repo / "_archived" / "orchestrate-workflow-legacy"
+    canonical = repo / "claude-config" / "commands" / "orchestrate.md"
+    details = {
+        "canonical": str(canonical),
+        "active_legacy_exists": active_legacy.exists(),
+        "archived_legacy_exists": archived_legacy.exists(),
+    }
+    if active_legacy.exists():
+        return CheckResult(
+            "workflow_tree",
+            "fail",
+            "active legacy orchestrate-workflow tree exists beside canonical Claude command",
+            details,
+        )
+    if not canonical.is_file():
+        return CheckResult("workflow_tree", "fail", "canonical orchestrate command missing", details)
+    return CheckResult("workflow_tree", "pass", "no active duplicate workflow tree", details)
+
+
+def one_sided_hooks_check(repo: Path) -> CheckResult:
+    settings = repo / "claude-config" / "settings.json"
+    capabilities = repo / "docs" / "AGENT-CAPABILITIES.md"
+    details: dict[str, Any] = {}
+    if not settings.is_file():
+        return CheckResult("one_sided_hooks", "fail", "Claude settings.json is missing", details)
+
+    try:
+        payload = json.loads(settings.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return CheckResult("one_sided_hooks", "fail", f"settings.json is invalid: {exc}", details)
+
+    hooks = payload.get("hooks") or {}
+    details["claude_hook_events"] = sorted(hooks)
+    documented = capabilities.is_file() and "Codex hooks are not ported" in capabilities.read_text(
+        encoding="utf-8"
+    )
+    details["codex_gap_documented"] = documented
+    if hooks and not documented:
+        return CheckResult(
+            "one_sided_hooks",
+            "fail",
+            "Claude hooks exist but the Codex hook gap is not documented",
+            details,
+        )
+    if hooks:
+        return CheckResult(
+            "one_sided_hooks",
+            "warn",
+            "Claude hooks exist; Codex hook gap is documented",
+            details,
+        )
+    return CheckResult("one_sided_hooks", "pass", "no one-sided hooks detected", details)
+
+
+def run_checks(repo: Path, home: Path | None = None) -> ParityReport:
+    repo = _repo_root(repo)
+    checks = [
+        skill_parity_check(repo, home),
+        capability_docs_check(repo),
+        workflow_tree_check(repo),
+        budget_check(repo),
+        one_sided_hooks_check(repo),
+    ]
+    return ParityReport(str(repo), checks)
+
+
+def render_text(report: ParityReport) -> str:
+    lines = [f"agent-parity: {'pass' if report.ok else 'fail'}", f"repo: {report.repo}"]
+    for check in report.checks:
+        lines.append("")
+        lines.append(f"{check.name}: {check.status}")
+        lines.append(f"  {check.message}")
+        if check.name == "budget_headroom":
+            lines.append(
+                "  headroom: "
+                f"CLAUDE.md {check.details.get('claude_headroom', 'n/a')} lines, "
+                f"always-load rules {check.details.get('rules_headroom', 'n/a')} lines"
+            )
+        if check.name == "skill_parity":
+            lines.append(
+                "  portable Claude skills: "
+                f"{len(check.details.get('portable_claude_skills', []))}"
+            )
+            lines.append(
+                "  Codex-native skills: "
+                f"{len(check.details.get('codex_native_skills', []))}"
+            )
+        if check.name == "one_sided_hooks":
+            events = ", ".join(check.details.get("claude_hook_events", [])) or "(none)"
+            lines.append(f"  Claude hook events: {events}")
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="agent-parity")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    check = sub.add_parser("check", help="report Claude/Codex parity drift")
+    check.add_argument("--repo", type=Path, default=Path.cwd(), help="repo root")
+    check.add_argument("--home", type=Path, help="installed HOME to verify skill links")
+    check.add_argument("--json", action="store_true", help="emit JSON")
+
+    args = parser.parse_args(argv)
+    if args.cmd == "check":
+        report = run_checks(args.repo, args.home)
+        if args.json:
+            print(json.dumps(report.to_dict(), indent=2, sort_keys=True))
+        else:
+            print(render_text(report), end="")
+        return 0 if report.ok else 1
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/lib/tests/test_agent_parity.py
+++ b/lib/tests/test_agent_parity.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from lib import agent_parity
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _make_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _write(repo / "claude-config" / "CLAUDE.md", "line\n")
+    _write(repo / "claude-config" / "rules" / "core.md", "---\npaths: [\"**\"]\n---\nrule\n")
+    _write(repo / "claude-config" / "settings.json", json.dumps({"hooks": {"Stop": []}}))
+    _write(repo / "claude-config" / "install.sh", "#!/bin/sh\n")
+    _write(repo / "claude-config" / "commands" / "orchestrate.md", "# Orchestrate\n")
+    _write(repo / "claude-config" / "agents" / "patch.md", "# PATCH\n")
+    _write(repo / "claude-config" / "hooks" / "verify.py", "print('ok')\n")
+    _write(repo / "codex-config" / "install.sh", "#!/bin/sh\n")
+    _write(repo / "codex-config" / "AGENTS.md", "# Codex\n")
+    _write(repo / "codex-config" / "config.toml.example", "model = 'x'\n")
+    _write(repo / "codex-config" / "rules" / "shared.rules", "# rules\n")
+    _write(repo / "codex-config" / "skills" / "native" / "SKILL.md", "---\nname: native\n---\n")
+    _write(repo / "new-project-agents.sh", "#!/bin/sh\n")
+    _write(repo / ".github" / "workflows" / "validate.yml", "name: validate\n")
+    _write(
+        repo / "docs" / "AGENT-CAPABILITIES.md",
+        "Codex hooks are not ported from Claude hooks.\n",
+    )
+
+    lint = repo / "claude-config" / "scripts" / "check-skill-portability.sh"
+    _write(
+        lint,
+        "#!/bin/sh\n"
+        "if grep -q 'Task tool' \"$1\"; then\n"
+        "  echo task-only\n"
+        "  exit 1\n"
+        "fi\n"
+        "exit 0\n",
+    )
+    lint.chmod(0o755)
+    _write(repo / "claude-config" / "skills" / "portable" / "SKILL.md", "portable\n")
+    _write(repo / "claude-config" / "skills" / "claude-only" / "SKILL.md", "Task tool\n")
+    return repo
+
+
+def test_skill_parity_enforces_installed_links(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path)
+    home = tmp_path / "home"
+    for root in (home / ".codex" / "skills", home / ".agents" / "skills"):
+        root.mkdir(parents=True)
+        os.symlink(repo / "claude-config" / "skills" / "portable", root / "portable")
+        os.symlink(repo / "codex-config" / "skills" / "native", root / "native")
+
+    result = agent_parity.skill_parity_check(repo, home)
+
+    assert result.status == "pass"
+    assert result.details["portable_claude_skills"] == ["portable"]
+
+
+def test_skill_parity_fails_missing_installed_link(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path)
+    home = tmp_path / "home"
+    (home / ".codex" / "skills").mkdir(parents=True)
+    (home / ".agents" / "skills").mkdir(parents=True)
+
+    result = agent_parity.skill_parity_check(repo, home)
+
+    assert result.status == "fail"
+
+
+def test_skill_parity_fails_lint_usage_errors(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path)
+    (repo / "claude-config" / "scripts" / "check-skill-portability.sh").unlink()
+
+    result = agent_parity.skill_parity_check(repo)
+
+    assert result.status == "fail"
+    assert "lint" in result.message
+
+
+def test_workflow_tree_detects_active_legacy_duplicate(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path)
+    _write(repo / "orchestrate-workflow" / "orchestrate.md", "legacy\n")
+
+    result = agent_parity.workflow_tree_check(repo)
+
+    assert result.status == "fail"
+    assert "legacy" in result.message
+
+
+def test_budget_headroom_reports_remaining_lines(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path)
+
+    result = agent_parity.budget_check(repo)
+
+    assert result.status == "pass"
+    assert result.details["claude_headroom"] == agent_parity.CLAUDE_MD_BUDGET - 1
+    assert result.details["rules_headroom"] < agent_parity.RULES_BUDGET
+
+
+def test_one_sided_hooks_are_warning_when_gap_is_documented(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path)
+
+    result = agent_parity.one_sided_hooks_check(repo)
+
+    assert result.status == "warn"
+    assert result.details["codex_gap_documented"] is True
+
+
+def test_cli_json_runs_against_current_repo() -> None:
+    repo = Path(__file__).resolve().parents[2]
+    script = repo / "bin" / "agent-parity"
+
+    completed = subprocess.run(
+        [sys.executable, str(script), "check", "--repo", str(repo), "--json"],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    payload = json.loads(completed.stdout)
+    assert payload["ok"] is True
+    assert any(check["name"] == "skill_parity" for check in payload["checks"])


### PR DESCRIPTION
## Summary
- add `bin/agent-parity check` backed by `lib.agent_parity` to report Claude/Codex drift, budget headroom, skill parity, stale workflow trees, capability paths, and documented one-sided hooks
- add Codex active memory recall guidance using the existing `~/agents/bin/memory recall --compact --limit 8` shared command surface
- strengthen CI Codex install smoke to assert every Codex-native and portable Claude skill is actually linked in both Codex skill locations

## Test Plan
- `ruff check .`
- `uv run --with pytest --with pyyaml python -m pytest claude-config/tests lib/tests -q` (634 passed)
- `uv run --with pytest --with pyyaml python -m pytest tests -q` (69 passed)
- `uv run --with pytest --with pyyaml python -m pytest action/tests decision/tests project/tests pulse/tests email-digest/tests -q` (233 passed)
- `bash -n install-all.sh && bash -n claude-config/install.sh && bash -n codex-config/install.sh && bash -n new-project-agents.sh && bash -n claude-config/new-project-claude.sh`
- `python3 -c "import json; json.load(open('claude-config/settings.json'))"`
- `SETTINGS_PATH=$PWD/claude-config/settings.json python3 claude-config/scripts/validate-hooks.py`
- `python3 claude-config/scripts/check-context-budgets.py`
- `python3 claude-config/scripts/check-context-budgets.py --payload-report`
- `codex execpolicy check --pretty --rules codex-config/rules/shared.rules -- git status`
- `bin/agent-parity check`
- temp-HOME `codex-config/install.sh` smoke with computed skill symlink assertions plus `bin/agent-parity check --home "$tmp"`

Closes #410
Closes #411
Closes #412
