### PR TITLE
feat(coding-memory): persistent warm embed service on jns (sub-second query)

### DIFF
--- a/claude-config/systemd/README.md
+++ b/claude-config/systemd/README.md
@@ -1,0 +1,23 @@
+# systemd units (jns / Linux)
+
+## `coding-memory-embed.service` — warm embedding service
+
+Keeps the FastEmbed `nomic-embed-text-v1.5` model loaded on jns so
+`bin/coding-memory query`/`ingest` skip the ~5s per-call cold start. Binds
+**127.0.0.1 only** (never externally reachable). The CLI opts in by setting
+`CODING_MEMORY_EMBED_URL=http://127.0.0.1:8788` in `~/.coding_memory.env`; if the
+service is down, embedding falls back to the in-process model (no failure).
+
+It uses `embedder._embed_local_*` directly, so it never calls itself.
+
+### Deploy (on jns)
+
+```bash
+sudo cp ~/agents/claude-config/systemd/coding-memory-embed.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now coding-memory-embed
+systemctl status coding-memory-embed --no-pager
+curl -s localhost:8788/health        # {"ok": true, ...}
+```
+
+Then add to `~/.coding_memory.env` on jns: `CODING_MEMORY_EMBED_URL=http://127.0.0.1:8788`.

--- a/claude-config/systemd/coding-memory-embed.service
+++ b/claude-config/systemd/coding-memory-embed.service
@@ -1,0 +1,22 @@
+# coding-memory warm embedding service (jns). Localhost-only; keeps the FastEmbed
+# model warm so query/ingest skip the ~5s cold start. The CLI opts in via
+# CODING_MEMORY_EMBED_URL and falls back to in-process embedding if this is down.
+# Deploy (jns): sudo cp claude-config/systemd/coding-memory-embed.service /etc/systemd/system/
+#               sudo systemctl daemon-reload && sudo systemctl enable --now coding-memory-embed
+[Unit]
+Description=coding-memory warm embedding service (localhost)
+After=network.target
+
+[Service]
+Type=simple
+User=jwj2002
+WorkingDirectory=/home/jwj2002/agents
+Environment=PYTHONPATH=/home/jwj2002/agents/lib
+Environment=FASTEMBED_CACHE=/home/jwj2002/buddy/memory/model_cache
+Environment=CODING_MEMORY_EMBED_PORT=8788
+ExecStart=/home/jwj2002/agents/.venv/bin/python -m coding_memory.embed_service
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/lib/coding_memory/__init__.py
+++ b/lib/coding_memory/__init__.py
@@ -61,6 +61,7 @@ _CFG_KEYS = (
     "CODING_MEMORY_SSH",
     "FASTEMBED_CACHE",
     "CODING_MEMORY_REMOTE_BIN",
+    "CODING_MEMORY_EMBED_URL",
 )
 
 
@@ -85,6 +86,11 @@ def load_config() -> dict:
         if os.environ.get(k):
             cfg[k] = os.environ[k]
     cfg.setdefault("CODING_MEMORY_REMOTE_BIN", "~/agents/bin/coding-memory")
+    # bridge file-configured embedder settings into the process env — the embedder
+    # reads these from os.environ (so the CLI uses the warm service when set).
+    for k in ("CODING_MEMORY_EMBED_URL", "FASTEMBED_CACHE"):
+        if cfg.get(k) and not os.environ.get(k):
+            os.environ[k] = cfg[k]
     return cfg
 
 

