### PR TITLE
feat(agent-git): require fresh validation-log with commands for runnable readiness

### DIFF
--- a/lib/agent_git.py
+++ b/lib/agent_git.py
@@ -258,9 +258,8 @@ RUNNABLE_SUFFIXES = {
     ".java", ".kt", ".c", ".cpp", ".h", ".sh",
 }
 VALIDATION_CMD_RE = re.compile(
-    r"(pytest|python\s+-m\s+pytest|ruff\s+check|ruff\s+format|"
-    r"npm\s+(test|run\s+(build|lint)))",
-    re.IGNORECASE,
+    r"(?im)^\s*(?:[$>]|\+\s*)?\s*"
+    r"(?:python\s+-m\s+pytest|pytest|ruff\s+(?:check|format)|npm\s+(?:test|run\s+(?:build|lint)))(?:\s|$)"
 )
 
 

--- a/lib/agent_git.py
+++ b/lib/agent_git.py
@@ -106,6 +106,7 @@ class ReadinessResult:
     summary: str | None
     test_evidence: list[str]
     pr_body: str | None = None
+    validation_log_status: str | None = None
     errors: list[str] = field(default_factory=list)
     warnings: list[str] = field(default_factory=list)
 
@@ -126,6 +127,7 @@ class ReadinessResult:
             "summary": self.summary,
             "test_evidence": self.test_evidence,
             "pr_body": self.pr_body,
+            "validation_log_status": self.validation_log_status,
             "errors": self.errors,
             "warnings": self.warnings,
         }
@@ -250,6 +252,15 @@ BRANCH_RE = re.compile(
 )
 COMMIT_RE = re.compile(
     r"^(feat|fix|docs|test|chore|perf|refactor|ci|style)(\([a-z0-9_.-]+\))?: [a-z0-9].{0,70}$"
+)
+RUNNABLE_SUFFIXES = {
+    ".py", ".js", ".jsx", ".ts", ".tsx", ".go", ".rs", ".rb",
+    ".java", ".kt", ".c", ".cpp", ".h", ".sh",
+}
+VALIDATION_CMD_RE = re.compile(
+    r"(pytest|python\s+-m\s+pytest|ruff\s+check|ruff\s+format|"
+    r"npm\s+(test|run\s+(build|lint)))",
+    re.IGNORECASE,
 )
 
 
