### PR TITLE
feat(coding-memory): recall telemetry (L1) — record events + weekly-report section

### DIFF
--- a/claude-config/scripts/cost_report_weekly.py
+++ b/claude-config/scripts/cost_report_weekly.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import json
 import socket
+import subprocess
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -25,15 +26,20 @@ import usage_aggregator as A  # noqa: E402
 import usage_email as E  # noqa: E402
 import usage_report as R  # noqa: E402
 
-TELEMETRY_DIR = Path.home() / ".claude" / "telemetry"          # read_shards globs */usage.jsonl under here
+TELEMETRY_DIR = (
+    Path.home() / ".claude" / "telemetry"
+)  # read_shards globs */usage.jsonl under here
 REPORTS_DIR = Path.home() / ".claude" / "cost-reports"
-EMAIL_STATE = Path.home() / ".claude" / "cost-telemetry" / "email-state.json"  # email-only state (no collector races)
+EMAIL_STATE = (
+    Path.home() / ".claude" / "cost-telemetry" / "email-state.json"
+)  # email-only state (no collector races)
 
 
 def _host() -> str:
     try:
         sys.path.insert(0, str(Path.home() / "agents" / "lib"))
         from project_resolver import get_host_name
+
         return get_host_name()
     except Exception:
         return socket.gethostname().split(".")[0] or "unknown"
@@ -51,6 +57,63 @@ def _save_state(state: dict) -> None:
     EMAIL_STATE.write_text(json.dumps(state, indent=2) + "\n", encoding="utf-8")
 
 
