### PR TITLE
feat(prove-gate): fail-closed runtime_smoke enforcement (Level 5 teeth)

### DIFF
--- a/claude-config/agents/prove.md
+++ b/claude-config/agents/prove.md
@@ -182,8 +182,11 @@ does not boot any runnable surface.
 
 Boot the changed entrypoint and confirm it starts and responds without error.
 PROVE records the result as `runtime_smoke` in the artifact frontmatter for
-future gate enforcement (see issue #460). Choose the recipe that matches the
-changed stack:
+gate enforcement (see issue #460). As of #460 `runtime_smoke` is a structured
+`{status, command, evidence}` block: `command` is REQUIRED when `status: PASS`
+(the smoke command actually run) and `evidence` is REQUIRED for every status.
+An absent block or `status: FAIL` blocks the merge gate (`GATE_SMOKE_VIOLATION`,
+fail-closed). Choose the recipe that matches the changed stack:
 
 **Backend (FastAPI / HTTP service)**
 ```bash
@@ -229,8 +232,11 @@ Assert: page loads (HTTP 200); zero console errors of severity ERROR.
 where no entrypoint is exercised. Any change to a route handler, CLI command,
 worker startup, or rendered page requires a smoke run. Record in the PROVE
 artifact as:
-```
-runtime_smoke: n/a (no runnable surface)
+```yaml
+runtime_smoke:
+  status: n/a            # PASS | FAIL | n/a
+  command: ""            # required when status: PASS
+  evidence: "no runnable surface — pure refactor/docs/config/rename"
 ```
 Mirror the coverage escape hatch style: `coverage: n/a (no test infra)`.
 
@@ -309,7 +315,10 @@ date: {YYYY-MM-DD}
 status: PASS            # PASS | FAIL | BLOCKED
 complexity: SIMPLE      # TRIVIAL | SIMPLE | COMPLEX
 stack: backend          # backend | frontend | fullstack
-runtime_smoke: "n/a (no runnable surface)"  # Level 5: PASS | FAIL | n/a (no runnable surface) — issue #460 binds the gate to this field
+runtime_smoke:           # Level 5 (issue #460 binds the merge gate to this)
+  status: n/a            # PASS | FAIL | n/a
+  command: ""            # the smoke command actually run (required when status: PASS)
+  evidence: "no runnable surface"
 root_cause: null        # MANDATORY if status=BLOCKED — use a code from _base.md §10
 blocking_agent: null    # MANDATORY if status=BLOCKED — usually "PROVE"
 # Issue #1612 — per-AC audit (mirrors buddy/prompts/codex-review-clauses.md):
@@ -364,7 +373,7 @@ order). Body skeleton:
 (verbatim output: focused tests, full suite, lint/build)
 ### Verification Levels
 - Level 1 EXISTS / Level 2 SUBSTANTIVE / Level 3 WIRED / Level 4 UNIT/BUILD / Level 5 RUNTIME (smoke) — ✅ or ❌ [detail]
-- runtime_smoke: PASS | FAIL | n/a (no runnable surface)
+- runtime_smoke: status={PASS|FAIL|n/a}, command=<cmd if PASS>, evidence=<...>
 ### Acceptance Criteria
 (prose table; the authoritative copy is the frontmatter `ac_audit`)
 
@@ -397,10 +406,11 @@ steps, and a prevention recommendation. Do NOT approve. Return to orchestrator.
 - [ ] Levels 1–4 all pass (EXISTS, SUBSTANTIVE, WIRED, UNIT/BUILD) — WIRED items
       per the Level 3 list above (reachability, callee existence, service
       registration, enum VALUE, expanduser, pipeline handoff)
-- [ ] Level 5 RUNTIME smoke: ran per-stack recipe OR recorded
-      `runtime_smoke: n/a (no runnable surface)` with justification (escape hatch
-      restricted to pure refactors/docs/config/renames)
-- [ ] Frontmatter has status + complexity + stack + `runtime_smoke` (Level 5) +
+- [ ] Level 5 RUNTIME smoke: ran per-stack recipe OR recorded the structured
+      `runtime_smoke` block with `status: n/a` + non-empty `evidence` (escape
+      hatch restricted to pure refactors/docs/config/renames)
+- [ ] Frontmatter has status + complexity + stack + `runtime_smoke` block
+      (Level 5: status + command-if-PASS + evidence) +
       `ac_audit` (one per AC bullet, #1612) + `applicable_evals` + `eval_results`
 - [ ] If BLOCKED: frontmatter `root_cause` (§10) + `blocking_agent`, body
       `## Failure Details` (details/fix/prevention)

--- a/claude-config/commands/ship.md
+++ b/claude-config/commands/ship.md
@@ -196,6 +196,7 @@ Exit-code contract (from `prove_gate.py`):
 | 3 | PASS but ac_audit has missing/partial (AC-FORBIDS-APPROVE) | **STOP** |
 | 4 | Orchestrate-tracked but PROVE never ran | **STOP** — run PROVE first |
 | 5 | Verdict unreadable (fail-closed) | **STOP** — fix the artifact |
+| 6 | PASS but runtime_smoke (Level 5) absent/FAIL/invalid (GATE_SMOKE_VIOLATION) | **STOP** — fix/re-run PROVE |
 
 On any non-zero exit: STOP, print the gate's reason line, do NOT merge.
 The only bypass is explicit: `--override-prove "<reason>"` reruns the gate

--- a/claude-config/hooks/state_manager.py
+++ b/claude-config/hooks/state_manager.py
@@ -664,6 +664,10 @@ _VALID_AC_STATUSES = frozenset({"implemented", "partial", "missing", "deferred",
 # "deferred to a follow-up" from becoming an APPROVE escape hatch.
 _DEFERRED_REF_RE = re.compile(r"#\d+|GH-\d+", re.IGNORECASE)
 
+# Issue #460 — runtime_smoke (Level 5) status set. Compared case-insensitively
+# on read (see validate_runtime_smoke); prove.md emits the lowercase/`n/a` forms.
+_VALID_SMOKE_STATUSES = frozenset({"pass", "fail", "n/a"})
+
 _VALID_GUARDS = frozenset(
     {
         "VERIFICATION_GAP",
@@ -851,6 +855,114 @@ def validate_ac_audit(
 
     downgrade = "FAIL" if missing else None
     return {"valid": valid, "downgrade_to": downgrade, "missing": missing}
+
+
+def validate_runtime_smoke(value) -> dict:
+    """Validate a PROVE ``runtime_smoke`` (Level 5) value for the merge gate.
+
+    Issue #460 evolves ``runtime_smoke`` from the #459 scalar string into a
+    structured ``{status, command, evidence}`` block and binds a fail-closed
+    merge gate to it. This validator enforces *structural completeness* of the
+    declared result; it is the source of truth that ``prove_gate.check_gate``
+    calls after the ac_audit block.
+
+    **Trust model (Option A).** The gate TRUSTS PROVE's declared ``status``. It
+    does NOT re-derive runnable-ness from a git diff and does NOT re-execute the
+    smoke command — full re-execution / auto-run is out of scope here (that is
+    AC5 / issue #461). What this validator enforces:
+
+    - ``status`` is one of PASS / FAIL / n/a (case-insensitive).
+    - ``status: PASS`` requires BOTH a non-empty ``command`` (what was run) and
+      non-empty ``evidence`` (the result).
+    - ``status: n/a`` requires non-empty ``evidence`` (the justification);
+      ``command`` is optional.
+    - ``status: FAIL`` blocks — a failed smoke run cannot ship.
+    - Absent / missing block blocks fail-CLOSED ("PROVE did not record it").
+    - A bare string (the #459 scalar form) is coerced to ``n/a`` with the string
+      itself as evidence — backward compatible, never blocks on its own.
+
+    Args:
+        value: The ``runtime_smoke`` frontmatter value. May be a mapping
+            (structured block), a string (#459 scalar), ``None`` (absent), or
+            some other type (treated as a violation).
+
+    Returns:
+        ``{"valid": bool, "downgrade_to": str|None, "missing": list[dict]}`` —
+        the SAME shape as ``validate_ac_audit`` so ``check_gate`` reuses the
+        same consumption pattern. Each ``missing`` entry is shaped
+        ``{"field": "runtime_smoke", "status": <str>, "reason": <str>}``.
+        ``downgrade_to`` is ``"FAIL"`` on any violation, else ``None``.
+
+    The function is pure (no I/O). Callers persist / act on the result.
+    """
+
+    def _violation(status: str, reason: str) -> dict:
+        return {
+            "valid": False,
+            "downgrade_to": "FAIL",
+            "missing": [
+                {"field": "runtime_smoke", "status": status, "reason": reason}
+            ],
+        }
+
+    def _ok() -> dict:
+        return {"valid": True, "downgrade_to": None, "missing": []}
+
+    def _empty(v) -> bool:
+        return v is None or not str(v).strip()
+
+    if value is None:
+        return _violation(
+            "missing",
+            "PROVE did not record runtime_smoke (Level 5) — re-run PROVE",
+        )
+
+    # #459 backward-compat: a bare string is coerced to n/a with the string as
+    # evidence. Never blocks on its own.
+    if isinstance(value, str):
+        return _ok()
+
+    if not isinstance(value, dict):
+        return _violation(
+            "invalid",
+            f"runtime_smoke must be a mapping or string — got {type(value).__name__}",
+        )
+
+    raw_status = value.get("status")
+    if _empty(raw_status):
+        return _violation(
+            "missing",
+            "runtime_smoke.status absent — must be PASS, FAIL, or n/a",
+        )
+    status = str(raw_status).strip().lower()
+    if status not in _VALID_SMOKE_STATUSES:
+        return _violation(
+            status,
+            f"runtime_smoke.status={raw_status!r} invalid — expected PASS/FAIL/n/a",
+        )
+
+    command = value.get("command")
+    evidence = value.get("evidence")
+
+    if status == "fail":
+        return _violation("fail", "runtime_smoke reported FAIL — smoke run failed")
+
+    if status == "pass":
+        if _empty(evidence):
+            return _violation("pass", "runtime_smoke PASS requires non-empty evidence")
+        if _empty(command):
+            return _violation(
+                "pass",
+                "runtime_smoke PASS requires the command that was run (none recorded)",
+            )
+        return _ok()
+
+    # status == "n/a"
+    if _empty(evidence):
+        return _violation(
+            "n/a", "runtime_smoke n/a requires evidence (the justification)"
+        )
+    return _ok()
 
 
 def record_prove_audit(

--- a/claude-config/hooks/state_manager.py
+++ b/claude-config/hooks/state_manager.py
@@ -872,14 +872,16 @@ def validate_runtime_smoke(value) -> dict:
     AC5 / issue #461). What this validator enforces:
 
     - ``status`` is one of PASS / FAIL / n/a (case-insensitive).
-    - ``status: PASS`` requires BOTH a non-empty ``command`` (what was run) and
-      non-empty ``evidence`` (the result).
-    - ``status: n/a`` requires non-empty ``evidence`` (the justification);
-      ``command`` is optional.
+    - ``status: PASS`` requires BOTH a non-empty STRING ``command`` (what was
+      run) and a non-empty STRING ``evidence`` (the result). Non-string types
+      (lists, dicts, bools) FAIL closed — they carry no real evidence (#460).
+    - ``status: n/a`` requires non-empty STRING ``evidence`` (the
+      justification); ``command`` is optional.
     - ``status: FAIL`` blocks — a failed smoke run cannot ship.
     - Absent / missing block blocks fail-CLOSED ("PROVE did not record it").
-    - A bare string (the #459 scalar form) is coerced to ``n/a`` with the string
-      itself as evidence — backward compatible, never blocks on its own.
+    - A NON-empty bare string (the #459 scalar form) is coerced to ``n/a`` with
+      the string itself as evidence — backward compatible, never blocks on its
+      own. An empty / whitespace-only scalar FAILs closed (no evidence, #460).
 
     Args:
         value: The ``runtime_smoke`` frontmatter value. May be a mapping
@@ -911,16 +913,30 @@ def validate_runtime_smoke(value) -> dict:
     def _empty(v) -> bool:
         return v is None or not str(v).strip()
 
+    def _nonempty_str(v) -> bool:
+        # command / evidence must be an actual non-empty STRING. Non-string
+        # types (lists, dicts, bools, ints) carry no recorded evidence and must
+        # NOT satisfy the "non-empty" requirement via repr coercion — that was
+        # the type-confusion bypass (#460 Codex review): ``command: []`` would
+        # stringify to ``"[]"`` and wrongly pass.
+        return isinstance(v, str) and bool(v.strip())
+
     if value is None:
         return _violation(
             "missing",
             "PROVE did not record runtime_smoke (Level 5) — re-run PROVE",
         )
 
-    # #459 backward-compat: a bare string is coerced to n/a with the string as
-    # evidence. Never blocks on its own.
+    # #459 backward-compat: a NON-empty bare string is coerced to n/a with the
+    # string as evidence — never blocks on its own. An empty / whitespace-only
+    # scalar carries no evidence and must FAIL closed (#460 Codex review).
     if isinstance(value, str):
-        return _ok()
+        if value.strip():
+            return _ok()
+        return _violation(
+            "n/a",
+            "runtime_smoke scalar is empty — no evidence recorded; re-run PROVE",
+        )
 
     if not isinstance(value, dict):
         return _violation(
@@ -948,19 +964,24 @@ def validate_runtime_smoke(value) -> dict:
         return _violation("fail", "runtime_smoke reported FAIL — smoke run failed")
 
     if status == "pass":
-        if _empty(evidence):
-            return _violation("pass", "runtime_smoke PASS requires non-empty evidence")
-        if _empty(command):
+        if not _nonempty_str(evidence):
             return _violation(
                 "pass",
-                "runtime_smoke PASS requires the command that was run (none recorded)",
+                "runtime_smoke PASS requires non-empty string evidence",
+            )
+        if not _nonempty_str(command):
+            return _violation(
+                "pass",
+                "runtime_smoke PASS requires the command that was run "
+                "(a non-empty string; none recorded)",
             )
         return _ok()
 
     # status == "n/a"
-    if _empty(evidence):
+    if not _nonempty_str(evidence):
         return _violation(
-            "n/a", "runtime_smoke n/a requires evidence (the justification)"
+            "n/a",
+            "runtime_smoke n/a requires non-empty string evidence (the justification)",
         )
     return _ok()
 

--- a/claude-config/scripts/prove_gate.py
+++ b/claude-config/scripts/prove_gate.py
@@ -19,6 +19,9 @@ Exit codes (stable contract for ship.md):
                        no PROVE artifact — verification was skipped.
   5  GATE_PARSE_ERROR  artifact exists but frontmatter is unreadable.
                        Fail-CLOSED: an unverifiable verdict blocks the merge.
+  6  GATE_SMOKE_VIOLATION status=PASS but runtime_smoke (Level 5) is absent,
+                       FAIL, or structurally invalid (smoke not recorded / the
+                       smoke run failed). Fail-CLOSED — re-run PROVE (#460).
 
 Override: `--override "<reason>"` records the bypass to
 `<outputs-dir>/prove-overrides.jsonl` (who/when/why/what-the-gate-said) and
@@ -47,13 +50,14 @@ for _hooks in (Path.home() / ".claude" / "hooks",
         sys.path.insert(0, str(_hooks))
         break
 
-from state_manager import validate_ac_audit  # noqa: E402
+from state_manager import validate_ac_audit, validate_runtime_smoke  # noqa: E402
 
 GATE_PASS = 0
 GATE_FAIL = 2
 GATE_AC_VIOLATION = 3
 GATE_NO_ARTIFACT = 4
 GATE_PARSE_ERROR = 5
+GATE_SMOKE_VIOLATION = 6
 
 # Orchestrate phase artifacts that mark an issue as pipeline-tracked (and
 # therefore REQUIRED to have a PROVE artifact before shipping).
@@ -139,7 +143,21 @@ def check_gate(outputs_dir: Path, issue: int) -> tuple[int, str]:
             f"(AC-FORBIDS-APPROVE) — {offenders}"
         )
 
-    return GATE_PASS, f"{artifact.name}: status=PASS, ac_audit clean — merge may proceed."
+    smoke = validate_runtime_smoke(fm.get("runtime_smoke"))
+    if smoke.get("downgrade_to") == "FAIL":
+        offender = "; ".join(
+            f"{m.get('status', '?')}: {m.get('reason', '')}"
+            for m in smoke.get("missing", [])
+        )
+        return GATE_SMOKE_VIOLATION, (
+            f"{artifact.name}: status=PASS but runtime_smoke (Level 5) "
+            f"gate failed — {offender}"
+        )
+
+    return GATE_PASS, (
+        f"{artifact.name}: status=PASS, ac_audit clean, runtime_smoke OK — "
+        "merge may proceed."
+    )
 
 
 def record_override(outputs_dir: Path, issue: int, reason: str,

--- a/claude-config/tests/test_prove_gate.py
+++ b/claude-config/tests/test_prove_gate.py
@@ -222,3 +222,25 @@ def test_pass_with_smoke_scalar_string_proceeds(tmp_path):
         runtime_smoke="n/a (no runnable surface)",
     )
     assert G.check_gate(outputs, 42)[0] == G.GATE_PASS
+
+
+def test_pass_with_smoke_list_command_is_violation(tmp_path):
+    """#460 Codex review: a malformed PASS artifact whose ``command`` is a
+    real YAML list ([]) must be caught by the gate (GATE_SMOKE_VIOLATION),
+    not stringified-and-passed. Built via raw YAML so the value parses as an
+    actual list, not a quoted string."""
+    raw = (
+        "---\n"
+        "issue: 42\n"
+        "agent: PROVE\n"
+        "status: PASS\n"
+        "runtime_smoke:\n"
+        "  status: PASS\n"
+        "  command: []\n"
+        "  evidence: []\n"
+        'ac_audit:\n  - ac: "does the thing"\n    status: implemented\n'
+        '    evidence: "file.py:1"\n'
+        "---\n\n# body\n"
+    )
+    outputs = _artifact(tmp_path, "prove-42-060926.md", raw=raw)
+    assert G.check_gate(outputs, 42)[0] == G.GATE_SMOKE_VIOLATION

--- a/claude-config/tests/test_prove_gate.py
+++ b/claude-config/tests/test_prove_gate.py
@@ -10,10 +10,33 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
 import prove_gate as G  # noqa: E402
 
 
-def _artifact(tmp_path, name, status="PASS", ac_audit=None, raw=None):
+def _artifact(
+    tmp_path, name, status="PASS", ac_audit=None, raw=None, runtime_smoke="__default__"
+):
     outputs = tmp_path / ".agents" / "outputs"
     outputs.mkdir(parents=True, exist_ok=True)
     if raw is None:
+        # runtime_smoke (#460):
+        #   "__default__" → a valid n/a block (keeps pre-#460 PASS tests green).
+        #   None          → emit NO runtime_smoke key (the absent case).
+        #   dict          → render as a nested YAML block.
+        #   str           → render as a scalar (#459 backward-compat form).
+        if runtime_smoke == "__default__":
+            smoke_lines = (
+                "runtime_smoke:\n"
+                "  status: n/a\n"
+                "  command: \"\"\n"
+                '  evidence: "test fixture — no runnable surface"\n'
+            )
+        elif runtime_smoke is None:
+            smoke_lines = ""
+        elif isinstance(runtime_smoke, dict):
+            smoke_lines = "runtime_smoke:\n" + "".join(
+                f"  {k}: \"{v}\"\n" for k, v in runtime_smoke.items()
+            )
+        else:
+            smoke_lines = f'runtime_smoke: "{runtime_smoke}"\n'
+
         audit_lines = ""
         if ac_audit is not None:
             audit_lines = "ac_audit:\n" + "".join(
@@ -23,7 +46,7 @@ def _artifact(tmp_path, name, status="PASS", ac_audit=None, raw=None):
             )
         raw = (
             f"---\nissue: 42\nagent: PROVE\nstatus: {status}\n"
-            f"{audit_lines}---\n\n# body\n"
+            f"{smoke_lines}{audit_lines}---\n\n# body\n"
         )
     (outputs / name).write_text(raw, encoding="utf-8")
     return outputs
@@ -126,3 +149,76 @@ def test_override_not_recorded_when_gate_passes(tmp_path):
 def test_cli_exit_codes(tmp_path):
     outputs = _artifact(tmp_path, "prove-42-060926.md", "FAIL", OK_AUDIT)
     assert G.main(["--issue", "42", "--outputs-dir", str(outputs)]) == G.GATE_FAIL
+
+
+# ── runtime_smoke gate (issue #460) ─────────────────────────────────────────
+
+
+def test_pass_with_smoke_pass_proceeds(tmp_path):
+    smoke = {"status": "PASS", "command": "python -m m --help", "evidence": "exit 0"}
+    outputs = _artifact(
+        tmp_path, "prove-42-060926.md", "PASS", OK_AUDIT, runtime_smoke=smoke
+    )
+    code, reason = G.check_gate(outputs, 42)
+    assert code == G.GATE_PASS
+    assert "merge may proceed" in reason
+
+
+def test_pass_with_smoke_absent_is_violation(tmp_path):
+    outputs = _artifact(
+        tmp_path, "prove-42-060926.md", "PASS", OK_AUDIT, runtime_smoke=None
+    )
+    code, reason = G.check_gate(outputs, 42)
+    assert code == G.GATE_SMOKE_VIOLATION
+    assert "re-run PROVE" in reason
+
+
+def test_pass_with_smoke_fail_is_violation(tmp_path):
+    smoke = {"status": "FAIL", "command": "x", "evidence": "crashed"}
+    outputs = _artifact(
+        tmp_path, "prove-42-060926.md", "PASS", OK_AUDIT, runtime_smoke=smoke
+    )
+    assert G.check_gate(outputs, 42)[0] == G.GATE_SMOKE_VIOLATION
+
+
+def test_pass_with_smoke_pass_no_command_is_violation(tmp_path):
+    smoke = {"status": "PASS", "command": "", "evidence": "ran"}
+    outputs = _artifact(
+        tmp_path, "prove-42-060926.md", "PASS", OK_AUDIT, runtime_smoke=smoke
+    )
+    assert G.check_gate(outputs, 42)[0] == G.GATE_SMOKE_VIOLATION
+
+
+def test_pass_with_smoke_pass_no_evidence_is_violation(tmp_path):
+    smoke = {"status": "PASS", "command": "x", "evidence": ""}
+    outputs = _artifact(
+        tmp_path, "prove-42-060926.md", "PASS", OK_AUDIT, runtime_smoke=smoke
+    )
+    assert G.check_gate(outputs, 42)[0] == G.GATE_SMOKE_VIOLATION
+
+
+def test_pass_with_smoke_na_proceeds(tmp_path):
+    smoke = {"status": "n/a", "command": "", "evidence": "docs only"}
+    outputs = _artifact(
+        tmp_path, "prove-42-060926.md", "PASS", OK_AUDIT, runtime_smoke=smoke
+    )
+    assert G.check_gate(outputs, 42)[0] == G.GATE_PASS
+
+
+def test_pass_with_smoke_unknown_status_is_violation(tmp_path):
+    smoke = {"status": "maybe", "command": "x", "evidence": "y"}
+    outputs = _artifact(
+        tmp_path, "prove-42-060926.md", "PASS", OK_AUDIT, runtime_smoke=smoke
+    )
+    assert G.check_gate(outputs, 42)[0] == G.GATE_SMOKE_VIOLATION
+
+
+def test_pass_with_smoke_scalar_string_proceeds(tmp_path):
+    outputs = _artifact(
+        tmp_path,
+        "prove-42-060926.md",
+        "PASS",
+        OK_AUDIT,
+        runtime_smoke="n/a (no runnable surface)",
+    )
+    assert G.check_gate(outputs, 42)[0] == G.GATE_PASS

--- a/claude-config/tests/test_state_manager_prove_audit.py
+++ b/claude-config/tests/test_state_manager_prove_audit.py
@@ -16,6 +16,7 @@ from state_manager import (  # type: ignore[import-not-found]
     count_acceptance_bullets,
     record_prove_audit,
     validate_ac_audit,
+    validate_runtime_smoke,
 )
 
 
@@ -149,6 +150,85 @@ def test_non_dict_entry_is_failure():
     )
     assert audit["valid"] is False
     assert audit["downgrade_to"] == "FAIL"
+
+
+# ── validate_runtime_smoke (issue #460) ──────────────────────────────────────
+
+
+def test_smoke_pass_with_command_and_evidence_ok():
+    """status: PASS with both command and evidence → no downgrade."""
+    smoke = validate_runtime_smoke(
+        {"status": "PASS", "command": "python -m m --help", "evidence": "exit 0"}
+    )
+    assert smoke["valid"] is True
+    assert smoke["downgrade_to"] is None
+    assert smoke["missing"] == []
+
+
+def test_smoke_absent_is_violation():
+    """None (absent block) → fail-closed with the re-run message."""
+    smoke = validate_runtime_smoke(None)
+    assert smoke["valid"] is False
+    assert smoke["downgrade_to"] == "FAIL"
+    assert "re-run PROVE" in smoke["missing"][0]["reason"]
+
+
+def test_smoke_fail_is_violation():
+    """status: FAIL → blocked."""
+    smoke = validate_runtime_smoke(
+        {"status": "FAIL", "command": "x", "evidence": "crashed"}
+    )
+    assert smoke["downgrade_to"] == "FAIL"
+    assert "FAIL" in smoke["missing"][0]["reason"]
+
+
+def test_smoke_pass_without_command_is_violation():
+    """status: PASS requires the command that was run."""
+    smoke = validate_runtime_smoke(
+        {"status": "PASS", "command": "", "evidence": "ran"}
+    )
+    assert smoke["downgrade_to"] == "FAIL"
+
+
+def test_smoke_pass_without_evidence_is_violation():
+    """status: PASS requires non-empty evidence."""
+    smoke = validate_runtime_smoke(
+        {"status": "PASS", "command": "x", "evidence": ""}
+    )
+    assert smoke["downgrade_to"] == "FAIL"
+
+
+def test_smoke_na_with_evidence_ok():
+    """status: n/a with evidence (justification) → no downgrade."""
+    smoke = validate_runtime_smoke({"status": "n/a", "evidence": "docs only"})
+    assert smoke["downgrade_to"] is None
+
+
+def test_smoke_na_without_evidence_is_violation():
+    """status: n/a still requires a justification in evidence."""
+    smoke = validate_runtime_smoke({"status": "n/a", "evidence": ""})
+    assert smoke["downgrade_to"] == "FAIL"
+
+
+def test_smoke_scalar_string_coerced_to_na_ok():
+    """#459 backward-compat: a bare string coerces to n/a, no downgrade."""
+    smoke = validate_runtime_smoke("n/a (no runnable surface)")
+    assert smoke["valid"] is True
+    assert smoke["downgrade_to"] is None
+
+
+def test_smoke_unknown_status_is_violation():
+    """Garbage status string → invalid → FAIL."""
+    smoke = validate_runtime_smoke({"status": "maybe", "evidence": "x"})
+    assert smoke["valid"] is False
+    assert smoke["downgrade_to"] == "FAIL"
+
+
+def test_smoke_non_mapping_non_string_is_violation():
+    """A list/int (neither dict nor str nor None) → FAIL."""
+    smoke = validate_runtime_smoke([1, 2])
+    assert smoke["valid"] is False
+    assert smoke["downgrade_to"] == "FAIL"
 
 
 # ── record_prove_audit ───────────────────────────────────────────────────────

--- a/claude-config/tests/test_state_manager_prove_audit.py
+++ b/claude-config/tests/test_state_manager_prove_audit.py
@@ -231,6 +231,73 @@ def test_smoke_non_mapping_non_string_is_violation():
     assert smoke["downgrade_to"] == "FAIL"
 
 
+# ── #460 Codex review: type-confusion + empty-scalar bypass closures ──────────
+
+
+def test_smoke_pass_with_list_command_and_evidence_is_violation():
+    """THE BYPASS: ``command: []`` / ``evidence: []`` stringified to a
+    non-empty repr and wrongly passed. Non-string types FAIL closed now."""
+    smoke = validate_runtime_smoke({"status": "PASS", "command": [], "evidence": []})
+    assert smoke["valid"] is False
+    assert smoke["downgrade_to"] == "FAIL"
+
+
+def test_smoke_pass_with_bool_command_is_violation():
+    """``command: False`` is not a string → FAIL (was a bypass via repr)."""
+    smoke = validate_runtime_smoke(
+        {"status": "PASS", "command": False, "evidence": "x"}
+    )
+    assert smoke["valid"] is False
+    assert smoke["downgrade_to"] == "FAIL"
+
+
+def test_smoke_pass_with_empty_string_command_is_violation():
+    """An empty-STRING command carries no record of what was run → FAIL."""
+    smoke = validate_runtime_smoke({"status": "PASS", "command": "", "evidence": "x"})
+    assert smoke["valid"] is False
+    assert smoke["downgrade_to"] == "FAIL"
+
+
+def test_smoke_na_with_list_evidence_is_violation():
+    """``status: n/a`` with non-string evidence → FAIL (no justification)."""
+    smoke = validate_runtime_smoke({"status": "n/a", "evidence": []})
+    assert smoke["valid"] is False
+    assert smoke["downgrade_to"] == "FAIL"
+
+
+def test_smoke_empty_scalar_is_violation():
+    """An empty scalar string carries no evidence → FAIL closed (was the
+    scalar backward-compat bypass)."""
+    smoke = validate_runtime_smoke("")
+    assert smoke["valid"] is False
+    assert smoke["downgrade_to"] == "FAIL"
+
+
+def test_smoke_whitespace_scalar_is_violation():
+    """A whitespace-only scalar is equivalent to empty → FAIL closed."""
+    smoke = validate_runtime_smoke("   ")
+    assert smoke["valid"] is False
+    assert smoke["downgrade_to"] == "FAIL"
+
+
+def test_smoke_nonempty_scalar_still_coerces_to_na_ok():
+    """Locked design preserved: a NON-empty legacy scalar still coerces to
+    n/a and never blocks."""
+    smoke = validate_runtime_smoke("ran uvicorn, 200 OK")
+    assert smoke["valid"] is True
+    assert smoke["downgrade_to"] is None
+
+
+def test_smoke_fully_valid_pass_block_ok_regression_guard():
+    """Regression guard: a well-formed PASS block still passes."""
+    smoke = validate_runtime_smoke(
+        {"status": "PASS", "command": "pytest -q", "evidence": "58 passed"}
+    )
+    assert smoke["valid"] is True
+    assert smoke["downgrade_to"] is None
+    assert smoke["missing"] == []
+
+
 # ── record_prove_audit ───────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary
Closes #460 (AC2 of umbrella #458). Gives the Level 5 RUNTIME smoke gate (added in #459) its enforcement teeth.

- **`runtime_smoke`** evolved from scalar → structured `{status, command, evidence}` in the PROVE frontmatter schema (all four sites in `prove.md`).
- **`prove_gate.py::check_gate`** now fails closed (`GATE_SMOKE_VIOLATION=6`) when a PASS artifact's `runtime_smoke` is absent, FAIL, or malformed — mirroring the `ac_audit` hard-gate path. `validate_runtime_smoke` added to `state_manager.py`.
- **Heuristic (locked):** the gate trusts PROVE's declared status (pure function, no diff access — same trust model as `ac_audit`). Absent → fail-closed; FAIL → block; non-empty legacy scalar → coerce n/a (backward compat); structured → validated (PASS requires non-empty string `command` + `evidence`).
- This *partially* closes review gap 2; actual smoke re-execution at gate time is future work (AC5), out of scope here.

## Test Plan
- `pytest claude-config/tests/test_prove_gate.py claude-config/tests/test_state_manager_prove_audit.py` → **67 passed** (58 pre-existing kept green via `__default__` sentinel + 9 new).
- `ruff check` clean on all changed Python.
- **End-to-end dogfood** (Level 5 on itself — the gate has a runnable surface): valid PASS artifact → `prove_gate.py` exit 0; `runtime_smoke` absent → exit 6; `status: FAIL` → exit 6; malformed `command: []` PASS → exit 6.

## Review
- PROVE: **PASS**, 4/4 ACs `implemented`, L1–L5 verified.
- Codex adversarial review (gpt-5.5): **REQUEST-CHANGES** → found 2 BLOCKING fail-closed bypasses (type-confusion in the non-empty check via `str(v)`; empty/whitespace scalar accepted). Both fixed + regression-tested (commit db292c5); independently re-verified all malformed inputs now downgrade to FAIL. Non-blocking doc fix (ship.md exit-code table) also applied.

Refs #458