### PR TITLE
feat(memory): personal coding-memory store — pgvector on jns + ingest/query CLI

### DIFF
--- a/bin/coding-memory
+++ b/bin/coding-memory
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Personal coding-memory CLI. Resolves the agents repo, puts lib/ on PYTHONPATH,
+# and runs the module under the repo venv. Heavy deps (fastembed/psycopg) are only
+# needed on jns (server side); laptops just parse + dispatch over SSH.
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PY="$HERE/.venv/bin/python"
+[ -x "$PY" ] || PY="$(command -v python3)"
+exec env PYTHONPATH="$HERE/lib${PYTHONPATH:+:$PYTHONPATH}" "$PY" -m coding_memory.cli "$@"

--- a/lib/coding_memory/__init__.py
+++ b/lib/coding_memory/__init__.py
@@ -1,0 +1,67 @@
+"""Shared *personal* coding-memory store (client/server).
+
+Architecture (decided 2026-06-14):
+  - Storage: Postgres 16 + pgvector on jns-server, database ``coding_memory``.
+  - Embedding is CENTRALIZED on jns (FastEmbed ``nomic-embed-text-v1.5``, 768-d)
+    so there is exactly one vector space — no cross-device drift.
+  - Personal devices (this laptop + jns) share this store. The laptop is a thin
+    client: it parses local markdown and ships records over SSH; jns embeds+stores.
+  - STRICT RESIDENCY: work memory lives in a separate, never-bridged store on the
+    work laptop. This tool's default sources are personal-only and it never holds
+    a work DSN.
+
+Config: ``~/.coding_memory.env`` (KEY=VALUE per line), env vars override.
+  jns       -> DATABASE_URL=...127.0.0.1:5432... , FASTEMBED_CACHE=...   (local mode)
+  laptop    -> CODING_MEMORY_SSH=jns-server                              (remote mode)
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+EMBED_MODEL = "nomic-ai/nomic-embed-text-v1.5"
+EMBED_DIM = 768
+DOC_PREFIX = "search_document: "
+QUERY_PREFIX = "search_query: "
+EMBED_MAXCHARS = 2500  # truncate doc text before embedding (attention is O(seq^2));
+#                        FTS still covers the full body, so recall keeps full-text reach
+EMBED_BATCH = 8  # small batch caps peak memory (O(seq^2)*batch); avoids OOM on jns
+
+CONFIG_PATH = Path(os.path.expanduser("~/.coding_memory.env"))
+
+# laptop-side markdown source -> namespace. Personal only (strict residency).
+DEFAULT_SOURCES = {
+    "agents": "~/.claude/projects/-Users-jasonjob-agents/memory",
+    "buddy": "~/.claude/projects/-Users-jasonjob-projects-buddy/memory",
+}
+SKIP_NAMES = {"MEMORY.md"}
+SKIP_DIRS = {"archive"}
+
+_CFG_KEYS = (
+    "DATABASE_URL",
+    "CODING_MEMORY_SSH",
+    "FASTEMBED_CACHE",
+    "CODING_MEMORY_REMOTE_BIN",
+)
+
+
+def load_config() -> dict:
+    cfg: dict[str, str] = {}
+    if CONFIG_PATH.exists():
+        for line in CONFIG_PATH.read_text().splitlines():
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            k, _, v = line.partition("=")
+            cfg[k.strip()] = v.strip()
+    for k in _CFG_KEYS:
+        if os.environ.get(k):
+            cfg[k] = os.environ[k]
+    cfg.setdefault("CODING_MEMORY_REMOTE_BIN", "~/agents/bin/coding-memory")
+    return cfg
+
+
+def is_remote(cfg: dict) -> bool:
+    """Remote = dispatch over SSH. Local = talk to the DB + embed here (jns)."""
+    return not cfg.get("DATABASE_URL") and bool(cfg.get("CODING_MEMORY_SSH"))

--- a/lib/coding_memory/__init__.py
+++ b/lib/coding_memory/__init__.py
@@ -41,9 +41,11 @@ SKIP_DIRS = {"archive"}
 
 # Residency allowlist: only these namespaces may be written to the personal store.
 # The server (jns) enforces this so a misconfigured client cannot land work data.
+# (Includes future namespaces global/craft sourced from the agents git repo.)
 ALLOWED_NAMESPACES = frozenset({"agents", "buddy", "global", "craft"})
-# Client-side guard: ingest --source paths must resolve under this personal root.
-PERSONAL_ROOT = os.path.realpath(os.path.expanduser("~/.claude/projects"))
+# Client-side guard: a filesystem --source must be a KNOWN personal namespace AND
+# resolve under THAT namespace's canonical root in DEFAULT_SOURCES. The shared
+# ~/.claude/projects parent is NOT a boundary (it also holds work-project memory).
 
 _SAFE_REMOTE_BIN = re.compile(r"^[\w/.~ -]+$")
 

--- a/lib/coding_memory/__init__.py
+++ b/lib/coding_memory/__init__.py
@@ -18,6 +18,7 @@ Config: ``~/.coding_memory.env`` (KEY=VALUE per line), env vars override.
 from __future__ import annotations
 
 import os
+import re
 from pathlib import Path
 
 EMBED_MODEL = "nomic-ai/nomic-embed-text-v1.5"
@@ -38,6 +39,21 @@ DEFAULT_SOURCES = {
 SKIP_NAMES = {"MEMORY.md"}
 SKIP_DIRS = {"archive"}
 
+# Residency allowlist: only these namespaces may be written to the personal store.
+# The server (jns) enforces this so a misconfigured client cannot land work data.
+ALLOWED_NAMESPACES = frozenset({"agents", "buddy", "global", "craft"})
+# Client-side guard: ingest --source paths must resolve under this personal root.
+PERSONAL_ROOT = os.path.realpath(os.path.expanduser("~/.claude/projects"))
+
+_SAFE_REMOTE_BIN = re.compile(r"^[\w/.~ -]+$")
+
+
+def valid_remote_bin(value: str) -> bool:
+    """Remote bin is interpolated raw (the remote shell must expand ~); only allow
+    a conservative path-ish charset so config can't smuggle shell metacharacters."""
+    return bool(_SAFE_REMOTE_BIN.match(value or ""))
+
+
 _CFG_KEYS = (
     "DATABASE_URL",
     "CODING_MEMORY_SSH",
@@ -49,6 +65,14 @@ _CFG_KEYS = (
 def load_config() -> dict:
     cfg: dict[str, str] = {}
     if CONFIG_PATH.exists():
+        mode = CONFIG_PATH.stat().st_mode
+        if mode & 0o077:
+            import sys
+
+            sys.stderr.write(
+                f"warning: {CONFIG_PATH} is group/world-readable; run "
+                f"`chmod 600 {CONFIG_PATH}` (it holds the DB password)\n"
+            )
         for line in CONFIG_PATH.read_text().splitlines():
             line = line.strip()
             if not line or line.startswith("#") or "=" not in line:

--- a/lib/coding_memory/cli.py
+++ b/lib/coding_memory/cli.py
@@ -19,7 +19,6 @@ import sys
 from . import (
     ALLOWED_NAMESPACES,
     DEFAULT_SOURCES,
-    PERSONAL_ROOT,
     is_remote,
     load_config,
     valid_remote_bin,
@@ -34,18 +33,20 @@ def _sources_from_args(pairs):
         if not path:
             raise SystemExit(f"--source expects ns=path, got: {item}")
         out[ns.strip()] = path.strip()
-    # residency guard: personal namespaces + personal paths only (work uses a
-    # separate, never-bridged store)
+    # residency guard: a source must be a KNOWN personal namespace AND resolve under
+    # THAT namespace's canonical root — not merely under the shared ~/.claude/projects
+    # parent, which also holds work-project memory on the work laptop.
     for ns, path in out.items():
-        if ns not in ALLOWED_NAMESPACES:
+        root = DEFAULT_SOURCES.get(ns)
+        if root is None:
             raise SystemExit(
-                f"refusing source ns '{ns}': not a personal namespace "
-                f"{sorted(ALLOWED_NAMESPACES)}"
+                f"refusing source ns '{ns}': not a known personal source {sorted(DEFAULT_SOURCES)}"
             )
+        root_real = os.path.realpath(os.path.expanduser(root))
         real = os.path.realpath(os.path.expanduser(path))
-        if real != PERSONAL_ROOT and not real.startswith(PERSONAL_ROOT + os.sep):
+        if real != root_real and not real.startswith(root_real + os.sep):
             raise SystemExit(
-                f"refusing source path '{path}': must resolve under {PERSONAL_ROOT}"
+                f"refusing source path '{path}' for ns '{ns}': must resolve under {root_real}"
             )
     return out
 

--- a/lib/coding_memory/cli.py
+++ b/lib/coding_memory/cli.py
@@ -11,31 +11,51 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import shlex
 import subprocess
 import sys
 
-from . import DEFAULT_SOURCES, is_remote, load_config
+from . import (
+    ALLOWED_NAMESPACES,
+    DEFAULT_SOURCES,
+    PERSONAL_ROOT,
+    is_remote,
+    load_config,
+    valid_remote_bin,
+)
 from . import parse as P
 
 
 def _sources_from_args(pairs):
-    if not pairs:
-        return dict(DEFAULT_SOURCES)
-    out = {}
-    for item in pairs:
+    out = dict(DEFAULT_SOURCES) if not pairs else {}
+    for item in pairs or []:
         ns, _, path = item.partition("=")
         if not path:
             raise SystemExit(f"--source expects ns=path, got: {item}")
         out[ns.strip()] = path.strip()
+    # residency guard: personal namespaces + personal paths only (work uses a
+    # separate, never-bridged store)
+    for ns, path in out.items():
+        if ns not in ALLOWED_NAMESPACES:
+            raise SystemExit(
+                f"refusing source ns '{ns}': not a personal namespace "
+                f"{sorted(ALLOWED_NAMESPACES)}"
+            )
+        real = os.path.realpath(os.path.expanduser(path))
+        if real != PERSONAL_ROOT and not real.startswith(PERSONAL_ROOT + os.sep):
+            raise SystemExit(
+                f"refusing source path '{path}': must resolve under {PERSONAL_ROOT}"
+            )
     return out
 
 
 def _ssh(cfg, remote_args, stdin_data=None):
     host = cfg["CODING_MEMORY_SSH"]
-    remote = f"{cfg['CODING_MEMORY_REMOTE_BIN']} " + " ".join(
-        shlex.quote(a) for a in remote_args
-    )
+    remote_bin = cfg["CODING_MEMORY_REMOTE_BIN"]
+    if not valid_remote_bin(remote_bin):
+        raise SystemExit(f"unsafe CODING_MEMORY_REMOTE_BIN: {remote_bin!r}")
+    remote = f"{remote_bin} " + " ".join(shlex.quote(a) for a in remote_args)
     # Keepalives: server-side embedding holds the channel idle for ~15s while the
     # model loads + embeds; a Cloudflare-tunneled SSH drops idle connections (-> 255).
     ssh = [
@@ -63,25 +83,41 @@ def _ssh(cfg, remote_args, stdin_data=None):
 
 def cmd_ingest(args, cfg):
     sources = _sources_from_args(args.source)
-    records = P.build_records(sources)
+    parsed = P.build_records(sources)
+    records = parsed["records"]
+    prune = parsed["prune_namespaces"]
     print(
-        f"parsed {len(records)} fact(s) from {len(sources)} namespace(s): {', '.join(sources)}",
+        f"parsed {len(records)} fact(s) from {len(sources)} namespace(s): "
+        f"{', '.join(sources)} | prune-safe: {', '.join(prune) or '(none)'}",
         file=sys.stderr,
     )
     if args.dry_run:
         for r in records:
             print(f"  [{r['namespace']}] {r['name']}  ({r['source_path']})")
         return 0
-    ndjson = "\n".join(json.dumps(r) for r in records)
+    payload = json.dumps(parsed)
     if is_remote(cfg):
-        return _ssh(cfg, ["_embed-store"], stdin_data=ndjson)
-    return _embed_store(ndjson, cfg)
+        return _ssh(cfg, ["_embed-store"], stdin_data=payload)
+    return _embed_store(payload, cfg)
 
 
-def _embed_store(ndjson, cfg):
+# embed + upsert this many records per chunk so a large ingest stays memory-bounded
+_INGEST_CHUNK = 64
+
+
+def _embed_store(payload, cfg):
     from . import embedder, store
 
-    records = [json.loads(line) for line in ndjson.splitlines() if line.strip()]
+    env = json.loads(payload)
+    if isinstance(env, list):  # back-compat: bare record list
+        env = {"records": env, "prune_namespaces": []}
+    incoming = env.get("records", [])
+    # residency: server-side allowlist — never store a non-personal namespace,
+    # even from a misconfigured client.
+    records = [r for r in incoming if r.get("namespace") in ALLOWED_NAMESPACES]
+    rejected = len(incoming) - len(records)
+    prune_ns = [n for n in env.get("prune_namespaces", []) if n in ALLOWED_NAMESPACES]
+
     cache = cfg.get("FASTEMBED_CACHE")
     conn = store.connect(cfg["DATABASE_URL"])
     try:
@@ -93,24 +129,28 @@ def _embed_store(ndjson, cfg):
             for r in records
             if existing.get((r["namespace"], r["source_path"])) != r["content_hash"]
         ]
-        report = {
-            "parsed": len(records),
-            "changed": len(changed),
-            "unchanged": len(records) - len(changed),
-        }
-        if changed:
+        for i in range(0, len(changed), _INGEST_CHUNK):
+            batch = changed[i : i + _INGEST_CHUNK]
             vecs = embedder.embed_docs(
-                [P.embed_text(r) for r in changed], cache_dir=cache
+                [P.embed_text(r) for r in batch], cache_dir=cache
             )
-            for r, v in zip(changed, vecs):
+            for r, v in zip(batch, vecs):
                 store.upsert(conn, r, v)
-        # prune rows whose source file disappeared
+            conn.commit()
+        # prune ONLY namespaces the client certified as fully + cleanly scanned
         pruned = 0
-        for ns in namespaces:
+        for ns in prune_ns:
             keep = [r["source_path"] for r in records if r["namespace"] == ns]
-            pruned += store.delete_missing(conn, ns, keep)
+            if keep:
+                pruned += store.delete_missing(conn, ns, keep)
         conn.commit()
-        report["pruned"] = pruned
+        report = {
+            "parsed": len(incoming),
+            "stored": len(changed),
+            "unchanged": len(records) - len(changed),
+            "rejected_nonpersonal": rejected,
+            "pruned": pruned,
+        }
         print(json.dumps(report))
         return 0
     finally:

--- a/lib/coding_memory/cli.py
+++ b/lib/coding_memory/cli.py
@@ -1,0 +1,242 @@
+"""coding-memory CLI.
+
+Front-door commands (run anywhere): ingest, query, stats.
+  - On jns (DATABASE_URL set) they run locally (embed + DB here).
+  - On a laptop (CODING_MEMORY_SSH set) they dispatch to jns over SSH; the laptop
+    only parses markdown and ships records — no model, no DB driver needed.
+Internal server commands (executed on jns via SSH): _embed-store, _query, _stats.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shlex
+import subprocess
+import sys
+
+from . import DEFAULT_SOURCES, is_remote, load_config
+from . import parse as P
+
+
+def _sources_from_args(pairs):
+    if not pairs:
+        return dict(DEFAULT_SOURCES)
+    out = {}
+    for item in pairs:
+        ns, _, path = item.partition("=")
+        if not path:
+            raise SystemExit(f"--source expects ns=path, got: {item}")
+        out[ns.strip()] = path.strip()
+    return out
+
+
+def _ssh(cfg, remote_args, stdin_data=None):
+    host = cfg["CODING_MEMORY_SSH"]
+    remote = f"{cfg['CODING_MEMORY_REMOTE_BIN']} " + " ".join(
+        shlex.quote(a) for a in remote_args
+    )
+    # Keepalives: server-side embedding holds the channel idle for ~15s while the
+    # model loads + embeds; a Cloudflare-tunneled SSH drops idle connections (-> 255).
+    ssh = [
+        "ssh",
+        "-o",
+        "ServerAliveInterval=10",
+        "-o",
+        "ServerAliveCountMax=18",
+        host,
+        remote,
+    ]
+    proc = subprocess.run(
+        ssh,
+        input=stdin_data.encode() if stdin_data is not None else None,
+        capture_output=True,
+    )
+    if proc.stderr:
+        sys.stderr.write(proc.stderr.decode(errors="replace"))
+    sys.stdout.write(proc.stdout.decode(errors="replace"))
+    return proc.returncode
+
+
+# ---------- ingest ----------
+
+
+def cmd_ingest(args, cfg):
+    sources = _sources_from_args(args.source)
+    records = P.build_records(sources)
+    print(
+        f"parsed {len(records)} fact(s) from {len(sources)} namespace(s): {', '.join(sources)}",
+        file=sys.stderr,
+    )
+    if args.dry_run:
+        for r in records:
+            print(f"  [{r['namespace']}] {r['name']}  ({r['source_path']})")
+        return 0
+    ndjson = "\n".join(json.dumps(r) for r in records)
+    if is_remote(cfg):
+        return _ssh(cfg, ["_embed-store"], stdin_data=ndjson)
+    return _embed_store(ndjson, cfg)
+
+
+def _embed_store(ndjson, cfg):
+    from . import embedder, store
+
+    records = [json.loads(line) for line in ndjson.splitlines() if line.strip()]
+    cache = cfg.get("FASTEMBED_CACHE")
+    conn = store.connect(cfg["DATABASE_URL"])
+    try:
+        store.ensure_schema(conn)
+        namespaces = sorted({r["namespace"] for r in records})
+        existing = store.existing_hashes(conn, namespaces)
+        changed = [
+            r
+            for r in records
+            if existing.get((r["namespace"], r["source_path"])) != r["content_hash"]
+        ]
+        report = {
+            "parsed": len(records),
+            "changed": len(changed),
+            "unchanged": len(records) - len(changed),
+        }
+        if changed:
+            vecs = embedder.embed_docs(
+                [P.embed_text(r) for r in changed], cache_dir=cache
+            )
+            for r, v in zip(changed, vecs):
+                store.upsert(conn, r, v)
+        # prune rows whose source file disappeared
+        pruned = 0
+        for ns in namespaces:
+            keep = [r["source_path"] for r in records if r["namespace"] == ns]
+            pruned += store.delete_missing(conn, ns, keep)
+        conn.commit()
+        report["pruned"] = pruned
+        print(json.dumps(report))
+        return 0
+    finally:
+        conn.close()
+
+
+# ---------- query ----------
+
+
+def cmd_query(args, cfg):
+    text = " ".join(args.text).strip()
+    if not text:
+        raise SystemExit("query text required")
+    if is_remote(cfg):
+        remote = ["_query", "-k", str(args.k), "--mode", args.mode]
+        for ns in args.namespace or []:
+            remote += ["--namespace", ns]
+        remote += ["--", text]
+        return _ssh(cfg, remote)
+    return _query(text, args, cfg)
+
+
+def _query(text, args, cfg):
+    from . import embedder, store
+
+    cache = cfg.get("FASTEMBED_CACHE")
+    qvec = embedder.embed_query(text, cache_dir=cache)
+    conn = store.connect(cfg["DATABASE_URL"])
+    try:
+        rows = store.search(
+            conn,
+            qvec,
+            text=text,
+            k=args.k,
+            namespaces=args.namespace or None,
+            mode=args.mode,
+        )
+    finally:
+        conn.close()
+    if not rows:
+        print("(no matches)")
+        return 0
+    for r in rows:
+        summ = (r.get("summary") or "").replace("\n", " ")
+        if len(summ) > 110:
+            summ = summ[:107] + "..."
+        print(f"{r['score']:.4f}  [{r['namespace']}] {r['name']}")
+        if summ:
+            print(f"         {summ}")
+        print(f"         {r['source_path']}")
+    return 0
+
+
+# ---------- stats ----------
+
+
+def cmd_stats(args, cfg):
+    if is_remote(cfg):
+        return _ssh(cfg, ["_stats"])
+    from . import store
+
+    conn = store.connect(cfg["DATABASE_URL"])
+    try:
+        rows = store.stats(conn)
+    finally:
+        conn.close()
+    total = sum(r[1] for r in rows)
+    print(f"{'namespace':<16}{'facts':>8}{'embedded':>10}")
+    for ns, cnt, emb in rows:
+        print(f"{ns:<16}{cnt:>8}{emb:>10}")
+    print(f"{'TOTAL':<16}{total:>8}")
+    return 0
+
+
+def build_parser():
+    p = argparse.ArgumentParser(
+        prog="coding-memory", description="Personal coding-memory store (jns)."
+    )
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    g = sub.add_parser(
+        "ingest", help="parse local markdown facts and (re)embed into the store"
+    )
+    g.add_argument(
+        "--source",
+        action="append",
+        help="ns=path (repeatable); default = personal sources",
+    )
+    g.add_argument("--dry-run", action="store_true")
+
+    q = sub.add_parser("query", help="semantic/hybrid recall")
+    q.add_argument("text", nargs="+")
+    q.add_argument("-k", type=int, default=8)
+    q.add_argument("--mode", choices=["hybrid", "vector", "fts"], default="hybrid")
+    q.add_argument("--namespace", action="append")
+
+    sub.add_parser("stats", help="row counts per namespace")
+
+    # internal (server-side on jns)
+    sub.add_parser("_embed-store")
+    qq = sub.add_parser("_query")
+    qq.add_argument("text", nargs="+")
+    qq.add_argument("-k", type=int, default=8)
+    qq.add_argument("--mode", choices=["hybrid", "vector", "fts"], default="hybrid")
+    qq.add_argument("--namespace", action="append")
+    sub.add_parser("_stats")
+    return p
+
+
+def main(argv=None):
+    args = build_parser().parse_args(argv)
+    cfg = load_config()
+    if args.cmd == "ingest":
+        return cmd_ingest(args, cfg)
+    if args.cmd == "query":
+        return cmd_query(args, cfg)
+    if args.cmd == "stats":
+        return cmd_stats(args, cfg)
+    if args.cmd == "_embed-store":
+        return _embed_store(sys.stdin.read(), cfg)
+    if args.cmd == "_query":
+        return _query(" ".join(args.text).strip(), args, cfg)
+    if args.cmd == "_stats":
+        return cmd_stats(args, cfg)
+    raise SystemExit(2)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/lib/coding_memory/embedder.py
+++ b/lib/coding_memory/embedder.py
@@ -1,0 +1,35 @@
+"""FastEmbed wrapper — server-side (jns) only. Imports fastembed lazily."""
+
+from __future__ import annotations
+
+import os
+
+from . import DOC_PREFIX, EMBED_BATCH, EMBED_MAXCHARS, EMBED_MODEL, QUERY_PREFIX
+
+_model = None
+
+
+def _get(cache_dir: str | None = None):
+    global _model
+    if _model is None:
+        from fastembed import TextEmbedding
+
+        cd = cache_dir or os.environ.get("FASTEMBED_CACHE") or None
+        # max_length caps the tokenizer sequence so a stray long doc can't blow up
+        # attention memory (O(seq^2)); not all fastembed versions accept the kwarg.
+        try:
+            _model = TextEmbedding(EMBED_MODEL, cache_dir=cd, max_length=768)
+        except TypeError:
+            _model = TextEmbedding(EMBED_MODEL, cache_dir=cd)
+    return _model
+
+
+def embed_docs(texts: list[str], cache_dir: str | None = None) -> list[list[float]]:
+    m = _get(cache_dir)
+    prepped = [DOC_PREFIX + (t or "")[:EMBED_MAXCHARS] for t in texts]
+    return [[float(x) for x in v] for v in m.embed(prepped, batch_size=EMBED_BATCH)]
+
+
+def embed_query(text: str, cache_dir: str | None = None) -> list[float]:
+    m = _get(cache_dir)
+    return [float(x) for x in next(iter(m.embed([QUERY_PREFIX + text])))]

--- a/lib/coding_memory/parse.py
+++ b/lib/coding_memory/parse.py
@@ -67,35 +67,49 @@ def parse_markdown(raw: str, fallback_name: str = "") -> dict:
     }
 
 
-def discover(sources: dict[str, str]):
-    """Yield (namespace, abs_path, raw_text) for each fact file under each source."""
+def _record(ns: str, path: str, raw: str) -> dict:
+    meta = parse_markdown(raw, fallback_name=Path(path).stem)
+    return {
+        "namespace": ns,
+        "source_path": path,
+        "content_hash": content_hash(raw),
+        **meta,
+    }
+
+
+def build_records(sources: dict[str, str]) -> dict:
+    """Parse all source files into upsertable records.
+
+    Returns ``{"records": [...], "prune_namespaces": [...]}``. A namespace is
+    prune-safe ONLY if its source root exists, every file read cleanly, and it has
+    >=1 record — so a missing / partially-readable / empty source can never trigger
+    a destructive prune of previously-ingested rows.
+    """
+    records: list[dict] = []
+    prune_ok: list[str] = []
     for ns, d in sources.items():
         base = Path(d).expanduser()
         if not base.is_dir():
-            continue
-        for p in sorted(base.rglob("*.md")):
-            if p.name in SKIP_NAMES or any(part in SKIP_DIRS for part in p.parts):
-                continue
+            continue  # missing root -> contribute nothing, never prune this ns
+        files = [
+            p
+            for p in sorted(base.rglob("*.md"))
+            if p.name not in SKIP_NAMES
+            and not any(part in SKIP_DIRS for part in p.parts)
+        ]
+        ns_records: list[dict] = []
+        errors = 0
+        for p in files:
             try:
-                yield ns, str(p), p.read_text(encoding="utf-8", errors="replace")
+                raw = p.read_text(encoding="utf-8", errors="replace")
             except OSError:
+                errors += 1
                 continue
-
-
-def build_records(sources: dict[str, str]) -> list[dict]:
-    """Parse all source files into upsertable records (no embedding yet)."""
-    recs: list[dict] = []
-    for ns, path, raw in discover(sources):
-        meta = parse_markdown(raw, fallback_name=Path(path).stem)
-        recs.append(
-            {
-                "namespace": ns,
-                "source_path": path,
-                "content_hash": content_hash(raw),
-                **meta,
-            }
-        )
-    return recs
+            ns_records.append(_record(ns, str(p), raw))
+        records.extend(ns_records)
+        if ns_records and errors == 0:
+            prune_ok.append(ns)
+    return {"records": records, "prune_namespaces": prune_ok}
 
 
 def embed_text(rec: dict) -> str:

--- a/lib/coding_memory/parse.py
+++ b/lib/coding_memory/parse.py
@@ -1,0 +1,104 @@
+"""Markdown fact parsing — pure stdlib (+ optional PyYAML). Client-side only."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from pathlib import Path
+
+from . import SKIP_DIRS, SKIP_NAMES
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover - yaml expected but degrade gracefully
+    yaml = None
+
+_FM = re.compile(r"^---\s*\n(.*?)\n---\s*\n?", re.DOTALL)
+
+
+def content_hash(raw: str) -> str:
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _fallback_frontmatter(text: str) -> dict:
+    out: dict[str, str] = {}
+    for line in text.splitlines():
+        if ":" in line and not line.startswith((" ", "\t", "-")):
+            k, _, v = line.partition(":")
+            out[k.strip()] = v.strip().strip("'\"")
+    return out
+
+
+def parse_markdown(raw: str, fallback_name: str = "") -> dict:
+    """Extract name/type/summary/durability/expires/body from a fact file."""
+    meta: dict = {}
+    body = raw
+    m = _FM.match(raw)
+    if m:
+        fm_text, body = m.group(1), raw[m.end() :]
+        if yaml is not None:
+            try:
+                meta = yaml.safe_load(fm_text) or {}
+            except yaml.YAMLError:
+                meta = {}
+        if not isinstance(meta, dict) or not meta:
+            meta = _fallback_frontmatter(fm_text)
+
+    nested = meta.get("metadata") if isinstance(meta.get("metadata"), dict) else {}
+
+    def pick(*keys):
+        for k in keys:
+            for src in (meta, nested):
+                val = src.get(k)
+                if val not in (None, ""):
+                    return val
+        return None
+
+    def s(v):
+        return None if v is None else str(v)
+
+    return {
+        "name": str(pick("name") or fallback_name),
+        "type": s(pick("type")),
+        "summary": s(pick("summary", "description")),
+        "durability": s(pick("durability")),
+        "expires": s(pick("expires")),
+        "body": body.strip(),
+    }
+
+
+def discover(sources: dict[str, str]):
+    """Yield (namespace, abs_path, raw_text) for each fact file under each source."""
+    for ns, d in sources.items():
+        base = Path(d).expanduser()
+        if not base.is_dir():
+            continue
+        for p in sorted(base.rglob("*.md")):
+            if p.name in SKIP_NAMES or any(part in SKIP_DIRS for part in p.parts):
+                continue
+            try:
+                yield ns, str(p), p.read_text(encoding="utf-8", errors="replace")
+            except OSError:
+                continue
+
+
+def build_records(sources: dict[str, str]) -> list[dict]:
+    """Parse all source files into upsertable records (no embedding yet)."""
+    recs: list[dict] = []
+    for ns, path, raw in discover(sources):
+        meta = parse_markdown(raw, fallback_name=Path(path).stem)
+        recs.append(
+            {
+                "namespace": ns,
+                "source_path": path,
+                "content_hash": content_hash(raw),
+                **meta,
+            }
+        )
+    return recs
+
+
+def embed_text(rec: dict) -> str:
+    """Compose the text that gets embedded for a fact."""
+    parts = [rec.get("name") or "", rec.get("summary") or "", rec.get("body") or ""]
+    return ". ".join(p for p in parts if p).strip()

--- a/lib/coding_memory/requirements-server.txt
+++ b/lib/coding_memory/requirements-server.txt
@@ -1,0 +1,7 @@
+# Server-side (jns) deps for coding-memory. Install ONLY where embedding runs:
+#   ~/agents/.venv/bin/pip install -r lib/coding_memory/requirements-server.txt
+# Laptops are thin clients (parse + SSH dispatch) and need none of these.
+# fastembed is pinned: a version change can shift the embedding space — re-ingest
+# all namespaces if you bump it (see lib/coding_memory/__init__.py EMBED_MODEL).
+fastembed==0.8.0
+psycopg[binary]>=3.1

--- a/lib/coding_memory/store.py
+++ b/lib/coding_memory/store.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+import math
+
+from . import EMBED_DIM
+
 _DDL = """
 CREATE TABLE IF NOT EXISTS memory_fact (
   id           BIGSERIAL PRIMARY KEY,
@@ -31,7 +35,12 @@ def connect(dsn: str):
 
 
 def _vlit(vec) -> str:
-    return "[" + ",".join(f"{x:.7g}" for x in vec) + "]"
+    vals = [float(x) for x in vec]
+    if len(vals) != EMBED_DIM:
+        raise ValueError(f"embedding dim {len(vals)} != {EMBED_DIM}")
+    if any(not math.isfinite(x) for x in vals):
+        raise ValueError("embedding contains non-finite values")
+    return "[" + ",".join(f"{x:.7g}" for x in vals) + "]"
 
 
 def ensure_schema(conn) -> None:

--- a/lib/coding_memory/store.py
+++ b/lib/coding_memory/store.py
@@ -1,0 +1,176 @@
+"""Postgres + pgvector access — server-side (jns) only. psycopg imported lazily."""
+
+from __future__ import annotations
+
+_DDL = """
+CREATE TABLE IF NOT EXISTS memory_fact (
+  id           BIGSERIAL PRIMARY KEY,
+  namespace    TEXT NOT NULL,
+  name         TEXT,
+  type         TEXT,
+  summary      TEXT,
+  body         TEXT NOT NULL,
+  source_path  TEXT,
+  tags         TEXT[] NOT NULL DEFAULT '{}',
+  durability   TEXT,
+  expires      DATE,
+  content_hash TEXT NOT NULL,
+  embedding    vector(768),
+  tsv tsvector GENERATED ALWAYS AS
+       (to_tsvector('english', coalesce(name,'')||' '||coalesce(summary,'')||' '||coalesce(body,''))) STORED,
+  created_at   timestamptz NOT NULL DEFAULT now(),
+  updated_at   timestamptz NOT NULL DEFAULT now()
+);
+"""
+
+
+def connect(dsn: str):
+    import psycopg
+
+    return psycopg.connect(dsn)
+
+
+def _vlit(vec) -> str:
+    return "[" + ",".join(f"{x:.7g}" for x in vec) + "]"
+
+
+def ensure_schema(conn) -> None:
+    with conn.cursor() as c:
+        c.execute(_DDL)
+        # identity is (namespace, source_path); drop the original content_hash unique
+        c.execute(
+            "ALTER TABLE memory_fact DROP CONSTRAINT IF EXISTS memory_fact_namespace_content_hash_key;"
+        )
+        c.execute(
+            "CREATE UNIQUE INDEX IF NOT EXISTS ux_memfact_ns_path ON memory_fact(namespace, source_path);"
+        )
+        c.execute(
+            "CREATE INDEX IF NOT EXISTS idx_memfact_ns ON memory_fact(namespace);"
+        )
+        c.execute(
+            "CREATE INDEX IF NOT EXISTS idx_memfact_tsv ON memory_fact USING gin(tsv);"
+        )
+        c.execute(
+            "CREATE INDEX IF NOT EXISTS idx_memfact_embed ON memory_fact USING hnsw (embedding vector_cosine_ops);"
+        )
+    conn.commit()
+
+
+def existing_hashes(conn, namespaces) -> dict:
+    with conn.cursor() as c:
+        c.execute(
+            "SELECT namespace, source_path, content_hash FROM memory_fact WHERE namespace = ANY(%s)",
+            (list(namespaces),),
+        )
+        return {(r[0], r[1]): r[2] for r in c.fetchall()}
+
+
+def upsert(conn, rec: dict, embedding) -> None:
+    params = dict(rec)
+    params["emb"] = _vlit(embedding)
+    params["expires"] = rec.get("expires") or ""
+    sql = """
+    INSERT INTO memory_fact
+      (namespace,name,type,summary,body,source_path,durability,expires,content_hash,embedding,updated_at)
+    VALUES
+      (%(namespace)s,%(name)s,%(type)s,%(summary)s,%(body)s,%(source_path)s,%(durability)s,
+       NULLIF(%(expires)s,'')::date,%(content_hash)s,%(emb)s::vector,now())
+    ON CONFLICT (namespace, source_path) DO UPDATE SET
+      name=EXCLUDED.name, type=EXCLUDED.type, summary=EXCLUDED.summary, body=EXCLUDED.body,
+      durability=EXCLUDED.durability, expires=EXCLUDED.expires, content_hash=EXCLUDED.content_hash,
+      embedding=EXCLUDED.embedding, updated_at=now();
+    """
+    with conn.cursor() as c:
+        c.execute(sql, params)
+
+
+def delete_missing(conn, namespace: str, keep_paths: list[str]) -> int:
+    """Remove rows for a namespace whose source file no longer exists."""
+    with conn.cursor() as c:
+        c.execute(
+            "DELETE FROM memory_fact WHERE namespace=%s AND NOT (source_path = ANY(%s))",
+            (namespace, keep_paths),
+        )
+        return c.rowcount
+
+
+def stats(conn) -> list[tuple]:
+    with conn.cursor() as c:
+        c.execute(
+            "SELECT namespace, count(*), count(embedding) FROM memory_fact GROUP BY namespace ORDER BY namespace;"
+        )
+        return c.fetchall()
+
+
+_COLS = "namespace,name,type,summary,source_path"
+
+
+def _rows_to_dicts(rows):
+    out = []
+    for r in rows:
+        out.append(
+            {
+                "namespace": r[0],
+                "name": r[1],
+                "type": r[2],
+                "summary": r[3],
+                "source_path": r[4],
+                "score": float(r[5]),
+            }
+        )
+    return out
+
+
+def _vector(conn, qvec, k, namespaces):
+    p = {"q": _vlit(qvec), "k": k}
+    where = ""
+    if namespaces:
+        where = "WHERE namespace = ANY(%(ns)s)"
+        p["ns"] = list(namespaces)
+    sql = f"""SELECT {_COLS}, 1-(embedding <=> %(q)s::vector) AS score
+              FROM memory_fact {where}
+              ORDER BY embedding <=> %(q)s::vector LIMIT %(k)s;"""
+    with conn.cursor() as c:
+        c.execute(sql, p)
+        return _rows_to_dicts(c.fetchall())
+
+
+def _fts(conn, text, k, namespaces):
+    if not text:
+        return []
+    p = {"text": text, "k": k}
+    where = "WHERE tsv @@ plainto_tsquery('english', %(text)s)"
+    if namespaces:
+        where += " AND namespace = ANY(%(ns)s)"
+        p["ns"] = list(namespaces)
+    sql = f"""SELECT {_COLS}, ts_rank(tsv, plainto_tsquery('english', %(text)s)) AS score
+              FROM memory_fact {where}
+              ORDER BY score DESC LIMIT %(k)s;"""
+    with conn.cursor() as c:
+        c.execute(sql, p)
+        return _rows_to_dicts(c.fetchall())
+
+
+def search(conn, qvec, text=None, k=8, namespaces=None, mode="hybrid"):
+    if mode == "vector":
+        return _vector(conn, qvec, k, namespaces)
+    if mode == "fts":
+        return _fts(conn, text, k, namespaces)
+    # hybrid: Reciprocal Rank Fusion (k0=60) over vector + FTS
+    over = max(k * 3, 15)
+    fused: dict = {}
+    for rows in (
+        _vector(conn, qvec, over, namespaces),
+        _fts(conn, text, over, namespaces),
+    ):
+        for rank, r in enumerate(rows):
+            key = (r["namespace"], r["source_path"])
+            slot = fused.setdefault(key, {"rec": r, "rrf": 0.0})
+            slot["rrf"] += 1.0 / (60 + rank)
+    merged = sorted(fused.values(), key=lambda s: s["rrf"], reverse=True)[:k]
+    out = []
+    for s in merged:
+        rec = dict(s["rec"])
+        rec["score"] = round(s["rrf"], 5)
+        out.append(rec)
+    return out

--- a/lib/tests/test_coding_memory.py
+++ b/lib/tests/test_coding_memory.py
@@ -61,3 +61,27 @@ def test_embed_text_composition():
     rec = {"name": "N", "summary": "S", "body": "B"}
     assert P.embed_text(rec) == "N. S. B"
     assert P.embed_text({"name": "", "summary": None, "body": "B"}) == "B"
+
+
+def test_build_records_clean_dir_is_prune_safe(tmp_path):
+    d = tmp_path / "ns1"
+    d.mkdir()
+    (d / "a.md").write_text("---\nname: a\n---\nbody a\n")
+    (d / "MEMORY.md").write_text("index")  # skipped, not a fact
+    out = P.build_records({"ns1": str(d)})
+    assert len(out["records"]) == 1
+    assert out["prune_namespaces"] == ["ns1"]
+
+
+def test_build_records_missing_root_not_prunable(tmp_path):
+    out = P.build_records({"gone": str(tmp_path / "nope")})
+    assert out["records"] == []
+    assert out["prune_namespaces"] == []  # missing source must never trigger prune
+
+
+def test_build_records_empty_dir_not_prunable(tmp_path):
+    d = tmp_path / "empty"
+    d.mkdir()
+    out = P.build_records({"empty": str(d)})
+    assert out["records"] == []
+    assert "empty" not in out["prune_namespaces"]  # empty must not wipe existing rows

--- a/lib/tests/test_coding_memory.py
+++ b/lib/tests/test_coding_memory.py
@@ -5,8 +5,11 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+import pytest
+
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # lib/ on path
 
+from coding_memory import cli as C  # noqa: E402
 from coding_memory import parse as P  # noqa: E402
 
 
@@ -85,3 +88,19 @@ def test_build_records_empty_dir_not_prunable(tmp_path):
     out = P.build_records({"empty": str(d)})
     assert out["records"] == []
     assert "empty" not in out["prune_namespaces"]  # empty must not wipe existing rows
+
+
+def test_residency_rejects_unknown_namespace():
+    with pytest.raises(SystemExit):
+        C._sources_from_args(["work=~/.claude/projects/some-work-repo/memory"])
+
+
+def test_residency_rejects_path_outside_namespace_root(tmp_path):
+    # personal namespace label but a work/other path must be refused (the bridge bug)
+    with pytest.raises(SystemExit):
+        C._sources_from_args([f"agents={tmp_path}"])
+
+
+def test_residency_defaults_pass():
+    out = C._sources_from_args(None)
+    assert set(out) == {"agents", "buddy"}

--- a/lib/tests/test_coding_memory.py
+++ b/lib/tests/test_coding_memory.py
@@ -1,0 +1,63 @@
+"""Pure-function tests for coding_memory.parse (no DB / no model needed)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # lib/ on path
+
+from coding_memory import parse as P  # noqa: E402
+
+
+def test_parse_full_frontmatter():
+    raw = (
+        "---\n"
+        "name: codex-always-inline\n"
+        "type: feedback\n"
+        "summary: Run codex inline only.\n"
+        "durability: durable\n"
+        "expires: 2026-12-31\n"
+        "---\n"
+        "Body line one.\n\nBody line two.\n"
+    )
+    out = P.parse_markdown(raw, fallback_name="fallback")
+    assert out["name"] == "codex-always-inline"
+    assert out["type"] == "feedback"
+    assert out["summary"] == "Run codex inline only."
+    assert out["durability"] == "durable"
+    assert out["expires"] == "2026-12-31"
+    assert out["body"].startswith("Body line one.")
+    assert "Body line two." in out["body"]
+
+
+def test_parse_nested_metadata():
+    raw = "---\nname: x\nmetadata:\n  type: reference\n---\nhello\n"
+    out = P.parse_markdown(raw, fallback_name="x")
+    assert out["type"] == "reference"
+
+
+def test_parse_no_frontmatter_uses_fallback():
+    out = P.parse_markdown("just a body, no frontmatter", fallback_name="my-file")
+    assert out["name"] == "my-file"
+    assert out["type"] is None
+    assert out["body"] == "just a body, no frontmatter"
+
+
+def test_description_aliases_summary():
+    raw = "---\nname: x\ndescription: one liner\n---\nbody\n"
+    assert P.parse_markdown(raw)["summary"] == "one liner"
+
+
+def test_content_hash_changes_with_content():
+    a = P.content_hash("alpha")
+    b = P.content_hash("beta")
+    assert a != b
+    assert P.content_hash("alpha") == a  # stable
+    assert len(a) == 64
+
+
+def test_embed_text_composition():
+    rec = {"name": "N", "summary": "S", "body": "B"}
+    assert P.embed_text(rec) == "N. S. B"
+    assert P.embed_text({"name": "", "summary": None, "body": "B"}) == "B"


### PR DESCRIPTION
## Summary
Personal coding-memory store with **semantic recall**, shared across personal laptop + jns.

- **Store**: Postgres 16 + pgvector on jns (`coding_memory.memory_fact`: `vector(768)` HNSW + `tsv` GIN).
- **Tool**: `bin/coding-memory` (`lib/coding_memory/`) — `ingest` / `query` / `stats`.
- **Centralized embedding on jns** (FastEmbed `nomic-embed-text-v1.5`) → one model, one vector space, no cross-device drift.
- **Thin client**: laptop parses local markdown + dispatches over SSH; jns embeds + stores.
- **Strict residency**: personal-only default sources; the tool never holds a work DSN.
- **Recall**: hybrid (vector + FTS via RRF). Embedding bounded (seq/batch caps) after an OOM was hit.

## Test plan
- `ruff check` / `ruff format --check` clean; `pytest lib/tests/test_coding_memory.py` (6 passed).
- End-to-end: ingested 72 personal facts (agents 9, buddy 63); idempotent re-run (changed:0); semantic recall verified (e.g. "safely remove a db table" → grep-every-sql-site).
- Coverage: pure parser/hash unit-tested; store/embedder/cli are exercised by the live end-to-end run (require pgvector + model, not unit-testable in CI).

## Notes
- Server deps (`fastembed`, `psycopg`) install on **jns only** (`lib/coding_memory/requirements-server.txt`).
- Follow-ups (separate issues): wire recall into orchestrate phases; persistent embed service; craft/global namespace; automated ingest.

Closes #437