### PR TITLE
feat(coding-memory): doctor + cross-platform SessionStart maintenance

### DIFF
--- a/claude-config/hooks/coding_memory_maint.py
+++ b/claude-config/hooks/coding_memory_maint.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import os
 import subprocess
 import sys
-from datetime import datetime, timezone
+from datetime import datetime
 from pathlib import Path
 
 CONFIG = Path(os.path.expanduser("~/.coding_memory.env"))
@@ -27,18 +27,21 @@ def _config_ok(path: Path = CONFIG) -> bool:
     config doesn't point at the personal store (or has none) never runs maintenance."""
     if not path.exists():
         return False
-    txt = path.read_text(errors="replace")
-    return "CODING_MEMORY_SSH=" in txt or "DATABASE_URL=" in txt
+    for line in path.read_text(errors="replace").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        k, _, v = line.partition("=")
+        if k.strip() in ("CODING_MEMORY_SSH", "DATABASE_URL") and v.strip():
+            return True
+    return False
 
 
 def _due(stamp_path: Path, today: str) -> bool:
     if not stamp_path.exists():
         return True
-    d = (
-        datetime.fromtimestamp(stamp_path.stat().st_mtime, tz=timezone.utc)
-        .date()
-        .isoformat()
-    )
+    # local date (matches the user's wall clock; avoids a double-run at the UTC boundary)
+    d = datetime.fromtimestamp(stamp_path.stat().st_mtime).date().isoformat()
     return d != today
 
 
@@ -56,10 +59,12 @@ def maybe_run(
     stamp_path=STAMP, today=None, config_ok=None, spawn_fn=_spawn, wrapper=WRAPPER
 ) -> bool:
     """Spawn daily maintenance if configured + due. Returns True if it spawned."""
-    today = today or datetime.now(timezone.utc).date().isoformat()
+    today = today or datetime.now().date().isoformat()  # local date
     ok = _config_ok() if config_ok is None else config_ok
     if not ok or not _due(stamp_path, today):
         return False
+    if not (Path(wrapper).exists() and os.access(str(wrapper), os.X_OK)):
+        return False  # can't run it -> don't stamp, so we retry next session
     spawn_fn(wrapper)
     stamp_path.parent.mkdir(parents=True, exist_ok=True)
     stamp_path.touch()

