### PR TITLE
feat(coding-memory): scheduled ingest via launchd on laptop

### DIFF
--- a/claude-config/launchd/README.md
+++ b/claude-config/launchd/README.md
@@ -152,3 +152,38 @@ tail -f ~/Library/Logs/claude-learn/cost-report.log
 ls ~/.claude/cost-reports/                     # the local report archive
 python3 ~/agents/claude-config/scripts/cost_report_weekly.py   # run once on demand
 ```
+
+---
+
+## Coding-memory ingest (`com.coding-memory-ingest`)
+
+**Daily** (`StartInterval 86400`, `RunAtLoad` false). Keeps the personal
+coding-memory store on jns fresh without a manual `bin/coding-memory ingest`.
+Logic lives in
+[`../scripts/coding-memory-ingest.sh`](../scripts/coding-memory-ingest.sh) so it
+is editable without redeploying the plist.
+
+Each run executes `bin/coding-memory ingest` with the **default personal sources
+only** (`agents`, `buddy`) — no `--source` override, so strict residency holds
+(work memory uses a separate, never-bridged store). Embedding happens on jns; the
+laptop only parses + dispatches over SSH (key auth — no credentials in the plist).
+On error (e.g. jns unreachable) it logs and exits non-zero; launchd retries on the
+next interval — no tight loop.
+
+### Deploy / reload
+
+```bash
+p=com.coding-memory-ingest
+cp "claude-config/launchd/$p.plist" ~/Library/LaunchAgents/
+launchctl unload "$HOME/Library/LaunchAgents/$p.plist" 2>/dev/null || true
+launchctl load   "$HOME/Library/LaunchAgents/$p.plist"
+```
+
+### Observe
+
+```bash
+launchctl list | grep coding-memory-ingest
+tail -f ~/.claude/logs/coding-memory-ingest.log
+bash ~/agents/claude-config/scripts/coding-memory-ingest.sh   # run once on demand
+~/agents/bin/coding-memory stats                              # rows per namespace
+```

--- a/claude-config/launchd/com.coding-memory-ingest.plist
+++ b/claude-config/launchd/com.coding-memory-ingest.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- coding-memory: daily personal ingest into the jns store. Logic lives in
+     scripts/coding-memory-ingest.sh (editable without redeploying this plist).
+     Default personal sources only (residency). NOT auto-installed by install.sh;
+     deploy manually (see launchd/README.md). RunAtLoad false: first run is one
+     interval after bootstrap. SSH key auth only — no credentials in this plist. -->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.coding-memory-ingest</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>/Users/jasonjob/agents/claude-config/scripts/coding-memory-ingest.sh</string>
+  </array>
+  <key>StartInterval</key>
+  <integer>86400</integer>
+  <key>RunAtLoad</key>
+  <false/>
+  <key>StandardOutPath</key>
+  <string>/Users/jasonjob/.claude/logs/coding-memory-ingest.log</string>
+  <key>StandardErrorPath</key>
+  <string>/Users/jasonjob/.claude/logs/coding-memory-ingest.log</string>
+</dict>
+</plist>

--- a/claude-config/scripts/coding-memory-ingest.sh
+++ b/claude-config/scripts/coding-memory-ingest.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Scheduled personal coding-memory ingest (launchd: com.coding-memory-ingest).
+# Thin wrapper so logic is editable without redeploying the plist. Runs the
+# default (personal-only) ingest — no --source override, so residency holds.
+# Fails soft: logs and exits non-zero on error; never retries in a tight loop
+# (launchd re-runs on the next StartInterval).
+set -uo pipefail
+REPO="$HOME/agents"
+LOG="$HOME/.claude/logs/coding-memory-ingest.log"
+mkdir -p "$(dirname "$LOG")"
+ts() { date "+%Y-%m-%dT%H:%M:%S%z"; }
+echo "[$(ts)] coding-memory ingest start" >>"$LOG"
+if "$REPO/bin/coding-memory" ingest >>"$LOG" 2>&1; then
+  echo "[$(ts)] ingest ok" >>"$LOG"
+else
+  rc=$?
+  echo "[$(ts)] ingest FAILED rc=$rc (jns unreachable? see output above)" >>"$LOG"
+  exit "$rc"
+fi


### PR DESCRIPTION
Daily launchd job running the default personal-only ingest (residency-safe), thin-wrapper logic, fail-soft. Codex R1: APPROVE. Closes #443