### PR TITLE
perf(memory): summaries-before-bodies + size/freshness-aware injection ranking

### DIFF
--- a/bin/memory
+++ b/bin/memory
@@ -73,6 +73,13 @@ def _split_frontmatter(text: str):
 
     Captures name/description/type; `type` may be top-level or nested under a
     `metadata:` block (both shapes exist in the store).
+
+    Surrounding single/double quotes are stripped from every parsed value so
+    that valid-YAML quoted forms like ``durability: "durable"`` are honored
+    identically by this CLI and by the SessionStart hook's `_fact_meta`
+    (which does ``.strip().strip("'\\"")``). Without this, the hook treats
+    ``durability: "durable"`` as durable while `memory doctor`/`archive` saw
+    the literal ``"durable"`` and could still flag the fact stale (#430).
     """
     meta = {
         "name": "",
@@ -94,7 +101,9 @@ def _split_frontmatter(text: str):
         for key in ("name", "description", "type", "expires", "summary", "durability"):
             # match `key:` whether top-level or indented (metadata.type)
             if s.startswith(key + ":") and not meta[key]:
-                meta[key] = s[len(key) + 1 :].strip()
+                # Mirror the hook's stripping exactly: trim whitespace then
+                # strip surrounding ' or " quotes.
+                meta[key] = s[len(key) + 1 :].strip().strip("'\"")
     return meta, body
 
 

--- a/bin/memory
+++ b/bin/memory
@@ -64,7 +64,7 @@ def _project_label(memory_dir: Path) -> str:
     if name == prefix:
         return "(home)"
     if name.startswith(prefix + "-"):
-        return name[len(prefix) + 1:]
+        return name[len(prefix) + 1 :]
     return name.lstrip("-")
 
 
@@ -74,20 +74,27 @@ def _split_frontmatter(text: str):
     Captures name/description/type; `type` may be top-level or nested under a
     `metadata:` block (both shapes exist in the store).
     """
-    meta = {"name": "", "description": "", "type": "", "expires": ""}
+    meta = {
+        "name": "",
+        "description": "",
+        "type": "",
+        "expires": "",
+        "summary": "",
+        "durability": "",
+    }
     if not text.startswith("---"):
         return meta, text
     end = text.find("\n---", 3)
     if end == -1:
         return meta, text
     fm = text[3:end]
-    body = text[end + 4:].lstrip("\n")
+    body = text[end + 4 :].lstrip("\n")
     for line in fm.splitlines():
         s = line.strip()
-        for key in ("name", "description", "type", "expires"):
+        for key in ("name", "description", "type", "expires", "summary", "durability"):
             # match `key:` whether top-level or indented (metadata.type)
             if s.startswith(key + ":") and not meta[key]:
-                meta[key] = s[len(key) + 1:].strip()
+                meta[key] = s[len(key) + 1 :].strip()
     return meta, body
 
 
@@ -107,13 +114,17 @@ def _is_expired(meta: dict, today: datetime.date) -> bool:
         return False
 
 
-def _is_stale_perishable(path: Path, meta: dict, mtime: float, now: float, stale_days: int) -> bool:
+def _is_stale_perishable(
+    path: Path, meta: dict, mtime: float, now: float, stale_days: int
+) -> bool:
     """Heuristic for the legacy backlog (no explicit `expires:`).
 
     Durable types (feedback/user/reference) never go stale. A `type: project`
     fact whose filename looks like session-state and is untouched > stale_days
-    is a TTL candidate.
+    is a TTL candidate. `durability: durable` overrides all type/filename checks.
     """
+    if meta.get("durability", "") == "durable":
+        return False
     if meta.get("type", "") != "project":
         return False
     if not PERISHABLE_PAT.search(path.name):
@@ -121,7 +132,14 @@ def _is_stale_perishable(path: Path, meta: dict, mtime: float, now: float, stale
     return (now - mtime) > stale_days * 86400
 
 
-def _ttl_reason(path: Path, meta: dict, mtime: float, today: datetime.date, now: float, stale_days: int):
+def _ttl_reason(
+    path: Path,
+    meta: dict,
+    mtime: float,
+    today: datetime.date,
+    now: float,
+    stale_days: int,
+):
     """Return a human reason string if the fact is a TTL candidate, else None."""
     if _is_expired(meta, today):
         return f"expired {meta['expires']}"
@@ -146,6 +164,7 @@ def _deindex(index_path: Path, filename: str) -> None:
 
 
 # ---------------------------------------------------------------- recall
+
 
 def cmd_recall(args) -> int:
     terms = [t.lower() for t in args.query.split() if t.strip()]
@@ -199,6 +218,8 @@ def cmd_recall(args) -> int:
             name = meta["name"] or path.stem
             desc = (" — " + meta["description"]) if meta["description"] else ""
             print(f"- {path}  [{label}{typ}] {name}{desc}")
+            if meta.get("summary"):
+                print(f"  ↳ {meta['summary']}")
         return 0
 
     print(f"# {len(hits)} fact(s) match {args.query!r} — showing {len(shown)}\n")
@@ -220,6 +241,7 @@ def cmd_recall(args) -> int:
 
 
 # ---------------------------------------------------------------- doctor
+
 
 def _ttl_candidates(mem: Path, today: datetime.date, now: float, stale_days: int):
     """List (filename, reason) for expired / stale-perishable facts in a store."""
@@ -259,7 +281,9 @@ def cmd_doctor(args) -> int:
         ttl = _ttl_candidates(mem, today, now, args.stale_days)
 
         if dead or unindexed or ttl or not index.is_file():
-            print(f"## {label}  ({len(files)} fact file(s), {len(targets)} index entr(ies))")
+            print(
+                f"## {label}  ({len(files)} fact file(s), {len(targets)} index entr(ies))"
+            )
             if not index.is_file():
                 print("  ! no MEMORY.md index")
             for d in dead:
@@ -267,7 +291,20 @@ def cmd_doctor(args) -> int:
             for u in unindexed:
                 print(f"  ⚠ unindexed:   {u} (file not in MEMORY.md)")
             for name, reason in ttl:
-                print(f"  ⏳ ttl:        {name}  ({reason}) → `memory archive`")
+                # _is_stale_perishable already returns False for durable facts;
+                # this [durable] tag is belt-and-suspenders for any future heuristic drift.
+                try:
+                    _meta, _ = _split_frontmatter(
+                        (mem / name).read_text(encoding="utf-8")
+                    )
+                    durable_tag = (
+                        " [durable]" if _meta.get("durability") == "durable" else ""
+                    )
+                except OSError:
+                    durable_tag = ""
+                print(
+                    f"  ⏳ ttl:        {name}  ({reason}){durable_tag} → `memory archive`"
+                )
             print()
         total_dead += len(dead)
         total_unindexed += len(unindexed)
@@ -283,6 +320,7 @@ def cmd_doctor(args) -> int:
 
 
 # ---------------------------------------------------------------- archive
+
 
 def cmd_archive(args) -> int:
     today = datetime.date.today()
@@ -312,13 +350,18 @@ def cmd_archive(args) -> int:
         print()
 
     if args.apply:
-        print(f"archived {moved} fact(s) → <project>/memory/{ARCHIVE_DIR}/ (recall skips them)")
+        print(
+            f"archived {moved} fact(s) → <project>/memory/{ARCHIVE_DIR}/ (recall skips them)"
+        )
     else:
-        print(f"{total} TTL candidate(s) across the store — re-run with --apply to archive")
+        print(
+            f"{total} TTL candidate(s) across the store — re-run with --apply to archive"
+        )
     return 0
 
 
 # ---------------------------------------------------------------- cli
+
 
 def main(argv=None) -> int:
     parser = argparse.ArgumentParser(prog="memory", description=__doc__.splitlines()[0])
@@ -326,22 +369,58 @@ def main(argv=None) -> int:
 
     p_recall = sub.add_parser("recall", help="search fact bodies and print matches")
     p_recall.add_argument("query", help="search terms (space-separated)")
-    p_recall.add_argument("--project", help="limit to projects whose label contains this substring")
-    p_recall.add_argument("--limit", type=int, default=5, help="max facts to print (default 5)")
-    p_recall.add_argument("--compact", action="store_true", help="one-line index per hit (path + name + description), no bodies")
-    p_recall.add_argument("--all", action="store_true", help="include explicitly-expired facts (hidden by default)")
+    p_recall.add_argument(
+        "--project", help="limit to projects whose label contains this substring"
+    )
+    p_recall.add_argument(
+        "--limit", type=int, default=5, help="max facts to print (default 5)"
+    )
+    p_recall.add_argument(
+        "--compact",
+        action="store_true",
+        help="one-line index per hit (path + name + description), no bodies",
+    )
+    p_recall.add_argument(
+        "--all",
+        action="store_true",
+        help="include explicitly-expired facts (hidden by default)",
+    )
     p_recall.set_defaults(func=cmd_recall)
 
-    p_doctor = sub.add_parser("doctor", help="reconcile indexes + report TTL candidates")
-    p_doctor.add_argument("--project", help="limit to projects whose label contains this substring")
-    p_doctor.add_argument("--strict", action="store_true", help="exit 1 if any drift or TTL candidate is found")
-    p_doctor.add_argument("--stale-days", type=int, default=STALE_DAYS, help=f"perishable-staleness threshold in days (default {STALE_DAYS})")
+    p_doctor = sub.add_parser(
+        "doctor", help="reconcile indexes + report TTL candidates"
+    )
+    p_doctor.add_argument(
+        "--project", help="limit to projects whose label contains this substring"
+    )
+    p_doctor.add_argument(
+        "--strict",
+        action="store_true",
+        help="exit 1 if any drift or TTL candidate is found",
+    )
+    p_doctor.add_argument(
+        "--stale-days",
+        type=int,
+        default=STALE_DAYS,
+        help=f"perishable-staleness threshold in days (default {STALE_DAYS})",
+    )
     p_doctor.set_defaults(func=cmd_doctor)
 
-    p_archive = sub.add_parser("archive", help="move expired/stale-perishable facts to memory/archive/")
-    p_archive.add_argument("--project", help="limit to projects whose label contains this substring")
-    p_archive.add_argument("--apply", action="store_true", help="perform the moves (default: dry-run)")
-    p_archive.add_argument("--stale-days", type=int, default=STALE_DAYS, help=f"perishable-staleness threshold in days (default {STALE_DAYS})")
+    p_archive = sub.add_parser(
+        "archive", help="move expired/stale-perishable facts to memory/archive/"
+    )
+    p_archive.add_argument(
+        "--project", help="limit to projects whose label contains this substring"
+    )
+    p_archive.add_argument(
+        "--apply", action="store_true", help="perform the moves (default: dry-run)"
+    )
+    p_archive.add_argument(
+        "--stale-days",
+        type=int,
+        default=STALE_DAYS,
+        help=f"perishable-staleness threshold in days (default {STALE_DAYS})",
+    )
     p_archive.set_defaults(func=cmd_archive)
 
     args = parser.parse_args(argv)

--- a/claude-config/CLAUDE.md
+++ b/claude-config/CLAUDE.md
@@ -156,44 +156,41 @@ configured here.
 ## Recalling project memory (active recall)
 
 Project facts live under `~/.claude/projects/<project>/memory/`. SessionStart
-auto-injects fact bodies directly (highest-value first, 6000-char budget,
-per-fact truncation, TTL-respected). Remaining facts are listed with a recall
-CTA. For manual recall of lower-ranked facts: `~/agents/bin/memory recall
-"<keywords>"`. Also: `memory doctor` (index drift + TTL) and
-`memory archive [--apply]`. Full workflow: `~/agents/docs/memory-review.md`.
+auto-injects summaries for all facts + full bodies for top-N (two-pass, 6000-char
+budget). Manual recall: `~/agents/bin/memory recall "<keywords>"`. Also:
+`memory doctor` (index drift + TTL) and `memory archive [--apply]`.
 
----
+### Memory Frontmatter Convention (on-touch only)
+
+Canonical fields: `name`, `type` (feedback|user|reference|project), `expires` (YYYY-MM-DD),
+`summary` (1-3 sentences; auto-recall uses verbatim, falls back to first sentence),
+`durability` (durable|session|handoff|temporary).
+
+`durability` effects: `durable` → resists freshness/size rank penalties, never flagged
+stale. `session`/`temporary` → summary-only injection, TTL candidate at 30d. Normalize
+on-touch only — no mass migration.
 
 ## Promoting project memory to global rules
 
-When a `~/.claude/projects/<project>/memory/feedback-*.md` lesson is
-**generally applicable** (workflow discipline, cross-stack mistakes, tool
-quirks — not domain-specific patterns), promote it to a global rule so every
-project inherits it. Full 6-step procedure + the "generally applicable vs
-project-local" test: `~/.claude/rules/memory-promotion.md` (on-demand).
+When a `feedback-*.md` lesson is **generally applicable**, promote it to a
+global rule. Full procedure: `~/.claude/rules/memory-promotion.md` (on-demand).
 
 ## Anti-patterns to avoid
 
-- Long CLAUDE.md (target <200 lines; enforced by
-  `claude-config/scripts/check-context-budgets.py` in CI).
-- Reaching for a subagent before exhausting CLAUDE.md and skills (Anthropic's recommended order).
+- Long CLAUDE.md (target <200 lines; `claude-config/scripts/check-context-budgets.py`).
+- Reaching for a subagent before exhausting CLAUDE.md and skills.
 - Editing `~/.claude/` directly. Always go through `~/agents/claude-config/`.
 - Putting secrets, ephemeral state, or large code patterns in CLAUDE.md.
-- Bypassing safety with `--no-verify`, `--force`, or `bypassPermissions` without explicit user approval.
-- **Letting project-local lessons stay project-local indefinitely.**
-  If a `feedback-*.md` file would help another project, promote it
-  per the procedure above.
+- Bypassing safety with `--no-verify`, `--force`, or `bypassPermissions`.
+- **Letting project-local lessons stay project-local.** Promote per the procedure above.
 
 ---
 
 ## ~/agents — personal velocity rules
 
-`~/agents` is personal tooling, not a product. Preserve fast iteration:
+`~/agents` is personal tooling. Preserve fast iteration:
 
-- **TRIVIAL/SIMPLE changes**: no manifest, no spec, no adversarial review.
-- **Major refactors (4+ files, new protocol, new command)**: produce a *lightweight*
-  code-reality manifest (`specs/<name>.code-reality.md`) before drafting; aim for
-  ≤2 review rounds, not the full spec-review-workflow ceremony.
-- Route substantive ~/agents work through `/orchestrate`; ad-hoc fixes via `/quick`.
-- All telemetry routes through the same `state_manager` hooks as `~/projects/` — no
-  separate recording path needed.
+- **TRIVIAL/SIMPLE**: no manifest, no spec, no adversarial review.
+- **Major refactors (4+ files)**: lightweight code-reality manifest before drafting.
+- Route substantive work through `/orchestrate`; ad-hoc fixes via `/quick`.
+- Telemetry routes through `state_manager` hooks — no separate recording path.

--- a/claude-config/hooks/sessionstart_restore_state.py
+++ b/claude-config/hooks/sessionstart_restore_state.py
@@ -484,11 +484,49 @@ def render_project_memory(fact_dir: Path, *, today: str | None = None) -> str:
 
     project = fact_dir.parent.name
 
+    # ---- Honest budget accounting (#430) ----
+    # Every character that ends up in the final rendered string is charged
+    # against AUTORECALL_TOTAL_CHARS, so the TOTAL rendered block length is
+    # <= the budget strictly. The render joins `lines` with "\n", so each line
+    # also costs one joining newline; `_cost` folds that in. We over-count the
+    # join by at most 1 char total (the final line has no trailing join), which
+    # only ever keeps us *under* budget — never over.
+    def _cost(text: str) -> int:
+        return len(text) + 1  # +1 for the "\n" inserted by "\n".join
+
+    # Fixed preamble that always renders, even with zero facts admitted: the
+    # section header and the "N summaries injected ..." line. The preamble
+    # embeds integer counts whose final widths aren't known until selection
+    # finishes, so reserve width for up to 4-digit counts up front and render
+    # the exact line later; the reserve is an upper bound on the real line.
+    header_line = "### Project Memory (auto-recalled)\n"
+    _preamble_tmpl = (
+        "{ns} summaries injected ({nb} of {ns2} with full body). "
+        "Verify against current code before acting — facts reflect what was "
+        "true when written.\n"
+    )
+    preamble_reserve = _cost(_preamble_tmpl.format(ns="0000", nb="0000", ns2="0000"))
+
+    # Full-body section header `\n#### Full bodies (top-NN)\n` — charged once,
+    # lazily, the first time a body is admitted (it only renders if non-empty).
+    def _full_body_header(n: int) -> str:
+        return f"\n#### Full bodies (top-{n})\n"
+
+    full_body_header_reserve = _cost(_full_body_header(9999))
+
+    # Trailing "Not injected (...)" CTA. It only renders when >=1 fact is
+    # omitted; the exact topic list isn't known up front, so reserve a fixed
+    # upper bound and render a line guaranteed not to exceed it at the end. We
+    # reserve this unconditionally during selection: if no fact ends up omitted
+    # the unused reserve just leaves the block under budget (still correct).
+    # The rendered CTA is truncated to `cta_reserve` so the reserve is a true
+    # upper bound regardless of fact-name length.
+    cta_reserve = 360
+
+    # Running total of charged characters.
+    used = _cost(header_line.rstrip("\n")) + preamble_reserve + cta_reserve
+
     # ---- Pass 1: summary injection ----
-    # Budget slice for summaries: up to half the total budget so full bodies
-    # can always fill the second half.
-    summary_budget = AUTORECALL_TOTAL_CHARS // 2
-    summary_used = 0
     summary_entries = []  # (safe_name, ftype, summary_text, fact_dict, verdict)
     leftover = []
 
@@ -501,13 +539,10 @@ def render_project_memory(fact_dir: Path, *, today: str | None = None) -> str:
         # Derive summary — safety-filtered inside _extract_summary.
         summary = _extract_summary(f, f["body"].strip())
 
-        # Summary line cost.
-        cost = len(summary) + len(safe_name) + 30
-        if summary_used + cost > summary_budget:
-            leftover.append(f)
-            continue
-
-        # Also classify the raw body for the body-pass safety check.
+        # Classify the raw body for the body-pass safety check. A suppressed
+        # body is replaced by the sentinel in the summary too, so charge the
+        # budget for the ACTUAL emitted summary text, not the pre-suppression
+        # candidate (#430 NIT).
         try:
             verdict, excerpt = _classify_body(f["body"].strip())
         except Exception:  # noqa: BLE001 — fail-open: filter errors must not crash hook
@@ -520,13 +555,19 @@ def render_project_memory(fact_dir: Path, *, today: str | None = None) -> str:
             # Suppressed body must not leak via its summary (PLAN: fail-safe).
             summary = _SUPPRESSED_BODY
 
+        # Exact emitted summary line: `**{name}** ({ftype}): {summary}`.
+        summary_line = f"**{safe_name}** ({f['type']}): {summary}"
+        cost = _cost(summary_line)
+        if used + cost > AUTORECALL_TOTAL_CHARS:
+            leftover.append(f)
+            continue
+
         summary_entries.append((safe_name, f["type"], summary, f, verdict))
-        summary_used += cost
+        used += cost
 
     # ---- Pass 2: full-body injection ----
-    body_budget = AUTORECALL_TOTAL_CHARS - summary_used
-    body_used = 0
     body_entries = []  # (safe_name, ftype, body_text)
+    body_header_charged = False
 
     for safe_name, ftype, _summary, f, verdict in summary_entries:
         # session/temporary facts are summary-only by declaration.
@@ -543,23 +584,27 @@ def render_project_memory(fact_dir: Path, *, today: str | None = None) -> str:
                 + f"\n… *(truncated — full fact: `{f['path']}`)*"
             )
 
-        cost = len(body) + len(safe_name) + 20
-        if body_used + cost > body_budget:
+        # Exact emitted body block: `**{name}** ({ftype}):\n{body}\n`.
+        body_block = f"**{safe_name}** ({ftype}):\n{body}\n"
+        cost = _cost(body_block)
+        # Charge the body-section header once, the first body admitted.
+        header_cost = 0 if body_header_charged else full_body_header_reserve
+        if used + header_cost + cost > AUTORECALL_TOTAL_CHARS:
             continue
+        if not body_header_charged:
+            used += header_cost
+            body_header_charged = True
         body_entries.append((safe_name, ftype, body))
-        body_used += cost
+        used += cost
 
     # Count only body-pass (non-suppressed) facts for the metrics record.
     real_injected = len(body_entries)
 
     # ---- Render ----
-    lines = ["### Project Memory (auto-recalled)\n"]
     n_summaries = len(summary_entries)
     n_bodies = len(body_entries)
-    lines.append(
-        f"{n_summaries} summaries injected ({n_bodies} of {n_summaries} with full body). "
-        "Verify against current code before acting — facts reflect what was true when written.\n"
-    )
+    lines = [header_line]
+    lines.append(_preamble_tmpl.format(ns=n_summaries, nb=n_bodies, ns2=n_summaries))
 
     # Summary section.
     for safe_name, ftype, summary, _f, _verdict in summary_entries:
@@ -567,7 +612,7 @@ def render_project_memory(fact_dir: Path, *, today: str | None = None) -> str:
 
     # Full-body section (omitted when empty).
     if body_entries:
-        lines.append(f"\n#### Full bodies (top-{n_bodies})\n")
+        lines.append(_full_body_header(n_bodies))
         for safe_name, ftype, body in body_entries:
             lines.append(f"**{safe_name}** ({ftype}):\n{body}\n")
 
@@ -576,13 +621,17 @@ def render_project_memory(fact_dir: Path, *, today: str | None = None) -> str:
             _redact_secret_name(f["name"]).replace("_", " ").replace("-", " ")
             for f in leftover[:8]
         )
-        lines.append(
+        cta_line = (
             f"\nNot injected ({len(leftover)}): {topics}. "
             "→ `~/agents/bin/memory recall <topic>` to pull these.\n"
         )
+        # Keep the rendered CTA within its reserved budget (true upper bound,
+        # independent of fact-name length). _cost adds 1 for the join newline.
+        if _cost(cta_line) > cta_reserve:
+            cta_line = cta_line[: cta_reserve - 1]
+        lines.append(cta_line)
 
-    total_used = summary_used + body_used
-    _log_autorecall(fact_dir, real_injected, len(facts), total_used)
+    _log_autorecall(fact_dir, real_injected, len(facts), used)
     return "\n".join(lines)
 
 

--- a/claude-config/hooks/sessionstart_restore_state.py
+++ b/claude-config/hooks/sessionstart_restore_state.py
@@ -330,6 +330,7 @@ def get_active_work(yaml_content: str) -> dict:
 # don't bloat. Chars ≈ 4 × tokens.
 AUTORECALL_TOTAL_CHARS = 6000
 AUTORECALL_PER_FACT_CHARS = 1200
+AUTORECALL_SUMMARY_CHARS = 200
 _TYPE_PRIORITY = {"feedback": 0, "user": 1, "reference": 2, "project": 3}
 
 
@@ -343,19 +344,112 @@ def _fact_meta(path: Path) -> dict | None:
         text = path.read_text(encoding="utf-8")
     except (OSError, UnicodeDecodeError):
         return None
-    meta = {"name": path.stem, "type": "project", "expires": None, "body": text}
+    meta = {
+        "name": path.stem,
+        "type": "project",
+        "expires": None,
+        "summary": "",
+        "durability": "",
+        "body": text,
+    }
     if text.startswith("---\n"):
         end = text.find("\n---", 4)
         if end != -1:
             for line in text[4:end].splitlines():
                 stripped = line.strip()
-                for key in ("type", "expires", "name"):
+                for key in ("type", "expires", "name", "summary", "durability"):
                     if stripped.startswith(f"{key}:"):
                         meta[key] = (
                             stripped.split(":", 1)[1].strip().strip("'\"") or meta[key]
                         )
             meta["body"] = text[end + 4 :].lstrip("-").lstrip("\n")
     return meta
+
+
+def _extract_summary(
+    meta: dict, body: str, *, max_chars: int = AUTORECALL_SUMMARY_CHARS
+) -> str:
+    """Derive a ≤max_chars summary for a fact.
+
+    Uses ``meta["summary"]`` if set; otherwise falls back to the first
+    non-header, non-list, non-empty sentence in the body. Always passes the
+    candidate through ``_classify_body`` — a suppressed body never leaks via
+    its summary. Fail-open: any exception returns a short safe default.
+    """
+    try:
+        candidate = meta.get("summary", "").strip()
+        if not candidate:
+            # Fallback: first non-header, non-list, non-empty sentence.
+            for raw_line in body.splitlines():
+                line = raw_line.strip()
+                if not line:
+                    continue
+                if line.startswith(("#", "-", "*", ">")):
+                    continue
+                # Split on ". " to get first sentence.
+                candidate = line.split(". ")[0].rstrip(".")
+                break
+        candidate = candidate[:max_chars]
+        # Safety: a suppressed body must not leak via its summary.
+        # "error" is fail-open (classifier failed internally) — treat as safe.
+        verdict, _ = _classify_body(candidate)
+        if verdict in ("secret", "injection"):
+            return _SUPPRESSED_BODY
+        return candidate
+    except Exception:  # noqa: BLE001 — fail-open: summary error must not crash hook
+        return ""
+
+
+def _rank_score(f: dict, today_str: str) -> float:
+    """Compute a sort key for fact ``f``; lower score = injected first.
+
+    Formula (all components non-negative except durability bonus):
+        base_priority     = _TYPE_PRIORITY.get(type, 9)          # 0..9
+        freshness_penalty = clamp((days - 30) / 30, 0, 2)        # 0 at <30d, +2 at >90d
+        size_penalty      = clamp((body_size - 1200) / 1200, 0, 1.5)  # project type only
+        durability_bonus  = -1.0 if durable else 0.0
+    """
+    try:
+        ftype = f.get("type", "project")
+        base = float(_TYPE_PRIORITY.get(ftype, 9))
+
+        # Freshness penalty: 0 for facts touched ≤30d ago, up to +2 at 90d+.
+        try:
+            mtime = f["path"].stat().st_mtime
+        except OSError:
+            mtime = 0.0
+        try:
+            today_date = date.fromisoformat(today_str)
+        except ValueError:
+            today_date = date.today()
+        days = (today_date - date.fromtimestamp(mtime)).days
+        freshness = max(0.0, min(2.0, (days - 30) / 30.0))
+
+        # session/temporary facts get an extra staleness multiplier.
+        durability = f.get("durability", "")
+        if durability in ("session", "temporary"):
+            freshness *= 1.5
+
+        # Size penalty: only for project-type facts (they are the over-represented class).
+        if ftype == "project":
+            body_size = len(f.get("body", "").strip())
+            size_penalty = max(
+                0.0,
+                min(
+                    1.5,
+                    (body_size - AUTORECALL_PER_FACT_CHARS)
+                    / float(AUTORECALL_PER_FACT_CHARS),
+                ),
+            )
+        else:
+            size_penalty = 0.0
+
+        # Durability bonus: durable facts resist size/freshness penalties.
+        dur_bonus = -1.0 if durability == "durable" else 0.0
+
+        return base + freshness + size_penalty + dur_bonus
+    except Exception:  # noqa: BLE001 — fail-open: ranking error must not crash hook
+        return float(_TYPE_PRIORITY.get(f.get("type", "project"), 9))
 
 
 def _expired(expires: str | None, today: str) -> bool:
@@ -365,9 +459,10 @@ def _expired(expires: str | None, today: str) -> bool:
 def render_project_memory(fact_dir: Path, *, today: str | None = None) -> str:
     """Build the auto-recalled Project Memory section (empty string if none).
 
-    Selection: non-expired facts ranked by type priority (feedback > user >
-    reference > project) then mtime (newest first), injected until the char
-    budget runs out. Remaining facts are listed as topics with the recall CTA.
+    Two-pass injection (#430):
+      Pass 1 — inject a summary line for every selected fact (budget: first half).
+      Pass 2 — inject full bodies for top-N eligible facts (remaining budget).
+    Total budget: AUTORECALL_TOTAL_CHARS (6000 chars, unchanged from #365).
     """
     from datetime import date
 
@@ -384,11 +479,63 @@ def render_project_memory(fact_dir: Path, *, today: str | None = None) -> str:
     if not facts:
         return ""
 
-    facts.sort(
-        key=lambda f: (_TYPE_PRIORITY.get(f["type"], 9), -f["path"].stat().st_mtime)
-    )
-    injected, leftover, used = [], [], 0
+    # Rank by _rank_score (lower = better); use path.name as deterministic tiebreaker.
+    facts.sort(key=lambda f: (_rank_score(f, today), f["path"].name))
+
+    project = fact_dir.parent.name
+
+    # ---- Pass 1: summary injection ----
+    # Budget slice for summaries: up to half the total budget so full bodies
+    # can always fill the second half.
+    summary_budget = AUTORECALL_TOTAL_CHARS // 2
+    summary_used = 0
+    summary_entries = []  # (safe_name, ftype, summary_text, fact_dict, verdict)
+    leftover = []
+
     for f in facts:
+        try:
+            safe_name = _redact_secret_name(f["name"])
+        except Exception:  # noqa: BLE001 — fail-open: redaction must not crash hook
+            safe_name = f["name"]
+
+        # Derive summary — safety-filtered inside _extract_summary.
+        summary = _extract_summary(f, f["body"].strip())
+
+        # Summary line cost.
+        cost = len(summary) + len(safe_name) + 30
+        if summary_used + cost > summary_budget:
+            leftover.append(f)
+            continue
+
+        # Also classify the raw body for the body-pass safety check.
+        try:
+            verdict, excerpt = _classify_body(f["body"].strip())
+        except Exception:  # noqa: BLE001 — fail-open: filter errors must not crash hook
+            verdict, excerpt = "error", None
+
+        if verdict == "error":
+            _log_classify_error(safe_name, project)
+        elif verdict != "ok":
+            _log_injection_skip(safe_name, verdict, excerpt or "", project)
+            # Suppressed body must not leak via its summary (PLAN: fail-safe).
+            summary = _SUPPRESSED_BODY
+
+        summary_entries.append((safe_name, f["type"], summary, f, verdict))
+        summary_used += cost
+
+    # ---- Pass 2: full-body injection ----
+    body_budget = AUTORECALL_TOTAL_CHARS - summary_used
+    body_used = 0
+    body_entries = []  # (safe_name, ftype, body_text)
+
+    for safe_name, ftype, _summary, f, verdict in summary_entries:
+        # session/temporary facts are summary-only by declaration.
+        if f.get("durability", "") in ("session", "temporary"):
+            continue
+        # Suppressed bodies are not injected.
+        if verdict not in ("ok", "error"):
+            continue
+
         body = f["body"].strip()
         if len(body) > AUTORECALL_PER_FACT_CHARS:
             body = (
@@ -396,61 +543,46 @@ def render_project_memory(fact_dir: Path, *, today: str | None = None) -> str:
                 + f"\n… *(truncated — full fact: `{f['path']}`)*"
             )
 
-        project = fact_dir.parent.name
-
-        # BLOCKING 3: the fact NAME is rendered to context and written to the
-        # log verbatim — run it through the same classifier and redact it in
-        # BOTH surfaces if it is secret/injection-shaped. Never emit raw name.
-        try:
-            safe_name = _redact_secret_name(f["name"])
-        except Exception:  # noqa: BLE001 — fail-open: redaction must not crash hook
-            safe_name = f["name"]
-
-        # Safety filter: check for secret-shaped or injection-phrase content.
-        try:
-            verdict, excerpt = _classify_body(body)
-        except Exception:  # noqa: BLE001 — fail-open: filter errors must not crash hook
-            verdict, excerpt = "error", None
-
-        if verdict == "error":
-            # NIT 1: classifier failed. Fail-open (inject the body) but emit a
-            # diagnostic so the failure is observable. Never logs the body.
-            _log_classify_error(safe_name, project)
-        elif verdict != "ok":
-            _log_injection_skip(safe_name, verdict, excerpt or "", project)
-            # Replace body with sentinel — fact name (redacted if needed) still
-            # appears in output but raw content is not injected.
-            body = _SUPPRESSED_BODY
-
-        cost = len(body) + len(safe_name) + 40
-        if used + cost > AUTORECALL_TOTAL_CHARS:
-            leftover.append(f)
+        cost = len(body) + len(safe_name) + 20
+        if body_used + cost > body_budget:
             continue
-        injected.append((safe_name, f["type"], body))
-        used += cost
+        body_entries.append((safe_name, ftype, body))
+        body_used += cost
 
-    # Count only non-suppressed facts for the metrics record.
-    real_injected = sum(1 for _, _, b in injected if b != _SUPPRESSED_BODY)
+    # Count only body-pass (non-suppressed) facts for the metrics record.
+    real_injected = len(body_entries)
 
+    # ---- Render ----
     lines = ["### Project Memory (auto-recalled)\n"]
+    n_summaries = len(summary_entries)
+    n_bodies = len(body_entries)
     lines.append(
-        f"{real_injected} of {len(facts)} fact bodies injected "
-        "(highest-value first, budget-capped). Verify against current code "
-        "before acting — facts reflect what was true when written.\n"
+        f"{n_summaries} summaries injected ({n_bodies} of {n_summaries} with full body). "
+        "Verify against current code before acting — facts reflect what was true when written.\n"
     )
-    for name, ftype, body in injected:
-        lines.append(f"**{name}** ({ftype}):\n{body}\n")
+
+    # Summary section.
+    for safe_name, ftype, summary, _f, _verdict in summary_entries:
+        lines.append(f"**{safe_name}** ({ftype}): {summary}")
+
+    # Full-body section (omitted when empty).
+    if body_entries:
+        lines.append(f"\n#### Full bodies (top-{n_bodies})\n")
+        for safe_name, ftype, body in body_entries:
+            lines.append(f"**{safe_name}** ({ftype}):\n{body}\n")
+
     if leftover:
         topics = ", ".join(
             _redact_secret_name(f["name"]).replace("_", " ").replace("-", " ")
             for f in leftover[:8]
         )
         lines.append(
-            f"Not injected ({len(leftover)}): {topics}. "
+            f"\nNot injected ({len(leftover)}): {topics}. "
             "→ `~/agents/bin/memory recall <topic>` to pull these.\n"
         )
 
-    _log_autorecall(fact_dir, real_injected, len(facts), used)
+    total_used = summary_used + body_used
+    _log_autorecall(fact_dir, real_injected, len(facts), total_used)
     return "\n".join(lines)
 
 

--- a/claude-config/tests/test_memory_cli_frontmatter.py
+++ b/claude-config/tests/test_memory_cli_frontmatter.py
@@ -1,0 +1,64 @@
+"""Tests for the `bin/memory` CLI frontmatter parser (#430).
+
+Focus: the CLI's `_split_frontmatter` must strip surrounding quotes from values
+exactly like the SessionStart hook's `_fact_meta`, so a valid-YAML quoted form
+such as `durability: "durable"` is honored as durable by the same code path
+`memory doctor` / `memory archive` use (and is therefore NOT flagged stale).
+"""
+
+import datetime
+import importlib.machinery
+import importlib.util
+import sys
+import time
+from pathlib import Path
+
+# `bin/memory` is extensionless; load it as a module via its file path.
+_MEMORY_PATH = Path(__file__).resolve().parents[2] / "bin" / "memory"
+_spec = importlib.util.spec_from_loader(
+    "memory_cli",
+    importlib.machinery.SourceFileLoader("memory_cli", str(_MEMORY_PATH)),
+)
+memory_cli = importlib.util.module_from_spec(_spec)
+sys.modules["memory_cli"] = memory_cli
+_spec.loader.exec_module(memory_cli)
+
+
+def test_split_frontmatter_strips_quotes_from_durability():
+    """`durability: "durable"` parses to the unquoted literal `durable`."""
+    text = '---\nname: f\ntype: project\ndurability: "durable"\n---\n\nbody'
+    meta, _body = memory_cli._split_frontmatter(text)
+    assert meta["durability"] == "durable"
+
+
+def test_split_frontmatter_strips_single_quotes():
+    text = "---\nname: f\ntype: project\nsummary: 'a quoted summary'\n---\n\nbody"
+    meta, _body = memory_cli._split_frontmatter(text)
+    assert meta["summary"] == "a quoted summary"
+
+
+def test_quoted_durable_not_flagged_stale_via_doctor_path(tmp_path):
+    """A perishable-named, old, `type: project` fact with `durability: "durable"`
+    (quoted) must be honored as durable by the SAME helper `memory doctor` /
+    `memory archive` use — i.e. it is NOT a TTL candidate. Before #430 the CLI
+    saw the literal `"durable"` (with quotes) and still flagged it stale."""
+    mem = tmp_path / "-Users-x-proj" / "memory"
+    mem.mkdir(parents=True)
+    # Perishable filename ('summary') + old mtime would normally trip the
+    # stale-perishable heuristic; quoted durable must override it.
+    fact = mem / "session-summary.md"
+    fact.write_text(
+        '---\nname: session-summary\ntype: project\ndurability: "durable"\n---\n\nthe why',
+        encoding="utf-8",
+    )
+    old = time.time() - 200 * 86400  # 200 days untouched
+    import os
+
+    os.utime(fact, (old, old))
+
+    today = datetime.date.today()
+    now = time.time()
+    # Drive the exact helper doctor/archive use to list TTL candidates.
+    cands = memory_cli._ttl_candidates(mem, today, now, memory_cli.STALE_DAYS)
+    names = [name for name, _reason in cands]
+    assert "session-summary.md" not in names

--- a/claude-config/tests/test_sessionstart_autorecall.py
+++ b/claude-config/tests/test_sessionstart_autorecall.py
@@ -11,11 +11,23 @@ TODAY = "2026-06-09"
 
 
 def _fact(
-    d, name, *, ftype="project", expires=None, body="the why lives here", mtime=None
+    d,
+    name,
+    *,
+    ftype="project",
+    expires=None,
+    body="the why lives here",
+    mtime=None,
+    summary=None,
+    durability=None,
 ):
     fm = f"---\nname: {name}\ntype: {ftype}\n"
     if expires:
         fm += f"expires: {expires}\n"
+    if summary is not None:
+        fm += f"summary: {summary}\n"
+    if durability is not None:
+        fm += f"durability: {durability}\n"
     fm += "---\n\n"
     p = d / f"{name}.md"
     p.write_text(fm + body, encoding="utf-8")
@@ -81,13 +93,18 @@ def test_feedback_outranks_project(tmp_path, monkeypatch):
 def test_budget_caps_injection_and_lists_leftovers(tmp_path, monkeypatch):
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     d = _memdir(tmp_path)
-    for i in range(12):
+    # Use 20 facts with 1100-char bodies so the summary budget (3000 chars) is
+    # exhausted before all can be summarised; this guarantees a "Not injected" line.
+    for i in range(20):
         _fact(d, f"fact-{i:02d}", ftype="feedback", body="B" * 1100, mtime=1000 + i)
     out = H.render_project_memory(d, today=TODAY)
     assert "Not injected" in out
     assert "memory recall" in out
-    # budget 6000 chars with ~1140-char facts → at most 5 injected
-    assert out.count("(feedback):") <= 5
+    # In the new two-pass format, full bodies (in body section) are budget-capped.
+    # With ~1120-char body cost and 3000-char body budget, at most ~2 get bodies.
+    # Count lines of the form "**name** (feedback):\n" (body section entries).
+    body_section_entries = out.count("(feedback):\n")
+    assert body_section_entries <= 3
 
 
 def test_long_body_truncated_with_pointer(tmp_path, monkeypatch):
@@ -633,3 +650,222 @@ def test_sk_proj_underscore_tail_suppressed(tmp_path, monkeypatch):
     out = H.render_project_memory(d, today=TODAY)
     assert raw not in out
     assert "[body suppressed" in out
+
+
+# ---------------------------------------------------------------- #430 tests
+
+# N1: explicit summary field is honored
+
+
+def test_summary_field_injected_before_body(tmp_path, monkeypatch):
+    """AC-a: explicit summary: field is rendered in the summary line before the
+    full-body section."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    d = _memdir(tmp_path)
+    _fact(
+        d,
+        "my-lesson",
+        ftype="feedback",
+        summary="Short summary.",
+        body="Long detailed body content that explains everything in detail.",
+    )
+    out = H.render_project_memory(d, today=TODAY)
+    # Summary line appears before the Full bodies header.
+    summary_pos = out.find("Short summary.")
+    bodies_pos = out.find("#### Full bodies")
+    assert summary_pos != -1, "explicit summary not found in output"
+    assert bodies_pos != -1, "Full bodies section not found"
+    assert summary_pos < bodies_pos, "summary should appear before full-body section"
+
+
+# N2: fallback summary from first sentence
+
+
+def test_summary_fallback_first_sentence(tmp_path, monkeypatch):
+    """AC-a: when summary: is absent, first sentence of body is used as summary."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    d = _memdir(tmp_path)
+    _fact(
+        d,
+        "no-summary",
+        ftype="feedback",
+        body="First sentence of the body. Second sentence with more detail.",
+    )
+    out = H.render_project_memory(d, today=TODAY)
+    # First sentence appears in summary section (before bodies section or as only line).
+    assert "First sentence of the body" in out
+
+
+# N3: fallback skips header lines
+
+
+def test_summary_fallback_skips_headers(tmp_path, monkeypatch):
+    """AC-a: fallback summary derivation skips header/list lines at the top."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    d = _memdir(tmp_path)
+    _fact(
+        d,
+        "header-body",
+        ftype="feedback",
+        body="# Main Header\n- list item\nActual content sentence.",
+    )
+    out = H.render_project_memory(d, today=TODAY)
+    # Header and list item are skipped; actual content is the summary.
+    assert "Actual content sentence" in out
+    # Header text should not appear as the summary prefix.
+    assert (
+        "# Main Header" not in out.split("#### Full bodies")[0]
+        if "#### Full bodies" in out
+        else True
+    )
+
+
+# N4: suppressed body → summary shows sentinel, not the secret
+
+
+def test_suppressed_body_not_summarized(tmp_path, monkeypatch):
+    """AC-a + #429: a fact with a secret body shows _SUPPRESSED_BODY in the summary
+    line and NEVER leaks the secret content via its summary."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    d = _memdir(tmp_path)
+    _fact(
+        d,
+        "secret-fact",
+        ftype="user",
+        body="My credentials: sk-ant-api03-abc1234567890abcdef is the key.",
+    )
+    out = H.render_project_memory(d, today=TODAY)
+    assert "secret-fact" in out
+    # Secret must not appear anywhere.
+    assert "sk-ant-api03-abc1234567890abcdef" not in out
+    # The suppressed sentinel must appear in the summary line.
+    assert "[body suppressed" in out
+
+
+# N5: oversized stale project fact ranks after fresh small feedback fact
+
+
+def test_ranking_penalizes_oversized_stale_project(tmp_path, monkeypatch):
+    """AC-b: a large stale project fact scores worse than a small fresh feedback fact."""
+    import time
+
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    d = _memdir(tmp_path)
+    now = time.time()
+    # Fresh small feedback fact (1 day ago).
+    _fact(d, "fresh-feedback", ftype="feedback", body="F" * 100, mtime=now - 86400)
+    # Stale large project fact (60 days ago).
+    _fact(d, "stale-project", ftype="project", body="P" * 2000, mtime=now - 60 * 86400)
+    out = H.render_project_memory(d, today=TODAY)
+    # fresh-feedback should appear before stale-project in output.
+    assert out.index("fresh-feedback") < out.index("stale-project")
+
+
+# N6: durability: durable resists staleness penalty
+
+
+def test_durability_durable_resists_staleness(tmp_path, monkeypatch):
+    """AC-b: a durable project fact ranks before a same-type non-durable fact
+    that was written at the same time.  The -1.0 durability bonus lowers the
+    score and lets the durable fact beat the non-durable one when both are
+    equally stale (60 days old, same body size = no size penalty).
+    Without the bonus the scores are equal; with it the durable fact wins."""
+    import time
+
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    d = _memdir(tmp_path)
+    now = time.time()
+    # Both facts: 60 days old (1.0 freshness penalty), body=500 (no size penalty).
+    # Durable gets -1.0 bonus → score 3.0; non-durable stays at 4.0.
+    _fact(
+        d,
+        "aa-durable",
+        ftype="project",
+        durability="durable",
+        body="D" * 500,
+        mtime=now - 60 * 86400,
+    )
+    _fact(
+        d,
+        "bb-nondurable",
+        ftype="project",
+        body="N" * 500,
+        mtime=now - 60 * 86400,
+    )
+    out = H.render_project_memory(d, today=TODAY)
+    # Durable fact should appear first because its score is lower.
+    assert out.index("aa-durable") < out.index("bb-nondurable")
+
+
+# N7: durability: session → appears in summary, NOT in full-body section
+
+
+def test_durability_session_summaries_only(tmp_path, monkeypatch):
+    """AC-b: a session-durability fact appears in the summary pass only; it must
+    NOT appear in the full-body section."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    d = _memdir(tmp_path)
+    _fact(
+        d,
+        "ephemeral",
+        ftype="project",
+        durability="session",
+        body="Session-scoped content that should not be in bodies.",
+    )
+    out = H.render_project_memory(d, today=TODAY)
+    # Name appears somewhere (summary pass).
+    assert "ephemeral" in out
+    # If there's a full-body section, 'ephemeral' must NOT be in it.
+    if "#### Full bodies" in out:
+        bodies_section = out.split("#### Full bodies")[1]
+        assert "ephemeral" not in bodies_section
+
+
+# N8: budget is never exceeded
+
+
+def test_budget_not_exceeded(tmp_path, monkeypatch):
+    """AC-c: with 20 facts of varying sizes, total rendered output stays within
+    the budget (with reasonable header overhead), and no single body exceeds
+    AUTORECALL_PER_FACT_CHARS."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    d = _memdir(tmp_path)
+    import random
+
+    random.seed(42)
+    types = ["feedback", "user", "reference", "project"]
+    for i in range(20):
+        body_len = random.randint(50, 3000)
+        _fact(
+            d,
+            f"fact-{i:02d}",
+            ftype=types[i % len(types)],
+            body="X" * body_len,
+        )
+    out = H.render_project_memory(d, today=TODAY)
+    # Total output should not drastically exceed the budget (allow 500 chars for headers).
+    assert len(out) <= H.AUTORECALL_TOTAL_CHARS + 500
+    # No single body block should exceed the per-fact cap.
+    for line in out.split("\n"):
+        if line.startswith("X"):
+            assert (
+                len(line) <= H.AUTORECALL_PER_FACT_CHARS + 10
+            )  # small fudge for trailing pointer
+
+
+# N9: fresh feedback outranks stale project in output order
+
+
+def test_ranking_fresh_feedback_beats_stale_project(tmp_path, monkeypatch):
+    """AC-b: fresh feedback fact outranks stale project fact in output."""
+    import time
+
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    d = _memdir(tmp_path)
+    now = time.time()
+    # Stale project (100 days ago).
+    _fact(d, "old-project", ftype="project", body="P" * 500, mtime=now - 100 * 86400)
+    # Fresh feedback (5 minutes ago).
+    _fact(d, "new-feedback", ftype="feedback", body="F" * 500, mtime=now - 300)
+    out = H.render_project_memory(d, today=TODAY)
+    assert out.index("new-feedback") < out.index("old-project")

--- a/claude-config/tests/test_sessionstart_autorecall.py
+++ b/claude-config/tests/test_sessionstart_autorecall.py
@@ -93,15 +93,17 @@ def test_feedback_outranks_project(tmp_path, monkeypatch):
 def test_budget_caps_injection_and_lists_leftovers(tmp_path, monkeypatch):
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     d = _memdir(tmp_path)
-    # Use 20 facts with 1100-char bodies so the summary budget (3000 chars) is
-    # exhausted before all can be summarised; this guarantees a "Not injected" line.
-    for i in range(20):
+    # Many facts with large bodies: under honest accounting (#430) every emitted
+    # char (summary lines + body blocks + headers + CTA) is charged against the
+    # single 6000 budget. With 40 facts whose ~200-char summaries alone exceed
+    # the budget, some are left out → a "Not injected" CTA must render.
+    for i in range(40):
         _fact(d, f"fact-{i:02d}", ftype="feedback", body="B" * 1100, mtime=1000 + i)
     out = H.render_project_memory(d, today=TODAY)
     assert "Not injected" in out
     assert "memory recall" in out
-    # In the new two-pass format, full bodies (in body section) are budget-capped.
-    # With ~1120-char body cost and 3000-char body budget, at most ~2 get bodies.
+    # Full bodies (in body section) remain budget-capped: with ~1120-char body
+    # cost competing against summaries in one 6000 budget, only a few fit.
     # Count lines of the form "**name** (feedback):\n" (body section entries).
     body_section_entries = out.count("(feedback):\n")
     assert body_section_entries <= 3
@@ -737,7 +739,9 @@ def test_suppressed_body_not_summarized(tmp_path, monkeypatch):
     out = H.render_project_memory(d, today=TODAY)
     assert "secret-fact" in out
     # Secret must not appear anywhere.
-    assert "sk-ant-api03-abc1234567890abcdef" not in out  # eval-ok: E15 — fabricated test fixture for safety-filter verification
+    assert (
+        "sk-ant-api03-abc1234567890abcdef" not in out
+    )  # eval-ok: E15 — fabricated test fixture for safety-filter verification
     # The suppressed sentinel must appear in the summary line.
     assert "[body suppressed" in out
 
@@ -825,9 +829,9 @@ def test_durability_session_summaries_only(tmp_path, monkeypatch):
 
 
 def test_budget_not_exceeded(tmp_path, monkeypatch):
-    """AC-c: with 20 facts of varying sizes, total rendered output stays within
-    the budget (with reasonable header overhead), and no single body exceeds
-    AUTORECALL_PER_FACT_CHARS."""
+    """AC-c: with 20 facts of varying sizes, the TOTAL rendered block length is
+    <= AUTORECALL_TOTAL_CHARS EXACTLY (no slack — #430 honest accounting), and
+    no single body exceeds AUTORECALL_PER_FACT_CHARS."""
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     d = _memdir(tmp_path)
     import random
@@ -843,14 +847,35 @@ def test_budget_not_exceeded(tmp_path, monkeypatch):
             body="X" * body_len,
         )
     out = H.render_project_memory(d, today=TODAY)
-    # Total output should not drastically exceed the budget (allow 500 chars for headers).
-    assert len(out) <= H.AUTORECALL_TOTAL_CHARS + 500
+    # Strict: every emitted character is charged against the budget.
+    assert len(out) <= H.AUTORECALL_TOTAL_CHARS
     # No single body block should exceed the per-fact cap.
     for line in out.split("\n"):
         if line.startswith("X"):
             assert (
                 len(line) <= H.AUTORECALL_PER_FACT_CHARS + 10
             )  # small fudge for trailing pointer
+
+
+def test_budget_strict_even_with_not_injected_cta(tmp_path, monkeypatch):
+    """#430: drive enough large facts to overflow the budget — which forces the
+    'Not injected (...)' CTA to render — and assert the TOTAL block length still
+    stays within AUTORECALL_TOTAL_CHARS exactly (CTA + headers + labels all
+    charged honestly)."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    d = _memdir(tmp_path)
+    # 40 large facts with long names guarantee leftovers (CTA renders) and
+    # exercise the per-entry label + CTA-truncation accounting.
+    for i in range(40):
+        _fact(
+            d,
+            f"a-very-long-feedback-fact-name-number-{i:03d}",
+            ftype="feedback",
+            body="Y" * 2500,
+        )
+    out = H.render_project_memory(d, today=TODAY)
+    assert "Not injected" in out  # CTA must render
+    assert len(out) <= H.AUTORECALL_TOTAL_CHARS
 
 
 # N9: fresh feedback outranks stale project in output order

--- a/claude-config/tests/test_sessionstart_autorecall.py
+++ b/claude-config/tests/test_sessionstart_autorecall.py
@@ -732,12 +732,12 @@ def test_suppressed_body_not_summarized(tmp_path, monkeypatch):
         d,
         "secret-fact",
         ftype="user",
-        body="My credentials: sk-ant-api03-abc1234567890abcdef is the key.",
+        body="My credentials: sk-ant-api03-abc1234567890abcdef is the key.",  # eval-ok: E15 — fabricated test fixture for safety-filter verification
     )
     out = H.render_project_memory(d, today=TODAY)
     assert "secret-fact" in out
     # Secret must not appear anywhere.
-    assert "sk-ant-api03-abc1234567890abcdef" not in out
+    assert "sk-ant-api03-abc1234567890abcdef" not in out  # eval-ok: E15 — fabricated test fixture for safety-filter verification
     # The suppressed sentinel must appear in the summary line.
     assert "[body suppressed" in out
 


### PR DESCRIPTION
## Summary

Performance rework of the SessionStart memory auto-recall hook so the right facts reach context within the fixed 6,000-char budget (audit finding: 58/78 fact bodies exceeded the per-fact cap and were truncating out precise facts).

- **Summaries-before-bodies**: optional `summary:` frontmatter (1–3 sentences); the hook injects summaries for all selected facts first, then full bodies only for the top-N. Falls back to a derived first-sentence summary when `summary:` is absent.
- **Size- + freshness-aware ranking** (`_rank_score`): type priority + freshness penalty + size penalty (project-type) + durability bonus; deterministic tiebreak.
- **`durability:` metadata** (`durable|session|handoff|temporary`, + optional `expires:`), honored in ranking and TTL — applied on-touch, no mass retrofit.
- **Reuses #429's safety filter**: summaries (explicit or derived) run through `_classify_body`, so a suppressed/secret fact never leaks via its summary.
- **Convention documented** in `claude-config/CLAUDE.md` (Memory Frontmatter Convention; on-touch normalization, no migration).

The 6,000-char budget value is **unchanged** — the win is signal-per-character.

## Test Plan
- `test_sessionstart_autorecall.py`: 54 tests (incl. summary honored/fallback/header-skip, suppressed-body-not-summarized, ranking penalizes oversized/stale, durable resists staleness, session→summary-only, and a **strict** budget invariant: `len(out) <= AUTORECALL_TOTAL_CHARS` even when the "N more not injected" CTA fires).
- `test_memory_cli_frontmatter.py`: 3 tests (CLI/hook quote-parsing parity; `durability: "durable"` honored by `doctor`/`archive`).
- `ruff` clean; E15 eval clean; CLAUDE.md 196/200 within budget.

## Review
`/codex:review` (one pass) found two concrete issues, both fixed in `2a940ed`: (1) budget accounting omitted wrapper/label/CTA chars (the bound is now honest and the test strict — independently verified worst-case 5,681 ≤ 6,000); (2) `bin/memory` didn't strip frontmatter quotes like the hook, so `durability: "durable"` could be seen as stale by `doctor`/`archive`.

Closes #430
🤖 Generated with [Claude Code](https://claude.com/claude-code)