--- a/claude-config/hooks/coding_memory_maint.py
+++ b/claude-config/hooks/coding_memory_maint.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""SessionStart hook: cross-platform daily coding-memory maintenance.
+
+Runs `ingest` + safe `doctor --prune-expired` at most once per day, in the
+BACKGROUND, ONLY where the personal store is configured (residency gate — work
+machines aren't). Never blocks or fails session start (fail-open). Works on
+macOS / WSL / Linux with no per-OS scheduler (cron/launchd/systemd).
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+CONFIG = Path(os.path.expanduser("~/.coding_memory.env"))
+STAMP = Path(os.path.expanduser("~/.claude/.coding-memory-maint-stamp"))
+WRAPPER = Path(
+    os.path.expanduser("~/agents/claude-config/scripts/coding-memory-maint.sh")
+)
+
+
+def _config_ok(path: Path = CONFIG) -> bool:
+    """Is the personal store configured here? Residency gate: a work machine whose
+    config doesn't point at the personal store (or has none) never runs maintenance."""
+    if not path.exists():
+        return False
+    txt = path.read_text(errors="replace")
+    return "CODING_MEMORY_SSH=" in txt or "DATABASE_URL=" in txt
+
+
+def _due(stamp_path: Path, today: str) -> bool:
+    if not stamp_path.exists():
+        return True
+    d = (
+        datetime.fromtimestamp(stamp_path.stat().st_mtime, tz=timezone.utc)
+        .date()
+        .isoformat()
+    )
+    return d != today
+
+
+def _spawn(wrapper: Path) -> None:
+    subprocess.Popen(  # detached, fully backgrounded; never waited on
+        ["/bin/bash", str(wrapper)],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        stdin=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+
+
+def maybe_run(
+    stamp_path=STAMP, today=None, config_ok=None, spawn_fn=_spawn, wrapper=WRAPPER
+) -> bool:
+    """Spawn daily maintenance if configured + due. Returns True if it spawned."""
+    today = today or datetime.now(timezone.utc).date().isoformat()
+    ok = _config_ok() if config_ok is None else config_ok
+    if not ok or not _due(stamp_path, today):
+        return False
+    spawn_fn(wrapper)
+    stamp_path.parent.mkdir(parents=True, exist_ok=True)
+    stamp_path.touch()
+    return True
+
+
+def main() -> int:
+    try:
+        maybe_run()
+    except Exception:  # fail-open: maintenance must never break session start
+        pass
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/claude-config/launchd/README.md
+++ b/claude-config/launchd/README.md
@@ -157,6 +157,12 @@ python3 ~/agents/claude-config/scripts/cost_report_weekly.py   # run once on dem
 
 ## Coding-memory ingest (`com.coding-memory-ingest`)
 
+> **Optional / macOS-only.** The canonical cross-platform maintenance is the
+> SessionStart hook `coding_memory_maint.py` (runs ingest + `doctor
+> --prune-expired` once/day, background, residency-gated, on macOS/WSL/Linux —
+> no scheduler needed). Use this launchd job only if you also want ingest to run
+> on macOS when you're *not* opening a Claude session.
+
 **Daily** (`StartInterval 86400`, `RunAtLoad` false). Keeps the personal
 coding-memory store on jns fresh without a manual `bin/coding-memory ingest`.
 Logic lives in

--- a/claude-config/scripts/coding-memory-maint.sh
+++ b/claude-config/scripts/coding-memory-maint.sh
@@ -1,17 +1,28 @@
 #!/usr/bin/env bash
 # Daily coding-memory maintenance, spawned detached by the SessionStart hook
 # (coding_memory_maint.py). Cross-platform (macOS/WSL/Linux). Personal store only
-# (residency enforced by the CLI). Runs the SAFE path: ingest (which prunes
-# deleted files on a clean scan) + doctor --prune-expired (TTL only). Never runs
-# the risky --prune-missing unattended.
+# (residency enforced by the CLI). Safe path: ingest (prunes deleted files on a
+# clean scan) + doctor --prune-expired (TTL only) — never --prune-missing unattended.
 set -uo pipefail
 REPO="$HOME/agents"
 LOG="$HOME/.claude/logs/coding-memory-maint.log"
+LOCK="$HOME/.claude/.coding-memory-maint.lock"   # mkdir lock: portable single-flight
 mkdir -p "$(dirname "$LOG")"
 ts() { date "+%Y-%m-%dT%H:%M:%S%z"; }
+
+# single-flight via atomic mkdir; steal a stale lock (>60m) so a hung run can't wedge
+# future runs forever. flock/timeout are unavailable on stock macOS, so avoid them.
+if ! mkdir "$LOCK" 2>/dev/null; then
+  if [ -n "$(find "$LOCK" -prune -mmin +60 2>/dev/null)" ]; then
+    rmdir "$LOCK" 2>/dev/null || rm -rf "$LOCK" 2>/dev/null
+    mkdir "$LOCK" 2>/dev/null || { echo "[$(ts)] lock contended; skip" >>"$LOG"; exit 0; }
+  else
+    echo "[$(ts)] another maint run holds the lock; skip" >>"$LOG"; exit 0
+  fi
+fi
+trap 'rmdir "$LOCK" 2>/dev/null || rm -rf "$LOCK" 2>/dev/null' EXIT
+
 echo "[$(ts)] maint start" >>"$LOG"
-"$REPO/bin/coding-memory" ingest >>"$LOG" 2>&1
-ing=$?
-"$REPO/bin/coding-memory" doctor --prune-expired >>"$LOG" 2>&1
-doc=$?
+"$REPO/bin/coding-memory" ingest >>"$LOG" 2>&1; ing=$?
+"$REPO/bin/coding-memory" doctor --prune-expired >>"$LOG" 2>&1; doc=$?
 echo "[$(ts)] maint done (ingest rc=$ing, doctor rc=$doc)" >>"$LOG"

--- a/claude-config/scripts/coding-memory-maint.sh
+++ b/claude-config/scripts/coding-memory-maint.sh
@@ -7,20 +7,24 @@ set -uo pipefail
 REPO="$HOME/agents"
 LOG="$HOME/.claude/logs/coding-memory-maint.log"
 LOCK="$HOME/.claude/.coding-memory-maint.lock"   # mkdir lock: portable single-flight
+TOKEN="$$.${RANDOM:-0}.$(date +%s)"              # this run's ownership token
 mkdir -p "$(dirname "$LOG")"
 ts() { date "+%Y-%m-%dT%H:%M:%S%z"; }
 
-# single-flight via atomic mkdir; steal a stale lock (>60m) so a hung run can't wedge
-# future runs forever. flock/timeout are unavailable on stock macOS, so avoid them.
+# Acquire: atomic mkdir; steal only a STALE lock (>60m) so a hung run can't wedge
+# future runs forever. flock/timeout aren't on stock macOS, so we avoid them.
 if ! mkdir "$LOCK" 2>/dev/null; then
   if [ -n "$(find "$LOCK" -prune -mmin +60 2>/dev/null)" ]; then
-    rmdir "$LOCK" 2>/dev/null || rm -rf "$LOCK" 2>/dev/null
+    rm -rf "$LOCK" 2>/dev/null
     mkdir "$LOCK" 2>/dev/null || { echo "[$(ts)] lock contended; skip" >>"$LOG"; exit 0; }
   else
     echo "[$(ts)] another maint run holds the lock; skip" >>"$LOG"; exit 0
   fi
 fi
-trap 'rmdir "$LOCK" 2>/dev/null || rm -rf "$LOCK" 2>/dev/null' EXIT
+printf '%s' "$TOKEN" >"$LOCK/owner"
+# Ownership-safe release: only remove the lock if WE still own it (a run that stole
+# our stale lock writes its own token, so our trap won't delete its lock).
+trap '[ "$(cat "$LOCK/owner" 2>/dev/null)" = "$TOKEN" ] && rm -rf "$LOCK" 2>/dev/null' EXIT
 
 echo "[$(ts)] maint start" >>"$LOG"
 "$REPO/bin/coding-memory" ingest >>"$LOG" 2>&1; ing=$?

--- a/claude-config/scripts/coding-memory-maint.sh
+++ b/claude-config/scripts/coding-memory-maint.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Daily coding-memory maintenance, spawned detached by the SessionStart hook
+# (coding_memory_maint.py). Cross-platform (macOS/WSL/Linux). Personal store only
+# (residency enforced by the CLI). Runs the SAFE path: ingest (which prunes
+# deleted files on a clean scan) + doctor --prune-expired (TTL only). Never runs
+# the risky --prune-missing unattended.
+set -uo pipefail
+REPO="$HOME/agents"
+LOG="$HOME/.claude/logs/coding-memory-maint.log"
+mkdir -p "$(dirname "$LOG")"
+ts() { date "+%Y-%m-%dT%H:%M:%S%z"; }
+echo "[$(ts)] maint start" >>"$LOG"
+"$REPO/bin/coding-memory" ingest >>"$LOG" 2>&1
+ing=$?
+"$REPO/bin/coding-memory" doctor --prune-expired >>"$LOG" 2>&1
+doc=$?
+echo "[$(ts)] maint done (ingest rc=$ing, doctor rc=$doc)" >>"$LOG"

--- a/claude-config/settings.json
+++ b/claude-config/settings.json
@@ -56,7 +56,6 @@
     ],
     "defaultMode": "auto"
   },
