### PR TITLE
feat(coding-memory): recall telemetry (L3) — on/off flag for causal proof

### DIFF
--- a/claude-config/commands/orchestrate.md
+++ b/claude-config/commands/orchestrate.md
@@ -347,12 +347,15 @@ _RECALL_FLAG="${CODING_MEMORY_RECALL:-on}"
 if [ "$_RECALL_FLAG" = "off" ]; then
   # Recall suppressed. Set block empty, write sidecar immediately, skip query.
   CODING_MEMORY_BLOCK=""
-  python3 - <<'SIDECAR_PY'
-import json
+  # Pass issue/date via ENV (the heredoc is single-quoted so $VARS would NOT
+  # expand inside it — int("$ISSUE") would raise and the sidecar never write).
+  RECALL_ISSUE="$ISSUE" RECALL_DATE="$MMDDYY" python3 - <<'SIDECAR_PY'
+import json, os
 from pathlib import Path
+_issue, _date = os.environ["RECALL_ISSUE"], os.environ["RECALL_DATE"]
 _sidecar = {
-    "issue": int("$ISSUE"),
-    "date": "$MMDDYY",
+    "issue": int(_issue),
+    "date": _date,
     "fired": False,
     "n": 0,
     "facts": [],
@@ -360,7 +363,7 @@ _sidecar = {
 }
 try:
     Path(".agents/outputs").mkdir(parents=True, exist_ok=True)
-    Path(f".agents/outputs/recall-$ISSUE-$MMDDYY.json").write_text(
+    Path(f".agents/outputs/recall-{_issue}-{_date}.json").write_text(
         json.dumps(_sidecar), encoding="utf-8"
     )
 except Exception:
@@ -405,10 +408,15 @@ when the `coding-memory query` command exits 0 and produces output; set it to
 `fired`, not `flag`). The sidecar write is fail-open: if it fails, continue
 without it — Step 4 handles the absent-file case.
 
-```python
-import json
+Run via a single-quoted heredoc with issue/date passed through the ENV (so the
+`$VARS` don't need shell expansion inside the heredoc; `{CODING_MEMORY_BLOCK}`
+is template-substituted by the orchestrator before the command runs):
+
+```bash
+RECALL_ISSUE="$ISSUE" RECALL_DATE="$MMDDYY" python3 - <<'SIDECAR_PY'
+import json, os
 from pathlib import Path
-# Parse the --for-prompt output to extract fired/n/facts.
+_issue, _date = os.environ["RECALL_ISSUE"], os.environ["RECALL_DATE"]
 # {CODING_MEMORY_BLOCK} was captured above from coding-memory query --for-prompt.
 _recall_block = """{CODING_MEMORY_BLOCK}"""
 _facts = [
@@ -416,22 +424,22 @@ _facts = [
     for ln in _recall_block.splitlines()
     if ln.strip().startswith("-")
 ]
-_fired = bool(_facts)
 _sidecar = {
-    "issue": int("$ISSUE"),
-    "date": "$MMDDYY",
-    "fired": _fired,
+    "issue": int(_issue),
+    "date": _date,
+    "fired": bool(_facts),
     "n": len(_facts),
     "facts": _facts,
-    "flag": "on",  # env flag was on; RECALL_CMD_OK affects fired, not flag
+    "flag": "on",  # env flag was on; command success affects fired, not flag
 }
 try:
     Path(".agents/outputs").mkdir(parents=True, exist_ok=True)
-    Path(f".agents/outputs/recall-$ISSUE-$MMDDYY.json").write_text(
+    Path(f".agents/outputs/recall-{_issue}-{_date}.json").write_text(
         json.dumps(_sidecar), encoding="utf-8"
     )
 except Exception:
     pass  # fail-open; Step 4 handles absent sidecar
+SIDECAR_PY
 ```
 
 ### Step 3: Spawn Agents (Task Tool)

--- a/claude-config/commands/orchestrate.md
+++ b/claude-config/commands/orchestrate.md
@@ -332,9 +332,48 @@ before?" check — it surfaces the one prior lesson that prevents a re-do (e.g. 
 gotcha for the subsystem you're about to touch), drawn from all your machines +
 cross-project `global` craft lessons.
 
+**L3 on/off flag (`CODING_MEMORY_RECALL`, default `on`):** Set
+`CODING_MEMORY_RECALL=off` in the environment to suppress the query entirely for
+a workflow run. Alternating `on`/`off` across runs creates a causal A/B
+comparison: the sidecar `flag` field records the env INTENT (`"on"` or `"off"`),
+not command success, so the weekly report can split first-pass rates cleanly by
+cohort. The ONLY call site is here — no other path can inject coding-memory when
+`off`.
+
 ```bash
-~/agents/bin/coding-memory query "<issue title + key nouns + changed paths>" -k 3 --for-prompt
+# L3: read env flag once. Default on (behavior-preserving).
+_RECALL_FLAG="${CODING_MEMORY_RECALL:-on}"
+
+if [ "$_RECALL_FLAG" = "off" ]; then
+  # Recall suppressed. Set block empty, write sidecar immediately, skip query.
+  CODING_MEMORY_BLOCK=""
+  python3 - <<'SIDECAR_PY'
+import json
+from pathlib import Path
+_sidecar = {
+    "issue": int("$ISSUE"),
+    "date": "$MMDDYY",
+    "fired": False,
+    "n": 0,
+    "facts": [],
+    "flag": "off",
+}
+try:
+    Path(".agents/outputs").mkdir(parents=True, exist_ok=True)
+    Path(f".agents/outputs/recall-$ISSUE-$MMDDYY.json").write_text(
+        json.dumps(_sidecar), encoding="utf-8"
+    )
+except Exception:
+    pass  # fail-open; Step 4 handles absent sidecar
+SIDECAR_PY
+
+else
+  # Recall enabled. Run query and write sidecar with flag:"on".
+  ~/agents/bin/coding-memory query "<issue title + key nouns + changed paths>" -k 3 --for-prompt
+fi
 ```
+
+When `_RECALL_FLAG=on`:
 
 - **Relevance-gated (NOT a fixed top-3):** `--for-prompt` keeps only facts whose
   cosine similarity clears the calibrated threshold (`RECALL_MIN_SCORE`, ~0.62).
@@ -356,13 +395,14 @@ cross-project `global` craft lessons.
   (then Read the source file of any hit for the full body). Prefer this precise
   pull over relying on the push.
 
-**Persist recall summary for outcome recording**: After capturing
-`{CODING_MEMORY_BLOCK}`, write a JSON sidecar so Step 4 can
-correlate the recall result with the PROVE outcome without threading
-it through Task() prompts (the orchestrator is stateless between calls).
-Set `RECALL_CMD_OK=1` when the `coding-memory query` command exits 0 and
-produces output; set it to `0` when the command errors, times out, or
-returns nothing. The sidecar write is fail-open: if it fails, continue
+**Persist recall summary for outcome recording** (when `_RECALL_FLAG=on`): After
+capturing `{CODING_MEMORY_BLOCK}`, write a JSON sidecar so Step 4 can correlate
+the recall result with the PROVE outcome without threading it through Task()
+prompts (the orchestrator is stateless between calls). Set `RECALL_CMD_OK=1`
+when the `coding-memory query` command exits 0 and produces output; set it to
+`0` when the command errors, times out, or returns nothing. The sidecar
+`flag` field is ALWAYS `"on"` here (the env flag was `on`; command errors affect
+`fired`, not `flag`). The sidecar write is fail-open: if it fails, continue
 without it — Step 4 handles the absent-file case.
 
 ```python
@@ -383,7 +423,7 @@ _sidecar = {
     "fired": _fired,
     "n": len(_facts),
     "facts": _facts,
-    "flag": "on" if "$RECALL_CMD_OK" == "1" else "off",
+    "flag": "on",  # env flag was on; RECALL_CMD_OK affects fired, not flag
 }
 try:
     Path(".agents/outputs").mkdir(parents=True, exist_ok=True)

--- a/claude-config/scripts/cost_report_weekly.py
+++ b/claude-config/scripts/cost_report_weekly.py
@@ -121,6 +121,79 @@ def _recall_correlation(metrics_path: Path) -> str:
         return ""  # fail-open — BLE001 exempt for scripts/
 
 
+def _recall_flag_delta(metrics_path: Path) -> str:
+    """Compute first-pass rate split by recall.flag (on vs off) from metrics.jsonl.
+
+    Returns a markdown subsection when each cohort (flag=="on" and flag=="off")
+    has N >= 3 qualifying records (records with both a recall.flag str AND a
+    first_pass_correct bool). Returns "" when the file is missing, unreadable,
+    or either cohort is below the minimum threshold. Returns a brief
+    "insufficient data" notice when ANY flag-bearing records exist but either
+    cohort is below threshold — so the report always shows experiment status
+    once data starts accumulating.
+
+    Fail-open: any I/O or parse error returns "". BLE001 exempt — scripts/.
+    """
+    try:
+        if not metrics_path.exists():
+            return ""
+        records = []
+        for line in metrics_path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                records.append(json.loads(line))
+            except Exception:
+                continue
+
+        on_pass = on_total = 0
+        off_pass = off_total = 0
+        for rec in records:
+            recall = rec.get("recall")
+            if not isinstance(recall, dict):
+                continue  # pre-L2 record — exclude
+            flag = recall.get("flag")
+            if flag not in ("on", "off"):
+                continue
+            fpc = rec.get("first_pass_correct")
+            if not isinstance(fpc, bool):
+                continue
+            if flag == "on":
+                on_total += 1
+                if fpc:
+                    on_pass += 1
+            else:
+                off_total += 1
+                if fpc:
+                    off_pass += 1
+
+        min_n = 3
+        if on_total < min_n or off_total < min_n:
+            if on_total + off_total > 0:
+                return (
+                    "### Flag delta (CODING_MEMORY_RECALL on vs off)\n\n"
+                    f"_insufficient data — on N={on_total}, off N={off_total} "
+                    f"(need ≥{min_n} each)_"
+                )
+            return ""
+
+        on_rate = f"{on_pass / on_total:.0%}"
+        off_rate = f"{off_pass / off_total:.0%}"
+
+        lines = [
+            "### Flag delta (CODING_MEMORY_RECALL on vs off)",
+            "",
+            "| cohort | issues | first-pass rate |",
+            "|--------|--------|-----------------|",
+            f"| recall on  | {on_total} | {on_rate} |",
+            f"| recall off | {off_total} | {off_rate} |",
+        ]
+        return "\n".join(lines)
+    except Exception:
+        return ""  # fail-open — BLE001 exempt for scripts/
+
+
 def format_recall_section(
     bin_path: Path | None = None,
     metrics_path: Path | None = None,
@@ -197,6 +270,13 @@ def format_recall_section(
             if corr:
                 lines.append("")
                 lines.extend(corr.splitlines())
+        except Exception:
+            pass  # fail-open — BLE001 exempt for scripts/
+        try:
+            flag_delta = _recall_flag_delta(metrics_path)
+            if flag_delta:
+                lines.append("")
+                lines.extend(flag_delta.splitlines())
         except Exception:
             pass  # fail-open — BLE001 exempt for scripts/
 

--- a/claude-config/tests/test_recall_l3_flag.py
+++ b/claude-config/tests/test_recall_l3_flag.py
@@ -1,0 +1,300 @@
+"""Tests for recall L3 on/off flag (issue #457).
+
+Covers:
+  Group A: _recall_flag_delta computation (on vs off cohorts, N guard, fail-open)
+  Group B: off-path sidecar fields + state_manager round-trip
+  Group C: format_recall_section includes flag delta when above/below threshold
+
+Run from the repo root:
+
+    python3 -m pytest claude-config/tests/test_recall_l3_flag.py -v
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "hooks"))
+
+import cost_report_weekly as CRW  # noqa: E402
+import state_manager as SM  # noqa: E402
+
+
+# ── Fixture helpers ───────────────────────────────────────────────────────────
+
+
+def _write_metrics(tmp_path: Path, records: list) -> Path:
+    p = tmp_path / "metrics.jsonl"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    with p.open("w", encoding="utf-8") as fh:
+        for r in records:
+            fh.write(json.dumps(r) + "\n")
+    return p
+
+
+def _on_rec(issue: int, fpc: bool) -> dict:
+    """Qualifying record with flag='on'."""
+    return {
+        "issue": issue,
+        "date": "2026-06-15",
+        "first_pass_correct": fpc,
+        "recall": {"fired": True, "n": 1, "facts": ["x"], "flag": "on"},
+    }
+
+
+def _off_rec(issue: int, fpc: bool) -> dict:
+    """Qualifying record with flag='off'."""
+    return {
+        "issue": issue,
+        "date": "2026-06-15",
+        "first_pass_correct": fpc,
+        "recall": {"fired": False, "n": 0, "facts": [], "flag": "off"},
+    }
+
+
+# ── Group A: _recall_flag_delta computation ───────────────────────────────────
+
+
+def test_flag_delta_on_vs_off(tmp_path):
+    """3 on-records (2 pass, 1 fail → 67%) + 3 off-records (1 pass, 2 fail → 33%)."""
+    p = _write_metrics(
+        tmp_path,
+        [
+            _on_rec(1, True),
+            _on_rec(2, True),
+            _on_rec(3, False),
+            _off_rec(10, True),
+            _off_rec(11, False),
+            _off_rec(12, False),
+        ],
+    )
+    result = CRW._recall_flag_delta(p)
+    assert "recall on" in result
+    assert "recall off" in result
+    assert "67%" in result  # on: 2/3
+    assert "33%" in result  # off: 1/3
+
+
+def test_flag_delta_insufficient_shows_n_message(tmp_path):
+    """2 on + 3 off — below threshold for on; must show insufficient-data message."""
+    p = _write_metrics(
+        tmp_path,
+        [
+            _on_rec(1, True),
+            _on_rec(2, False),
+            _off_rec(10, True),
+            _off_rec(11, False),
+            _off_rec(12, False),
+        ],
+    )
+    result = CRW._recall_flag_delta(p)
+    assert result != ""
+    assert "insufficient data" in result
+    assert "on N=2" in result
+    assert "off N=3" in result
+
+
+def test_flag_delta_no_data_returns_empty(tmp_path):
+    """Empty metrics file → empty string (no records at all)."""
+    p = _write_metrics(tmp_path, [])
+    assert CRW._recall_flag_delta(p) == ""
+
+
+def test_flag_delta_missing_file_returns_empty(tmp_path):
+    """Non-existent file → fail-open → empty string."""
+    absent = tmp_path / "no_such_file.jsonl"
+    assert CRW._recall_flag_delta(absent) == ""
+
+
+def test_flag_delta_excludes_pre_l2_records(tmp_path):
+    """Records without a 'recall' field are excluded (not counted in any cohort)."""
+    p = _write_metrics(
+        tmp_path,
+        [
+            {"issue": i, "date": "2026-06-15", "first_pass_correct": True}
+            for i in range(1, 10)
+        ],
+    )
+    # No flag-bearing records → nothing to report
+    assert CRW._recall_flag_delta(p) == ""
+
+
+def test_flag_delta_excludes_missing_fpc(tmp_path):
+    """Records without first_pass_correct bool are not counted."""
+    p = _write_metrics(
+        tmp_path,
+        [
+            # on records: 2 with fpc, 1 without → only 2 qualify
+            _on_rec(1, True),
+            _on_rec(2, True),
+            {
+                "issue": 3,
+                "date": "2026-06-15",
+                "recall": {"fired": True, "n": 0, "facts": [], "flag": "on"},
+            },
+            # off records: 3 qualify
+            _off_rec(10, True),
+            _off_rec(11, False),
+            _off_rec(12, False),
+        ],
+    )
+    # on cohort only has 2 qualifying → insufficient message
+    result = CRW._recall_flag_delta(p)
+    assert "insufficient data" in result
+    assert "on N=2" in result
+
+
+def test_flag_delta_excludes_invalid_flag_values(tmp_path):
+    """Records with flag values other than 'on'/'off' are skipped."""
+    p = _write_metrics(
+        tmp_path,
+        [
+            # These would have been L2-style "on" when RECALL_CMD_OK=1 but
+            # the value is invalid — excluded from the flag-delta split.
+            {
+                "issue": i,
+                "date": "2026-06-15",
+                "first_pass_correct": True,
+                "recall": {"fired": True, "n": 1, "facts": [], "flag": "unknown"},
+            }
+            for i in range(1, 10)
+        ],
+    )
+    assert CRW._recall_flag_delta(p) == ""
+
+
+# ── Group B: off-path sidecar fields + state_manager round-trip ───────────────
+
+
+def test_off_path_sidecar_fields():
+    """The off-path sidecar dict matches the expected shape (flag=off, fired=False, n=0)."""
+    # Replicate the sidecar construction logic from the off-path in orchestrate.md.
+    sidecar = {
+        "issue": 457,
+        "date": "061525",
+        "fired": False,
+        "n": 0,
+        "facts": [],
+        "flag": "off",
+    }
+    assert sidecar["flag"] == "off"
+    assert sidecar["fired"] is False
+    assert sidecar["n"] == 0
+    assert sidecar["facts"] == []
+
+
+def test_off_path_sidecar_passes_state_manager_validation(tmp_path):
+    """The off-path sidecar dict is accepted by record_metrics without being dropped."""
+    off_sidecar = {
+        "fired": False,
+        "n": 0,
+        "facts": [],
+        "flag": "off",
+    }
+    SM.record_metrics(
+        project_dir=tmp_path,
+        issue=457,
+        status="PASS",
+        complexity="SIMPLE",
+        stack="backend",
+        agents_run=["MAP-PLAN", "PATCH", "PROVE"],
+        first_pass_correct=True,
+        recall=off_sidecar,
+    )
+    metrics_path = tmp_path / ".claude" / "memory" / "metrics.jsonl"
+    assert metrics_path.exists()
+    record = json.loads(metrics_path.read_text(encoding="utf-8").strip())
+    assert "recall" in record
+    assert record["recall"]["flag"] == "off"
+    assert record["recall"]["fired"] is False
+    assert record["recall"]["n"] == 0
+    assert record["recall"]["facts"] == []
+
+
+def test_on_path_sidecar_flag_is_always_on(tmp_path):
+    """The on-path sidecar uses flag='on' regardless of RECALL_CMD_OK."""
+    # Simulate the on-path sidecar when query returned nothing (RECALL_CMD_OK=0).
+    on_sidecar_no_output = {
+        "fired": False,
+        "n": 0,
+        "facts": [],
+        "flag": "on",  # env flag was on — command result doesn't change flag
+    }
+    SM.record_metrics(
+        project_dir=tmp_path,
+        issue=458,
+        status="PASS",
+        complexity="SIMPLE",
+        stack="backend",
+        agents_run=["MAP-PLAN", "PATCH", "PROVE"],
+        first_pass_correct=True,
+        recall=on_sidecar_no_output,
+    )
+    metrics_path = tmp_path / ".claude" / "memory" / "metrics.jsonl"
+    record = json.loads(metrics_path.read_text(encoding="utf-8").strip())
+    assert record["recall"]["flag"] == "on"
+    assert record["recall"]["fired"] is False
+
+
+# ── Group C: format_recall_section includes flag delta ────────────────────────
+
+
+def _make_fake_run():
+    """Return a monkeypatch-able subprocess.run stub for coding-memory CLI."""
+
+    def _fake_run(cmd, **kwargs):
+        class _R:
+            returncode = 0
+            stdout = json.dumps(
+                {
+                    "n_total": 5,
+                    "n_push": 3,
+                    "n_pull": 2,
+                    "n_injected_total": 4,
+                    "n_returned_total": 5,
+                    "p50_latency_ms": 120,
+                    "top_facts": [],
+                    "days": 7,
+                }
+            )
+
+        return _R()
+
+    return _fake_run
+
+
+def test_format_recall_section_includes_flag_delta(tmp_path, monkeypatch):
+    """format_recall_section includes 'Flag delta' when both cohorts are above threshold."""
+    p = _write_metrics(
+        tmp_path,
+        [_on_rec(i, True) for i in range(1, 4)]
+        + [_off_rec(i, False) for i in range(10, 13)],
+    )
+    monkeypatch.setattr(subprocess, "run", _make_fake_run())
+    section = CRW.format_recall_section(metrics_path=p)
+    assert "Flag delta" in section
+    assert "recall on" in section
+    assert "recall off" in section
+
+
+def test_format_recall_section_flag_delta_shows_insufficient_when_below_n(
+    tmp_path, monkeypatch
+):
+    """format_recall_section shows 'insufficient data' when one cohort is below N=3."""
+    p = _write_metrics(
+        tmp_path,
+        [
+            _on_rec(1, True),
+            _on_rec(2, False),  # on: only 2 records
+            _off_rec(10, True),
+            _off_rec(11, False),
+            _off_rec(12, False),
+        ],
+    )
+    monkeypatch.setattr(subprocess, "run", _make_fake_run())
+    section = CRW.format_recall_section(metrics_path=p)
+    assert "insufficient data" in section


### PR DESCRIPTION
CODING_MEMORY_RECALL=on|off gates Step 2.85 (off → no push, flag:off sidecar; single call site verified); weekly report adds the on/off first-pass delta (N>=3 gate). Orchestrated (MAP-PLAN→PATCH→PROVE PASS, 587/587). Codex R1→R2: APPROVE (fixed single-quoted-heredoc sidecar bug affecting L2+L3 recording). Closes #457