--- a/lib/coding_memory/embed_service.py
+++ b/lib/coding_memory/embed_service.py
@@ -1,0 +1,65 @@
+"""Warm embedding service for coding-memory (jns, localhost-only). stdlib only.
+
+Keeps the FastEmbed model loaded so query/ingest skip the ~5s cold start. Binds
+127.0.0.1 ONLY (never externally reachable). Start via systemd
+(claude-config/systemd/coding-memory-embed.service). The CLI opts in by setting
+CODING_MEMORY_EMBED_URL and falls back to in-process embedding if this is down.
+
+  POST /embed  {"texts": [...], "kind": "doc"|"query"} -> {"vectors": [[...], ...]}
+  GET  /health -> {"ok": true, "model": "..."}
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+from . import EMBED_MODEL, embedder
+
+HOST = "127.0.0.1"  # localhost only — residency + no external exposure
+PORT = int(os.environ.get("CODING_MEMORY_EMBED_PORT", "8788"))
+
+
+class _Handler(BaseHTTPRequestHandler):
+    def _send(self, code: int, obj: dict) -> None:
+        body = json.dumps(obj).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self):  # noqa: N802 (stdlib handler name)
+        if self.path == "/health":
+            self._send(200, {"ok": True, "model": EMBED_MODEL})
+        else:
+            self._send(404, {"error": "not found"})
+
+    def do_POST(self):  # noqa: N802
+        if self.path != "/embed":
+            self._send(404, {"error": "not found"})
+            return
+        try:
+            n = int(self.headers.get("Content-Length", 0))
+            data = json.loads(self.rfile.read(n) or b"{}")
+            texts = data.get("texts") or []
+            if data.get("kind") == "query":
+                vecs = [embedder._embed_local_query(t) for t in texts]
+            else:
+                vecs = embedder._embed_local_docs(texts)
+            self._send(200, {"vectors": vecs})
+        except Exception as exc:  # daemon: one bad request must not kill the service
+            self._send(500, {"error": str(exc)})
+
+    def log_message(self, *args):  # silence per-request stderr noise
+        pass
+
+
+def main() -> None:
+    embedder._get()  # warm the model at startup so the first request is fast
+    ThreadingHTTPServer((HOST, PORT), _Handler).serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/coding_memory/embedder.py
+++ b/lib/coding_memory/embedder.py
@@ -20,6 +20,10 @@ import urllib.request
 from . import DOC_PREFIX, EMBED_BATCH, EMBED_MAXCHARS, EMBED_MODEL, QUERY_PREFIX
 
 _LOOPBACK = frozenset({"127.0.0.1", "localhost", "::1"})
+# No-proxy opener: even a loopback URL could be routed off-box via HTTP_PROXY/
+# http_proxy env. ProxyHandler({}) disables all proxies so fact text never leaves
+# the host (residency).
+_NO_PROXY_OPENER = urllib.request.build_opener(urllib.request.ProxyHandler({}))
 
 _model = None
 _SERVICE_TIMEOUT = 30  # seconds; warm calls return in well under this
@@ -76,7 +80,7 @@ def _try_service(texts: list[str], kind: str) -> list[list[float]] | None:
         method="POST",
     )
     try:
-        with urllib.request.urlopen(req, timeout=_SERVICE_TIMEOUT) as resp:
+        with _NO_PROXY_OPENER.open(req, timeout=_SERVICE_TIMEOUT) as resp:
             vecs = json.loads(resp.read()).get("vectors")
         if isinstance(vecs, list) and len(vecs) == len(texts):
             return vecs

--- a/lib/coding_memory/embedder.py
+++ b/lib/coding_memory/embedder.py
@@ -1,12 +1,25 @@
-"""FastEmbed wrapper — server-side (jns) only. Imports fastembed lazily."""
+"""Embedding — server-side (jns) only.
+
+Two layers:
+  * ``_embed_local_*`` load the FastEmbed model in-process (the ~5s cold start on
+    first use). The warm embed service calls these directly.
+  * public ``embed_docs`` / ``embed_query`` try the warm localhost service first
+    (when ``CODING_MEMORY_EMBED_URL`` is set) and fall back to the in-process model
+    if the service is unreachable — so a coding-memory call never hard-depends on
+    the service being up.
+"""
 
 from __future__ import annotations
 
+import json
 import os
+import urllib.error
+import urllib.request
 
 from . import DOC_PREFIX, EMBED_BATCH, EMBED_MAXCHARS, EMBED_MODEL, QUERY_PREFIX
 
 _model = None
+_SERVICE_TIMEOUT = 30  # seconds; warm calls return in well under this
 
 
 def _get(cache_dir: str | None = None):
@@ -24,12 +37,52 @@ def _get(cache_dir: str | None = None):
     return _model
 
 
-def embed_docs(texts: list[str], cache_dir: str | None = None) -> list[list[float]]:
+# ---- in-process (model) path: also the warm-service worker + fallback ----
+
+
+def _embed_local_docs(
+    texts: list[str], cache_dir: str | None = None
+) -> list[list[float]]:
     m = _get(cache_dir)
     prepped = [DOC_PREFIX + (t or "")[:EMBED_MAXCHARS] for t in texts]
     return [[float(x) for x in v] for v in m.embed(prepped, batch_size=EMBED_BATCH)]
 
 
-def embed_query(text: str, cache_dir: str | None = None) -> list[float]:
+def _embed_local_query(text: str, cache_dir: str | None = None) -> list[float]:
     m = _get(cache_dir)
     return [float(x) for x in next(iter(m.embed([QUERY_PREFIX + text])))]
+
+
+# ---- warm-service path (opt-in via CODING_MEMORY_EMBED_URL) ----
+
+
+def _try_service(texts: list[str], kind: str) -> list[list[float]] | None:
+    """POST to the warm embed service; return vectors, or None to fall back."""
+    base = os.environ.get("CODING_MEMORY_EMBED_URL")
+    if not base:
+        return None
+    payload = json.dumps({"texts": texts, "kind": kind}).encode()
+    req = urllib.request.Request(
+        base.rstrip("/") + "/embed",
+        data=payload,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=_SERVICE_TIMEOUT) as resp:
+            vecs = json.loads(resp.read()).get("vectors")
+        if isinstance(vecs, list) and len(vecs) == len(texts):
+            return vecs
+        return None
+    except (urllib.error.URLError, OSError, ValueError, TimeoutError):
+        return None  # service down/slow/garbled -> caller falls back to local
+
+
+def embed_docs(texts: list[str], cache_dir: str | None = None) -> list[list[float]]:
+    vecs = _try_service(texts, "doc")
+    return vecs if vecs is not None else _embed_local_docs(texts, cache_dir)
+
+
+def embed_query(text: str, cache_dir: str | None = None) -> list[float]:
+    vecs = _try_service([text], "query")
+    return vecs[0] if vecs is not None else _embed_local_query(text, cache_dir)

--- a/lib/coding_memory/embedder.py
+++ b/lib/coding_memory/embedder.py
@@ -14,9 +14,12 @@ from __future__ import annotations
 import json
 import os
 import urllib.error
+import urllib.parse
 import urllib.request
 
 from . import DOC_PREFIX, EMBED_BATCH, EMBED_MAXCHARS, EMBED_MODEL, QUERY_PREFIX
+
+_LOOPBACK = frozenset({"127.0.0.1", "localhost", "::1"})
 
 _model = None
 _SERVICE_TIMEOUT = 30  # seconds; warm calls return in well under this
@@ -60,6 +63,10 @@ def _try_service(texts: list[str], kind: str) -> list[list[float]] | None:
     """POST to the warm embed service; return vectors, or None to fall back."""
     base = os.environ.get("CODING_MEMORY_EMBED_URL")
     if not base:
+        return None
+    # Residency: only ever POST memory text to a loopback service. A misconfigured
+    # (or hostile) non-local URL must never receive fact text — fall back to local.
+    if urllib.parse.urlparse(base).hostname not in _LOOPBACK:
         return None
     payload = json.dumps({"texts": texts, "kind": kind}).encode()
     req = urllib.request.Request(

--- a/lib/tests/test_coding_memory.py
+++ b/lib/tests/test_coding_memory.py
@@ -119,3 +119,11 @@ def test_embed_service_unreachable_returns_none(monkeypatch):
     # pointed at a dead port -> _try_service swallows the error and returns None
     monkeypatch.setenv("CODING_MEMORY_EMBED_URL", "http://127.0.0.1:1")
     assert E._try_service(["x"], "doc") is None
+
+
+def test_embed_service_non_loopback_refused(monkeypatch):
+    from coding_memory import embedder as E
+
+    # residency: a non-loopback URL must never receive fact text -> fall back local
+    monkeypatch.setenv("CODING_MEMORY_EMBED_URL", "http://example.com:8788")
+    assert E._try_service(["x"], "doc") is None

--- a/lib/tests/test_coding_memory.py
+++ b/lib/tests/test_coding_memory.py
@@ -104,3 +104,18 @@ def test_residency_rejects_path_outside_namespace_root(tmp_path):
 def test_residency_defaults_pass():
     out = C._sources_from_args(None)
     assert set(out) == {"agents", "buddy"}
+
+
+def test_embed_service_disabled_returns_none(monkeypatch):
+    from coding_memory import embedder as E
+
+    monkeypatch.delenv("CODING_MEMORY_EMBED_URL", raising=False)
+    assert E._try_service(["x"], "doc") is None  # no URL -> caller falls back to local
+
+
+def test_embed_service_unreachable_returns_none(monkeypatch):
+    from coding_memory import embedder as E
+
+    # pointed at a dead port -> _try_service swallows the error and returns None
+    monkeypatch.setenv("CODING_MEMORY_EMBED_URL", "http://127.0.0.1:1")
+    assert E._try_service(["x"], "doc") is None

--- a/ruff.toml
+++ b/ruff.toml
@@ -30,3 +30,6 @@ extend-select = ["E722", "BLE"]
 "claude-config/statusline.py" = ["BLE001"]
 "obsidian-agent/**" = ["BLE001"]
 "code-review/**" = ["BLE001"]
+# The warm embed service is a long-running localhost daemon on jns — a broad
+# catch in its request handler keeps one bad request from killing the service.
+"lib/coding_memory/embed_service.py" = ["BLE001"]


### PR DESCRIPTION
Localhost-only warm embedding service (stdlib HTTP) + CLI service-first/local-fallback. Validated on jns: warm 0.23s vs cold 1.69s, 127.0.0.1-only, fallback works. Loopback-only + no-proxy guards (Codex R1/R2). Codex R3: APPROVE. Closes #442