-  "model": "claude-fable-5[1m]",
   "hooks": {
     "PreCompact": [
       {
@@ -88,6 +87,10 @@
           {
             "type": "command",
             "command": "python3 ~/agents/claude-config/scripts/cost_telemetry_freshness.py --hook"
+          },
+          {
+            "type": "command",
+            "command": "python3 ~/.claude/hooks/coding_memory_maint.py"
           }
         ]
       }

--- a/claude-config/tests/test_coding_memory_maint.py
+++ b/claude-config/tests/test_coding_memory_maint.py
@@ -1,0 +1,55 @@
+"""Tests for the cross-platform coding-memory maintenance SessionStart guard."""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "hooks"))
+
+import coding_memory_maint as M  # noqa: E402
+
+
+def test_skips_when_not_configured(tmp_path):
+    calls = []
+    ran = M.maybe_run(
+        stamp_path=tmp_path / "s",
+        today="2026-06-15",
+        config_ok=False,
+        spawn_fn=lambda w: calls.append(w),
+    )
+    assert ran is False and calls == []  # residency gate: never run unconfigured
+
+
+def test_runs_when_due(tmp_path):
+    calls = []
+    stamp = tmp_path / "s"
+    ran = M.maybe_run(
+        stamp_path=stamp,
+        today="2026-06-15",
+        config_ok=True,
+        spawn_fn=lambda w: calls.append(w),
+    )
+    assert ran is True and len(calls) == 1 and stamp.exists()
+
+
+def test_skips_when_already_run_today(tmp_path):
+    stamp = tmp_path / "s"
+    stamp.touch()  # mtime = now -> today
+    today = datetime.now(timezone.utc).date().isoformat()
+    calls = []
+    ran = M.maybe_run(
+        stamp_path=stamp,
+        today=today,
+        config_ok=True,
+        spawn_fn=lambda w: calls.append(w),
+    )
+    assert ran is False and calls == []  # at most once per day
+
+
+def test_config_ok_detects_personal_store(tmp_path):
+    p = tmp_path / "cfg"
+    assert M._config_ok(p) is False
+    p.write_text("CODING_MEMORY_SSH=jns-server\n")
+    assert M._config_ok(p) is True

--- a/claude-config/tests/test_coding_memory_maint.py
+++ b/claude-config/tests/test_coding_memory_maint.py
@@ -3,12 +3,19 @@
 from __future__ import annotations
 
 import sys
-from datetime import datetime, timezone
+from datetime import datetime
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "hooks"))
 
 import coding_memory_maint as M  # noqa: E402
+
+
+def _exe_wrapper(tmp_path):
+    w = tmp_path / "w.sh"
+    w.write_text("#!/bin/bash\n")
+    w.chmod(0o755)
+    return w
 
 
 def test_skips_when_not_configured(tmp_path):
@@ -18,6 +25,7 @@ def test_skips_when_not_configured(tmp_path):
         today="2026-06-15",
         config_ok=False,
         spawn_fn=lambda w: calls.append(w),
+        wrapper=_exe_wrapper(tmp_path),
     )
     assert ran is False and calls == []  # residency gate: never run unconfigured
 
@@ -30,22 +38,37 @@ def test_runs_when_due(tmp_path):
         today="2026-06-15",
         config_ok=True,
         spawn_fn=lambda w: calls.append(w),
+        wrapper=_exe_wrapper(tmp_path),
     )
     assert ran is True and len(calls) == 1 and stamp.exists()
 
 
 def test_skips_when_already_run_today(tmp_path):
     stamp = tmp_path / "s"
