### PR TITLE
feat(coding-memory): global namespace (cross-project craft) + stable origin

### DIFF
--- a/lib/coding_memory/__init__.py
+++ b/lib/coding_memory/__init__.py
@@ -32,12 +32,22 @@ EMBED_BATCH = 8  # small batch caps peak memory (O(seq^2)*batch); avoids OOM on 
 CONFIG_PATH = Path(os.path.expanduser("~/.coding_memory.env"))
 
 # laptop-side markdown source -> namespace. Personal only (strict residency).
+# `global` is git-tracked craft knowledge in the agents repo, shared across machines.
 DEFAULT_SOURCES = {
     "agents": "~/.claude/projects/-Users-jasonjob-agents/memory",
     "buddy": "~/.claude/projects/-Users-jasonjob-projects-buddy/memory",
+    "global": "~/agents/memory/global",
 }
 SKIP_NAMES = {"MEMORY.md"}
 SKIP_DIRS = {"archive"}
+
+# Shared namespaces are identical on every machine (git-synced), so they get a fixed
+# origin + repo-relative source_path -> one row per fact regardless of which machine
+# ingests them (no cross-machine duplicates crowding recall). Project namespaces stay
+# per-origin (their content differs per machine).
+SHARED_NAMESPACES = frozenset({"global"})
+SHARED_ORIGIN = "shared"
+REPO_ROOT = os.path.realpath(os.path.expanduser("~/agents"))
 
 # Residency allowlist: only these namespaces may be written to the personal store.
 # The server (jns) enforces this so a misconfigured client cannot land work data.
@@ -62,6 +72,7 @@ _CFG_KEYS = (
     "FASTEMBED_CACHE",
     "CODING_MEMORY_REMOTE_BIN",
     "CODING_MEMORY_EMBED_URL",
+    "CODING_MEMORY_ORIGIN",
 )
 
 
@@ -86,9 +97,10 @@ def load_config() -> dict:
         if os.environ.get(k):
             cfg[k] = os.environ[k]
     cfg.setdefault("CODING_MEMORY_REMOTE_BIN", "~/agents/bin/coding-memory")
-    # bridge file-configured embedder settings into the process env — the embedder
-    # reads these from os.environ (so the CLI uses the warm service when set).
-    for k in ("CODING_MEMORY_EMBED_URL", "FASTEMBED_CACHE"):
+    # bridge file-configured settings into the process env — the embedder + the
+    # origin resolver read these from os.environ (so the CLI uses the warm service
+    # and a STABLE per-machine origin, not a volatile hostname).
+    for k in ("CODING_MEMORY_EMBED_URL", "FASTEMBED_CACHE", "CODING_MEMORY_ORIGIN"):
         if cfg.get(k) and not os.environ.get(k):
             os.environ[k] = cfg[k]
     return cfg

--- a/lib/coding_memory/cli.py
+++ b/lib/coding_memory/cli.py
@@ -96,7 +96,6 @@ def cmd_ingest(args, cfg):
         for r in records:
             print(f"  [{r['namespace']}] {r['name']}  ({r['source_path']})")
         return 0
-    parsed["origin"] = P.ORIGIN
     payload = json.dumps(parsed)
     if is_remote(cfg):
         return _ssh(cfg, ["_embed-store"], stdin_data=payload)
@@ -114,7 +113,6 @@ def _embed_store(payload, cfg):
     if isinstance(env, list):  # back-compat: bare record list
         env = {"records": env, "prune_namespaces": []}
     incoming = env.get("records", [])
-    origin = env.get("origin") or "unknown"
     # residency: server-side allowlist — never store a non-personal namespace,
     # even from a misconfigured client.
     records = [r for r in incoming if r.get("namespace") in ALLOWED_NAMESPACES]
@@ -123,35 +121,41 @@ def _embed_store(payload, cfg):
 
     cache = cfg.get("FASTEMBED_CACHE")
     conn = store.connect(cfg["DATABASE_URL"])
+    stored = pruned = 0
     try:
         store.ensure_schema(conn)