@@ -538,6 +549,62 @@ def build_pr_body(issue: int | None, summary: str | None, test_evidence: list[st
     )
 
 
+def _is_runnable_change(changed_files: list[str]) -> bool:
+    """True iff any changed path has a code suffix (see RUNNABLE_SUFFIXES)."""
+    return any(Path(p).suffix.lower() in RUNNABLE_SUFFIXES for p in changed_files)
+
+
+def _validate_log(
+    validation_log: str | None,
+    runnable: bool,
+    runner: Runner,
+    repo: Path,
+) -> tuple[list[str], str | None]:
+    """Validate a runnable change's --validation-log.
+
+    Returns (errors, status). status is one of
+    "ok"|"missing"|"absent"|"stale"|"no_commands"|None (non-runnable).
+    """
+    if not runnable:
+        return [], None
+    if not validation_log:
+        return (
+            ["Runnable change requires --validation-log "
+             "(a file with test/lint output)."],
+            "absent",
+        )
+    log_path = Path(validation_log)
+    if not log_path.is_absolute():
+        log_path = (Path.cwd() / log_path).resolve()
+    if not log_path.is_file():
+        return ([f"Validation log not found: {validation_log}"], "missing")
+    text = log_path.read_text(encoding="utf-8", errors="replace")
+
+    # Freshness: mtime >= HEAD commit epoch, OR HEAD short sha appears in log.
+    head_ct = run_git(runner, repo, ["show", "-s", "--format=%ct", "HEAD"])
+    short_sha = run_git(runner, repo, ["rev-parse", "--short", "HEAD"])
+    sha = short_sha.stdout.strip()
+    fresh = False
+    if head_ct.returncode == 0 and head_ct.stdout.strip().isdigit():
+        fresh = int(log_path.stat().st_mtime) >= int(head_ct.stdout.strip())
+    if not fresh and sha and sha in text:
+        fresh = True
+    if not fresh:
+        return (
+            ["Validation log is stale (older than HEAD and does not "
+             "reference the HEAD commit). Re-run tests after committing."],
+            "stale",
+        )
+
+    if not VALIDATION_CMD_RE.search(text):
+        return (
+            ["Validation log does not contain a recognized test/lint command "
+             "(pytest, ruff check, ruff format, npm test/run build/run lint)."],
+            "no_commands",
+        )
+    return [], "ok"
+
+
 def readiness(
     repo: Path,
     *,
@@ -548,6 +615,7 @@ def readiness(
     test_evidence: list[str] | None = None,
     allowed_paths: list[str] | None = None,
     generate_pr_body: bool = False,
+    validation_log: str | None = None,
     runner: Runner | None = None,
 ) -> ReadinessResult:
     runner = runner or Runner()
@@ -569,6 +637,7 @@ def readiness(
             changed_files=[],
             summary=summary,
             test_evidence=test_evidence,
+            validation_log_status=None,
             errors=[f"Not a git repository: {repo}"],
         )
 
@@ -616,6 +685,12 @@ def readiness(
     if not test_evidence:
         errors.append("Test Plan evidence is required.")
 
+    runnable = _is_runnable_change(changed_files)
+    log_errors, validation_log_status = _validate_log(
+        validation_log, runnable, runner, repo
+    )
+    errors.extend(log_errors)
+
     if stage == "merge":
         warnings.append("Merge-stage readiness currently validates local branch evidence only; CI state is handled by GitHub checks.")
 
@@ -632,6 +707,7 @@ def readiness(
         summary=summary,
         test_evidence=test_evidence,
         pr_body=body,
+        validation_log_status=validation_log_status,
         errors=errors,
         warnings=warnings,
     )
@@ -648,6 +724,7 @@ def render_readiness_text(result: ReadinessResult) -> str:
         f"commits: {len(result.commits)}",
         f"changed_files: {len(result.changed_files)}",
         f"test_evidence: {len(result.test_evidence)}",
+        f"validation_log: {result.validation_log_status or '(n/a)'}",
     ]
     if result.pr_body:
         lines.extend(["", "pr_body:", result.pr_body.rstrip()])
@@ -961,6 +1038,7 @@ def ship(
     no_fetch: bool = False,
     skip_checks_wait: bool = False,
     comment_on_stop: bool = False,
+    validation_log: str | None = None,
     runner: Runner | None = None,
 ) -> ShipResult:
     runner = runner or Runner()
@@ -1008,6 +1086,7 @@ def ship(
         test_evidence=test_evidence,
         allowed_paths=allowed_paths,
         generate_pr_body=True,
+        validation_log=validation_log,
         runner=runner,
     )
     add_warnings(readiness_result.warnings)
@@ -1278,6 +1357,11 @@ def add_readiness_parser(subparsers: argparse._SubParsersAction[argparse.Argumen
     parser.add_argument("--test-evidence", action="append", default=[], help="test plan evidence; repeatable")
     parser.add_argument("--allowed-path", action="append", default=[], help="allowed changed-file prefix; repeatable")
     parser.add_argument("--generate-pr-body", action="store_true", help="include generated PR body in output")
+    parser.add_argument(
+        "--validation-log",
+        dest="validation_log",
+        help="path to a file containing test/lint output (required for runnable code changes)",
+    )
 
 
 def add_ship_parser(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
@@ -1292,6 +1376,11 @@ def add_ship_parser(subparsers: argparse._SubParsersAction[argparse.ArgumentPars
     parser.add_argument("--no-fetch", action="store_true", help="skip git fetch origin --prune during preflight")
     parser.add_argument("--skip-checks-wait", action="store_true", help="do not wait for gh pr checks before merge")
     parser.add_argument("--comment-on-stop", action="store_true", help="comment on the linked issue or PR when stopped")
+    parser.add_argument(
+        "--validation-log",
+        dest="validation_log",
+        help="path to a file containing test/lint output (required for runnable code changes)",
+    )
 
 
 def add_cleanup_parser(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
@@ -1404,6 +1493,7 @@ def main(argv: list[str] | None = None) -> int:
             no_fetch=args.no_fetch,
             skip_checks_wait=args.skip_checks_wait,
             comment_on_stop=args.comment_on_stop,
+            validation_log=args.validation_log,
         )
         if args.json:
             print(json.dumps(result.to_dict(), indent=2, sort_keys=True))
@@ -1421,6 +1511,7 @@ def main(argv: list[str] | None = None) -> int:
             test_evidence=args.test_evidence,
             allowed_paths=args.allowed_path,
             generate_pr_body=args.generate_pr_body,
+            validation_log=args.validation_log,
         )
         if args.json:
             print(json.dumps(result.to_dict(), indent=2, sort_keys=True))

--- a/lib/tests/test_agent_git.py
+++ b/lib/tests/test_agent_git.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 import pytest
@@ -53,6 +55,12 @@ def commit_file(work: Path, path: str = "tooling.txt", message: str = "feat(git)
     target.write_text("content\n", encoding="utf-8")
     git(["add", path], work)
     git(["commit", "-m", message], work)
+
+
+def write_log(tmp_path: Path, body: str = "pytest lib/tests/ -q\n... passed\n") -> Path:
+    log = tmp_path / "validation.log"
+    log.write_text(body, encoding="utf-8")
+    return log
 
 
 def test_preflight_fails_on_main_branch(tmp_path: Path) -> None:
@@ -163,6 +171,7 @@ def test_readiness_passes_with_issue_summary_tests_and_scope(tmp_path: Path) -> 
     work = make_repo(tmp_path)
     branch_for_issue(work, 42)
     commit_file(work, "src/tool.py")
+    log = write_log(tmp_path)
 
     result = readiness(
         work,
@@ -171,6 +180,7 @@ def test_readiness_passes_with_issue_summary_tests_and_scope(tmp_path: Path) -> 
         test_evidence=["pytest lib/tests/test_agent_git.py -q"],
         allowed_paths=["src/"],
         generate_pr_body=True,
+        validation_log=str(log),
     )
 
     assert result.ok
@@ -242,6 +252,7 @@ def test_readiness_cli_generates_pr_body(tmp_path: Path) -> None:
     work = make_repo(tmp_path)
     branch_for_issue(work, 42)
     commit_file(work, "src/tool.py")
+    log = write_log(tmp_path)
     script = Path(__file__).resolve().parents[2] / "bin" / "agent-git"
 
     completed = subprocess.run(
@@ -259,6 +270,8 @@ def test_readiness_cli_generates_pr_body(tmp_path: Path) -> None:
             "pytest lib/tests/test_agent_git.py -q",
             "--allowed-path",
             "src/",
+            "--validation-log",
+            str(log),
             "--generate-pr-body",
             "--json",
         ],
@@ -278,6 +291,7 @@ def test_ship_dry_run_passes_through_gates(tmp_path: Path) -> None:
     work = make_repo(tmp_path)
     branch_for_issue(work, 42)
     commit_file(work, "src/tool.py")
+    log = write_log(tmp_path)
 
     result = ship(
         work,
@@ -287,6 +301,7 @@ def test_ship_dry_run_passes_through_gates(tmp_path: Path) -> None:
         allowed_paths=["src/"],
         dry_run=True,
         no_fetch=True,
+        validation_log=str(log),
     )
 
     assert result.ok
@@ -336,6 +351,7 @@ def test_ship_cli_dry_run_json(tmp_path: Path) -> None:
     work = make_repo(tmp_path)
     branch_for_issue(work, 42)
     commit_file(work, "src/tool.py")
+    log = write_log(tmp_path)
     script = Path(__file__).resolve().parents[2] / "bin" / "agent-git"
 
     completed = subprocess.run(
@@ -353,6 +369,8 @@ def test_ship_cli_dry_run_json(tmp_path: Path) -> None:
             "pytest lib/tests/test_agent_git.py -q",
             "--allowed-path",
             "src/",
+            "--validation-log",
+            str(log),
             "--dry-run",
             "--no-fetch",
             "--json",
@@ -368,6 +386,183 @@ def test_ship_cli_dry_run_json(tmp_path: Path) -> None:
     assert payload["ok"] is True
     assert payload["dry_run"] is True
     assert "squash_merge" in payload["steps"]
+
+
+def test_readiness_runnable_without_log_errors(tmp_path: Path) -> None:
+    work = make_repo(tmp_path)
+    branch_for_issue(work, 42)
+    commit_file(work, "src/foo.py")
+
+    result = readiness(
+        work,
+        issue=42,
+        summary="add shared git tooling",
+        test_evidence=["pytest -q"],
+        allowed_paths=["src/"],
+        validation_log=None,
+    )
+
+    assert not result.ok
+    assert any("requires --validation-log" in error for error in result.errors)
+    assert result.validation_log_status == "absent"
+
+
+def test_readiness_runnable_missing_log_file_errors(tmp_path: Path) -> None:
+    work = make_repo(tmp_path)
+    branch_for_issue(work, 42)
+    commit_file(work, "src/foo.py")
+
+    result = readiness(
+        work,
+        issue=42,
+        summary="add shared git tooling",
+        test_evidence=["pytest -q"],
+        allowed_paths=["src/"],
+        validation_log=str(tmp_path / "nope.log"),
+    )
+
+    assert not result.ok
+    assert any("not found" in error for error in result.errors)
+    assert result.validation_log_status == "missing"
+
+
+def test_readiness_runnable_stale_log_errors(tmp_path: Path) -> None:
+    work = make_repo(tmp_path)
+    branch_for_issue(work, 42)
+    commit_file(work, "src/foo.py")
+    log = write_log(tmp_path, "ran the suite via pytest -q\n... passed\n")
+    old = time.time() - 3600
+    os.utime(log, (old, old))
+
+    result = readiness(
+        work,
+        issue=42,
+        summary="add shared git tooling",
+        test_evidence=["pytest -q"],
+        allowed_paths=["src/"],
+        validation_log=str(log),
+    )
+
+    assert not result.ok
+    assert any("stale" in error for error in result.errors)
+    assert result.validation_log_status == "stale"
+
+
+def test_readiness_runnable_fresh_log_with_pytest_passes(tmp_path: Path) -> None:
+    work = make_repo(tmp_path)
+    branch_for_issue(work, 42)
+    commit_file(work, "src/foo.py")
+    log = write_log(tmp_path)
+
+    result = readiness(
+        work,
+        issue=42,
+        summary="add shared git tooling",
+        test_evidence=["pytest -q"],
+        allowed_paths=["src/"],
+        validation_log=str(log),
+    )
+
+    assert result.ok
+    assert result.validation_log_status == "ok"
+
+
+def test_readiness_non_runnable_md_prose_passes(tmp_path: Path) -> None:
+    work = make_repo(tmp_path)
+    branch_for_issue(work, 42)
+    commit_file(work, "docs/guide.md", "docs(guide): add guide")
+
+    result = readiness(
+        work,
+        issue=42,
+        summary="add a guide",
+        test_evidence=["manual review"],
+        allowed_paths=["docs/"],
+        validation_log=None,
+    )
+
+    assert result.ok
+    assert result.validation_log_status is None
+
+
+def test_readiness_runnable_log_without_command_errors(tmp_path: Path) -> None:
+    work = make_repo(tmp_path)
+    branch_for_issue(work, 42)
+    commit_file(work, "src/foo.py")
+    log = write_log(tmp_path, "all good, ran the suite\n")
+
+    result = readiness(
+        work,
+        issue=42,
+        summary="add shared git tooling",
+        test_evidence=["pytest -q"],
+        allowed_paths=["src/"],
+        validation_log=str(log),
+    )
+
+    assert not result.ok
+    assert any("recognized test/lint command" in error for error in result.errors)
+    assert result.validation_log_status == "no_commands"
+
+
+def test_readiness_runnable_fresh_via_sha_passes(tmp_path: Path) -> None:
+    work = make_repo(tmp_path)
+    branch_for_issue(work, 42)
+    commit_file(work, "src/foo.py")
+    sha = git(["rev-parse", "--short", "HEAD"], work).stdout.strip()
+    log = write_log(tmp_path, f"pytest -q\nvalidated at {sha}\n")
+    old = time.time() - 3600
+    os.utime(log, (old, old))
+
+    result = readiness(
+        work,
+        issue=42,
+        summary="add shared git tooling",
+        test_evidence=["pytest -q"],
+        allowed_paths=["src/"],
+        validation_log=str(log),
+    )
+
+    assert result.ok
+    assert result.validation_log_status == "ok"
+
+
+def test_readiness_cli_validation_log(tmp_path: Path) -> None:
+    work = make_repo(tmp_path)
+    branch_for_issue(work, 42)
+    commit_file(work, "src/tool.py")
+    log = write_log(tmp_path)
+    script = Path(__file__).resolve().parents[2] / "bin" / "agent-git"
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            "readiness",
+            "--repo",
+            str(work),
+            "--issue",
+            "42",
+            "--summary",
+            "add shared git tooling",
+            "--test-evidence",
+            "pytest lib/tests/test_agent_git.py -q",
+            "--allowed-path",
+            "src/",
+            "--validation-log",
+            str(log),
+            "--json",
+        ],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+    assert completed.returncode == 0
+    payload = json.loads(completed.stdout)
+    assert payload["ok"] is True
+    assert payload["validation_log_status"] == "ok"
 
 
 def test_cleanup_deletes_merged_branch(tmp_path: Path) -> None:

--- a/lib/tests/test_agent_git.py
+++ b/lib/tests/test_agent_git.py
@@ -505,6 +505,45 @@ def test_readiness_runnable_log_without_command_errors(tmp_path: Path) -> None:
     assert result.validation_log_status == "no_commands"
 
 
+def test_readiness_runnable_log_with_prose_only_command_errors(tmp_path: Path) -> None:
+    work = make_repo(tmp_path)
+    branch_for_issue(work, 42)
+    commit_file(work, "src/foo.py")
+    log = write_log(tmp_path, "we will run pytest later\n")
+
+    result = readiness(
+        work,
+        issue=42,
+        summary="add shared git tooling",
+        test_evidence=["pytest -q"],
+        allowed_paths=["src/"],
+        validation_log=str(log),
+    )
+
+    assert not result.ok
+    assert any("recognized test/lint command" in error for error in result.errors)
+    assert result.validation_log_status == "no_commands"
+
+
+def test_readiness_runnable_log_with_prompt_prefixed_command_passes(tmp_path: Path) -> None:
+    work = make_repo(tmp_path)
+    branch_for_issue(work, 42)
+    commit_file(work, "src/foo.py")
+    log = write_log(tmp_path, "$ pytest -q\n... 35 passed\n")
+
+    result = readiness(
+        work,
+        issue=42,
+        summary="add shared git tooling",
+        test_evidence=["pytest -q"],
+        allowed_paths=["src/"],
+        validation_log=str(log),
+    )
+
+    assert result.ok
+    assert result.validation_log_status == "ok"
+
+
 def test_readiness_runnable_fresh_via_sha_passes(tmp_path: Path) -> None:
     work = make_repo(tmp_path)
     branch_for_issue(work, 42)


### PR DESCRIPTION
## Summary
Closes #462 (AC4 of umbrella #458). Stops `agent-git readiness`/`ship` from accepting prose `--test-evidence` as proof for runnable changes.

- New `--validation-log` flag on both `readiness` and `ship`. For a **runnable** change (a changed file with a code suffix in `RUNNABLE_SUFFIXES`), readiness now requires a validation log that (a) exists, (b) is fresh vs HEAD (`mtime ≥ HEAD %ct` OR log contains HEAD short-sha), and (c) contains a real test/lint **command line** (`pytest`/`ruff`/`npm` anchored to line start).
- Non-runnable changes (docs/`.md`/config) stay on the existing prose `test_evidence` path — docs PRs are not affected.
- `--test-evidence` still feeds the PR body. `ship --dry-run` does not bypass the gate.
- Blast radius is self-contained: only the CLI entry + test file import these functions.

## Test Plan
- `pytest lib/tests/test_agent_git.py` → **37 passed** (27 baseline + 10 new/updated). Collateral `test_prove_gate.py`+`test_state_manager_prove_audit.py` → 77 passed. ruff clean. Coverage `lib.agent_git` 56.8%→58.3%.
- **CLI dogfood**: runnable `.py` + no log → exit 1 "Runnable change requires --validation-log"; fresh log w/ `pytest` → pass; `.md`-only + prose → pass.

## Review
- PROVE: PASS, 3/3 ACs.
- Codex adversarial review (gpt-5.5): REQUEST-CHANGES → command regex was substring-based, so prose like "we will run pytest later" passed. Fixed by anchoring to line start (multiline, optional shell-prompt prefix) + 2 regression tests; independently re-verified prose→no-match, real command lines→match. Codex also confirmed the runnable-heuristic edge cases (`.PY`, `.py.bak`, no-extension, deletion-only) and threading are correct.

Refs #458