### PR TITLE
chore(#399): remove telegram from enabledPlugins (plugin uninstalled)

### DIFF
--- a/claude-config/settings.json
+++ b/claude-config/settings.json
@@ -146,8 +146,7 @@
     "typescript-lsp@claude-plugins-official": true,
     "pyright-lsp@claude-plugins-official": true,
     "pr-review-toolkit@claude-plugins-official": true,
-    "playwright@claude-plugins-official": true,
-    "telegram@claude-plugins-official": true
+    "playwright@claude-plugins-official": true
   },
   "extraKnownMarketplaces": {
     "openai-codex": {


### PR DESCRIPTION
Repo-side completion of the #399 removal: enabledPlugins is what Claude
Code consults at startup, so without this commit any checkout/pull
re-enables the unconfigured plugin and resurrects the -32000 reconnect
error — including on the machines #401 will sync.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