-        namespaces = sorted({r["namespace"] for r in records})
-        store.claim_unowned(conn, origin, namespaces)  # one-time: adopt legacy rows
-        existing = store.existing_hashes(conn, origin, namespaces)
-        changed = [
-            r
-            for r in records
-            if existing.get((r["namespace"], r["source_path"])) != r["content_hash"]
-        ]
-        for i in range(0, len(changed), _INGEST_CHUNK):
-            batch = changed[i : i + _INGEST_CHUNK]
-            vecs = embedder.embed_docs(
-                [P.embed_text(r) for r in batch], cache_dir=cache
-            )
-            for r, v in zip(batch, vecs):
-                store.upsert(conn, r, v, origin)
+        # group by each record's own origin: project namespaces use the machine
+        # hostname; shared (git-synced) namespaces use "shared". Each origin is
+        # diffed/pruned independently so machines never clobber each other.
+        for origin in sorted({r.get("origin") or "unknown" for r in records}):
+            orecs = [r for r in records if (r.get("origin") or "unknown") == origin]
+            onamespaces = sorted({r["namespace"] for r in orecs})
+            store.claim_unowned(conn, origin, onamespaces)  # adopt legacy rows once
+            existing = store.existing_hashes(conn, origin, onamespaces)
+            changed = [
+                r
+                for r in orecs
+                if existing.get((r["namespace"], r["source_path"])) != r["content_hash"]
+            ]
+            for i in range(0, len(changed), _INGEST_CHUNK):
+                batch = changed[i : i + _INGEST_CHUNK]
+                vecs = embedder.embed_docs(
+                    [P.embed_text(r) for r in batch], cache_dir=cache
+                )
+                for r, v in zip(batch, vecs):
+                    store.upsert(conn, r, v, origin)
+                conn.commit()
+            stored += len(changed)
+            for ns in onamespaces:
+                if ns in prune_ns:
+                    keep = [r["source_path"] for r in orecs if r["namespace"] == ns]
+                    if keep:
+                        pruned += store.delete_missing(conn, origin, ns, keep)
             conn.commit()
-        # prune ONLY this machine's rows, in namespaces the client cleanly scanned
-        pruned = 0
-        for ns in prune_ns:
-            keep = [r["source_path"] for r in records if r["namespace"] == ns]
-            if keep:
-                pruned += store.delete_missing(conn, origin, ns, keep)
-        conn.commit()
         report = {
             "parsed": len(incoming),
-            "stored": len(changed),
-            "unchanged": len(records) - len(changed),
+            "stored": stored,
+            "unchanged": len(records) - stored,
             "rejected_nonpersonal": rejected,
             "pruned": pruned,
         }
