### PR TITLE
feat(codex): add lifecycle hook adapters

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Validate settings.json is valid JSON
         run: python3 -c "import json; json.load(open('claude-config/settings.json'))"
 
+      - name: Validate Codex hooks.json is valid JSON
+        run: python3 -m json.tool codex-config/hooks.json >/dev/null
+
       - name: Validate shell script syntax
         run: |
           bash -n install-all.sh
@@ -128,6 +131,8 @@ jobs:
           tmp="$(mktemp -d)"
           HOME="$tmp" ./codex-config/install.sh
           test -L "$tmp/.codex/AGENTS.md"
+          test -L "$tmp/.codex/hooks.json"
+          test -L "$tmp/.codex/hooks"
           test -L "$tmp/.codex/rules/shared.rules"
 
           assert_skill_link() {

--- a/codex-config/README.md
+++ b/codex-config/README.md
@@ -1,8 +1,8 @@
 # Codex Configuration
 
 Portable Codex configuration that can be installed on any machine. Uses
-symlinks from `~/.codex` to this repo for shared Codex guidance, shared
-command-policy rules, and user skills while preserving local
+symlinks from `~/.codex` to this repo for shared Codex guidance, lifecycle
+hooks, shared command-policy rules, and user skills while preserving local
 auth/history/sessions and machine-specific approval rules.
 
 ## Installation
@@ -19,6 +19,8 @@ git clone https://github.com/jwj2002/agents.git ~/agents
 
 ```text
 ~/.codex/AGENTS.md               -> ~/agents/codex-config/AGENTS.md
+~/.codex/hooks.json              -> ~/agents/codex-config/hooks.json
+~/.codex/hooks/                  -> ~/agents/codex-config/hooks/
 ~/.codex/rules/shared.rules      -> ~/agents/codex-config/rules/shared.rules
 ~/.codex/skills/user             -> ~/agents/codex-config/skills/
 ~/.codex/skills/<name>           -> shared skill folders
@@ -27,6 +29,10 @@ git clone https://github.com/jwj2002/agents.git ~/agents
 
 `AGENTS.md` is the behavioral instruction surface. `.rules` files are Codex
 command-policy files written in Starlark; do not put prose instructions there.
+`hooks.json` wires lifecycle hooks for bounded memory context, pre-compact
+state checkpoints, context headroom warnings, stop-time completion checks, and
+lightweight telemetry. After hook changes, review and trust the hook definitions
+inside Codex with `/hooks`.
 
 Codex skill links are written to both `~/.codex/skills` and
 `~/.agents/skills`. The former preserves current local behavior; the latter is

--- a/codex-config/hooks.json
+++ b/codex-config/hooks.json
@@ -1,0 +1,60 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ~/.codex/hooks/session_start_memory.py",
+            "timeout": 10,
+            "statusMessage": "Loading bounded memory context"
+          }
+        ]
+      }
+    ],
+    "PreCompact": [
+      {
+        "matcher": "manual|auto",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ~/.codex/hooks/precompact_checkpoint.py",
+            "timeout": 10,
+            "statusMessage": "Checkpointing Codex state"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ~/.codex/hooks/context_monitor.py",
+            "timeout": 5,
+            "statusMessage": "Checking context headroom"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ~/.codex/hooks/stop_verify.py",
+            "timeout": 10,
+            "statusMessage": "Checking completion discipline"
+          },
+          {
+            "type": "command",
+            "command": "python3 ~/.codex/hooks/session_telemetry.py",
+            "timeout": 5,
+            "statusMessage": "Recording Codex telemetry"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/codex-config/hooks/context_monitor.py
+++ b/codex-config/hooks/context_monitor.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""PostToolUse hook: warn when Codex context headroom gets low."""
+
+from __future__ import annotations
+
+from hook_common import HOOK_EXCEPTIONS, add_repo_to_path, emit, fail_open, read_payload
+
+
+def main() -> int:
+    add_repo_to_path()
+    try:
+        from lib.context_budget import should_warn
+
+        payload = read_payload()
+        severity, pct = should_warn(payload)
+        if severity != "NONE" and pct is not None:
+            emit(
+                "PostToolUse",
+                context=(
+                    f"Context headroom is {pct:.0f}% ({severity}). Finish the current "
+                    "task or compact before starting new complex work."
+                ),
+            )
+    except HOOK_EXCEPTIONS:
+        return fail_open()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/codex-config/hooks/hook_common.py
+++ b/codex-config/hooks/hook_common.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Common helpers for Codex lifecycle hook wrappers."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+HOOK_EXCEPTIONS = (ImportError, OSError, RuntimeError, TypeError, ValueError)
+
+
+def add_repo_to_path() -> Path:
+    repo = Path(__file__).resolve().parents[2]
+    if str(repo) not in sys.path:
+        sys.path.insert(0, str(repo))
+    return repo
+
+
+def read_payload() -> dict[str, Any]:
+    try:
+        payload = json.load(sys.stdin)
+    except (json.JSONDecodeError, OSError):
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def emit(event: str, *, message: str | None = None, context: str | None = None) -> None:
+    payload: dict[str, Any] = {"event": event}
+    if message:
+        payload["message"] = message
+    if context:
+        payload["additional_context"] = context
+    print(json.dumps(payload, sort_keys=True))
+
+
+def fail_open() -> int:
+    return 0

--- a/codex-config/hooks/precompact_checkpoint.py
+++ b/codex-config/hooks/precompact_checkpoint.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+"""PreCompact hook: persist a compact resume checkpoint for Codex."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from hook_common import HOOK_EXCEPTIONS, add_repo_to_path, emit, fail_open, read_payload
+
+
+def main() -> int:
+    add_repo_to_path()
+    try:
+        from lib.agent_state import write_codex_checkpoint
+
+        payload = read_payload()
+        path = write_codex_checkpoint(Path(os.getcwd()), payload)
+        emit("PreCompact", message=f"checkpoint written: {path}")
+    except HOOK_EXCEPTIONS:
+        return fail_open()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/codex-config/hooks/session_start_memory.py
+++ b/codex-config/hooks/session_start_memory.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+"""SessionStart hook: inject bounded, verify-first memory context."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from hook_common import HOOK_EXCEPTIONS, add_repo_to_path, emit, fail_open, read_payload
+
+
+def main() -> int:
+    add_repo_to_path()
+    try:
+        from lib.agent_memory import render_codex_memory_context
+
+        read_payload()
+        context = render_codex_memory_context(Path(os.getcwd()))
+        if context:
+            emit("SessionStart", context=context)
+    except HOOK_EXCEPTIONS:
+        return fail_open()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/codex-config/hooks/session_telemetry.py
+++ b/codex-config/hooks/session_telemetry.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+"""Stop hook: append lightweight, derived Codex session telemetry."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from hook_common import HOOK_EXCEPTIONS, add_repo_to_path, emit, fail_open, read_payload
+
+
+def main() -> int:
+    add_repo_to_path()
+    try:
+        from lib.agent_telemetry import append_event, build_event
+
+        payload = read_payload()
+        path = append_event(build_event(payload, "Stop", Path(os.getcwd())))
+        emit("Stop", message=f"telemetry recorded: {path}")
+    except HOOK_EXCEPTIONS:
+        return fail_open()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/codex-config/hooks/stop_verify.py
+++ b/codex-config/hooks/stop_verify.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Stop hook: surface unfinished-work signals before Codex declares completion."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from hook_common import HOOK_EXCEPTIONS, add_repo_to_path, emit, fail_open, read_payload
+
+
+def main() -> int:
+    add_repo_to_path()
+    try:
+        from lib.agent_completion import completion_warnings
+
+        read_payload()
+        warnings = completion_warnings(Path(os.getcwd()))
+        if warnings:
+            emit(
+                "Stop",
+                context=(
+                    "Completion check found possible unfinished work: "
+                    + " | ".join(warnings)
+                ),
+            )
+    except HOOK_EXCEPTIONS:
+        return fail_open()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/codex-config/install.sh
+++ b/codex-config/install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Install Codex configuration: shared guidance, rules, and user skills symlinks.
+# Install Codex configuration: shared guidance, rules, hooks, and user skills.
 #
 # Usage: ./install.sh
 #
@@ -54,6 +54,8 @@ echo "Phase 1: Symlinks"
 mkdir -p "$CODEX_DIR" "$CODEX_DIR/rules" "$CODEX_DIR/skills" "$AGENTS_SKILLS_DIR"
 
 link_item "$SCRIPT_DIR/AGENTS.md" "$CODEX_DIR/AGENTS.md" "AGENTS.md"
+link_item "$SCRIPT_DIR/hooks.json" "$CODEX_DIR/hooks.json" "hooks.json"
+link_item "$SCRIPT_DIR/hooks" "$CODEX_DIR/hooks" "hooks"
 link_item "$SCRIPT_DIR/rules/shared.rules" "$CODEX_DIR/rules/shared.rules" "rules/shared.rules"
 link_item "$SCRIPT_DIR/skills" "$CODEX_DIR/skills/user" "skills/user"
 
@@ -131,7 +133,13 @@ echo ""
 echo "Phase 3: Verify"
 ERRORS=0
 
-for target in "$CODEX_DIR/AGENTS.md" "$CODEX_DIR/rules/shared.rules" "$CODEX_DIR/skills/user"; do
+for target in \
+    "$CODEX_DIR/AGENTS.md" \
+    "$CODEX_DIR/hooks.json" \
+    "$CODEX_DIR/hooks" \
+    "$CODEX_DIR/rules/shared.rules" \
+    "$CODEX_DIR/skills/user"
+do
     if [ -L "$target" ] && [ -e "$target" ]; then
         :
     else
@@ -151,6 +159,7 @@ echo "  Claude→Codex: $SKILLS_PORTED skill(s) shared, $SKILLS_SKIPPED skipped 
 echo "  Notes:       ~/.codex/skills/.system remains local and untouched"
 echo "               ~/.codex/rules/default.rules remains local (machine approvals)"
 echo "               ~/.codex/AGENTS.md is shared Codex guidance"
+echo "               ~/.codex/hooks.json and ~/.codex/hooks require Codex /hooks trust review after changes"
 echo "               ~/.agents/skills contains documented Codex user skill links"
 
 if [ "$BACKUP_CREATED" = true ]; then

--- a/docs/AGENT-CAPABILITIES.md
+++ b/docs/AGENT-CAPABILITIES.md
@@ -39,12 +39,26 @@ state hooks.
 - Global Codex install: `codex-config/install.sh`
 - Global Codex guidance: `codex-config/AGENTS.md` -> `~/.codex/AGENTS.md`
 - Codex config template: `codex-config/config.toml.example`
+- Codex lifecycle hooks: `codex-config/hooks.json` and `codex-config/hooks/`
 - Codex command policy: `codex-config/rules/*.rules`
 - Codex-native skills: `codex-config/skills/`
 - Optional project Codex config: `.codex/config.toml`
 
 Codex `.rules` files are Starlark command-policy files. They are not
 instruction files. Prose guidance belongs in `AGENTS.md`.
+
+Codex hooks currently cover the high-value cross-agent performance and
+discipline adapters:
+
+- `SessionStart`: bounded memory context from the shared memory store, with
+  verify-against-code discipline.
+- `PreCompact`: compact YAML checkpoint under
+  `.agents/outputs/codex_checkpoints/PERSISTENT_STATE.yaml`.
+- `PostToolUse`: context headroom warnings.
+- `Stop`: unfinished-work warnings and lightweight derived telemetry.
+
+They do not attempt to mirror Claude transcript-only hooks that depend on
+Claude-specific payloads.
 
 ## Skill Support
 
@@ -115,6 +129,7 @@ bash -n codex-config/install.sh
 bash -n new-project-agents.sh
 bash -n claude-config/new-project-claude.sh
 python3 -c "import json; json.load(open('claude-config/settings.json'))"
+python3 -m json.tool codex-config/hooks.json >/dev/null
 SETTINGS_PATH=$PWD/claude-config/settings.json python3 claude-config/scripts/validate-hooks.py
 codex execpolicy check --pretty --rules codex-config/rules/shared.rules -- git status
 bin/agent-parity check
@@ -145,7 +160,7 @@ instead of claiming test coverage.
 - `/orchestrate` is still Claude-only.
 - Codex can maintain this repo directly, but there is no Codex-native
   orchestrate equivalent yet.
-- Codex hooks are not ported from Claude hooks. Port only after reviewing
-  Codex hook event semantics and trust behavior.
+- Codex hooks cover memory, checkpointing, context, completion, and telemetry.
+  They are not a full port of every Claude transcript-specific hook.
 - CI installs Codex CLI only for unauthenticated policy parsing. It does not
   validate authenticated Codex sessions, app connectors, or cloud tasks.

--- a/lib/agent_completion.py
+++ b/lib/agent_completion.py
@@ -1,0 +1,113 @@
+"""Completion-discipline checks shared by lifecycle hooks."""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    returncode: int
+    stdout: str
+
+
+def run(args: list[str], cwd: Path, timeout: int = 10) -> CommandResult:
+    """Run a small local command and return stripped stdout.
+
+    Hooks are advisory and must fail open. Callers treat non-zero return codes
+    as missing signal, not fatal errors.
+    """
+    try:
+        result = subprocess.run(
+            args,
+            cwd=cwd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return CommandResult(-1, "")
+    return CommandResult(result.returncode, result.stdout.strip())
+
+
+def check_uncommitted_changes(cwd: Path) -> str | None:
+    result = run(["git", "diff", "--name-only", "HEAD"], cwd)
+    if result.returncode != 0 or not result.stdout:
+        return None
+    files = [line for line in result.stdout.splitlines() if line.strip()]
+    if not files:
+        return None
+    preview = ", ".join(files[:5])
+    suffix = f", +{len(files) - 5} more" if len(files) > 5 else ""
+    return f"Uncommitted changes ({len(files)} files): {preview}{suffix}"
+
+
+def check_unpushed_commits(cwd: Path) -> str | None:
+    result = run(["git", "log", "@{u}..HEAD", "--oneline"], cwd)
+    if result.returncode != 0 or not result.stdout:
+        return None
+    count = len(result.stdout.splitlines())
+    return f"{count} commit(s) not pushed to upstream"
+
+
+def check_branch_ahead_no_pr(cwd: Path) -> str | None:
+    branch_result = run(["git", "branch", "--show-current"], cwd)
+    branch = branch_result.stdout.strip()
+    if branch_result.returncode != 0 or not branch or branch in {"main", "master"}:
+        return None
+
+    ahead_result = run(["git", "log", "origin/main..HEAD", "--oneline"], cwd)
+    if ahead_result.returncode != 0 or not ahead_result.stdout:
+        return None
+
+    pr_result = run(
+        ["gh", "pr", "list", "--head", branch, "--state", "open", "--json", "number"],
+        cwd,
+        timeout=3,
+    )
+    if pr_result.returncode != 0:
+        return None
+    try:
+        prs = json.loads(pr_result.stdout or "[]")
+    except json.JSONDecodeError:
+        return None
+    if prs:
+        return None
+    count = len(ahead_result.stdout.splitlines())
+    return f"branch '{branch}' is {count} commit(s) ahead of origin/main with no open PR"
+
+
+def check_todos_in_changes(cwd: Path) -> str | None:
+    result = run(["git", "diff", "HEAD"], cwd)
+    if result.returncode != 0 or not result.stdout:
+        return None
+    count = 0
+    for line in result.stdout.splitlines():
+        if not line.startswith("+") or line.startswith("+++"):
+            continue
+        if re.search(r"\b(TODO|FIXME|HACK)\b", line):
+            count += 1
+    if not count:
+        return None
+    return f"{count} TODO/FIXME/HACK marker(s) in diff"
+
+
+def completion_warnings(cwd: Path) -> list[str]:
+    """Return advisory warnings that work may be unfinished."""
+    warnings: list[str] = []
+    for check in (
+        check_uncommitted_changes,
+        check_unpushed_commits,
+        check_branch_ahead_no_pr,
+        check_todos_in_changes,
+    ):
+        warning = check(cwd)
+        if warning:
+            warnings.append(warning)
+    return warnings

--- a/lib/agent_memory.py
+++ b/lib/agent_memory.py
@@ -1,0 +1,165 @@
+"""Bounded Codex memory rendering from the shared Claude memory store."""
+
+from __future__ import annotations
+
+import datetime as dt
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+PROJECTS_ROOT = Path.home() / ".claude" / "projects"
+INDEX_NAME = "MEMORY.md"
+TYPE_PRIORITY = {"feedback": 0, "user": 1, "reference": 2, "project": 3}
+
+
+@dataclass(frozen=True)
+class MemoryFact:
+    path: Path
+    project: str
+    meta: dict[str, str]
+    body: str
+    mtime: float
+
+
+def encoded_project_path(project_dir: Path) -> str:
+    return str(project_dir.resolve()).replace("/", "-")
+
+
+def split_frontmatter(text: str) -> tuple[dict[str, str], str]:
+    meta = {"name": "", "description": "", "type": "", "expires": ""}
+    if not text.startswith("---"):
+        return meta, text
+    end = text.find("\n---", 3)
+    if end == -1:
+        return meta, text
+    frontmatter = text[3:end]
+    body = text[end + 4 :].lstrip("\n")
+    for line in frontmatter.splitlines():
+        stripped = line.strip().strip("'\"")
+        for key in meta:
+            if stripped.startswith(f"{key}:") and not meta[key]:
+                meta[key] = stripped[len(key) + 1 :].strip().strip("'\"")
+    return meta, body
+
+
+def _is_expired(meta: dict[str, str], today: dt.date) -> bool:
+    raw = (meta.get("expires") or "").strip()
+    if not raw:
+        return False
+    try:
+        return dt.date.fromisoformat(raw) < today
+    except ValueError:
+        return False
+
+
+def _memory_dirs(project_dir: Path, home: Path) -> list[Path]:
+    encoded = encoded_project_path(project_dir)
+    candidates = [home / ".claude" / "projects" / encoded / "memory"]
+    projects_root = home / ".claude" / "projects"
+    if projects_root.is_dir():
+        for path in sorted(projects_root.glob("*/memory")):
+            if path not in candidates and path.is_dir():
+                candidates.append(path)
+    return [path for path in candidates if path.is_dir()]
+
+
+def _project_label(memory_dir: Path) -> str:
+    name = memory_dir.parent.name
+    return name.lstrip("-") or name
+
+
+def _query_terms(project_dir: Path) -> set[str]:
+    terms = {project_dir.name.lower()}
+    for part in project_dir.parts[-3:]:
+        for token in re.split(r"[^A-Za-z0-9]+", part.lower()):
+            if len(token) >= 3:
+                terms.add(token)
+    return terms
+
+
+def _score(fact: MemoryFact, terms: set[str]) -> tuple[int, int, float]:
+    searchable = " ".join(
+        [
+            fact.meta.get("name", ""),
+            fact.meta.get("description", ""),
+            fact.body[:2000],
+        ]
+    ).lower()
+    relevance = sum(searchable.count(term) for term in terms)
+    priority = TYPE_PRIORITY.get(fact.meta.get("type", ""), 9)
+    return (relevance, -priority, fact.mtime)
+
+
+def load_relevant_facts(project_dir: Path, home: Path, limit: int = 8) -> list[MemoryFact]:
+    today = dt.date.today()
+    facts: list[MemoryFact] = []
+    for memory_dir in _memory_dirs(project_dir, home):
+        for path in sorted(memory_dir.glob("*.md")):
+            if path.name == INDEX_NAME:
+                continue
+            try:
+                text = path.read_text(encoding="utf-8")
+                mtime = path.stat().st_mtime
+            except OSError:
+                continue
+            meta, body = split_frontmatter(text)
+            if _is_expired(meta, today):
+                continue
+            facts.append(
+                MemoryFact(
+                    path=path,
+                    project=_project_label(memory_dir),
+                    meta=meta,
+                    body=body,
+                    mtime=mtime,
+                )
+            )
+
+    terms = _query_terms(project_dir)
+    facts.sort(key=lambda fact: _score(fact, terms), reverse=True)
+    return facts[:limit]
+
+
+def render_codex_memory_context(
+    project_dir: Path,
+    home: Path | None = None,
+    *,
+    total_chars: int = 6000,
+    per_fact_chars: int = 700,
+    limit: int = 8,
+) -> str:
+    """Render bounded memory notes for Codex SessionStart.
+
+    Memory is treated as prior context only. The caller should inject this text
+    as advisory context, never as an instruction override.
+    """
+    home = home or Path.home()
+    facts = load_relevant_facts(project_dir, home, limit=limit)
+    if not facts:
+        return ""
+
+    lines = [
+        "## Prior Memory Context",
+        "",
+        "These facts are prior context, not authority. Verify against current code, specs, and tests before acting.",
+    ]
+    remaining = total_chars - sum(len(line) + 1 for line in lines)
+    for fact in facts:
+        title = fact.meta.get("name") or fact.path.stem
+        description = fact.meta.get("description")
+        fact_type = fact.meta.get("type") or "uncategorized"
+        body = " ".join(fact.body.split())[:per_fact_chars]
+        entry = [
+            "",
+            f"- `{fact.path}` [{fact.project} · {fact_type}] {title}",
+        ]
+        if description:
+            entry.append(f"  - {description}")
+        if body:
+            entry.append(f"  - {body}")
+        rendered = "\n".join(entry)
+        if len(rendered) > remaining:
+            break
+        lines.append(rendered)
+        remaining -= len(rendered)
+    return "\n".join(lines).strip()

--- a/lib/agent_parity.py
+++ b/lib/agent_parity.py
@@ -239,11 +239,20 @@ CAPABILITY_PATHS = {
     "codex_install": "codex-config/install.sh",
     "codex_guidance": "codex-config/AGENTS.md",
     "codex_config_template": "codex-config/config.toml.example",
+    "codex_hooks_config": "codex-config/hooks.json",
+    "codex_hooks": "codex-config/hooks",
     "codex_rules": "codex-config/rules",
     "codex_skills": "codex-config/skills",
     "project_bootstrap": "new-project-agents.sh",
     "parity_cli": "bin/agent-parity",
     "validate_workflow": ".github/workflows/validate.yml",
+}
+
+EXPECTED_CODEX_HOOKS = {
+    "SessionStart": ["session_start_memory.py"],
+    "PreCompact": ["precompact_checkpoint.py"],
+    "PostToolUse": ["context_monitor.py"],
+    "Stop": ["stop_verify.py", "session_telemetry.py"],
 }
 
 
@@ -293,9 +302,97 @@ def workflow_tree_check(repo: Path) -> CheckResult:
     return CheckResult("workflow_tree", "pass", "no active duplicate workflow tree", details)
 
 
+def _codex_hook_commands(hooks_json: Path) -> tuple[dict[str, list[str]], str | None]:
+    try:
+        payload = json.loads(hooks_json.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return ({}, f"hooks.json is invalid: {exc}")
+    hooks = payload.get("hooks")
+    if not isinstance(hooks, dict):
+        return ({}, "hooks.json must contain a top-level hooks object")
+
+    commands: dict[str, list[str]] = {}
+    for event, groups in hooks.items():
+        if not isinstance(groups, list):
+            return ({}, f"hooks.{event} must be a list")
+        event_commands: list[str] = []
+        for group in groups:
+            if not isinstance(group, dict):
+                return ({}, f"hooks.{event} entries must be objects")
+            handlers = group.get("hooks")
+            if not isinstance(handlers, list):
+                return ({}, f"hooks.{event} matcher group must contain hooks list")
+            for handler in handlers:
+                if not isinstance(handler, dict):
+                    return ({}, f"hooks.{event} handlers must be objects")
+                if handler.get("type") != "command":
+                    return ({}, f"hooks.{event} handler is not type=command")
+                command = handler.get("command")
+                if not isinstance(command, str) or not command.strip():
+                    return ({}, f"hooks.{event} handler has no command")
+                event_commands.append(command)
+        commands[event] = event_commands
+    return (commands, None)
+
+
+def codex_hooks_check(repo: Path, home: Path | None = None) -> CheckResult:
+    hooks_json = repo / "codex-config" / "hooks.json"
+    hooks_dir = repo / "codex-config" / "hooks"
+    details: dict[str, Any] = {
+        "expected_events": EXPECTED_CODEX_HOOKS,
+    }
+    errors: list[str] = []
+
+    if not hooks_json.is_file():
+        errors.append("missing codex-config/hooks.json")
+        commands: dict[str, list[str]] = {}
+    else:
+        commands, parse_error = _codex_hook_commands(hooks_json)
+        if parse_error:
+            errors.append(parse_error)
+        details["configured_commands"] = commands
+
+    if not hooks_dir.is_dir():
+        errors.append("missing codex-config/hooks")
+
+    for event, scripts in EXPECTED_CODEX_HOOKS.items():
+        configured = "\n".join(commands.get(event, []))
+        if event not in commands:
+            errors.append(f"missing Codex hook event {event}")
+        for script in scripts:
+            path = hooks_dir / script
+            if not path.is_file():
+                errors.append(f"missing Codex hook script {path.relative_to(repo)}")
+            if script not in configured:
+                errors.append(f"{event} does not reference {script}")
+
+    if home is not None:
+        installed = {
+            "hooks_json": home / ".codex" / "hooks.json",
+            "hooks_dir": home / ".codex" / "hooks",
+        }
+        link_checks: dict[str, dict[str, str]] = {}
+        for name, link in installed.items():
+            expected = (hooks_json if name == "hooks_json" else hooks_dir).resolve()
+            if not link.is_symlink():
+                errors.append(f"{link} is not a symlink")
+                continue
+            actual = link.resolve()
+            link_checks[str(link)] = {
+                "target": str(actual),
+                "expected": str(expected),
+            }
+            if actual != expected:
+                errors.append(f"{link} points to {actual}, expected {expected}")
+        details["installed_links"] = link_checks
+
+    if errors:
+        return CheckResult("codex_hooks", "fail", "Codex hook setup is incomplete", details | {"errors": errors})
+    return CheckResult("codex_hooks", "pass", "Codex hooks are configured and linkable", details)
+
+
 def one_sided_hooks_check(repo: Path) -> CheckResult:
     settings = repo / "claude-config" / "settings.json"
-    capabilities = repo / "docs" / "AGENT-CAPABILITIES.md"
     details: dict[str, Any] = {}
     if not settings.is_file():
         return CheckResult("one_sided_hooks", "fail", "Claude settings.json is missing", details)
@@ -307,24 +404,28 @@ def one_sided_hooks_check(repo: Path) -> CheckResult:
 
     hooks = payload.get("hooks") or {}
     details["claude_hook_events"] = sorted(hooks)
-    documented = capabilities.is_file() and "Codex hooks are not ported" in capabilities.read_text(
-        encoding="utf-8"
-    )
-    details["codex_gap_documented"] = documented
-    if hooks and not documented:
+    commands, parse_error = _codex_hook_commands(repo / "codex-config" / "hooks.json")
+    if parse_error:
         return CheckResult(
             "one_sided_hooks",
             "fail",
-            "Claude hooks exist but the Codex hook gap is not documented",
+            f"Codex hook config cannot be compared: {parse_error}",
             details,
         )
-    if hooks:
+    codex_events = set(commands)
+    claude_events = set(hooks)
+    details["codex_hook_events"] = sorted(codex_events)
+    one_sided = sorted(claude_events - codex_events)
+    details["claude_only_events"] = one_sided
+    if one_sided:
         return CheckResult(
             "one_sided_hooks",
             "warn",
-            "Claude hooks exist; Codex hook gap is documented",
+            "some Claude hook events have no Codex adapter yet",
             details,
         )
+    if hooks:
+        return CheckResult("one_sided_hooks", "pass", "Claude hook events have Codex adapters", details)
     return CheckResult("one_sided_hooks", "pass", "no one-sided hooks detected", details)
 
 
@@ -335,6 +436,7 @@ def run_checks(repo: Path, home: Path | None = None) -> ParityReport:
         capability_docs_check(repo),
         workflow_tree_check(repo),
         budget_check(repo),
+        codex_hooks_check(repo, home),
         one_sided_hooks_check(repo),
     ]
     return ParityReport(str(repo), checks)
@@ -364,6 +466,11 @@ def render_text(report: ParityReport) -> str:
         if check.name == "one_sided_hooks":
             events = ", ".join(check.details.get("claude_hook_events", [])) or "(none)"
             lines.append(f"  Claude hook events: {events}")
+            codex_events = ", ".join(check.details.get("codex_hook_events", [])) or "(none)"
+            lines.append(f"  Codex hook events: {codex_events}")
+        if check.name == "codex_hooks":
+            events = ", ".join(check.details.get("expected_events", {}).keys())
+            lines.append(f"  expected Codex events: {events}")
     return "\n".join(lines) + "\n"
 
 

--- a/lib/agent_state.py
+++ b/lib/agent_state.py
@@ -1,0 +1,75 @@
+"""Compact checkpoint helpers for Codex hooks."""
+
+from __future__ import annotations
+
+import re
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from lib.agent_completion import run
+
+ISSUE_RE = re.compile(r"(?:#|issue[-/ ]?)(\d+)", re.IGNORECASE)
+
+
+def current_branch(cwd: Path) -> str | None:
+    result = run(["git", "branch", "--show-current"], cwd, timeout=3)
+    if result.returncode != 0 or not result.stdout:
+        return None
+    return result.stdout
+
+
+def issue_refs_from_payload(payload: dict[str, Any]) -> list[int]:
+    refs: set[int] = set()
+    for value in _walk_values(payload):
+        if not isinstance(value, str):
+            continue
+        for match in ISSUE_RE.finditer(value):
+            refs.add(int(match.group(1)))
+    return sorted(refs)
+
+
+def _walk_values(value: object) -> list[object]:
+    if isinstance(value, dict):
+        out: list[object] = []
+        for child in value.values():
+            out.extend(_walk_values(child))
+        return out
+    if isinstance(value, list):
+        out = []
+        for child in value:
+            out.extend(_walk_values(child))
+        return out
+    return [value]
+
+
+def write_codex_checkpoint(
+    project_dir: Path,
+    payload: dict[str, Any],
+    *,
+    now: datetime | None = None,
+) -> Path:
+    now = now or datetime.now(UTC)
+    out_dir = project_dir / ".agents" / "outputs" / "codex_checkpoints"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    path = out_dir / "PERSISTENT_STATE.yaml"
+
+    branch = current_branch(project_dir)
+    refs = issue_refs_from_payload(payload)
+    session_id = str(payload.get("session_id") or payload.get("thread_id") or "unknown")
+    trigger = str(payload.get("trigger") or payload.get("matcher") or payload.get("event") or "unknown")
+    lines = [
+        "# Codex persistent state",
+        f"updated_at: {now.isoformat()}",
+        f"project_dir: {project_dir}",
+        f"session_id: {session_id}",
+        f"trigger: {trigger}",
+        f"branch: {branch or ''}",
+        "issue_refs:",
+    ]
+    if refs:
+        lines.extend(f"  - {ref}" for ref in refs)
+    else:
+        lines.append("  []")
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return path

--- a/lib/agent_telemetry.py
+++ b/lib/agent_telemetry.py
@@ -1,0 +1,50 @@
+"""Secret-safe Codex hook telemetry."""
+
+from __future__ import annotations
+
+import json
+import socket
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from lib.agent_state import issue_refs_from_payload
+
+
+def telemetry_path(home: Path | None = None) -> Path:
+    home = home or Path.home()
+    return home / ".codex" / "telemetry" / "session-events.jsonl"
+
+
+def build_event(payload: dict[str, Any], event: str, cwd: Path) -> dict[str, Any]:
+    return {
+        "timestamp": datetime.now(UTC).isoformat(),
+        "event": event,
+        "session_id": payload.get("session_id") or payload.get("thread_id"),
+        "cwd": str(cwd),
+        "branch": _branch_name(cwd),
+        "issue_refs": issue_refs_from_payload(payload),
+        "model": payload.get("model"),
+        "host": socket.gethostname(),
+    }
+
+
+def append_event(event: dict[str, Any], home: Path | None = None) -> Path:
+    path = telemetry_path(home)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(event, sort_keys=True, separators=(",", ":")) + "\n")
+        fh.flush()
+    return path
+
+
+def _branch_name(cwd: Path) -> str | None:
+    try:
+        from lib.agent_completion import run
+
+        result = run(["git", "branch", "--show-current"], cwd, timeout=3)
+    except ImportError:
+        return None
+    if result.returncode != 0 or not result.stdout:
+        return None
+    return result.stdout