+def format_recall_section(bin_path: Path | None = None) -> str:
+    """Shell out to coding-memory recall-report --json --days 7.
+
+    Fail-open: returns a one-line "data unavailable" notice on any error
+    so the weekly report still sends when jns is unreachable or the CLI
+    is absent. Broad catch is intentional (BLE001 exempted for scripts/).
+    Uses the absolute bin path so launchd's restricted PATH is not a problem.
+    """
+    if bin_path is None:
+        bin_path = Path.home() / "agents" / "bin" / "coding-memory"
+    stub = "## Recall (last 7 days)\n\n_data unavailable this week_"
+    try:
+        proc = subprocess.run(
+            [str(bin_path), "recall-report", "--json", "--days", "7"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if proc.returncode != 0 or not proc.stdout.strip():
+            return stub
+        data = json.loads(proc.stdout)
+    except Exception:
+        return stub
+
+    n_total = data.get("n_total", 0)
+    n_push = data.get("n_push", 0)
+    n_pull = data.get("n_pull", 0)
+    n_inj = data.get("n_injected_total", 0)
+    n_ret = data.get("n_returned_total", 0)
+    p50 = data.get("p50_latency_ms")
+    top_facts = data.get("top_facts", [])
+    days = data.get("days", 7)
+
+    eff_str = f"{n_inj / n_ret:.0%}" if n_ret else "n/a"
+    p50_str = f"{p50} ms" if p50 is not None else "n/a"
+
+    lines = [
+        f"## Recall (last {days} days)",
+        "",
+        "| metric | value |",
+        "|--------|-------|",
+        f"| total queries | {n_total} |",
+        f"| push (prompt inject) | {n_push} |",
+        f"| pull (interactive) | {n_pull} |",
+        f"| gate efficiency (injected/returned) | {eff_str} |",
+        f"| p50 latency | {p50_str} |",
+    ]
+    if top_facts:
+        lines += ["", "**Top surfaced facts:**", ""]
+        for f in top_facts:
+            lines.append(
+                f"- [{f.get('ns', '?')}] {f.get('name', '?')} ×{f.get('count', 0)}"
+            )
+
+    return "\n".join(lines)
+
+
 def main() -> int:
     now = datetime.now(timezone.utc)
     host = _host()
@@ -61,20 +124,33 @@ def main() -> int:
     agg = A.aggregate(records)
     REPORTS_DIR.mkdir(parents=True, exist_ok=True)
     html_path = REPORTS_DIR / f"cost-report-{host}-{wk}.html"
-    R.write_report(agg, html_path, records=records)          # writes .html + .md
-    md = html_path.with_suffix(".md").read_text(encoding="utf-8")  # email body = the local .md
-    kpi_section = KPI.format_kpi_section(KPI.compute_kpis(
-        metrics_path=Path.home() / ".claude" / "memory" / "metrics.jsonl",
-        prove_log_path=Path.home() / ".claude" / "memory" / "prove-log.jsonl",
-        overrides_paths=[Path.home() / ".agents" / "outputs" / "prove-overrides.jsonl"],
-    ))
+    R.write_report(agg, html_path, records=records)  # writes .html + .md
+    md = html_path.with_suffix(".md").read_text(
+        encoding="utf-8"
+    )  # email body = the local .md
+    kpi_section = KPI.format_kpi_section(
+        KPI.compute_kpis(
+            metrics_path=Path.home() / ".claude" / "memory" / "metrics.jsonl",
+            prove_log_path=Path.home() / ".claude" / "memory" / "prove-log.jsonl",
+            overrides_paths=[
+                Path.home() / ".agents" / "outputs" / "prove-overrides.jsonl"
+            ],
+        )
+    )
     if kpi_section:
         md = md + "\n\n" + kpi_section
+    recall_section = format_recall_section()
+    if recall_section:
+        md = md + "\n\n" + recall_section
     print(f"[{now.isoformat()}] local report: {html_path} ({len(records)} records)")
 
     state = _load_state()
     code, new_state = E.send_weekly(
-        md_summary=md, html_path=str(html_path), state=state, host=host, now=now,
+        md_summary=md,
+        html_path=str(html_path),
+        state=state,
+        host=host,
+        now=now,
     )
     if code == E.SENT_OR_SKIP and new_state != state:
         try:

--- a/claude-config/scripts/cost_report_weekly.py
+++ b/claude-config/scripts/cost_report_weekly.py
@@ -78,17 +78,19 @@ def format_recall_section(bin_path: Path | None = None) -> str:
         if proc.returncode != 0 or not proc.stdout.strip():
             return stub
         data = json.loads(proc.stdout)
+        n_total = int(data.get("n_total") or 0)
+        n_push = int(data.get("n_push") or 0)
+        n_pull = int(data.get("n_pull") or 0)
+        n_inj = int(data.get("n_injected_total") or 0)
+        n_ret = int(data.get("n_returned_total") or 0)
+        p50_raw = data.get("p50_latency_ms")
+        p50 = int(p50_raw) if p50_raw is not None else None
+        top_facts = (
+            data.get("top_facts") if isinstance(data.get("top_facts"), list) else []
+        )
+        days = int(data.get("days") or 7)
     except Exception:
         return stub
-
-    n_total = data.get("n_total", 0)
-    n_push = data.get("n_push", 0)
-    n_pull = data.get("n_pull", 0)
-    n_inj = data.get("n_injected_total", 0)
-    n_ret = data.get("n_returned_total", 0)
-    p50 = data.get("p50_latency_ms")
-    top_facts = data.get("top_facts", [])
-    days = data.get("days", 7)
 
     eff_str = f"{n_inj / n_ret:.0%}" if n_ret else "n/a"
     p50_str = f"{p50} ms" if p50 is not None else "n/a"
@@ -104,12 +106,15 @@ def format_recall_section(bin_path: Path | None = None) -> str:
         f"| gate efficiency (injected/returned) | {eff_str} |",
         f"| p50 latency | {p50_str} |",
     ]
-    if top_facts:
-        lines += ["", "**Top surfaced facts:**", ""]
-        for f in top_facts:
-            lines.append(
-                f"- [{f.get('ns', '?')}] {f.get('name', '?')} ×{f.get('count', 0)}"
-            )
+    try:
+        if top_facts:
+            lines += ["", "**Top surfaced facts:**", ""]
+            for f in top_facts:
+                lines.append(
+                    f"- [{f.get('ns', '?')}] {f.get('name', '?')} ×{int(f.get('count') or 0)}"
+                )
+    except Exception:
+        pass  # malformed top_facts entry — omit the section, report still sends
 
     return "\n".join(lines)
 

--- a/lib/coding_memory/cli.py
+++ b/lib/coding_memory/cli.py
@@ -16,6 +16,7 @@ import re
 import shlex
 import subprocess
 import sys
+import time
 
 from . import (
     ALLOWED_NAMESPACES,
@@ -235,6 +236,7 @@ def _query(text, args, cfg):
     # threshold (usually 0-1), so weak/irrelevant matches never bloat a phase prompt.
     mode = "vector" if for_prompt else args.mode
     conn = store.connect(cfg["DATABASE_URL"])
+    t0 = time.monotonic()
     try:
         rows = store.search(
             conn,
@@ -244,12 +246,40 @@ def _query(text, args, cfg):
             namespaces=args.namespace or None,
             mode=mode,
         )
+        latency_ms = int((time.monotonic() - t0) * 1000)
+
+        # split pre/post gate so we can record both counts
+        rows_pre_gate = rows
+        if for_prompt:
+            ms = getattr(args, "min_score", None)
+            min_score = ms if ms is not None else RECALL_MIN_SCORE  # allow explicit 0.0
+            rows = [r for r in rows_pre_gate if r.get("score", 0.0) >= min_score]
+
+        # fail-open recall telemetry: a DB write error must never break the query
+        try:
+            import psycopg as _psycopg  # noqa: PLC0415
+
+            origin = cfg.get("CODING_MEMORY_ORIGIN") or P.current_origin()
+            store.log_recall(
+                conn,
+                origin=origin,
+                kind="push" if for_prompt else "pull",
+                mode=mode,
+                n_returned=len(rows_pre_gate),
+                n_injected=len(rows),
+                top_score=rows[0]["score"] if rows else None,
+                facts=[
+                    {"ns": r["namespace"], "name": r["name"], "score": r["score"]}
+                    for r in rows[:5]
+                ],
+                latency_ms=latency_ms,
+            )
+        except _psycopg.Error:
+            pass  # fail-open: logging must never break recall
     finally:
         conn.close()
+
     if for_prompt:
-        ms = getattr(args, "min_score", None)
-        min_score = ms if ms is not None else RECALL_MIN_SCORE  # allow explicit 0.0
-        rows = [r for r in rows if r.get("score", 0.0) >= min_score]
         block = _prompt_block(rows)  # empty -> nothing injected (fail-open)
         if block:
             print(block)
@@ -423,6 +453,46 @@ def _eval_run(as_json, cfg):
     return 0
 
 
+# ---------- recall-report ----------
+
+
+def cmd_recall_report(args, cfg):
+    if is_remote(cfg):
+        remote = ["_recall-report", "--days", str(args.days)]
+        if args.json:
+            remote.append("--json")
+        return _ssh(cfg, remote)
+    return _recall_report(args, cfg)
+
+
+def _recall_report(args, cfg):
+    from . import store
+
+    conn = store.connect(cfg["DATABASE_URL"])
+    try:
+        store.ensure_schema(conn)  # bootstraps recall_event on first use
+        data = store.recall_report_agg(conn, days=args.days)
+    finally:
+        conn.close()
+    if args.json:
+        print(json.dumps(data))
+        return 0
+    d = args.days
+    print(f"Recall telemetry (last {d} days)")
+    print(f"  total queries : {data['n_total']}")
+    print(f"  push (prompt) : {data['n_push']}")
+    print(f"  pull (interactive): {data['n_pull']}")
+    if data["n_returned_total"]:
+        eff = data["n_injected_total"] / data["n_returned_total"]
+        print(f"  gate efficiency : {eff:.0%} injected/returned")
+    print(f"  p50 latency   : {data['p50_latency_ms']} ms")
+    if data["top_facts"]:
+        print("  top surfaced facts:")
+        for f in data["top_facts"]:
+            print(f"    [{f['ns']}] {_sanitize(f['name'])} x{f['count']}")
+    return 0
+
+
 def build_parser():
     p = argparse.ArgumentParser(
         prog="coding-memory", description="Personal coding-memory store (jns)."
@@ -479,6 +549,10 @@ def build_parser():
     )
     ev.add_argument("--json", action="store_true")
 
+    rr = sub.add_parser("recall-report", help="recall telemetry summary")
+    rr.add_argument("--days", type=int, default=7, help="look-back window (default 7)")
+    rr.add_argument("--json", action="store_true", help="emit JSON")
+
     # internal (server-side on jns)
     sub.add_parser("_embed-store")
     qq = sub.add_parser("_query")
@@ -492,6 +566,9 @@ def build_parser():
     sub.add_parser("_doctor")
     _ev = sub.add_parser("_eval")
     _ev.add_argument("--json", action="store_true")
+    _rr = sub.add_parser("_recall-report")
+    _rr.add_argument("--days", type=int, default=7)
+    _rr.add_argument("--json", action="store_true")
     return p
 
 
@@ -508,6 +585,8 @@ def main(argv=None):
         return cmd_doctor(args, cfg)
     if args.cmd == "eval":
         return cmd_eval(args, cfg)
+    if args.cmd == "recall-report":
+        return cmd_recall_report(args, cfg)
     if args.cmd == "_embed-store":
         return _embed_store(sys.stdin.read(), cfg)
     if args.cmd == "_query":
@@ -518,6 +597,8 @@ def main(argv=None):
         return _doctor(sys.stdin.read(), cfg)
     if args.cmd == "_eval":
         return _eval_run(args.json, cfg)
+    if args.cmd == "_recall-report":
+        return _recall_report(args, cfg)
     raise SystemExit(2)
 
 

--- a/lib/coding_memory/cli.py
+++ b/lib/coding_memory/cli.py
@@ -261,7 +261,7 @@ def _query(text, args, cfg):
 
             origin = cfg.get("CODING_MEMORY_ORIGIN") or P.current_origin()
             store.log_recall(
-                conn,
+                cfg["DATABASE_URL"],
                 origin=origin,
                 kind="push" if for_prompt else "pull",
                 mode=mode,

--- a/lib/coding_memory/store.py
+++ b/lib/coding_memory/store.py
@@ -299,7 +299,7 @@ def prune_expired(conn, namespaces=None) -> int:
 
 
 def log_recall(
-    conn,
+    dsn: str,
     *,
     origin: str,
     kind: str,
@@ -310,11 +310,14 @@ def log_recall(
     facts: list[dict],
     latency_ms: int,
 ) -> None:
-    """INSERT one recall_event row and commit.
+    """INSERT one recall_event row via an isolated autocommit connection.
 
-    Truncates facts to the top 5 before storage (privacy/lean).
-    Callers wrap in a narrow try/except psycopg.Error for fail-open logging.
+    Opens its own autocommit connection so a logging INSERT failure can never
+    abort the caller's query transaction. Truncates facts to the top 5 before
+    storage (privacy/lean). Callers wrap in a narrow try/except for fail-open.
     """
+    import psycopg  # noqa: PLC0415 — lazy; callers may not have psycopg
+
     top5 = facts[:5]
     sql = """
     INSERT INTO recall_event
@@ -322,21 +325,21 @@ def log_recall(
     VALUES
       (%s, %s, %s, %s, %s, %s, %s::jsonb, %s)
     """
-    with conn.cursor() as c:
-        c.execute(
-            sql,
-            (
-                origin,
-                kind,
-                mode,
-                n_returned,
-                n_injected,
-                top_score,
-                json.dumps(top5),
-                latency_ms,
-            ),
-        )
-    conn.commit()
+    with psycopg.connect(dsn, autocommit=True) as c:
+        with c.cursor() as cur:
+            cur.execute(
+                sql,
+                (
+                    origin,
+                    kind,
+                    mode,
+                    n_returned,
+                    n_injected,
+                    top_score,
+                    json.dumps(top5),
+                    latency_ms,
+                ),
+            )
 
 
 def recall_report_agg(conn, *, days: int = 7) -> dict:
@@ -346,6 +349,7 @@ def recall_report_agg(conn, *, days: int = 7) -> dict:
     n_returned_total, p50_latency_ms (int|None), top_facts ([{ns,name,count}]
     top 5), days.
     """
+    days = max(1, min(int(days), 365))  # clamp to sane range before binding
     agg_sql = """
     SELECT
         count(*)                                         AS n_total,
@@ -355,7 +359,7 @@ def recall_report_agg(conn, *, days: int = 7) -> dict:
         coalesce(sum(n_returned), 0)                     AS n_returned_total,
         percentile_cont(0.5) WITHIN GROUP (ORDER BY latency_ms) AS p50_latency_ms
     FROM recall_event
-    WHERE ts >= now() - INTERVAL '%(days)s days'
+    WHERE ts >= now() - make_interval(days => %(days)s)
     """
     facts_sql = """
     SELECT
@@ -364,7 +368,7 @@ def recall_report_agg(conn, *, days: int = 7) -> dict:
         count(*)   AS cnt
     FROM recall_event,
          jsonb_array_elements(facts) AS f
-    WHERE ts >= now() - INTERVAL '%(days)s days'
+    WHERE ts >= now() - make_interval(days => %(days)s)
     GROUP BY f->>'ns', f->>'name'
     ORDER BY cnt DESC
     LIMIT 5

--- a/lib/coding_memory/store.py
+++ b/lib/coding_memory/store.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import math
 
 from . import EMBED_DIM
@@ -25,6 +26,21 @@ CREATE TABLE IF NOT EXISTS memory_fact (
        (to_tsvector('english', coalesce(name,'')||' '||coalesce(summary,'')||' '||coalesce(body,''))) STORED,
   created_at   timestamptz NOT NULL DEFAULT now(),
   updated_at   timestamptz NOT NULL DEFAULT now()
+);
+"""
+
+_RECALL_DDL = """
+CREATE TABLE IF NOT EXISTS recall_event (
+  id           BIGSERIAL PRIMARY KEY,
+  ts           TIMESTAMPTZ NOT NULL DEFAULT now(),
+  origin       TEXT,
+  kind         TEXT NOT NULL CHECK (kind IN ('push', 'pull')),
+  mode         TEXT,
+  n_returned   INT,
+  n_injected   INT,
+  top_score    REAL,
+  facts        JSONB,
+  latency_ms   INT
 );
 """
 
@@ -67,6 +83,9 @@ def ensure_schema(conn) -> None:
         c.execute(
             "CREATE INDEX IF NOT EXISTS idx_memfact_embed ON memory_fact USING hnsw (embedding vector_cosine_ops);"
         )
+        # recall telemetry table (#455)
+        c.execute(_RECALL_DDL)
+        c.execute("CREATE INDEX IF NOT EXISTS idx_recall_event_ts ON recall_event(ts);")
     conn.commit()
 
 
@@ -274,3 +293,105 @@ def prune_expired(conn, namespaces=None) -> int:
     with conn.cursor() as c:
         c.execute(q, params)
         return c.rowcount
+
+
+# ---- recall telemetry (#455) ----
+
+
+def log_recall(
+    conn,
+    *,
+    origin: str,
+    kind: str,
+    mode: str,
+    n_returned: int,
+    n_injected: int,
+    top_score: float | None,
+    facts: list[dict],
+    latency_ms: int,
+) -> None:
+    """INSERT one recall_event row and commit.
+
+    Truncates facts to the top 5 before storage (privacy/lean).
+    Callers wrap in a narrow try/except psycopg.Error for fail-open logging.
+    """
+    top5 = facts[:5]
+    sql = """
+    INSERT INTO recall_event
+      (origin, kind, mode, n_returned, n_injected, top_score, facts, latency_ms)
+    VALUES
+      (%s, %s, %s, %s, %s, %s, %s::jsonb, %s)
+    """
+    with conn.cursor() as c:
+        c.execute(
+            sql,
+            (
+                origin,
+                kind,
+                mode,
+                n_returned,
+                n_injected,
+                top_score,
+                json.dumps(top5),
+                latency_ms,
+            ),
+        )
+    conn.commit()
+
+
+def recall_report_agg(conn, *, days: int = 7) -> dict:
+    """Aggregate recall_event rows for the last `days` days.
+
+    Returns a dict with keys: n_total, n_push, n_pull, n_injected_total,
+    n_returned_total, p50_latency_ms (int|None), top_facts ([{ns,name,count}]
+    top 5), days.
+    """
+    agg_sql = """
+    SELECT
+        count(*)                                         AS n_total,
+        count(*) FILTER (WHERE kind='push')              AS n_push,
+        count(*) FILTER (WHERE kind='pull')              AS n_pull,
+        coalesce(sum(n_injected), 0)                     AS n_injected_total,
+        coalesce(sum(n_returned), 0)                     AS n_returned_total,
+        percentile_cont(0.5) WITHIN GROUP (ORDER BY latency_ms) AS p50_latency_ms
+    FROM recall_event
+    WHERE ts >= now() - INTERVAL '%(days)s days'
+    """
+    facts_sql = """
+    SELECT
+        f->>'ns'   AS ns,
+        f->>'name' AS name,
+        count(*)   AS cnt
+    FROM recall_event,
+         jsonb_array_elements(facts) AS f
+    WHERE ts >= now() - INTERVAL '%(days)s days'
+    GROUP BY f->>'ns', f->>'name'
+    ORDER BY cnt DESC
+    LIMIT 5
+    """
+    with conn.cursor() as c:
+        c.execute(agg_sql, {"days": days})
+        row = c.fetchone()
+        n_total = int(row[0]) if row else 0
+        n_push = int(row[1]) if row else 0
+        n_pull = int(row[2]) if row else 0
+        n_injected_total = int(row[3]) if row else 0
+        n_returned_total = int(row[4]) if row else 0
+        p50_raw = row[5] if row else None
+        p50_latency_ms = int(p50_raw) if p50_raw is not None else None
+
+        c.execute(facts_sql, {"days": days})
+        top_facts = [
+            {"ns": r[0], "name": r[1], "count": int(r[2])} for r in c.fetchall()
+        ]
+
+    return {
+        "n_total": n_total,
+        "n_push": n_push,
+        "n_pull": n_pull,
+        "n_injected_total": n_injected_total,
+        "n_returned_total": n_returned_total,
+        "p50_latency_ms": p50_latency_ms,
+        "top_facts": top_facts,
+        "days": days,
+    }

--- a/lib/tests/test_coding_memory.py
+++ b/lib/tests/test_coding_memory.py
@@ -6,7 +6,7 @@ import json
 import subprocess
 import sys
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -185,54 +185,63 @@ def test_embed_service_non_loopback_refused(monkeypatch):
 # ---- recall telemetry unit tests (#455) ----
 
 
-def test_log_recall_inserts_and_commits():
-    """log_recall calls INSERT and commits — happy path via mock conn."""
-    conn = MagicMock()
-    cursor_ctx = MagicMock()
+def _make_autocommit_mock():
+    """Build a mock autocommit connection context + cursor for log_recall tests."""
     cursor_obj = MagicMock()
+    cursor_ctx = MagicMock()
     cursor_ctx.__enter__ = MagicMock(return_value=cursor_obj)
     cursor_ctx.__exit__ = MagicMock(return_value=False)
-    conn.cursor.return_value = cursor_ctx
 
-    S.log_recall(
-        conn,
-        origin="test-host",
-        kind="push",
-        mode="vector",
-        n_returned=5,
-        n_injected=3,
-        top_score=0.87,
-        facts=[{"ns": "agents", "name": "foo", "score": 0.87}],
-        latency_ms=42,
-    )
+    conn_obj = MagicMock()
+    conn_obj.cursor.return_value = cursor_ctx
+    conn_ctx = MagicMock()
+    conn_ctx.__enter__ = MagicMock(return_value=conn_obj)
+    conn_ctx.__exit__ = MagicMock(return_value=False)
+    return conn_ctx, conn_obj, cursor_obj
+
+
+def test_log_recall_inserts_and_commits():
+    """log_recall opens its own autocommit connection and INSERTs — happy path."""
+    conn_ctx, conn_obj, cursor_obj = _make_autocommit_mock()
+
+    with patch("psycopg.connect", return_value=conn_ctx) as mock_connect:
+        S.log_recall(
+            "postgresql://test/db",
+            origin="test-host",
+            kind="push",
+            mode="vector",
+            n_returned=5,
+            n_injected=3,
+            top_score=0.87,
+            facts=[{"ns": "agents", "name": "foo", "score": 0.87}],
+            latency_ms=42,
+        )
+        mock_connect.assert_called_once_with("postgresql://test/db", autocommit=True)
 
     assert cursor_obj.execute.called
     sql_arg = cursor_obj.execute.call_args[0][0]
     assert "INSERT INTO recall_event" in sql_arg
-    conn.commit.assert_called_once()
+    # no explicit commit — autocommit=True means there is none
+    conn_obj.commit.assert_not_called()
 
 
 def test_log_recall_truncates_facts_to_5():
     """log_recall stores at most 5 facts even when caller passes more."""
-    conn = MagicMock()
-    cursor_ctx = MagicMock()
-    cursor_obj = MagicMock()
-    cursor_ctx.__enter__ = MagicMock(return_value=cursor_obj)
-    cursor_ctx.__exit__ = MagicMock(return_value=False)
-    conn.cursor.return_value = cursor_ctx
+    conn_ctx, conn_obj, cursor_obj = _make_autocommit_mock()
 
     facts_8 = [{"ns": "a", "name": f"f{i}", "score": 0.9} for i in range(8)]
-    S.log_recall(
-        conn,
-        origin="test-host",
-        kind="pull",
-        mode="hybrid",
-        n_returned=8,
-        n_injected=8,
-        top_score=0.9,
-        facts=facts_8,
-        latency_ms=10,
-    )
+    with patch("psycopg.connect", return_value=conn_ctx):
+        S.log_recall(
+            "postgresql://test/db",
+            origin="test-host",
+            kind="pull",
+            mode="hybrid",
+            n_returned=8,
+            n_injected=8,
+            top_score=0.9,
+            facts=facts_8,
+            latency_ms=10,
+        )
 
     call_args = cursor_obj.execute.call_args[0]
     params = call_args[1]  # second positional arg is the params tuple
@@ -267,6 +276,35 @@ def test_recall_report_agg_returns_shape():
     assert len(result["top_facts"]) == 1
     assert result["top_facts"][0]["ns"] == "agents"
     assert result["top_facts"][0]["count"] == 4
+
+
+def test_recall_report_agg_uses_make_interval():
+    """recall_report_agg SQL must use make_interval(days => ...) not quoted INTERVAL.
+
+    Regression guard: a placeholder inside a quoted literal (INTERVAL '%(days)s days')
+    is fragile and non-portable. Binding via make_interval() is the correct form.
+    """
+    conn = MagicMock()
+    cursor_ctx = MagicMock()
+    cursor_obj = MagicMock()
+    cursor_ctx.__enter__ = MagicMock(return_value=cursor_obj)
+    cursor_ctx.__exit__ = MagicMock(return_value=False)
+    conn.cursor.return_value = cursor_ctx
+
+    cursor_obj.fetchone.return_value = (0, 0, 0, 0, 0, None)
+    cursor_obj.fetchall.return_value = []
+
+    S.recall_report_agg(conn, days=7)
+
+    # Both SQL calls (agg + facts) must use bound make_interval, not quoted literal
+    executed_sqls = [call[0][0] for call in cursor_obj.execute.call_args_list]
+    for sql in executed_sqls:
+        assert "make_interval(days =>" in sql, (
+            f"SQL must use make_interval(days => ...) for interval binding; got:\n{sql}"
+        )
+        assert "INTERVAL '" not in sql, (
+            f"SQL must not use quoted INTERVAL literal; got:\n{sql}"
+        )
 
 
 def test_format_recall_section_data_unavailable(monkeypatch):

--- a/lib/tests/test_coding_memory.py
+++ b/lib/tests/test_coding_memory.py
@@ -202,6 +202,7 @@ def _make_autocommit_mock():
 
 def test_log_recall_inserts_and_commits():
     """log_recall opens its own autocommit connection and INSERTs — happy path."""
+    pytest.importorskip("psycopg")  # server-only driver; absent in CI
     conn_ctx, conn_obj, cursor_obj = _make_autocommit_mock()
 
     with patch("psycopg.connect", return_value=conn_ctx) as mock_connect:
@@ -227,6 +228,7 @@ def test_log_recall_inserts_and_commits():
 
 def test_log_recall_truncates_facts_to_5():
     """log_recall stores at most 5 facts even when caller passes more."""
+    pytest.importorskip("psycopg")  # server-only driver; absent in CI
     conn_ctx, conn_obj, cursor_obj = _make_autocommit_mock()
 
     facts_8 = [{"ns": "a", "name": f"f{i}", "score": 0.9} for i in range(8)]

--- a/lib/tests/test_coding_memory.py
+++ b/lib/tests/test_coding_memory.py
@@ -2,15 +2,23 @@
 
 from __future__ import annotations
 
+import json
+import subprocess
 import sys
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # lib/ on path
+# scripts/ on path for format_recall_section import
+sys.path.insert(
+    0, str(Path(__file__).resolve().parents[2] / "claude-config" / "scripts")
+)
 
 from coding_memory import cli as C  # noqa: E402
 from coding_memory import parse as P  # noqa: E402
+from coding_memory import store as S  # noqa: E402
 
 
 def test_parse_full_frontmatter():
@@ -172,3 +180,143 @@ def test_embed_service_non_loopback_refused(monkeypatch):
     # residency: a non-loopback URL must never receive fact text -> fall back local
     monkeypatch.setenv("CODING_MEMORY_EMBED_URL", "http://example.com:8788")
     assert E._try_service(["x"], "doc") is None
+
+
+# ---- recall telemetry unit tests (#455) ----
+
+
+def test_log_recall_inserts_and_commits():
+    """log_recall calls INSERT and commits — happy path via mock conn."""
+    conn = MagicMock()
+    cursor_ctx = MagicMock()
+    cursor_obj = MagicMock()
+    cursor_ctx.__enter__ = MagicMock(return_value=cursor_obj)
+    cursor_ctx.__exit__ = MagicMock(return_value=False)
+    conn.cursor.return_value = cursor_ctx
+
+    S.log_recall(
+        conn,
+        origin="test-host",
+        kind="push",
+        mode="vector",
+        n_returned=5,
+        n_injected=3,
+        top_score=0.87,
+        facts=[{"ns": "agents", "name": "foo", "score": 0.87}],
+        latency_ms=42,
+    )
+
+    assert cursor_obj.execute.called
+    sql_arg = cursor_obj.execute.call_args[0][0]
+    assert "INSERT INTO recall_event" in sql_arg
+    conn.commit.assert_called_once()
+
+
+def test_log_recall_truncates_facts_to_5():
+    """log_recall stores at most 5 facts even when caller passes more."""
+    conn = MagicMock()
+    cursor_ctx = MagicMock()
+    cursor_obj = MagicMock()
+    cursor_ctx.__enter__ = MagicMock(return_value=cursor_obj)
+    cursor_ctx.__exit__ = MagicMock(return_value=False)
+    conn.cursor.return_value = cursor_ctx
+
+    facts_8 = [{"ns": "a", "name": f"f{i}", "score": 0.9} for i in range(8)]
+    S.log_recall(
+        conn,
+        origin="test-host",
+        kind="pull",
+        mode="hybrid",
+        n_returned=8,
+        n_injected=8,
+        top_score=0.9,
+        facts=facts_8,
+        latency_ms=10,
+    )
+
+    call_args = cursor_obj.execute.call_args[0]
+    params = call_args[1]  # second positional arg is the params tuple
+    facts_json_str = params[6]  # 7th param = facts JSONB
+    stored = json.loads(facts_json_str)
+    assert len(stored) == 5
+
+
+def test_recall_report_agg_returns_shape():
+    """recall_report_agg returns the expected dict shape via mock cursor."""
+    conn = MagicMock()
+    cursor_ctx = MagicMock()
+    cursor_obj = MagicMock()
+    cursor_ctx.__enter__ = MagicMock(return_value=cursor_obj)
+    cursor_ctx.__exit__ = MagicMock(return_value=False)
+    conn.cursor.return_value = cursor_ctx
+
+    # First fetchone (agg query): n_total, n_push, n_pull, n_inj, n_ret, p50
+    cursor_obj.fetchone.return_value = (10, 7, 3, 15, 20, 38.5)
+    # fetchall (top_facts query): [(ns, name, count), ...]
+    cursor_obj.fetchall.return_value = [("agents", "some-fact", 4)]
+
+    result = S.recall_report_agg(conn, days=7)
+
+    assert result["n_total"] == 10
+    assert result["n_push"] == 7
+    assert result["n_pull"] == 3
+    assert result["n_injected_total"] == 15
+    assert result["n_returned_total"] == 20
+    assert result["p50_latency_ms"] == 38
+    assert result["days"] == 7
+    assert len(result["top_facts"]) == 1
+    assert result["top_facts"][0]["ns"] == "agents"
+    assert result["top_facts"][0]["count"] == 4
+
+
+def test_format_recall_section_data_unavailable(monkeypatch):
+    """format_recall_section returns stub when subprocess exits non-zero."""
+    import cost_report_weekly as W
+
+    mock_result = MagicMock()
+    mock_result.returncode = 1
+    mock_result.stdout = ""
+    monkeypatch.setattr(subprocess, "run", lambda *a, **kw: mock_result)
+
+    out = W.format_recall_section()
+    assert "data unavailable" in out
+    assert "## Recall" in out
+
+
+def test_format_recall_section_renders_table(monkeypatch):
+    """format_recall_section renders the markdown table when data is valid."""
+    import cost_report_weekly as W
+
+    payload = {
+        "n_total": 42,
+        "n_push": 30,
+        "n_pull": 12,
+        "n_injected_total": 25,
+        "n_returned_total": 30,
+        "p50_latency_ms": 55,
+        "top_facts": [{"ns": "agents", "name": "some-rule", "count": 7}],
+        "days": 7,
+    }
+
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+    mock_result.stdout = json.dumps(payload)
+    monkeypatch.setattr(subprocess, "run", lambda *a, **kw: mock_result)
+
+    out = W.format_recall_section()
+    assert "## Recall (last 7 days)" in out
+    assert "42" in out  # n_total
+    assert "some-rule" in out
+
+
+def test_format_recall_section_exception_returns_stub(monkeypatch):
+    """format_recall_section is fail-open even on subprocess.TimeoutExpired."""
+    import cost_report_weekly as W
+
+    def _raise(*a, **kw):
+        raise subprocess.TimeoutExpired(cmd="coding-memory", timeout=30)
+
+    monkeypatch.setattr(subprocess, "run", _raise)
+
+    out = W.format_recall_section()
+    assert "data unavailable" in out


### PR DESCRIPTION
Records every recall (push + pull) in a jns `recall_event` table (isolated autocommit conn, fail-open, no raw query text), adds `coding-memory recall-report --json`, and a fail-open `format_recall_section` in the weekly cost report. Orchestrated (MAP-PLAN→PATCH→PROVE, PROVE PASS). Codex R1→R2: APPROVE. Closes #455