@@ -249,7 +253,7 @@ def cmd_doctor(args, cfg):
         existing.setdefault(r["namespace"], []).append(r["source_path"])
     payload = json.dumps(
         {
-            "origin": P.ORIGIN,
+            "origin": P.current_origin(),
             "existing": existing,
             "scanned": parsed["prune_namespaces"],
             "prune_expired": args.prune_expired,

--- a/lib/coding_memory/parse.py
+++ b/lib/coding_memory/parse.py
@@ -3,13 +3,22 @@
 from __future__ import annotations
 
 import hashlib
+import os
 import re
 import socket
 from pathlib import Path
 
-from . import SKIP_DIRS, SKIP_NAMES
+from . import REPO_ROOT, SHARED_NAMESPACES, SHARED_ORIGIN, SKIP_DIRS, SKIP_NAMES
 
-ORIGIN = socket.gethostname()  # this machine — per-origin identity in the shared store
+
+def current_origin() -> str:
+    """Stable per-machine identity for the shared store. Prefer the explicit config
+    value (CODING_MEMORY_ORIGIN, bridged into the env by load_config); fall back to
+    the SHORT hostname. NOT the raw FQDN — macOS appends volatile DHCP/domain
+    suffixes that would split one machine's facts across multiple origins.
+    Resolved lazily (not at import) so it sees the bridged config value."""
+    return os.environ.get("CODING_MEMORY_ORIGIN") or socket.gethostname().split(".")[0]
+
 
 try:
     import yaml
@@ -72,10 +81,19 @@ def parse_markdown(raw: str, fallback_name: str = "") -> dict:
 
 def _record(ns: str, path: str, raw: str) -> dict:
     meta = parse_markdown(raw, fallback_name=Path(path).stem)
+    if ns in SHARED_NAMESPACES:
+        # git-synced: fixed origin + repo-relative path -> identical on every machine
+        origin = SHARED_ORIGIN
+        try:
+            source_path = os.path.relpath(os.path.realpath(path), REPO_ROOT)
+        except ValueError:
+            source_path = path
+    else:
+        origin, source_path = current_origin(), path
     return {
-        "origin": ORIGIN,
+        "origin": origin,
         "namespace": ns,
-        "source_path": path,
+        "source_path": source_path,
         "content_hash": content_hash(raw),
         **meta,
     }

--- a/lib/tests/test_coding_memory.py
+++ b/lib/tests/test_coding_memory.py
@@ -103,7 +103,18 @@ def test_residency_rejects_path_outside_namespace_root(tmp_path):
 
 def test_residency_defaults_pass():
     out = C._sources_from_args(None)
-    assert set(out) == {"agents", "buddy"}
+    assert set(out) == {"agents", "buddy", "global"}
+
+
+def test_global_record_uses_shared_origin():
+    # git-synced global facts get a fixed origin so they dedupe across machines
+    rec = P._record("global", "/x/agents/memory/global/foo.md", "---\nname: f\n---\nb")
+    assert rec["origin"] == "shared"
+
+
+def test_project_record_uses_hostname_origin():
+    rec = P._record("agents", "/x/.claude/projects/p/memory/foo.md", "body")
+    assert rec["origin"] == P.current_origin()
 
 
 def test_embed_service_disabled_returns_none(monkeypatch):

--- a/memory/global/audit-storage-not-just-api.md
+++ b/memory/global/audit-storage-not-just-api.md
@@ -1,0 +1,10 @@
+---
+name: audit-storage-not-just-api
+type: feedback
+summary: When retiring/refactoring a system with an API and a backing store, grep the storage layer and direct-DB callers too — not just the API surface.
+durability: durable
+---
+When auditing a system that has both an API surface and a backing store, grep for
+**direct backend access** in addition to the API. Callers that hit the store
+directly (raw `sqlite3.connect`, direct table reads) bypass the API and won't show
+up in API-name greps — and they break silently when the store changes.

--- a/memory/global/grep-every-sql-site.md
+++ b/memory/global/grep-every-sql-site.md
@@ -1,0 +1,11 @@
+---
+name: grep-every-sql-site-before-dropping
+type: feedback
+summary: Before a spec/PR drops or renames a DB table or column, grep EVERY SQL site (incl. raw strings, ORMs, migrations) — API-surface greps miss direct callers.
+durability: durable
+---
+Before locking any change that drops or renames a database table/column, run an
+exhaustive grep for **every** SQL site — raw query strings, ORM models, migrations,
+views, and direct-DB callers that bypass the API. API-surface greps alone miss the
+callers that will break at runtime. Same lesson as auditing storage independently
+of the API surface. See [[audit-storage-not-just-api]].

--- a/memory/global/pytest-no-dash-x.md
+++ b/memory/global/pytest-no-dash-x.md
@@ -1,0 +1,9 @@
+---
+name: pytest-no-dash-x-for-validation
+type: feedback
+summary: Don't use `pytest -x` for validation runs — it stops at the first failure and hides downstream regressions. Run the full suite to see every failure.
+durability: durable
+---
+`pytest -x` stops at the first failure, so it hides downstream regressions you
+introduced. For a validation run (PROVE, pre-PR), run the full suite without `-x`
+so every failure surfaces at once. A clean `-x` run is not evidence the suite passes.

--- a/memory/global/verify-code-reality-first.md
+++ b/memory/global/verify-code-reality-first.md
@@ -1,0 +1,10 @@
+---
+name: verify-code-reality-before-locking-a-spec
+type: feedback
+summary: Read the actual code before locking a spec or asserting behavior. Assumptions about code/spec/data shape are the #1 failure (VERIFICATION_GAP).
+durability: durable
+---
+Before locking a spec or claiming "X is handled/unchanged", read the actual code —
+don't assume structure, data shape, or dependency behavior. Unverified assumptions
+are the dominant failure mode. A 45-minute code-reality pass up front beats hours
+of adversarial-review rework.


### PR DESCRIPTION
Adds a git-tracked 'global' craft namespace (surfaces in every personal project; 4 seeded lessons), a fixed 'shared' origin + repo-relative path so git-synced facts store once across machines, and a stable per-machine CODING_MEMORY_ORIGIN (fixes hostname-drift row doubling). Codex R1: APPROVE (1 non-blocking: doctor doesn't manage shared-origin drift — safe/intended). Closes #444