-    stamp.touch()  # mtime = now -> today
-    today = datetime.now(timezone.utc).date().isoformat()
+    stamp.touch()  # mtime = now -> today (local)
+    today = datetime.now().date().isoformat()
     calls = []
     ran = M.maybe_run(
         stamp_path=stamp,
         today=today,
         config_ok=True,
         spawn_fn=lambda w: calls.append(w),
+        wrapper=_exe_wrapper(tmp_path),
     )
     assert ran is False and calls == []  # at most once per day
+
+
+def test_skips_when_wrapper_missing(tmp_path):
+    calls = []
+    ran = M.maybe_run(
+        stamp_path=tmp_path / "s",
+        today="2026-06-15",
+        config_ok=True,
+        spawn_fn=lambda w: calls.append(w),
+        wrapper=tmp_path / "does-not-exist.sh",
+    )
+    # don't run (or stamp) if we can't execute it -> retry next session
+    assert ran is False and calls == [] and not (tmp_path / "s").exists()
 
 
 def test_config_ok_detects_personal_store(tmp_path):
@@ -53,3 +76,9 @@ def test_config_ok_detects_personal_store(tmp_path):
     assert M._config_ok(p) is False
     p.write_text("CODING_MEMORY_SSH=jns-server\n")
     assert M._config_ok(p) is True
+
+
+def test_config_ok_ignores_comments_and_empty(tmp_path):
+    p = tmp_path / "cfg"
+    p.write_text("# CODING_MEMORY_SSH=jns-server\nDATABASE_URL=\n")
+    assert M._config_ok(p) is False  # commented + empty value must not enable

--- a/lib/coding_memory/cli.py
+++ b/lib/coding_memory/cli.py
@@ -226,6 +226,81 @@ def cmd_stats(args, cfg):
     return 0
 
 
