### PR TITLE
feat(coding-memory): recall telemetry (L2) — tie recall to outcome in metrics

### DIFF
--- a/claude-config/commands/orchestrate.md
+++ b/claude-config/commands/orchestrate.md
@@ -356,6 +356,44 @@ cross-project `global` craft lessons.
   (then Read the source file of any hit for the full body). Prefer this precise
   pull over relying on the push.
 
+**Persist recall summary for outcome recording**: After capturing
+`{CODING_MEMORY_BLOCK}`, write a JSON sidecar so Step 4 can
+correlate the recall result with the PROVE outcome without threading
+it through Task() prompts (the orchestrator is stateless between calls).
+Set `RECALL_CMD_OK=1` when the `coding-memory query` command exits 0 and
+produces output; set it to `0` when the command errors, times out, or
+returns nothing. The sidecar write is fail-open: if it fails, continue
+without it — Step 4 handles the absent-file case.
+
+```python
+import json
+from pathlib import Path
+# Parse the --for-prompt output to extract fired/n/facts.
+# {CODING_MEMORY_BLOCK} was captured above from coding-memory query --for-prompt.
+_recall_block = """{CODING_MEMORY_BLOCK}"""
+_facts = [
+    ln.strip().lstrip("- ").split(":")[0].strip()
+    for ln in _recall_block.splitlines()
+    if ln.strip().startswith("-")
+]
+_fired = bool(_facts)
+_sidecar = {
+    "issue": int("$ISSUE"),
+    "date": "$MMDDYY",
+    "fired": _fired,
+    "n": len(_facts),
+    "facts": _facts,
+    "flag": "on" if "$RECALL_CMD_OK" == "1" else "off",
+}
+try:
+    Path(".agents/outputs").mkdir(parents=True, exist_ok=True)
+    Path(f".agents/outputs/recall-$ISSUE-$MMDDYY.json").write_text(
+        json.dumps(_sidecar), encoding="utf-8"
+    )
+except Exception:
+    pass  # fail-open; Step 4 handles absent sidecar
+```
+
 ### Step 3: Spawn Agents (Task Tool)
 
 **CRITICAL**: Use the Task tool to spawn each phase agent via **native subagent
@@ -536,10 +574,24 @@ if status == "PASS":
         status = "FAIL"
         print(f"PROVE PASS downgraded to FAIL: {downgrade_reason}")
 
+# Read recall sidecar written at Step 2.85 (fail-open: absent/malformed sidecar → no recall field)
+import glob as _glob
+_recall_kwarg = {}
+try:
+    _sidecar_candidates = sorted(
+        _glob.glob(".agents/outputs/recall-$ISSUE-*.json")
+    )
+    if _sidecar_candidates:
+        _sc = json.loads(Path(_sidecar_candidates[-1]).read_text(encoding="utf-8"))
+        _recall_kwarg = {"recall": _sc}
+except Exception:
+    pass  # fail-open; record_metrics still runs, just without recall field
+
 record_metrics(
     Path("."), int("$ISSUE"), status, complexity, stack, agents_run,
     root_cause=root_cause,
     blocking_agent=("PROVE" if status in ("BLOCKED", "FAIL") else None),
+    **_recall_kwarg,
 )
 
 # Always log the per-AC audit row, regardless of verdict — clean PASS

--- a/claude-config/commands/orchestrate.md
+++ b/claude-config/commands/orchestrate.md
@@ -574,15 +574,13 @@ if status == "PASS":
         status = "FAIL"
         print(f"PROVE PASS downgraded to FAIL: {downgrade_reason}")
 
-# Read recall sidecar written at Step 2.85 (fail-open: absent/malformed sidecar → no recall field)
-import glob as _glob
+# Read recall sidecar written at Step 2.85 using the EXACT current-run path.
+# Never glob: a glob could pick up an older run's sidecar if this run's write failed.
 _recall_kwarg = {}
 try:
-    _sidecar_candidates = sorted(
-        _glob.glob(".agents/outputs/recall-$ISSUE-*.json")
-    )
-    if _sidecar_candidates:
-        _sc = json.loads(Path(_sidecar_candidates[-1]).read_text(encoding="utf-8"))
+    _sidecar_path = Path(".agents/outputs/recall-$ISSUE-$MMDDYY.json")
+    if _sidecar_path.exists():
+        _sc = json.loads(_sidecar_path.read_text(encoding="utf-8"))
         _recall_kwarg = {"recall": _sc}
 except Exception:
     pass  # fail-open; record_metrics still runs, just without recall field

