### PR TITLE
chore(gitignore): keep work project trackers out of the personal repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,10 @@ telemetry/*/failures.jsonl
 # Safety: these local-only files must never appear in the tracked memory dir
 claude-config/memory/failures.jsonl
 claude-config/memory/metrics.jsonl
+
+# Work-confidential project trackers — read/written by the project + dashboard
+# skills via the YAML interface (project_resolver.py: KNOWLEDGE_PROJECTS_DIR).
+# This repo (jwj2002/agents) is pulled on both home and work machines, so these
+# must never be committed here. Cross-work-machine sync (private work repo /
+# M365 symlink) is TBD; until then they stay local to each work machine.
+knowledge/projects/


### PR DESCRIPTION
## Summary
`knowledge/projects/*.yaml` are work-confidential project trackers (e.g. `vaultiq-platform.yaml`) read/written by the `project` and `dashboard` skills via `project_resolver.KNOWLEDGE_PROJECTS_DIR`. Because `jwj2002/agents` is pulled on both home and work machines, these were at risk of being committed and synced to a personal context.

This adds `knowledge/projects/` to `.gitignore`. The directory was never tracked, so there is no history to scrub — this just prevents accidental `git add`.

Cross-work-machine sync (private work repo / M365 symlink) is deferred; the path is a constant in `project_resolver.py`, so a symlink can slot in later with zero code changes.

Also cleaned up locally (untracked, not part of this diff): dead `knowledge-mcp/` node_modules (server archived in #146) and orphaned `knowledge.db-wal/-shm` sidecars.

## Test Plan
- `git check-ignore knowledge/projects/vaultiq-platform.yaml` → matches (ignored)
- `git status` no longer lists `knowledge/projects/` as untracked