+# ---------- doctor ----------
+
+
+def cmd_doctor(args, cfg):
+    # client gathers the laptop's filesystem view (which source files still exist)
+    # so jns can detect drift; only cleanly-scanned namespaces are prune-eligible.
+    sources = _sources_from_args(args.source)
+    parsed = P.build_records(sources)
+    existing: dict = {}
+    for r in parsed["records"]:
+        existing.setdefault(r["namespace"], []).append(r["source_path"])
+    payload = json.dumps(
+        {
+            "existing": existing,
+            "scanned": parsed["prune_namespaces"],
+            "prune_expired": args.prune_expired,
+            "prune_missing": args.prune_missing,
+            "json": args.json,
+        }
+    )
+    if is_remote(cfg):
+        return _ssh(cfg, ["_doctor"], stdin_data=payload)
+    return _doctor(payload, cfg)
+
+
+def _doctor(payload, cfg):
+    from . import store
+
+    env = json.loads(payload)
+    existing = env.get("existing", {})
+    scanned = [n for n in env.get("scanned", []) if n in ALLOWED_NAMESPACES]
+    conn = store.connect(cfg["DATABASE_URL"])
+    try:
+        store.ensure_schema(conn)
+        expired = store.expired_rows(conn)
+        dups = store.duplicate_names(conn)
+        drift = {ns: store.drift_rows(conn, ns, existing.get(ns, [])) for ns in scanned}
+        pruned_expired = store.prune_expired(conn) if env.get("prune_expired") else 0
+        pruned_missing = 0
+        if env.get("prune_missing"):
+            for ns in scanned:  # scanned => root present, fully read, >=1 file
+                keep = existing.get(ns, [])
+                if keep:
+                    pruned_missing += store.delete_missing(conn, ns, keep)
+        conn.commit()
+    finally:
+        conn.close()
+
+    report = {
+        "expired": expired,
+        "duplicates": dups,
+        "drift": {k: v for k, v in drift.items() if v},
+        "scanned_namespaces": scanned,
+        "pruned_expired": pruned_expired,
+        "pruned_missing": pruned_missing,
+    }
+    if env.get("json"):
+        print(json.dumps(report, indent=2))
+        return 0
+    drift_total = sum(len(v) for v in report["drift"].values())
+    print(
+        f"expired: {len(expired)}   drift: {drift_total}   duplicate-names: {len(dups)}"
+    )
+    for e in expired:
+        print(f"  EXPIRED [{e['namespace']}] {e['name']} (expires {e['expires']})")
+    for ns, rows in report["drift"].items():
+        for d in rows:
+            print(f"  DRIFT   [{ns}] {d['name']} — source gone: {d['source_path']}")
+    for d in dups:
+        print(f"  DUP     [{d['namespace']}] {d['name']} x{d['count']}")
+    if env.get("prune_expired") or env.get("prune_missing"):
+        print(f"pruned: expired={pruned_expired} missing={pruned_missing}")
+    return 0
+
+
 def build_parser():
     p = argparse.ArgumentParser(
         prog="coding-memory", description="Personal coding-memory store (jns)."
@@ -250,6 +325,22 @@ def build_parser():
 
     sub.add_parser("stats", help="row counts per namespace")
 
+    d = sub.add_parser(
+        "doctor", help="report freshness/expiry/drift/duplicates (+ optional prune)"
+    )
+    d.add_argument("--source", action="append")
+    d.add_argument(
+        "--prune-expired",
+        action="store_true",
+        help="delete rows past their expires date",
+    )
+    d.add_argument(
+        "--prune-missing",
+        action="store_true",
+        help="delete drift rows in cleanly-scanned namespaces only",
+    )
+    d.add_argument("--json", action="store_true")
+
     # internal (server-side on jns)
     sub.add_parser("_embed-store")
     qq = sub.add_parser("_query")
@@ -258,6 +349,7 @@ def build_parser():
     qq.add_argument("--mode", choices=["hybrid", "vector", "fts"], default="hybrid")
     qq.add_argument("--namespace", action="append")
     sub.add_parser("_stats")
+    sub.add_parser("_doctor")
     return p
 
 
@@ -270,12 +362,16 @@ def main(argv=None):
         return cmd_query(args, cfg)
     if args.cmd == "stats":
         return cmd_stats(args, cfg)
+    if args.cmd == "doctor":
+        return cmd_doctor(args, cfg)
     if args.cmd == "_embed-store":
         return _embed_store(sys.stdin.read(), cfg)
     if args.cmd == "_query":
         return _query(" ".join(args.text).strip(), args, cfg)
     if args.cmd == "_stats":
         return cmd_stats(args, cfg)
+    if args.cmd == "_doctor":
+        return _doctor(sys.stdin.read(), cfg)
     raise SystemExit(2)
 
 

--- a/lib/coding_memory/cli.py
+++ b/lib/coding_memory/cli.py
@@ -96,6 +96,7 @@ def cmd_ingest(args, cfg):
         for r in records:
             print(f"  [{r['namespace']}] {r['name']}  ({r['source_path']})")
         return 0
+    parsed["origin"] = P.ORIGIN
     payload = json.dumps(parsed)
     if is_remote(cfg):
         return _ssh(cfg, ["_embed-store"], stdin_data=payload)
@@ -113,6 +114,7 @@ def _embed_store(payload, cfg):
     if isinstance(env, list):  # back-compat: bare record list
         env = {"records": env, "prune_namespaces": []}
     incoming = env.get("records", [])
+    origin = env.get("origin") or "unknown"
     # residency: server-side allowlist — never store a non-personal namespace,
     # even from a misconfigured client.
     records = [r for r in incoming if r.get("namespace") in ALLOWED_NAMESPACES]
@@ -124,7 +126,8 @@ def _embed_store(payload, cfg):
     try:
         store.ensure_schema(conn)
         namespaces = sorted({r["namespace"] for r in records})
-        existing = store.existing_hashes(conn, namespaces)
+        store.claim_unowned(conn, origin, namespaces)  # one-time: adopt legacy rows
+        existing = store.existing_hashes(conn, origin, namespaces)
         changed = [
             r
             for r in records
@@ -136,14 +139,14 @@ def _embed_store(payload, cfg):
                 [P.embed_text(r) for r in batch], cache_dir=cache
             )
             for r, v in zip(batch, vecs):
-                store.upsert(conn, r, v)
+                store.upsert(conn, r, v, origin)
             conn.commit()
-        # prune ONLY namespaces the client certified as fully + cleanly scanned
+        # prune ONLY this machine's rows, in namespaces the client cleanly scanned
         pruned = 0
         for ns in prune_ns:
             keep = [r["source_path"] for r in records if r["namespace"] == ns]
             if keep:
-                pruned += store.delete_missing(conn, ns, keep)
+                pruned += store.delete_missing(conn, origin, ns, keep)
         conn.commit()
         report = {
             "parsed": len(incoming),
@@ -232,6 +235,13 @@ def cmd_stats(args, cfg):
 def cmd_doctor(args, cfg):
     # client gathers the laptop's filesystem view (which source files still exist)
     # so jns can detect drift; only cleanly-scanned namespaces are prune-eligible.
+    if args.prune_missing and args.source:
+        # a custom --source can be a subdir of the canonical root; pruning "missing"
+        # against it would wipe the rest of the namespace. Only the default roots
+        # (full scan) may drive --prune-missing.
+        raise SystemExit(
+            "--prune-missing cannot be combined with --source (use default roots)"
+        )
     sources = _sources_from_args(args.source)
     parsed = P.build_records(sources)
     existing: dict = {}
@@ -239,6 +249,7 @@ def cmd_doctor(args, cfg):
         existing.setdefault(r["namespace"], []).append(r["source_path"])
     payload = json.dumps(
         {
+            "origin": P.ORIGIN,
             "existing": existing,
             "scanned": parsed["prune_namespaces"],
             "prune_expired": args.prune_expired,
@@ -251,25 +262,37 @@ def cmd_doctor(args, cfg):
     return _doctor(payload, cfg)
 
 
+def _sanitize(s: str) -> str:
+    # strip control chars so DB-derived names/paths can't injure the terminal/log
+    return "".join(ch if ch.isprintable() else "?" for ch in str(s or ""))
+
+
 def _doctor(payload, cfg):
     from . import store
 
     env = json.loads(payload)
+    origin = env.get("origin") or "unknown"
     existing = env.get("existing", {})
     scanned = [n for n in env.get("scanned", []) if n in ALLOWED_NAMESPACES]
+    allowed = sorted(ALLOWED_NAMESPACES)
     conn = store.connect(cfg["DATABASE_URL"])
     try:
         store.ensure_schema(conn)
-        expired = store.expired_rows(conn)
+        expired = store.expired_rows(conn, allowed)
         dups = store.duplicate_names(conn)
-        drift = {ns: store.drift_rows(conn, ns, existing.get(ns, [])) for ns in scanned}
-        pruned_expired = store.prune_expired(conn) if env.get("prune_expired") else 0
+        drift = {
+            ns: store.drift_rows(conn, origin, ns, existing.get(ns, []))
+            for ns in scanned
+        }
+        pruned_expired = (
+            store.prune_expired(conn, allowed) if env.get("prune_expired") else 0
+        )
         pruned_missing = 0
         if env.get("prune_missing"):
             for ns in scanned:  # scanned => root present, fully read, >=1 file
                 keep = existing.get(ns, [])
                 if keep:
-                    pruned_missing += store.delete_missing(conn, ns, keep)
+                    pruned_missing += store.delete_missing(conn, origin, ns, keep)
         conn.commit()
     finally:
         conn.close()
@@ -290,12 +313,16 @@ def _doctor(payload, cfg):
         f"expired: {len(expired)}   drift: {drift_total}   duplicate-names: {len(dups)}"
     )
     for e in expired:
-        print(f"  EXPIRED [{e['namespace']}] {e['name']} (expires {e['expires']})")
+        print(
+            f"  EXPIRED [{e['namespace']}] {_sanitize(e['name'])} (expires {e['expires']})"
+        )
     for ns, rows in report["drift"].items():
         for d in rows:
-            print(f"  DRIFT   [{ns}] {d['name']} — source gone: {d['source_path']}")
+            print(
+                f"  DRIFT   [{ns}] {_sanitize(d['name'])} — source gone: {_sanitize(d['source_path'])}"
+            )
     for d in dups:
-        print(f"  DUP     [{d['namespace']}] {d['name']} x{d['count']}")
+        print(f"  DUP     [{d['namespace']}] {_sanitize(d['name'])} x{d['count']}")
     if env.get("prune_expired") or env.get("prune_missing"):
         print(f"pruned: expired={pruned_expired} missing={pruned_missing}")
     return 0

--- a/lib/coding_memory/parse.py
+++ b/lib/coding_memory/parse.py
@@ -4,9 +4,12 @@ from __future__ import annotations
 
 import hashlib
 import re
+import socket
 from pathlib import Path
 
 from . import SKIP_DIRS, SKIP_NAMES
+
+ORIGIN = socket.gethostname()  # this machine — per-origin identity in the shared store
 
 try:
     import yaml
@@ -70,6 +73,7 @@ def parse_markdown(raw: str, fallback_name: str = "") -> dict:
 def _record(ns: str, path: str, raw: str) -> dict:
     meta = parse_markdown(raw, fallback_name=Path(path).stem)
     return {
+        "origin": ORIGIN,
         "namespace": ns,
         "source_path": path,
         "content_hash": content_hash(raw),

--- a/lib/coding_memory/store.py
+++ b/lib/coding_memory/store.py
@@ -74,6 +74,14 @@ def claim_unowned(conn, origin: str, namespaces) -> int:
     """One-time migration: assign legacy rows (origin IS NULL) in the ingested
     namespaces to the ingesting machine, so they participate in per-origin identity."""
     with conn.cursor() as c:
+        # First drop any legacy NULL row that already has a claimed counterpart for
+        # this origin — otherwise the UPDATE would violate (origin,namespace,source_path).
+        c.execute(
+            "DELETE FROM memory_fact m WHERE m.origin IS NULL AND m.namespace = ANY(%s) "
+            "AND EXISTS (SELECT 1 FROM memory_fact o "
+            "WHERE o.origin=%s AND o.namespace=m.namespace AND o.source_path=m.source_path)",
+            (list(namespaces), origin),
+        )
         c.execute(
             "UPDATE memory_fact SET origin=%s WHERE origin IS NULL AND namespace = ANY(%s)",
             (origin, list(namespaces)),
@@ -131,7 +139,7 @@ def stats(conn) -> list[tuple]:
         return c.fetchall()
 
 
-_COLS = "namespace,name,type,summary,source_path"
+_COLS = "origin,namespace,name,type,summary,source_path"
 
 
 def _rows_to_dicts(rows):
@@ -139,12 +147,13 @@ def _rows_to_dicts(rows):
     for r in rows:
         out.append(
             {
-                "namespace": r[0],
-                "name": r[1],
-                "type": r[2],
-                "summary": r[3],
-                "source_path": r[4],
-                "score": float(r[5]),
+                "origin": r[0],
+                "namespace": r[1],
+                "name": r[2],
+                "type": r[3],
+                "summary": r[4],
+                "source_path": r[5],
+                "score": float(r[6]),
             }
         )
     return out
@@ -193,7 +202,7 @@ def search(conn, qvec, text=None, k=8, namespaces=None, mode="hybrid"):
         _fts(conn, text, over, namespaces),
     ):
         for rank, r in enumerate(rows):
-            key = (r["namespace"], r["source_path"])
+            key = (r["origin"], r["namespace"], r["source_path"])  # per-origin distinct
             slot = fused.setdefault(key, {"rec": r, "rrf": 0.0})
             slot["rrf"] += 1.0 / (60 + rank)
     merged = sorted(fused.values(), key=lambda s: s["rrf"], reverse=True)[:k]

--- a/lib/coding_memory/store.py
+++ b/lib/coding_memory/store.py
@@ -9,6 +9,7 @@ from . import EMBED_DIM
 _DDL = """
 CREATE TABLE IF NOT EXISTS memory_fact (
   id           BIGSERIAL PRIMARY KEY,
+  origin       TEXT,
   namespace    TEXT NOT NULL,
   name         TEXT,
   type         TEXT,
@@ -46,12 +47,16 @@ def _vlit(vec) -> str:
 def ensure_schema(conn) -> None:
     with conn.cursor() as c:
         c.execute(_DDL)
-        # identity is (namespace, source_path); drop the original content_hash unique
+        # migrate to per-origin identity (origin, namespace, source_path) so multiple
+        # machines can share one store without clobbering each other's rows.
+        c.execute("ALTER TABLE memory_fact ADD COLUMN IF NOT EXISTS origin TEXT;")
         c.execute(
             "ALTER TABLE memory_fact DROP CONSTRAINT IF EXISTS memory_fact_namespace_content_hash_key;"
         )
+        c.execute("DROP INDEX IF EXISTS ux_memfact_ns_path;")
         c.execute(
-            "CREATE UNIQUE INDEX IF NOT EXISTS ux_memfact_ns_path ON memory_fact(namespace, source_path);"
+            "CREATE UNIQUE INDEX IF NOT EXISTS ux_memfact_origin_ns_path "
+            "ON memory_fact(origin, namespace, source_path);"
         )
         c.execute(
             "CREATE INDEX IF NOT EXISTS idx_memfact_ns ON memory_fact(namespace);"
@@ -65,26 +70,39 @@ def ensure_schema(conn) -> None:
     conn.commit()
 
 
-def existing_hashes(conn, namespaces) -> dict:
+def claim_unowned(conn, origin: str, namespaces) -> int:
+    """One-time migration: assign legacy rows (origin IS NULL) in the ingested
+    namespaces to the ingesting machine, so they participate in per-origin identity."""
     with conn.cursor() as c:
         c.execute(
-            "SELECT namespace, source_path, content_hash FROM memory_fact WHERE namespace = ANY(%s)",
-            (list(namespaces),),
+            "UPDATE memory_fact SET origin=%s WHERE origin IS NULL AND namespace = ANY(%s)",
+            (origin, list(namespaces)),
+        )
+        return c.rowcount
+
+
+def existing_hashes(conn, origin: str, namespaces) -> dict:
+    with conn.cursor() as c:
+        c.execute(
+            "SELECT namespace, source_path, content_hash FROM memory_fact "
+            "WHERE origin=%s AND namespace = ANY(%s)",
+            (origin, list(namespaces)),
         )
         return {(r[0], r[1]): r[2] for r in c.fetchall()}
 
 
-def upsert(conn, rec: dict, embedding) -> None:
+def upsert(conn, rec: dict, embedding, origin: str) -> None:
     params = dict(rec)
+    params["origin"] = origin
     params["emb"] = _vlit(embedding)
     params["expires"] = rec.get("expires") or ""
     sql = """
     INSERT INTO memory_fact
-      (namespace,name,type,summary,body,source_path,durability,expires,content_hash,embedding,updated_at)
+      (origin,namespace,name,type,summary,body,source_path,durability,expires,content_hash,embedding,updated_at)
     VALUES
-      (%(namespace)s,%(name)s,%(type)s,%(summary)s,%(body)s,%(source_path)s,%(durability)s,
+      (%(origin)s,%(namespace)s,%(name)s,%(type)s,%(summary)s,%(body)s,%(source_path)s,%(durability)s,
        NULLIF(%(expires)s,'')::date,%(content_hash)s,%(emb)s::vector,now())
-    ON CONFLICT (namespace, source_path) DO UPDATE SET
+    ON CONFLICT (origin, namespace, source_path) DO UPDATE SET
       name=EXCLUDED.name, type=EXCLUDED.type, summary=EXCLUDED.summary, body=EXCLUDED.body,
       durability=EXCLUDED.durability, expires=EXCLUDED.expires, content_hash=EXCLUDED.content_hash,
       embedding=EXCLUDED.embedding, updated_at=now();
@@ -93,12 +111,14 @@ def upsert(conn, rec: dict, embedding) -> None:
         c.execute(sql, params)
 
 
-def delete_missing(conn, namespace: str, keep_paths: list[str]) -> int:
-    """Remove rows for a namespace whose source file no longer exists."""
+def delete_missing(conn, origin: str, namespace: str, keep_paths: list[str]) -> int:
+    """Remove THIS machine's rows for a namespace whose source file no longer exists.
+    Scoped to origin so one machine never prunes another machine's rows."""
     with conn.cursor() as c:
         c.execute(
-            "DELETE FROM memory_fact WHERE namespace=%s AND NOT (source_path = ANY(%s))",
-            (namespace, keep_paths),
+            "DELETE FROM memory_fact "
+            "WHERE origin=%s AND namespace=%s AND NOT (source_path = ANY(%s))",
+            (origin, namespace, keep_paths),
         )
         return c.rowcount
 
@@ -220,17 +240,18 @@ def duplicate_names(conn):
         ]
 
 
-def drift_rows(conn, namespace, existing_paths):
-    """Rows in `namespace` whose source_path is NOT in the caller's existing set.
-
-    Caller must have CLEANLY scanned this namespace (root present, fully readable,
-    >=1 file) — otherwise an incomplete scan would mislabel live rows as drift.
+def drift_rows(conn, origin, namespace, existing_paths):
+    """THIS machine's rows in `namespace` whose source_path is NOT in the caller's
+    existing set. Scoped to origin (one machine's scan can't mislabel another's
+    rows). Caller must have CLEANLY scanned this namespace (root present, fully
+    readable, >=1 file), else an incomplete scan would mislabel live rows as drift.
     """
     with conn.cursor() as c:
         c.execute(
             "SELECT source_path, name FROM memory_fact "
-            "WHERE namespace = %s AND NOT (source_path = ANY(%s)) ORDER BY source_path",
-            (namespace, list(existing_paths)),
+            "WHERE origin=%s AND namespace=%s AND NOT (source_path = ANY(%s)) "
+            "ORDER BY source_path",
+            (origin, namespace, list(existing_paths)),
         )
         return [{"source_path": r[0], "name": r[1]} for r in c.fetchall()]
 

--- a/lib/coding_memory/store.py
+++ b/lib/coding_memory/store.py
@@ -183,3 +183,64 @@ def search(conn, qvec, text=None, k=8, namespaces=None, mode="hybrid"):
         rec["score"] = round(s["rrf"], 5)
         out.append(rec)
     return out
+
+
+# ---- doctor: freshness / expiry / drift / duplicates ----
+
+
+def expired_rows(conn, namespaces=None):
+    q = (
+        "SELECT namespace, name, source_path, expires FROM memory_fact "
+        "WHERE expires IS NOT NULL AND expires < CURRENT_DATE"
+    )
+    params: tuple = ()
+    if namespaces:
+        q += " AND namespace = ANY(%s)"
+        params = (list(namespaces),)
+    q += " ORDER BY namespace, expires"
+    with conn.cursor() as c:
+        c.execute(q, params)
+        return [
+            {"namespace": r[0], "name": r[1], "source_path": r[2], "expires": str(r[3])}
+            for r in c.fetchall()
+        ]
+
+
+def duplicate_names(conn):
+    q = (
+        "SELECT namespace, name, count(*), array_agg(source_path) "
+        "FROM memory_fact GROUP BY namespace, name HAVING count(*) > 1 "
+        "ORDER BY namespace, name"
+    )
+    with conn.cursor() as c:
+        c.execute(q)
+        return [
+            {"namespace": r[0], "name": r[1], "count": r[2], "paths": r[3]}
+            for r in c.fetchall()
+        ]
+
+
+def drift_rows(conn, namespace, existing_paths):
+    """Rows in `namespace` whose source_path is NOT in the caller's existing set.
+
+    Caller must have CLEANLY scanned this namespace (root present, fully readable,
+    >=1 file) — otherwise an incomplete scan would mislabel live rows as drift.
+    """
+    with conn.cursor() as c:
+        c.execute(
+            "SELECT source_path, name FROM memory_fact "
+            "WHERE namespace = %s AND NOT (source_path = ANY(%s)) ORDER BY source_path",
+            (namespace, list(existing_paths)),
+        )
+        return [{"source_path": r[0], "name": r[1]} for r in c.fetchall()]
+
+
+def prune_expired(conn, namespaces=None) -> int:
+    q = "DELETE FROM memory_fact WHERE expires IS NOT NULL AND expires < CURRENT_DATE"
+    params: tuple = ()
+    if namespaces:
+        q += " AND namespace = ANY(%s)"
+        params = (list(namespaces),)
+    with conn.cursor() as c:
+        c.execute(q, params)
+        return c.rowcount


### PR DESCRIPTION
doctor (expired/drift/duplicates + scoped prune) and a cross-platform (macOS/WSL/Linux) SessionStart maintenance guard (ingest + doctor --prune-expired, once/day, background, residency-gated, fail-open). Adds per-origin identity so multiple machines share one store without clobbering (recall stays cross-origin = combined memory). Codex R1→R2→R3: APPROVE. Closes #445