--- a/claude-config/hooks/state_manager.py
+++ b/claude-config/hooks/state_manager.py
@@ -392,29 +392,36 @@ def record_metrics(
             record["codex_overturned"] = dict(codex_overturned)
 
     if recall is not None:
-        _flag = recall.get("flag", "")
-        _fired = recall.get("fired")
-        _facts = recall.get("facts")
-        _n = recall.get("n")
-        if _flag not in _VALID_RECALL_FLAGS:
-            logging.warning(
-                "record_metrics: dropped recall with invalid flag %r", _flag
-            )
-        elif not isinstance(_fired, bool):
-            logging.warning(
-                "record_metrics: dropped recall with non-bool fired %r", _fired
-            )
-        elif not isinstance(_facts, list):
-            logging.warning(
-                "record_metrics: dropped recall with non-list facts %r", _facts
-            )
+        if not isinstance(recall, dict):
+            logging.warning("record_metrics: dropped non-dict recall %r", recall)
         else:
-            record["recall"] = {
-                "fired": _fired,
-                "n": max(0, int(_n)) if _n is not None else 0,
-                "facts": [str(f) for f in _facts],
-                "flag": _flag,
-            }
+            _flag = recall.get("flag", "")
+            _fired = recall.get("fired")
+            _facts = recall.get("facts")
+            _n = recall.get("n")
+            if _flag not in _VALID_RECALL_FLAGS:
+                logging.warning(
+                    "record_metrics: dropped recall with invalid flag %r", _flag
+                )
+            elif not isinstance(_fired, bool):
+                logging.warning(
+                    "record_metrics: dropped recall with non-bool fired %r", _fired
+                )
+            elif not isinstance(_facts, list):
+                logging.warning(
+                    "record_metrics: dropped recall with non-list facts %r", _facts
+                )
+            else:
+                try:
+                    _n_val = max(0, int(_n)) if _n is not None else 0
+                except (TypeError, ValueError):
+                    _n_val = 0
+                record["recall"] = {
+                    "fired": _fired,
+                    "n": _n_val,
+                    "facts": [str(f) for f in _facts],
+                    "flag": _flag,
+                }
 
     target = _memory_dir(project_dir) / "metrics.jsonl"
     try:

--- a/claude-config/hooks/state_manager.py
+++ b/claude-config/hooks/state_manager.py
@@ -33,14 +33,15 @@ logging.basicConfig(
 
 try:
     import yaml
+
     HAS_YAML = True
 except ImportError:
     HAS_YAML = False
 
 
-
-
-def _event_id(issue: int, date: str, project: str, root_cause: str, details: str) -> str:
+def _event_id(
+    issue: int, date: str, project: str, root_cause: str, details: str
+) -> str:
     """Stable content-hash identifier for a failure record (M4).
 
     SHA-1 of ``issue|date|project|root_cause|details`` (pipe-delimited, UTF-8).
@@ -78,7 +79,13 @@ def ensure_event_id(record: dict) -> dict:
 
 
 def _state_path(project_dir: Path) -> Path:
-    return project_dir / ".agents" / "outputs" / "claude_checkpoints" / "PERSISTENT_STATE.yaml"
+    return (
+        project_dir
+        / ".agents"
+        / "outputs"
+        / "claude_checkpoints"
+        / "PERSISTENT_STATE.yaml"
+    )
 
 
 def load_state(project_dir: Path) -> dict:
@@ -106,8 +113,14 @@ def _write_state(project_dir: Path, data: dict) -> None:
         yaml.safe_dump(data, f, default_flow_style=False, sort_keys=False)
 
 
-def update_phase(project_dir: Path, issue: int, branch: str, phase: str, action: str,
-                  worktree_path: str | None = None) -> None:
+def update_phase(
+    project_dir: Path,
+    issue: int,
+    branch: str,
+    phase: str,
+    action: str,
+    worktree_path: str | None = None,
+) -> None:
     """Update active_work with current phase. Tracks completed phases for --resume.
 
     Args:
@@ -197,7 +210,9 @@ def update_from_extracted(project_dir: Path, extracted: dict) -> None:
     if extracted.get("last_phase"):
         data["active_work"]["phase"] = extracted["last_phase"]
     if extracted.get("artifacts_created"):
-        data["active_work"]["last_action"] = f"Created {extracted['artifacts_created'][-1]}"
+        data["active_work"]["last_action"] = (
+            f"Created {extracted['artifacts_created'][-1]}"
+        )
 
     if "meta" not in data:
         data["meta"] = {}
@@ -225,6 +240,7 @@ def update_from_extracted(project_dir: Path, extracted: dict) -> None:
 # read-only filesystem, etc.) we log a warning to ~/.claude/hooks.log and
 # return None. Losing one metric line is acceptable; failing a successful
 # orchestrate run because we couldn't write a metric is not.
+
 
 def _memory_dir(project_dir: Path) -> Path:
     return project_dir / ".claude" / "memory"
@@ -267,6 +283,7 @@ def record_metrics(
     tier_corrected_to: str | None = None,
     guards_fired: list[str] | None = None,
     codex_overturned: dict | None = None,
+    recall: dict | None = None,
 ) -> None:
     """Append a single record to ``.claude/memory/metrics.jsonl``.
 
@@ -314,6 +331,14 @@ def record_metrics(
             the PROVE verdict. Both ``state`` and ``category`` must
             pass validation; the whole dict is dropped (with a WARNING)
             if either is invalid. DORMANT — schema only; no producer yet.
+        recall: Optional dict written by the orchestrator sidecar
+            (issue #456) with shape
+            ``{"fired": bool, "n": int, "facts": list[str],
+            "flag": "on"|"off"}``.
+            ``flag`` must be in ``_VALID_RECALL_FLAGS``; ``fired`` must
+            be bool; ``facts`` must be list. On any validation failure
+            the whole dict is omitted (WARNING logged, no raise).
+            Included in the record only when supplied.
 
     Returns: None. Errors are logged to ``~/.claude/hooks.log``; the
     function never raises into the orchestrator.
@@ -347,9 +372,7 @@ def record_metrics(
         valid = [g for g in guards_fired if g in _VALID_GUARDS]
         dropped = set(guards_fired) - set(valid)
         if dropped:
-            logging.warning(
-                "record_metrics: dropped unknown guards %r", dropped
-            )
+            logging.warning("record_metrics: dropped unknown guards %r", dropped)
         if valid:
             record["guards_fired"] = valid
 
@@ -358,16 +381,40 @@ def record_metrics(
         _cat = codex_overturned.get("category", "")
         if _state not in _VALID_CODEX_STATES:
             logging.warning(
-                "record_metrics: dropped codex_overturned with invalid "
-                "state %r", _state
+                "record_metrics: dropped codex_overturned with invalid state %r", _state
             )
         elif _cat not in _VALID_CODEX_CATEGORIES:
             logging.warning(
-                "record_metrics: dropped codex_overturned with invalid "
-                "category %r", _cat
+                "record_metrics: dropped codex_overturned with invalid category %r",
+                _cat,
             )
         else:
             record["codex_overturned"] = dict(codex_overturned)
+
+    if recall is not None:
+        _flag = recall.get("flag", "")
+        _fired = recall.get("fired")
+        _facts = recall.get("facts")
+        _n = recall.get("n")
+        if _flag not in _VALID_RECALL_FLAGS:
+            logging.warning(
+                "record_metrics: dropped recall with invalid flag %r", _flag
+            )
+        elif not isinstance(_fired, bool):
+            logging.warning(
+                "record_metrics: dropped recall with non-bool fired %r", _fired
+            )
+        elif not isinstance(_facts, list):
+            logging.warning(
+                "record_metrics: dropped recall with non-list facts %r", _facts
+            )
+        else:
+            record["recall"] = {
+                "fired": _fired,
+                "n": max(0, int(_n)) if _n is not None else 0,
+                "facts": [str(f) for f in _facts],
+                "flag": _flag,
+            }
 
     target = _memory_dir(project_dir) / "metrics.jsonl"
     try:
@@ -477,12 +524,12 @@ def flip_to_correction(
     target = _memory_dir(project_dir) / "metrics.jsonl"
     try:
         if not target.exists():
-            logging.warning(
-                f"flip_to_correction: metrics.jsonl not found at {target}"
-            )
+            logging.warning(f"flip_to_correction: metrics.jsonl not found at {target}")
             return False
 
-        lines = [ln for ln in target.read_text(encoding="utf-8").splitlines() if ln.strip()]
+        lines = [
+            ln for ln in target.read_text(encoding="utf-8").splitlines() if ln.strip()
+        ]
         last_record: dict | None = None
         for line in lines:
             try:
@@ -610,13 +657,25 @@ _VALID_AC_STATUSES = frozenset({"implemented", "partial", "missing", "deferred",
 # "deferred to a follow-up" from becoming an APPROVE escape hatch.
 _DEFERRED_REF_RE = re.compile(r"#\d+|GH-\d+", re.IGNORECASE)
 
-_VALID_GUARDS = frozenset({
-    "VERIFICATION_GAP", "ENUM_VALUE", "COMPONENT_API",
-})
+_VALID_GUARDS = frozenset(
+    {
+        "VERIFICATION_GAP",
+        "ENUM_VALUE",
+        "COMPONENT_API",
+    }
+)
 _VALID_CODEX_STATES = frozenset({"not_run", "confirmed", "overturned"})
-_VALID_CODEX_CATEGORIES = frozenset({
-    "auth", "migration", "enum_contract", "cross_module", "secrets",
-})
+_VALID_CODEX_CATEGORIES = frozenset(
+    {
+        "auth",
+        "migration",
+        "enum_contract",
+        "cross_module",
+        "secrets",
+    }
+)
+_VALID_RECALL_KEYS = frozenset({"fired", "n", "facts", "flag"})
+_VALID_RECALL_FLAGS = frozenset({"on", "off"})
 
 
 def _ac_label(entry: dict, idx: int) -> str:
@@ -674,7 +733,9 @@ def count_acceptance_bullets(issue_body: str) -> int:
     return count
 
 
-def validate_ac_audit(ac_audit: list | None, expected_ac_count: int | None = None) -> dict:
+def validate_ac_audit(
+    ac_audit: list | None, expected_ac_count: int | None = None
+) -> dict:
     """Validate a PROVE ``ac_audit`` array against the AC-FORBIDS-APPROVE rule.
 
     Mirrors the Codex-side rule from issue #1609: a PROVE verdict of PASS
@@ -712,11 +773,13 @@ def validate_ac_audit(ac_audit: list | None, expected_ac_count: int | None = Non
         return {
             "valid": False,
             "downgrade_to": "FAIL",
-            "missing": [{
-                "ac": "(no ac_audit array)",
-                "status": "missing",
-                "reason": "PROVE artifact has no ac_audit entries; cannot verify AC coverage",
-            }],
+            "missing": [
+                {
+                    "ac": "(no ac_audit array)",
+                    "status": "missing",
+                    "reason": "PROVE artifact has no ac_audit entries; cannot verify AC coverage",
+                }
+            ],
         }
 
     valid = True
@@ -725,48 +788,58 @@ def validate_ac_audit(ac_audit: list | None, expected_ac_count: int | None = Non
     # uncovered slots so the verdict downgrades.
     if isinstance(expected_ac_count, int) and expected_ac_count > len(ac_audit):
         for slot in range(len(ac_audit), expected_ac_count):
-            missing.append({
-                "ac": f"AC#{slot + 1}",
-                "status": "missing",
-                "reason": (
-                    f"issue declares {expected_ac_count} AC bullets but "
-                    f"ac_audit has only {len(ac_audit)} entries; "
-                    f"AC #{slot + 1} omitted"
-                ),
-            })
+            missing.append(
+                {
+                    "ac": f"AC#{slot + 1}",
+                    "status": "missing",
+                    "reason": (
+                        f"issue declares {expected_ac_count} AC bullets but "
+                        f"ac_audit has only {len(ac_audit)} entries; "
+                        f"AC #{slot + 1} omitted"
+                    ),
+                }
+            )
 
     for idx, entry in enumerate(ac_audit):
         if not isinstance(entry, dict):
             valid = False
-            missing.append({
-                "ac": _ac_label({}, idx),
-                "status": "invalid",
-                "reason": f"ac_audit[{idx}] is not an object",
-            })
+            missing.append(
+                {
+                    "ac": _ac_label({}, idx),
+                    "status": "invalid",
+                    "reason": f"ac_audit[{idx}] is not an object",
+                }
+            )
             continue
         status = entry.get("status")
         if status not in _VALID_AC_STATUSES:
             valid = False
-            missing.append({
-                "ac": _ac_label(entry, idx),
-                "status": str(status),
-                "reason": f"unknown status {status!r}; expected one of {sorted(_VALID_AC_STATUSES)}",
-            })
+            missing.append(
+                {
+                    "ac": _ac_label(entry, idx),
+                    "status": str(status),
+                    "reason": f"unknown status {status!r}; expected one of {sorted(_VALID_AC_STATUSES)}",
+                }
+            )
             continue
         if status in ("missing", "partial"):
-            missing.append({
-                "ac": _ac_label(entry, idx),
-                "status": status,
-                "reason": f"AC #{idx + 1} marked {status}",
-            })
+            missing.append(
+                {
+                    "ac": _ac_label(entry, idx),
+                    "status": status,
+                    "reason": f"AC #{idx + 1} marked {status}",
+                }
+            )
         elif status == "deferred":
             evidence = entry.get("evidence")
             if not isinstance(evidence, str) or not _DEFERRED_REF_RE.search(evidence):
-                missing.append({
-                    "ac": _ac_label(entry, idx),
-                    "status": "missing",
-                    "reason": "deferred without follow-up issue # — treated as missing",
-                })
+                missing.append(
+                    {
+                        "ac": _ac_label(entry, idx),
+                        "status": "missing",
+                        "reason": "deferred without follow-up issue # — treated as missing",
+                    }
+                )
         # implemented + n/a are clean; nothing to record.
 
     downgrade = "FAIL" if missing else None

--- a/claude-config/scripts/cost_report_weekly.py
+++ b/claude-config/scripts/cost_report_weekly.py
@@ -57,13 +57,88 @@ def _save_state(state: dict) -> None:
     EMAIL_STATE.write_text(json.dumps(state, indent=2) + "\n", encoding="utf-8")
 
 
-def format_recall_section(bin_path: Path | None = None) -> str:
+def _recall_correlation(metrics_path: Path) -> str:
+    """Compute first-pass rate split by recall.fired from metrics.jsonl.
+
+    Returns a markdown subsection when each cohort has N >= 3 qualifying
+    records (records with both a recall.fired bool AND a first_pass_correct
+    bool). Returns "" when the file is missing, unreadable, or either cohort
+    is below the minimum threshold.
+
+    Fail-open: any I/O or parse error returns "". BLE001 exempt — scripts/.
+    """
+    try:
+        if not metrics_path.exists():
+            return ""
+        records = []
+        for line in metrics_path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                records.append(json.loads(line))
+            except Exception:
+                continue
+
+        fired_pass = fired_total = 0
+        not_fired_pass = not_fired_total = 0
+        for rec in records:
+            recall = rec.get("recall")
+            if not isinstance(recall, dict):
+                continue  # pre-L2 record — exclude from split
+            fired = recall.get("fired")
+            if not isinstance(fired, bool):
+                continue
+            fpc = rec.get("first_pass_correct")
+            if not isinstance(fpc, bool):
+                continue
+            if fired:
+                fired_total += 1
+                if fpc:
+                    fired_pass += 1
+            else:
+                not_fired_total += 1
+                if fpc:
+                    not_fired_pass += 1
+
+        min_n = 3
+        if fired_total < min_n or not_fired_total < min_n:
+            return ""
+
+        fired_rate = f"{fired_pass / fired_total:.0%}"
+        not_fired_rate = f"{not_fired_pass / not_fired_total:.0%}"
+
+        lines = [
+            "### Outcome correlation (from metrics.jsonl)",
+            "",
+            "| cohort | issues | first-pass rate |",
+            "|--------|--------|-----------------|",
+            f"| recall fired | {fired_total} | {fired_rate} |",
+            f"| recall not fired | {not_fired_total} | {not_fired_rate} |",
+        ]
+        return "\n".join(lines)
+    except Exception:
+        return ""  # fail-open — BLE001 exempt for scripts/
+
+
+def format_recall_section(
+    bin_path: Path | None = None,
+    metrics_path: Path | None = None,
+) -> str:
     """Shell out to coding-memory recall-report --json --days 7.
 
     Fail-open: returns a one-line "data unavailable" notice on any error
     so the weekly report still sends when jns is unreachable or the CLI
     is absent. Broad catch is intentional (BLE001 exempted for scripts/).
     Uses the absolute bin path so launchd's restricted PATH is not a problem.
+
+    Args:
+        bin_path: Path to the coding-memory binary. Defaults to
+            ~/agents/bin/coding-memory.
+        metrics_path: Optional path to metrics.jsonl. When supplied, an
+            "Outcome correlation" subsection is appended showing first-pass
+            rate split by recall.fired (issue #456). Omitted when None or
+            when either cohort has fewer than 3 qualifying records.
     """
     if bin_path is None:
         bin_path = Path.home() / "agents" / "bin" / "coding-memory"
@@ -116,6 +191,15 @@ def format_recall_section(bin_path: Path | None = None) -> str:
     except Exception:
         pass  # malformed top_facts entry — omit the section, report still sends
 
+    if metrics_path is not None:
+        try:
+            corr = _recall_correlation(metrics_path)
+            if corr:
+                lines.append("")
+                lines.extend(corr.splitlines())
+        except Exception:
+            pass  # fail-open — BLE001 exempt for scripts/
+
     return "\n".join(lines)
 
 
@@ -144,7 +228,9 @@ def main() -> int:
     )
     if kpi_section:
         md = md + "\n\n" + kpi_section
-    recall_section = format_recall_section()
+    recall_section = format_recall_section(
+        metrics_path=Path.home() / ".claude" / "memory" / "metrics.jsonl"
+    )
     if recall_section:
         md = md + "\n\n" + recall_section
     print(f"[{now.isoformat()}] local report: {html_path} ({len(records)} records)")

--- a/claude-config/tests/test_cost_report_recall_correlation.py
+++ b/claude-config/tests/test_cost_report_recall_correlation.py
@@ -1,0 +1,338 @@
+"""Tests for recall outcome correlation in cost_report_weekly.py (issue #456).
+
+Covers:
+  - _recall_correlation split by recall.fired
+  - N<3 gate returns ""
+  - pre-L2 records (no recall field) excluded from split
+  - format_recall_section appends correlation block when metrics_path supplied
+  - format_recall_section fail-open when metrics_path doesn't exist
+
+Run from the repo root:
+
+    python3 -m pytest claude-config/tests/test_cost_report_recall_correlation.py -v
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+import cost_report_weekly as CRW  # noqa: E402
+
+
+# ── Fixture helpers ───────────────────────────────────────────────────────────
+
+
+def _write_metrics(tmp_path: Path, records: list) -> Path:
+    p = tmp_path / "metrics.jsonl"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    with p.open("w", encoding="utf-8") as fh:
+        for r in records:
+            fh.write(json.dumps(r) + "\n")
+    return p
+
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+
+
+def test_correlation_fired_vs_not(tmp_path):
+    """Split by recall.fired; compute first-pass rate per cohort."""
+    p = _write_metrics(
+        tmp_path,
+        [
+            # fired=True cohort: 2 pass, 1 fail → 67%
+            {
+                "issue": 1,
+                "date": "2026-06-09",
+                "first_pass_correct": True,
+                "recall": {"fired": True, "n": 1, "facts": ["x"], "flag": "on"},
+            },
+            {
+                "issue": 2,
+                "date": "2026-06-09",
+                "first_pass_correct": True,
+                "recall": {"fired": True, "n": 1, "facts": ["y"], "flag": "on"},
+            },
+            {
+                "issue": 3,
+                "date": "2026-06-09",
+                "first_pass_correct": False,
+                "recall": {"fired": True, "n": 0, "facts": [], "flag": "on"},
+            },
+            # fired=False cohort: 1 pass, 2 fail → 33%
+            {
+                "issue": 4,
+                "date": "2026-06-09",
+                "first_pass_correct": True,
+                "recall": {"fired": False, "n": 0, "facts": [], "flag": "on"},
+            },
+            {
+                "issue": 5,
+                "date": "2026-06-09",
+                "first_pass_correct": False,
+                "recall": {"fired": False, "n": 0, "facts": [], "flag": "on"},
+            },
+            {
+                "issue": 6,
+                "date": "2026-06-09",
+                "first_pass_correct": False,
+                "recall": {"fired": False, "n": 0, "facts": [], "flag": "on"},
+            },
+        ],
+    )
+    result = CRW._recall_correlation(p)
+    assert "recall fired" in result
+    assert "67%" in result  # fired: 2/3 = 67%
+    assert "33%" in result  # not fired: 1/3 = 33%
+
+
+def test_correlation_omitted_when_too_few_fired(tmp_path):
+    """Returns '' when fired cohort has fewer than 3 qualifying records."""
+    p = _write_metrics(
+        tmp_path,
+        [
+            {
+                "issue": 1,
+                "date": "2026-06-09",
+                "first_pass_correct": True,
+                "recall": {"fired": True, "n": 1, "facts": [], "flag": "on"},
+            },
+            # not_fired cohort has 3, but fired only has 1
+            {
+                "issue": 2,
+                "date": "2026-06-09",
+                "first_pass_correct": True,
+                "recall": {"fired": False, "n": 0, "facts": [], "flag": "on"},
+            },
+            {
+                "issue": 3,
+                "date": "2026-06-09",
+                "first_pass_correct": False,
+                "recall": {"fired": False, "n": 0, "facts": [], "flag": "on"},
+            },
+            {
+                "issue": 4,
+                "date": "2026-06-09",
+                "first_pass_correct": False,
+                "recall": {"fired": False, "n": 0, "facts": [], "flag": "on"},
+            },
+        ],
+    )
+    assert CRW._recall_correlation(p) == ""
+
+
+def test_correlation_omitted_when_too_few_not_fired(tmp_path):
+    """Returns '' when not-fired cohort has fewer than 3 qualifying records."""
+    p = _write_metrics(
+        tmp_path,
+        [
+            # fired cohort has 3
+            {
+                "issue": 1,
+                "date": "2026-06-09",
+                "first_pass_correct": True,
+                "recall": {"fired": True, "n": 1, "facts": [], "flag": "on"},
+            },
+            {
+                "issue": 2,
+                "date": "2026-06-09",
+                "first_pass_correct": True,
+                "recall": {"fired": True, "n": 1, "facts": [], "flag": "on"},
+            },
+            {
+                "issue": 3,
+                "date": "2026-06-09",
+                "first_pass_correct": False,
+                "recall": {"fired": True, "n": 0, "facts": [], "flag": "on"},
+            },
+            # not_fired only has 1
+            {
+                "issue": 4,
+                "date": "2026-06-09",
+                "first_pass_correct": True,
+                "recall": {"fired": False, "n": 0, "facts": [], "flag": "on"},
+            },
+        ],
+    )
+    assert CRW._recall_correlation(p) == ""
+
+
+def test_correlation_excludes_no_recall_field(tmp_path):
+    """Records without recall field (pre-L2) are excluded from the split."""
+    p = _write_metrics(
+        tmp_path,
+        [
+            # 3 pre-L2 records (no recall field) — should NOT be counted
+            {"issue": i, "date": "2026-06-09", "first_pass_correct": True}
+            for i in range(1, 4)
+        ]
+        + [
+            # Only 1 fired record — below threshold
+            {
+                "issue": 10,
+                "date": "2026-06-09",
+                "first_pass_correct": True,
+                "recall": {"fired": True, "n": 1, "facts": [], "flag": "on"},
+            },
+        ],
+    )
+    # Only 1 fired record, 0 not-fired → below threshold → empty
+    assert CRW._recall_correlation(p) == ""
+
+
+def test_correlation_missing_file_returns_empty(tmp_path):
+    """Returns '' when the metrics file doesn't exist."""
+    absent = tmp_path / "no_such_file.jsonl"
+    assert CRW._recall_correlation(absent) == ""
+
+
+def test_correlation_excludes_records_missing_fpc(tmp_path):
+    """Records without first_pass_correct bool are excluded from rate computation."""
+    p = _write_metrics(
+        tmp_path,
+        [
+            # fired cohort: 3 records but one lacks first_pass_correct → only 2 qualify
+            {
+                "issue": 1,
+                "date": "2026-06-09",
+                "first_pass_correct": True,
+                "recall": {"fired": True, "n": 1, "facts": [], "flag": "on"},
+            },
+            {
+                "issue": 2,
+                "date": "2026-06-09",
+                "first_pass_correct": True,
+                "recall": {"fired": True, "n": 1, "facts": [], "flag": "on"},
+            },
+            {
+                "issue": 3,
+                "date": "2026-06-09",  # no first_pass_correct
+                "recall": {"fired": True, "n": 0, "facts": [], "flag": "on"},
+            },
+            # not_fired cohort: 3 qualify
+            {
+                "issue": 4,
+                "date": "2026-06-09",
+                "first_pass_correct": True,
+                "recall": {"fired": False, "n": 0, "facts": [], "flag": "on"},
+            },
+            {
+                "issue": 5,
+                "date": "2026-06-09",
+                "first_pass_correct": False,
+                "recall": {"fired": False, "n": 0, "facts": [], "flag": "on"},
+            },
+            {
+                "issue": 6,
+                "date": "2026-06-09",
+                "first_pass_correct": False,
+                "recall": {"fired": False, "n": 0, "facts": [], "flag": "on"},
+            },
+        ],
+    )
+    # fired cohort only has 2 qualifying records → below threshold
+    assert CRW._recall_correlation(p) == ""
+
+
+def test_format_recall_section_includes_correlation_when_metrics_path_supplied(
+    tmp_path, monkeypatch
+):
+    """format_recall_section appends correlation block when metrics_path given."""
+    p = _write_metrics(
+        tmp_path,
+        [
+            {
+                "issue": i,
+                "date": "2026-06-09",
+                "first_pass_correct": True,
+                "recall": {"fired": True, "n": 1, "facts": [], "flag": "on"},
+            }
+            for i in range(1, 4)
+        ]
+        + [
+            {
+                "issue": i,
+                "date": "2026-06-09",
+                "first_pass_correct": False,
+                "recall": {"fired": False, "n": 0, "facts": [], "flag": "on"},
+            }
+            for i in range(10, 13)
+        ],
+    )
+
+    # Stub out the coding-memory subprocess call to avoid requiring the CLI.
+    def _fake_run(cmd, **kwargs):
+        class _R:
+            returncode = 0
+            stdout = json.dumps(
+                {
+                    "n_total": 5,
+                    "n_push": 3,
+                    "n_pull": 2,
+                    "n_injected_total": 4,
+                    "n_returned_total": 5,
+                    "p50_latency_ms": 120,
+                    "top_facts": [],
+                    "days": 7,
+                }
+            )
+
+        return _R()
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+
+    section = CRW.format_recall_section(metrics_path=p)
+    assert "Outcome correlation" in section
+    assert "recall fired" in section
+    assert "recall not fired" in section
+
+
+def test_format_recall_section_no_crash_when_metrics_absent(tmp_path, monkeypatch):
+    """format_recall_section is fail-open when metrics_path doesn't exist."""
+    absent = tmp_path / "no_such_file.jsonl"
+
+    def _fake_run(cmd, **kwargs):
+        class _R:
+            returncode = 0
+            stdout = json.dumps(
+                {
+                    "n_total": 0,
+                    "n_push": 0,
+                    "n_pull": 0,
+                    "n_injected_total": 0,
+                    "n_returned_total": 0,
+                    "p50_latency_ms": None,
+                    "top_facts": [],
+                    "days": 7,
+                }
+            )
+
+        return _R()
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+
+    section = CRW.format_recall_section(metrics_path=absent)
+    # Must return a string without raising
+    assert isinstance(section, str)
+    # Correlation subsection absent (not enough data)
+    assert "Outcome correlation" not in section
+
+
+def test_format_recall_section_no_metrics_path_backward_compat(monkeypatch):
+    """format_recall_section without metrics_path still works (backward compat)."""
+
+    def _fake_run(cmd, **kwargs):
+        class _R:
+            returncode = 1
+            stdout = ""
+
+        return _R()
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+
+    section = CRW.format_recall_section()
+    assert "data unavailable" in section

--- a/claude-config/tests/test_state_manager_decision_fields.py
+++ b/claude-config/tests/test_state_manager_decision_fields.py
@@ -181,18 +181,21 @@ def test_backward_compatibility(project_dir, tmp_path):
 
     # Write a legacy record (no decision fields) via raw write to simulate a
     # pre-change record that would have been written before issue #217.
-    _write_raw_metrics(project_dir, [
-        {
-            "issue": 100,
-            "date": "2026-01-01",
-            "recorded_at": "2026-01-01T10:00:00.000000Z",
-            "status": "PASS",
-            "complexity": "TRIVIAL",
-            "stack": "backend",
-            "agents_run": ["PATCH"],
-            "project": "agents",
-        }
-    ])
+    _write_raw_metrics(
+        project_dir,
+        [
+            {
+                "issue": 100,
+                "date": "2026-01-01",
+                "recorded_at": "2026-01-01T10:00:00.000000Z",
+                "status": "PASS",
+                "complexity": "TRIVIAL",
+                "stack": "backend",
+                "agents_run": ["PATCH"],
+                "project": "agents",
+            }
+        ],
+    )
 
     # Write a record with decision fields for a different issue.
     record_metrics(
@@ -221,7 +224,10 @@ def test_backward_compatibility(project_dir, tmp_path):
     # New record's decision fields must survive the rollup.
     assert issue200["tier_corrected_to"] == "COMPLEX"
     assert issue200["guards_fired"] == ["ENUM_VALUE"]
-    assert issue200["codex_overturned"] == {"state": "confirmed", "category": "migration"}
+    assert issue200["codex_overturned"] == {
+        "state": "confirmed",
+        "category": "migration",
+    }
 
 
 # ── Test 4: Field-level dedup collision (AC4b, TAUTOLOGY GUARD) ─────────────
@@ -238,31 +244,34 @@ def test_dedup_collision(project_dir, tmp_path):
     global_dir = tmp_path / "global"
 
     # Record A: older timestamp, HAS tier_corrected_to.
-    _write_raw_metrics(project_dir, [
-        {
-            "issue": 5,
-            "date": "2026-01-01",
-            "recorded_at": "2026-01-01T10:00:00.000000Z",
-            "status": "PASS",
-            "complexity": "SIMPLE",
-            "stack": "backend",
-            "agents_run": ["PATCH"],
-            "project": "agents",
-            "tier_corrected_to": "COMPLEX",
-        },
-        # Record B: newer timestamp (higher recorded_at), SAME key, NO tier_corrected_to.
-        # Under old last-wins code, B overwrites A entirely, losing tier_corrected_to.
-        {
-            "issue": 5,
-            "date": "2026-01-01",
-            "recorded_at": "2026-01-01T11:00:00.000000Z",
-            "status": "PASS",
-            "complexity": "SIMPLE",
-            "stack": "backend",
-            "agents_run": ["PATCH", "PROVE"],
-            "project": "agents",
-        },
-    ])
+    _write_raw_metrics(
+        project_dir,
+        [
+            {
+                "issue": 5,
+                "date": "2026-01-01",
+                "recorded_at": "2026-01-01T10:00:00.000000Z",
+                "status": "PASS",
+                "complexity": "SIMPLE",
+                "stack": "backend",
+                "agents_run": ["PATCH"],
+                "project": "agents",
+                "tier_corrected_to": "COMPLEX",
+            },
+            # Record B: newer timestamp (higher recorded_at), SAME key, NO tier_corrected_to.
+            # Under old last-wins code, B overwrites A entirely, losing tier_corrected_to.
+            {
+                "issue": 5,
+                "date": "2026-01-01",
+                "recorded_at": "2026-01-01T11:00:00.000000Z",
+                "status": "PASS",
+                "complexity": "SIMPLE",
+                "stack": "backend",
+                "agents_run": ["PATCH", "PROVE"],
+                "project": "agents",
+            },
+        ],
+    )
 
     aggregate("metrics", [source_dir], global_dir)
     global_rows = _read_global_metrics(global_dir)
@@ -382,3 +391,86 @@ def test_size_budget():
     }
     size = len(json.dumps(rec).encode("utf-8"))
     assert size <= 4096, f"Record size {size} exceeds 4096-byte PIPE_BUF budget"
+
+
+# ── Tests 8–12: recall= field round-trip and validation (issue #456) ─────────
+
+
+def test_recall_present_when_supplied(project_dir):
+    """recall= field is written when valid dict is supplied."""
+    record_metrics(
+        project_dir,
+        456,
+        "PASS",
+        "MODERATE",
+        "backend",
+        ["MAP-PLAN", "PATCH", "PROVE"],
+        recall={"fired": True, "n": 2, "facts": ["fact_a", "fact_b"], "flag": "on"},
+    )
+    row = _read_metrics(project_dir)[0]
+    assert "recall" in row
+    assert row["recall"]["fired"] is True
+    assert row["recall"]["n"] == 2
+    assert row["recall"]["facts"] == ["fact_a", "fact_b"]
+    assert row["recall"]["flag"] == "on"
+
+
+def test_recall_absent_when_not_supplied(project_dir):
+    """recall= field omitted when not passed (compact PASS records)."""
+    record_metrics(
+        project_dir,
+        100,
+        "PASS",
+        "SIMPLE",
+        "backend",
+        ["MAP-PLAN", "PATCH", "PROVE"],
+    )
+    row = _read_metrics(project_dir)[0]
+    assert "recall" not in row
+
+
+def test_recall_dropped_on_invalid_flag(project_dir):
+    """recall dict with unknown flag is dropped with warning, no raise."""
+    record_metrics(
+        project_dir,
+        457,
+        "PASS",
+        "SIMPLE",
+        "backend",
+        [],
+        recall={"fired": True, "n": 1, "facts": ["x"], "flag": "maybe"},
+    )
+    row = _read_metrics(project_dir)[0]
+    assert "recall" not in row
+
+
+def test_recall_dropped_on_non_bool_fired(project_dir):
+    """recall dict with non-bool fired is dropped."""
+    record_metrics(
+        project_dir,
+        458,
+        "PASS",
+        "SIMPLE",
+        "backend",
+        [],
+        recall={"fired": "yes", "n": 1, "facts": [], "flag": "on"},
+    )
+    row = _read_metrics(project_dir)[0]
+    assert "recall" not in row
+
+
+def test_recall_fired_false_with_empty_facts(project_dir):
+    """recall fired=False with n=0 and empty facts is valid."""
+    record_metrics(
+        project_dir,
+        459,
+        "PASS",
+        "SIMPLE",
+        "backend",
+        [],
+        recall={"fired": False, "n": 0, "facts": [], "flag": "on"},
+    )
+    row = _read_metrics(project_dir)[0]
+    assert row["recall"]["fired"] is False
+    assert row["recall"]["n"] == 0
+    assert row["recall"]["facts"] == []

--- a/claude-config/tests/test_state_manager_decision_fields.py
+++ b/claude-config/tests/test_state_manager_decision_fields.py
@@ -474,3 +474,38 @@ def test_recall_fired_false_with_empty_facts(project_dir):
     assert row["recall"]["fired"] is False
     assert row["recall"]["n"] == 0
     assert row["recall"]["facts"] == []
+
+
+# ── Tests 13–14: Codex R1 remediation (issue #456) ─────────────────────────
+
+
+def test_recall_non_dict_does_not_raise(project_dir):
+    """record_metrics with recall='not-a-dict' must not raise; recall omitted."""
+    record_metrics(
+        project_dir,
+        460,
+        "PASS",
+        "SIMPLE",
+        "backend",
+        [],
+        recall="not-a-dict",
+    )
+    rows = _read_metrics(project_dir)
+    assert len(rows) == 1
+    assert "recall" not in rows[0]
+
+
+def test_recall_non_int_n_does_not_raise(project_dir):
+    """record_metrics with n='abc' must not raise; n recorded as 0."""
+    record_metrics(
+        project_dir,
+        461,
+        "PASS",
+        "SIMPLE",
+        "backend",
+        [],
+        recall={"flag": "on", "fired": True, "facts": [], "n": "abc"},
+    )
+    rows = _read_metrics(project_dir)
+    assert len(rows) == 1
+    assert rows[0]["recall"]["n"] == 0


### PR DESCRIPTION
record_metrics gains a fail-open recall= field; orchestrate writes a recall sidecar at Step 2.85 and reads the exact current-run file at Step 4; weekly report shows fired-vs-not PASS-rate (N>=3 gate). Orchestrated (MAP-PLAN→PATCH→PROVE PASS, 573/573). Codex R1→R2: APPROVE (fixed non-dict/int raise + stale-sidecar reuse). Closes #456