### PR TITLE
fix(tests): make date-coupled tests time-independent

### DIFF
--- a/claude-config/tests/test_cost_telemetry_freshness.py
+++ b/claude-config/tests/test_cost_telemetry_freshness.py
@@ -9,7 +9,9 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
 
 import cost_telemetry_freshness as F  # noqa: E402
 
-NOW = datetime(2026, 6, 8, 12, 0, tzinfo=timezone.utc)
+# Dynamic so test_main_exit_codes (which calls F.main using the real current time)
+# stays in sync; a hardcoded NOW time-bombs as days pass.
+NOW = datetime.now(timezone.utc)
 
 
 def _state(base: Path, last_success, extra=None):

--- a/claude-config/tests/test_sessionstart_pull_guard.py
+++ b/claude-config/tests/test_sessionstart_pull_guard.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import os
 import subprocess
 import sys
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -21,8 +21,11 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "hooks"))
 
 import sessionstart_restore_state as H  # noqa: E402
 
-TODAY = "2026-06-10"
-YESTERDAY = "2026-06-09"
+# Computed dynamically so the suite never time-bombs as the calendar advances
+# (prod stamps with the real current date; hardcoded dates drift out of sync).
+_TODAY = datetime.now(timezone.utc).date()
+TODAY = _TODAY.isoformat()
+YESTERDAY = (_TODAY - timedelta(days=1)).isoformat()
 
 
 def _ok_result():


### PR DESCRIPTION
Fixes two time-bomb tests turning main red as the calendar advanced. Compute reference dates dynamically (test-only, no behavior change). Closes #439