### PR TITLE
feat(prove): require concrete evidence token for implemented ac_audit entries

### DIFF
--- a/claude-config/agents/prove.md
+++ b/claude-config/agents/prove.md
@@ -252,7 +252,7 @@ For each AC bullet in the issue body / PLAN / MAP-PLAN:
 
 | Status | Meaning |
 |--------|---------|
-| `implemented` | Diff clearly satisfies this AC. Evidence cites `file:line` or a test path. |
+| `implemented` | Diff clearly satisfies this AC. Evidence MUST contain at least one verifier token: a `file:line` reference (e.g. `src/foo.py:42`), a pytest node id (`tests/test_foo.py::test_bar`), or an explicit `test:` / `command:` / `smoke:` prefix. Tokenless or empty evidence downgrades the verdict to `FAIL`. |
 | `partial` | Diff addresses part of the AC but not all of it. Evidence names what is missing. |
 | `missing` | No code in the diff addresses this AC. |
 | `deferred` | Diff explicitly defers this AC AND `evidence` cites a follow-up issue # (e.g. `"deferred to #1620"`). |
@@ -280,6 +280,11 @@ the contract:
 | {verbatim AC bullet 2} | deferred | deferred to #1620 |
 | {verbatim AC bullet 3} | partial | only the read path landed; write path missing — would need `src/bar.py` change |
 ```
+
+All three token forms count: `src/foo.py:42` (file:line), `tests/test_foo.py::test_x`
+(pytest node id), `command: pytest -q → 58 passed` (command: prefix).
+A bare file path without a line number or `::test_name` suffix does NOT satisfy
+the token requirement and will downgrade the verdict to `FAIL`.
 
 ---
 

--- a/claude-config/hooks/state_manager.py
+++ b/claude-config/hooks/state_manager.py
@@ -670,7 +670,7 @@ _DEFERRED_REF_RE = re.compile(r"#\d+|GH-\d+", re.IGNORECASE)
 _EVIDENCE_TOKEN_RE = re.compile(
     r"[\w./\-]+\.\w+:\d+"          # file:line or file:line-range
     r"|[\w./\-]+\.py::[\w\[\]_-]+" # pytest node id (path.py::test_name)
-    r"|(?:test:|command:|smoke:)",  # explicit verifier prefixes
+    r"|(?:test:|command:|smoke:)\s*\S",  # verifier prefix MUST have non-whitespace payload
 )
 
 # Issue #460 — runtime_smoke (Level 5) status set. Compared case-insensitively

--- a/claude-config/hooks/state_manager.py
+++ b/claude-config/hooks/state_manager.py
@@ -664,6 +664,15 @@ _VALID_AC_STATUSES = frozenset({"implemented", "partial", "missing", "deferred",
 # "deferred to a follow-up" from becoming an APPROVE escape hatch.
 _DEFERRED_REF_RE = re.compile(r"#\d+|GH-\d+", re.IGNORECASE)
 
+# Evidence-token patterns accepted as proof for status="implemented".
+# At least ONE match is required; tokenless/empty evidence downgrades to FAIL.
+# Accepted forms: file:line  |  path.py::test_name  |  test:/command:/smoke: prefix.
+_EVIDENCE_TOKEN_RE = re.compile(
+    r"[\w./\-]+\.\w+:\d+"          # file:line or file:line-range
+    r"|[\w./\-]+\.py::[\w\[\]_-]+" # pytest node id (path.py::test_name)
+    r"|(?:test:|command:|smoke:)",  # explicit verifier prefixes
+)
+
 # Issue #460 — runtime_smoke (Level 5) status set. Compared case-insensitively
 # on read (see validate_runtime_smoke); prove.md emits the lowercase/`n/a` forms.
 _VALID_SMOKE_STATUSES = frozenset({"pass", "fail", "n/a"})
@@ -851,7 +860,20 @@ def validate_ac_audit(
                         "reason": "deferred without follow-up issue # — treated as missing",
                     }
                 )
-        # implemented + n/a are clean; nothing to record.
+        elif status == "implemented":
+            evidence = entry.get("evidence")
+            if not isinstance(evidence, str) or not _EVIDENCE_TOKEN_RE.search(evidence):
+                missing.append(
+                    {
+                        "ac": _ac_label(entry, idx),
+                        "status": "missing",
+                        "reason": (
+                            "implemented evidence lacks a verifier token "
+                            "(need file:line, path.py::test_name, or test:/command:/smoke: prefix)"
+                        ),
+                    }
+                )
+        # n/a is clean; nothing to record.
 
     downgrade = "FAIL" if missing else None
     return {"valid": valid, "downgrade_to": downgrade, "missing": missing}

--- a/claude-config/tests/test_state_manager_prove_audit.py
+++ b/claude-config/tests/test_state_manager_prove_audit.py
@@ -557,3 +557,48 @@ def test_implemented_missing_evidence_key_downgrades_to_fail():
     )
     assert audit["downgrade_to"] == "FAIL"
     assert "verifier token" in audit["missing"][0]["reason"]
+
+
+# ── Codex review fix: require payload after test:/command:/smoke: (#461) ──────
+
+
+def test_implemented_command_prefix_no_payload_downgrades_to_fail():
+    """'command:' with no payload is not a valid token — bypass closed."""
+    audit = validate_ac_audit(
+        [{"ac": "AC 1", "status": "implemented", "evidence": "command:"}]
+    )
+    assert audit["downgrade_to"] == "FAIL"
+    assert "verifier token" in audit["missing"][0]["reason"]
+
+
+def test_implemented_smoke_prefix_whitespace_only_downgrades_to_fail():
+    """'smoke:   ' (whitespace only after colon) is not a valid token."""
+    audit = validate_ac_audit(
+        [{"ac": "AC 1", "status": "implemented", "evidence": "smoke:   "}]
+    )
+    assert audit["downgrade_to"] == "FAIL"
+    assert "verifier token" in audit["missing"][0]["reason"]
+
+
+def test_implemented_prose_with_bare_command_prefix_downgrades_to_fail():
+    """'implemented; command:' has no payload after the prefix — FAIL."""
+    audit = validate_ac_audit(
+        [{"ac": "AC 1", "status": "implemented", "evidence": "implemented; command:"}]
+    )
+    assert audit["downgrade_to"] == "FAIL"
+    assert "verifier token" in audit["missing"][0]["reason"]
+
+
+def test_implemented_command_prefix_with_real_payload_passes():
+    """Regression guard: 'command: pytest -q' still passes (real payload)."""
+    audit = validate_ac_audit(
+        [
+            {
+                "ac": "AC 1",
+                "status": "implemented",
+                "evidence": "command: pytest -q",
+            }
+        ]
+    )
+    assert audit["downgrade_to"] is None
+    assert audit["missing"] == []

--- a/claude-config/tests/test_state_manager_prove_audit.py
+++ b/claude-config/tests/test_state_manager_prove_audit.py
@@ -59,7 +59,7 @@ def test_partial_status_forbids_pass():
     """AC marked `partial` → FAIL."""
     audit = validate_ac_audit(
         [
-            {"ac": "AC 1", "status": "implemented", "evidence": "tests/test_a.py"},
+            {"ac": "AC 1", "status": "implemented", "evidence": "tests/test_a.py::test_something"},
             {"ac": "AC 2", "status": "partial", "evidence": "only read path; write path missing"},
         ]
     )
@@ -440,10 +440,10 @@ def test_emit_fewer_than_expected_is_failure():
     implemented) → FAIL because AC #5 is silently omitted."""
     audit = validate_ac_audit(
         [
-            {"ac": "AC 1", "status": "implemented", "evidence": "src/a.py"},
-            {"ac": "AC 2", "status": "implemented", "evidence": "src/b.py"},
-            {"ac": "AC 3", "status": "implemented", "evidence": "src/c.py"},
-            {"ac": "AC 4", "status": "implemented", "evidence": "src/d.py"},
+            {"ac": "AC 1", "status": "implemented", "evidence": "src/a.py:1"},
+            {"ac": "AC 2", "status": "implemented", "evidence": "src/b.py:2"},
+            {"ac": "AC 3", "status": "implemented", "evidence": "src/c.py:3"},
+            {"ac": "AC 4", "status": "implemented", "evidence": "src/d.py:4"},
         ],
         expected_ac_count=5,
     )
@@ -454,8 +454,8 @@ def test_emit_fewer_than_expected_is_failure():
 def test_emit_equal_to_expected_is_pass():
     audit = validate_ac_audit(
         [
-            {"ac": "AC 1", "status": "implemented", "evidence": "src/a.py"},
-            {"ac": "AC 2", "status": "implemented", "evidence": "src/b.py"},
+            {"ac": "AC 1", "status": "implemented", "evidence": "src/a.py:1"},
+            {"ac": "AC 2", "status": "implemented", "evidence": "src/b.py:2"},
         ],
         expected_ac_count=2,
     )
@@ -466,9 +466,9 @@ def test_emit_more_than_expected_is_pass():
     """Tolerate over-counting; under-counting is the load-bearing case."""
     audit = validate_ac_audit(
         [
-            {"ac": "AC 1", "status": "implemented", "evidence": "src/a.py"},
-            {"ac": "AC 2", "status": "implemented", "evidence": "src/b.py"},
-            {"ac": "AC 3 (bonus)", "status": "implemented", "evidence": "src/c.py"},
+            {"ac": "AC 1", "status": "implemented", "evidence": "src/a.py:1"},
+            {"ac": "AC 2", "status": "implemented", "evidence": "src/b.py:2"},
+            {"ac": "AC 3 (bonus)", "status": "implemented", "evidence": "src/c.py:3"},
         ],
         expected_ac_count=2,
     )
@@ -480,7 +480,80 @@ def test_expected_ac_count_none_skips_coverage_check():
     emit-only validation behavior (unit tests, issues with no parseable
     AC section)."""
     audit = validate_ac_audit(
-        [{"ac": "AC 1", "status": "implemented", "evidence": "src/a.py"}],
+        [{"ac": "AC 1", "status": "implemented", "evidence": "src/a.py:1"}],
         expected_ac_count=None,
     )
     assert audit["downgrade_to"] is None
+
+
+# ── evidence token gate (issue #461) ─────────────────────────────────────────
+
+
+def test_implemented_with_file_line_token_passes():
+    """file:line token is the canonical implemented evidence form."""
+    audit = validate_ac_audit(
+        [
+            {"ac": "AC 1", "status": "implemented", "evidence": "src/foo.py:42"},
+        ]
+    )
+    assert audit["downgrade_to"] is None
+    assert audit["missing"] == []
+
+
+def test_implemented_with_pytest_node_id_passes():
+    """pytest node id (path.py::test_name) counts as a verifier token."""
+    audit = validate_ac_audit(
+        [
+            {"ac": "AC 1", "status": "implemented",
+             "evidence": "tests/test_foo.py::test_bar"},
+        ]
+    )
+    assert audit["downgrade_to"] is None
+    assert audit["missing"] == []
+
+
+def test_implemented_with_command_prefix_passes():
+    """Explicit command:/test:/smoke: prefix counts as a verifier token."""
+    audit = validate_ac_audit(
+        [
+            {"ac": "AC 1", "status": "implemented",
+             "evidence": "command: ruff check . -> 0 errors"},
+        ]
+    )
+    assert audit["downgrade_to"] is None
+
+
+def test_implemented_with_empty_evidence_downgrades_to_fail():
+    """Empty evidence on implemented — no token -> downgrade to FAIL."""
+    audit = validate_ac_audit(
+        [
+            {"ac": "AC 1", "status": "implemented", "evidence": ""},
+        ]
+    )
+    assert audit["downgrade_to"] == "FAIL"
+    assert len(audit["missing"]) == 1
+    assert "verifier token" in audit["missing"][0]["reason"]
+    assert audit["missing"][0]["status"] == "missing"
+
+
+def test_implemented_with_hand_wavy_prose_downgrades_to_fail():
+    """Prose without a concrete token -> downgrade to FAIL."""
+    audit = validate_ac_audit(
+        [
+            {"ac": "AC 1", "status": "implemented",
+             "evidence": "implemented in the service layer"},
+        ]
+    )
+    assert audit["downgrade_to"] == "FAIL"
+    assert "verifier token" in audit["missing"][0]["reason"]
+
+
+def test_implemented_missing_evidence_key_downgrades_to_fail():
+    """No evidence key at all -> None -> no token -> FAIL."""
+    audit = validate_ac_audit(
+        [
+            {"ac": "AC 1", "status": "implemented"},
+        ]
+    )
+    assert audit["downgrade_to"] == "FAIL"
+    assert "verifier token" in audit["missing"][0]["reason"]


### PR DESCRIPTION
## Summary
Closes #461 (AC3 of umbrella #458). Makes AC-FORBIDS-APPROVE airtight on *content*, not just structure.

- `validate_ac_audit` now requires every `implemented` entry's `evidence` to contain a concrete verifier token: a `file:line` ref, a pytest `::node` id, or a `test:`/`command:`/`smoke:` prefix **with a non-whitespace payload**. Tokenless/empty/prose evidence → downgrade to FAIL via the existing `missing` channel.
- Scope: `implemented` only; `n/a` stays exempt; `deferred` keeps its `#`-ref rule.
- `prove.md` AC-audit docs/examples updated to state the token requirement.

## Test Plan
- `pytest test_state_manager_prove_audit.py test_prove_gate.py` → **77 passed** (67 baseline + 10 new).
- ruff clean. Regex sanity: all real #459/#460 evidence forms pass; hand-wavy prose and bare prefixes fail.
- Dogfood: this PR's own PROVE artifact uses token-bearing evidence and passed the (new) validator at the orchestrate Step-4 recorder.

## Review
- PROVE: PASS, 4/4 ACs implemented.
- Codex adversarial review (gpt-5.5): REQUEST-CHANGES → found a bypass (`test:`/`command:`/`smoke:` accepted with no payload, so `evidence: "command:"` passed). Fixed (`\s*\S` payload required) + 4 regression tests; independently re-verified `command:`→FAIL, `command: foo`→pass.

Refs #458