### PR TITLE
test(coding-memory): recall-quality eval — fixed query/fact pairs

### DIFF
--- a/lib/coding_memory/cli.py
+++ b/lib/coding_memory/cli.py
@@ -328,6 +328,41 @@ def _doctor(payload, cfg):
     return 0
 
 
+# ---------- eval (recall quality) ----------
+
+
+def cmd_eval(args, cfg):
+    if is_remote(cfg):
+        return _ssh(cfg, ["_eval"] + (["--json"] if args.json else []))
+    return _eval_run(args.json, cfg)
+
+
+def _eval_run(as_json, cfg):
+    from . import embedder, eval_recall, store
+
+    cache = cfg.get("FASTEMBED_CACHE")
+    conn = store.connect(cfg["DATABASE_URL"])
+    try:
+
+        def search_fn(query, mode, k):
+            qvec = embedder.embed_query(query, cache_dir=cache)
+            return store.search(conn, qvec, text=query, k=k, mode=mode)
+
+        result = eval_recall.score(search_fn)
+    finally:
+        conn.close()
+    if as_json:
+        print(json.dumps(result))
+        return 0
+    n = result["n"]
+    print(f"recall eval over {n} pairs   (hit@k)")
+    print(f"{'mode':<8}{'@1':>6}{'@3':>6}{'@5':>6}")
+    for m in eval_recall.MODES:
+        h = result[m]
+        print(f"{m:<8}{h[1]:>6}{h[3]:>6}{h[5]:>6}")
+    return 0
+
+
 def build_parser():
     p = argparse.ArgumentParser(
         prog="coding-memory", description="Personal coding-memory store (jns)."
@@ -368,6 +403,11 @@ def build_parser():
     )
     d.add_argument("--json", action="store_true")
 
+    ev = sub.add_parser(
+        "eval", help="recall-quality scoreboard (fixed query/fact pairs)"
+    )
+    ev.add_argument("--json", action="store_true")
+
     # internal (server-side on jns)
     sub.add_parser("_embed-store")
     qq = sub.add_parser("_query")
@@ -377,6 +417,8 @@ def build_parser():
     qq.add_argument("--namespace", action="append")
     sub.add_parser("_stats")
     sub.add_parser("_doctor")
+    _ev = sub.add_parser("_eval")
+    _ev.add_argument("--json", action="store_true")
     return p
 
 
@@ -391,6 +433,8 @@ def main(argv=None):
         return cmd_stats(args, cfg)
     if args.cmd == "doctor":
         return cmd_doctor(args, cfg)
+    if args.cmd == "eval":
+        return cmd_eval(args, cfg)
     if args.cmd == "_embed-store":
         return _embed_store(sys.stdin.read(), cfg)
     if args.cmd == "_query":
@@ -399,6 +443,8 @@ def main(argv=None):
         return cmd_stats(args, cfg)
     if args.cmd == "_doctor":
         return _doctor(sys.stdin.read(), cfg)
+    if args.cmd == "_eval":
+        return _eval_run(args.json, cfg)
     raise SystemExit(2)
 
 

--- a/lib/coding_memory/eval_recall.py
+++ b/lib/coding_memory/eval_recall.py
@@ -1,0 +1,61 @@
+"""Recall-quality eval: fixed (query -> expected fact) pairs to score recall.
+
+NOT a CI gate (needs the live store + model). Run `coding-memory eval`. The
+queries deliberately share few keywords with their target fact, so this measures
+SEMANTIC recall (not literal matching) and catches regressions when the embedding
+model or ranking changes. Facts are identified by source-file stem (stable across
+name edits).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+EVAL_PAIRS = [
+    (
+        "safely remove a database table without breaking callers",
+        "feedback_spec_grep_every_sql_site",
+    ),
+    (
+        "run code review in the foreground instead of the background",
+        "feedback_codex_always_inline",
+    ),
+    (
+        "a test flag that hides downstream failures",
+        "feedback_pytest_no_dash_x_for_validation",
+    ),
+    (
+        "settings reject an unknown environment variable",
+        "gotcha-pydantic-settings-extra-forbid",
+    ),
+    (
+        "when retiring a system audit the storage layer not just the API",
+        "retirement_audit_method",
+    ),
+    (
+        "a background pipeline swallowed an exception silently",
+        "feedback_silent_fire_and_forget_pipelines_must_be_audited_at_boundaries",
+    ),
+    ("where does the shared coding memory store live", "coding_memory_store_jns"),
+    ("keep telemetry shards out of the git repository", "telemetry_shards_local_only"),
+    (
+        "verify the real code before locking a spec",
+        "feedback_spec_code_reality_manifest_first",
+    ),
+]
+MODES = ("hybrid", "vector", "fts")
+KS = (1, 3, 5)
+
+
+def score(search_fn) -> dict:
+    """search_fn(query, mode, k) -> list of dicts with 'source_path'.
+    Returns {mode: {k: hit_count}, 'n': len}."""
+    out: dict = {m: dict.fromkeys(KS, 0) for m in MODES}
+    for query, expected in EVAL_PAIRS:
+        for m in MODES:
+            stems = [Path(r["source_path"]).stem for r in search_fn(query, m, max(KS))]
+            for k in KS:
+                if expected in stems[:k]:
+                    out[m][k] += 1
+    out["n"] = len(EVAL_PAIRS)
+    return out

--- a/lib/tests/test_coding_memory_recall_quality.py
+++ b/lib/tests/test_coding_memory_recall_quality.py
@@ -1,0 +1,42 @@
+"""Recall-quality eval gate (manual / non-CI).
+
+Invokes `coding-memory eval --json` against the LIVE store and asserts recall hasn't
+regressed from the recorded baseline. Skips automatically where the store isn't
+configured/reachable (e.g. CI), so it never blocks the normal suite. Run on a
+configured machine with: `pytest -m eval lib/tests/test_coding_memory_recall_quality.py`
+
+Baseline 2026-06-15 (n=9):  hybrid 8/8/8 · vector 8/8/8 · fts 4/4/4  (hit@1/@3/@5)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+BIN = Path(__file__).resolve().parents[2] / "bin" / "coding-memory"
+
+
+@pytest.mark.eval
+def test_recall_quality_not_regressed():
+    if not Path(os.path.expanduser("~/.coding_memory.env")).exists():
+        pytest.skip("coding-memory not configured on this host")
+    if not BIN.exists():
+        pytest.skip("coding-memory CLI not found")
+    try:
+        out = subprocess.run(
+            [str(BIN), "eval", "--json"], capture_output=True, text=True, timeout=180
+        )
+    except (OSError, subprocess.TimeoutExpired) as e:
+        pytest.skip(f"eval unavailable: {e}")
+    if out.returncode != 0 or not out.stdout.strip():
+        pytest.skip(f"store unreachable / eval failed: {out.stderr[:200]}")
+
+    data = json.loads(out.stdout)
+    n = data["n"]
+    # JSON keys are strings; hybrid is the production recall mode.
+    hybrid_at3 = data["hybrid"]["3"]
+    assert hybrid_at3 >= 7, f"hybrid hit@3 regressed: {hybrid_at3}/{n} (baseline 8)"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,4 @@
 [pytest]
 addopts = --ignore=_archived/
+markers =
+    eval: recall-quality eval; needs the live store (skipped where unconfigured)


### PR DESCRIPTION
coding-memory eval scores semantic recall (hit@1/3/5, hybrid/vector/fts) over 9 fixed pairs; pytest gate asserts no regression, auto-skips in CI. Baseline: hybrid 8/8/8, fts 4/4/4. Codex R1: APPROVE. Closes #446