--- a/lib/context_budget.py
+++ b/lib/context_budget.py
@@ -1,0 +1,92 @@
+"""Context budget extraction for lifecycle hooks."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+from typing import Any
+
+DEBOUNCE_INTERVAL = 10
+WARN_THRESHOLD = 35.0
+CRIT_THRESHOLD = 25.0
+SEVERITY_ORDER = {"NONE": 0, "WARNING": 1, "CRITICAL": 2}
+
+
+def percent_remaining(payload: dict[str, Any]) -> float | None:
+    context_window = payload.get("context_window")
+    if isinstance(context_window, dict):
+        used = _number(context_window.get("used"))
+        total = _number(context_window.get("total"))
+        remaining = _number(context_window.get("remaining"))
+        if total and remaining is not None:
+            return max(0.0, min(100.0, (remaining / total) * 100.0))
+        if total and used is not None:
+            return max(0.0, min(100.0, ((total - used) / total) * 100.0))
+
+    for key in ("percent_remaining", "context_percent_remaining"):
+        value = _number(payload.get(key))
+        if value is not None:
+            return max(0.0, min(100.0, value))
+    return None
+
+
+def _number(value: object) -> float | None:
+    if isinstance(value, int | float):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value.rstrip("%"))
+        except ValueError:
+            return None
+    return None
+
+
+def severity_for(percent: float) -> str:
+    if percent <= CRIT_THRESHOLD:
+        return "CRITICAL"
+    if percent <= WARN_THRESHOLD:
+        return "WARNING"
+    return "NONE"
+
+
+def state_path(session_id: str) -> Path:
+    safe = "".join(ch if ch.isalnum() or ch in "-_" else "_" for ch in session_id)
+    return Path(tempfile.gettempdir()) / f"codex-context-monitor-{safe or 'unknown'}.json"
+
+
+def should_warn(payload: dict[str, Any]) -> tuple[str, float | None]:
+    pct = percent_remaining(payload)
+    if pct is None:
+        return ("NONE", None)
+    severity = severity_for(pct)
+    if severity == "NONE":
+        _save_state(payload, {"tool_call_count": 0, "last_severity": "NONE"})
+        return ("NONE", pct)
+
+    state = _load_state(payload)
+    count = int(state.get("tool_call_count", 0)) + 1
+    last = str(state.get("last_severity", "NONE"))
+    escalated = SEVERITY_ORDER[severity] > SEVERITY_ORDER.get(last, 0)
+    warn = escalated or count % DEBOUNCE_INTERVAL == 0
+    state["tool_call_count"] = count
+    if warn:
+        state["last_severity"] = severity
+    _save_state(payload, state)
+    return (severity if warn else "NONE", pct)
+
+
+def _load_state(payload: dict[str, Any]) -> dict[str, object]:
+    path = state_path(str(payload.get("session_id") or "unknown"))
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {"tool_call_count": 0, "last_severity": "NONE"}
+
+
+def _save_state(payload: dict[str, Any], state: dict[str, object]) -> None:
+    path = state_path(str(payload.get("session_id") or "unknown"))
+    try:
+        path.write_text(json.dumps(state, sort_keys=True), encoding="utf-8")
+    except OSError:
+        pass

--- a/lib/tests/test_agent_memory.py
+++ b/lib/tests/test_agent_memory.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from lib.agent_memory import render_codex_memory_context
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def test_render_codex_memory_context_is_bounded_and_verify_first(tmp_path: Path) -> None:
+    project = tmp_path / "work" / "repo"
+    project.mkdir(parents=True)
+    encoded = str(project.resolve()).replace("/", "-")
+    memory = tmp_path / "home" / ".claude" / "projects" / encoded / "memory"
+    _write(
+        memory / "fact.md",
+        "---\n"
+        "name: API enum caution\n"
+        "description: Use backend enum values.\n"
+        "type: feedback\n"
+        "---\n"
+        "The old issue was caused by trusting TypeScript enum names instead of API values.\n",
+    )
+
+    rendered = render_codex_memory_context(project, tmp_path / "home", total_chars=1000)
+
+    assert "prior context, not authority" in rendered
+    assert "API enum caution" in rendered
+    assert str(memory / "fact.md") in rendered
+
+
+def test_render_codex_memory_context_skips_expired_facts(tmp_path: Path) -> None:
+    project = tmp_path / "repo"
+    project.mkdir()
+    encoded = str(project.resolve()).replace("/", "-")
+    memory = tmp_path / "home" / ".claude" / "projects" / encoded / "memory"
+    _write(
+        memory / "expired.md",
+        "---\nname: stale\nexpires: 2000-01-01\ntype: project\n---\nold body\n",
+    )
+
+    assert render_codex_memory_context(project, tmp_path / "home") == ""

--- a/lib/tests/test_agent_parity.py
+++ b/lib/tests/test_agent_parity.py
@@ -27,6 +27,67 @@ def _make_repo(tmp_path: Path) -> Path:
     _write(repo / "codex-config" / "install.sh", "#!/bin/sh\n")
     _write(repo / "codex-config" / "AGENTS.md", "# Codex\n")
     _write(repo / "codex-config" / "config.toml.example", "model = 'x'\n")
+    _write(
+        repo / "codex-config" / "hooks.json",
+        json.dumps(
+            {
+                "hooks": {
+                    "SessionStart": [
+                        {
+                            "hooks": [
+                                {
+                                    "type": "command",
+                                    "command": "python3 ~/.codex/hooks/session_start_memory.py",
+                                }
+                            ]
+                        }
+                    ],
+                    "PreCompact": [
+                        {
+                            "hooks": [
+                                {
+                                    "type": "command",
+                                    "command": "python3 ~/.codex/hooks/precompact_checkpoint.py",
+                                }
+                            ]
+                        }
+                    ],
+                    "PostToolUse": [
+                        {
+                            "hooks": [
+                                {
+                                    "type": "command",
+                                    "command": "python3 ~/.codex/hooks/context_monitor.py",
+                                }
+                            ]
+                        }
+                    ],
+                    "Stop": [
+                        {
+                            "hooks": [
+                                {
+                                    "type": "command",
+                                    "command": "python3 ~/.codex/hooks/stop_verify.py",
+                                },
+                                {
+                                    "type": "command",
+                                    "command": "python3 ~/.codex/hooks/session_telemetry.py",
+                                },
+                            ]
+                        }
+                    ],
+                }
+            }
+        ),
+    )
+    for script in (
+        "session_start_memory.py",
+        "precompact_checkpoint.py",
+        "context_monitor.py",
+        "stop_verify.py",
+        "session_telemetry.py",
+    ):
+        _write(repo / "codex-config" / "hooks" / script, "#!/usr/bin/env python3\n")
     _write(repo / "codex-config" / "rules" / "shared.rules", "# rules\n")
     _write(repo / "codex-config" / "skills" / "native" / "SKILL.md", "---\nname: native\n---\n")
     _write(repo / "new-project-agents.sh", "#!/bin/sh\n")
@@ -87,6 +148,28 @@ def test_skill_parity_fails_lint_usage_errors(tmp_path: Path) -> None:
     assert "lint" in result.message
 
 
+def test_codex_hooks_enforces_installed_links(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path)
+    home = tmp_path / "home"
+    (home / ".codex").mkdir(parents=True)
+    os.symlink(repo / "codex-config" / "hooks.json", home / ".codex" / "hooks.json")
+    os.symlink(repo / "codex-config" / "hooks", home / ".codex" / "hooks")
+
+    result = agent_parity.codex_hooks_check(repo, home)
+
+    assert result.status == "pass"
+
+
+def test_codex_hooks_fail_when_script_missing(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path)
+    (repo / "codex-config" / "hooks" / "stop_verify.py").unlink()
+
+    result = agent_parity.codex_hooks_check(repo)
+
+    assert result.status == "fail"
+    assert "stop_verify.py" in result.details["errors"][-1]
+
+
 def test_workflow_tree_detects_active_legacy_duplicate(tmp_path: Path) -> None:
     repo = _make_repo(tmp_path)
     _write(repo / "orchestrate-workflow" / "orchestrate.md", "legacy\n")
@@ -112,8 +195,13 @@ def test_one_sided_hooks_are_warning_when_gap_is_documented(tmp_path: Path) -> N
 
     result = agent_parity.one_sided_hooks_check(repo)
 
-    assert result.status == "warn"
-    assert result.details["codex_gap_documented"] is True
+    assert result.status == "pass"
+    assert result.details["codex_hook_events"] == [
+        "PostToolUse",
+        "PreCompact",
+        "SessionStart",
+        "Stop",
+    ]
 
 
 def test_cli_json_runs_against_current_repo() -> None:

--- a/lib/tests/test_codex_hook_helpers.py
+++ b/lib/tests/test_codex_hook_helpers.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from lib.agent_state import write_codex_checkpoint
+from lib.context_budget import percent_remaining, severity_for
+
+
+def test_context_budget_extracts_remaining_from_used_total() -> None:
+    assert percent_remaining({"context_window": {"used": 75, "total": 100}}) == 25
+    assert severity_for(25) == "CRITICAL"
+    assert severity_for(35) == "WARNING"
+    assert severity_for(80) == "NONE"
+
+
+def test_write_codex_checkpoint_is_compact_yaml(tmp_path: Path) -> None:
+    path = write_codex_checkpoint(
+        tmp_path,
+        {"session_id": "s1", "trigger": "auto", "message": "working issue #422"},
+    )
+
+    text = path.read_text(encoding="utf-8")
+    assert "session_id: s1" in text
+    assert "trigger: auto" in text
+    assert "  - 422" in text
+
+
+def test_codex_hook_wrappers_emit_json_or_nothing(tmp_path: Path) -> None:
+    repo = Path(__file__).resolve().parents[2]
+    payload = json.dumps({"session_id": "test", "context_percent_remaining": 20})
+    env = os.environ.copy()
+    env["HOME"] = str(tmp_path / "home")
+    for script in sorted((repo / "codex-config" / "hooks").glob("*.py")):
+        if script.name == "hook_common.py":
+            continue
+        completed = subprocess.run(
+            [sys.executable, str(script)],
+            input=payload,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            cwd=tmp_path,
+            env=env,
+            check=False,
+        )
+        assert completed.returncode == 0, completed.stderr
+        output = completed.stdout.strip()
+        if output:
+            json.loads(output)


### PR DESCRIPTION
## Summary
- Adds Codex lifecycle hooks for bounded memory recall, pre-compact checkpoints, context headroom warnings, stop-time completion checks, and lightweight telemetry.
- Links `hooks.json` and `hooks/` through the Codex installer and validates those symlinks in CI.
- Extends `bin/agent-parity check` so Codex hook config, scripts, and installed links are mechanically checked.
- Updates capability docs to distinguish the new Codex hook adapters from Claude transcript-only hooks.

## Test Plan
- `ruff check .`
- `/Users/jasonjob/agents/.venv/bin/python -m pytest claude-config/tests lib/tests -q` (641 passed)
- `/Users/jasonjob/agents/.venv/bin/python -m pytest tests -q` (69 passed)
- `/Users/jasonjob/agents/.venv/bin/python -m pytest action/tests decision/tests project/tests pulse/tests email-digest/tests -q` (233 passed)
- `bin/agent-parity check`
- temp HOME `codex-config/install.sh` smoke plus `bin/agent-parity check --home`
- `python3 -m json.tool codex-config/hooks.json >/dev/null`; `bash -n` installer scripts; `validate-hooks.py`; `check-context-budgets.py`; `codex execpolicy check`

Closes #417
Closes #418
Closes #419
Closes #420
Closes #421
Closes #422
