### PR TITLE
feat(smoke): runtime_smoke_gate.py — map changed files to smoke obligations

### DIFF
--- a/claude-config/agents/prove.md
+++ b/claude-config/agents/prove.md
@@ -228,6 +228,16 @@ Assert: no ImportError, no AttributeError on startup symbols.
 ```
 Assert: page loads (HTTP 200); zero console errors of severity ERROR.
 
+**Determining obligations (helper):** PROVE may run
+`python3 ~/agents/claude-config/scripts/runtime_smoke_gate.py --repo <repo> --diff-range origin/main...HEAD`
+to map the diff to smoke obligations (`backend_http`/`cli`/`worker`/`frontend`)
+and discover a project-local `smoke.sh`. Exit 0 = obligation satisfied
+(`smoke.sh` passed) or n/a → record `runtime_smoke.status: PASS` or `n/a`.
+Exit 1 = obligation present but no `smoke.sh` → run the emitted recipe ad-hoc and
+record `status: PASS` with the command, or mark the AC partial. Exit 3 =
+`smoke.sh` ran and FAILED → record `status: FAIL`. The helper does NOT block
+merges — `prove_gate.py` (#460) enforces the recorded `runtime_smoke` block.
+
 **Escape hatch** — use ONLY for pure refactors, docs, config, or rename changes
 where no entrypoint is exercised. Any change to a route handler, CLI command,
 worker startup, or rendered page requires a smoke run. Record in the PROVE

--- a/claude-config/scripts/runtime_smoke_gate.py
+++ b/claude-config/scripts/runtime_smoke_gate.py
@@ -1,0 +1,244 @@
+"""Runtime-smoke obligation helper for PROVE Level 5 (issue #463, AC5 of #458).
+
+Usage (from any project repo):
+  python3 ~/agents/claude-config/scripts/runtime_smoke_gate.py \
+      [--diff-range origin/main...HEAD] [--repo .] \
+      [--smoke-sh path/to/smoke.sh] [--timeout 60]
+
+Maps a git changeset to a set of smoke OBLIGATIONS (backend_http, cli, worker,
+frontend), discovers a project-local `smoke.sh`, runs it under a timeout, and —
+when an obligation exists but no `smoke.sh` is found — prints the obligation
+list plus the documented uvicorn/health recipe as an advisory.
+
+Exit codes:
+  0  no obligation (n/a) OR smoke.sh ran and PASSED
+  1  obligation detected but no smoke.sh (advisory — prints obligations + recipe)
+  2  operational error (could not read the diff, or smoke.sh failed to launch)
+  3  smoke.sh ran and FAILED (non-zero exit, incl. timeout)
+
+This is a HELPER — it determines obligations and runs a discovered smoke.sh.
+It does NOT block merges; enforcement of the recorded `runtime_smoke` block
+stays in `prove_gate.py` (#460).
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from enum import Enum
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from evals.common import ChangeSet, DiffError, changeset_from_git  # noqa: E402
+
+
+class SmokeObligation(str, Enum):
+    BACKEND_HTTP = "backend_http"
+    CLI = "cli"
+    WORKER = "worker"
+    FRONTEND = "frontend"
+
+
+# Backend HTTP smoke recipe — embedded verbatim from
+# rules/post-merge-verification.md lines 27-31, with a placeholder caveat. The
+# app module path and health route are PROJECT-SPECIFIC placeholders.
+BACKEND_HTTP_RECIPE = """\
+# Backend HTTP smoke — project-specific placeholders: app.main:app, /api/v1/health
+timeout 15 python3 -m uvicorn app.main:app --host 127.0.0.1 --port 9999 &
+sleep 5
+HTTP_CODE=$(curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:9999/api/v1/health 2>/dev/null)
+kill %1 2>/dev/null
+# HTTP_CODE should be 200 — replace app.main:app and /api/v1/health for your project
+"""
+
+# --- path patterns -----------------------------------------------------------
+_BACKEND_PATH_RE = re.compile(r"(^|/)routers/|(^|/)app/|(^|/)main\.py$|^main\.py$")
+_CLI_RE = re.compile(r"(^|/)bin/|(^|/)cli\.py$|(^|/)__main__\.py$")
+_WORKER_PATH_RE = re.compile(r"(^|/)services/|(^|/)workers/")
+_FRONTEND_PATH_RE = re.compile(r"(^|/)(pages|routes|app)/")
+_FRONTEND_EXT_RE = re.compile(r"\.(tsx|jsx)$")
+
+# --- content patterns (added lines / file text) ------------------------------
+_BACKEND_CONTENT_RE = re.compile(
+    r"FastAPI\(|@(app|router)\.(get|post|put|delete|patch)\b"
+)
+# WORKER content marker fires on a lifespan/service DEFINITION or REGISTRATION
+# (not a bare prose/comment/regex mention) so docs and this tool's own source
+# that merely name the words don't false-positive. Patterns:
+#   - `def lifespan` / `async def lifespan` (a lifespan handler)
+#   - `lifespan=`                            (FastAPI lifespan kwarg wiring)
+#   - `ServiceContainer(`                    (instantiating the container)
+#   - `_workers[`                            (registering in the worker dict)
+_WORKER_CONTENT_RE = re.compile(
+    r"\b(async\s+)?def\s+lifespan\b|\blifespan\s*=|\bServiceContainer\s*\(|\b_workers\["
+)
+
+
+# Test files are exercised by the test runner, never booted as a runnable
+# surface — and their fixtures intentionally contain route/worker/CLI example
+# strings, so they must be excluded from obligation detection.
+_TEST_PATH_RE = re.compile(r"(^|/)tests?/|(^|/)test_[^/]*\.py$|_test\.py$|\.spec\.(t|j)sx?$|\.test\.(t|j)sx?$")
+
+
+def _is_test_path(path: str) -> bool:
+    return bool(_TEST_PATH_RE.search(path))
+
+
+def _added_text(cs: ChangeSet, path: str) -> str:
+    """Added-line text, excluding comment-only lines (never an obligation)."""
+    return "\n".join(
+        text
+        for _, text in cs.added_lines(path)
+        if not text.lstrip().startswith("#")
+    )
+
+
+def _content_matches(cs: ChangeSet, path: str, pattern: re.Pattern[str]) -> bool:
+    """True if PATTERN hits the added lines, or (fallback) the whole file text.
+
+    The file-text fallback catches the case where the route/marker lives
+    elsewhere in a file whose changed lines don't themselves contain it.
+    """
+    if pattern.search(_added_text(cs, path)):
+        return True
+    return bool(pattern.search(cs.file_text(path) or ""))
+
+
+def _backend_http_hit(cs: ChangeSet, path: str) -> bool:
+    """BACKEND_HTTP requires BOTH a backend path AND FastAPI content.
+
+    Path alone must NOT fire — this is what keeps ``app/``-shaped tooling and
+    this repo's own ``claude-config/scripts/*.py`` from resolving to
+    BACKEND_HTTP (the central anti-false-positive design point).
+    """
+    if not _BACKEND_PATH_RE.search(path):
+        return False
+    return _content_matches(cs, path, _BACKEND_CONTENT_RE)
+
+
+def _worker_hit(cs: ChangeSet, path: str) -> bool:
+    if _WORKER_PATH_RE.search(path):
+        return True
+    # Content marker is a secondary trigger: only on Python source, and only on
+    # ADDED lines (no whole-file fallback) — a worker entrypoint is being added,
+    # not merely mentioned in a doc or comment elsewhere in the file.
+    if not path.endswith(".py"):
+        return False
+    return bool(_WORKER_CONTENT_RE.search(_added_text(cs, path)))
+
+
+def _frontend_hit(path: str) -> bool:
+    return bool(_FRONTEND_EXT_RE.search(path) and _FRONTEND_PATH_RE.search(path))
+
+
+def obligations(cs: ChangeSet) -> set[str]:
+    """Map a changeset to the set of SmokeObligation values. Empty set = n/a."""
+    obs: set[str] = set()
+    for path in cs.paths:
+        if _is_test_path(path):
+            continue
+        if _backend_http_hit(cs, path):
+            obs.add(SmokeObligation.BACKEND_HTTP.value)
+        if _CLI_RE.search(path):
+            obs.add(SmokeObligation.CLI.value)
+        if _worker_hit(cs, path):
+            obs.add(SmokeObligation.WORKER.value)
+        if _frontend_hit(path):
+            obs.add(SmokeObligation.FRONTEND.value)
+    return obs
+
+
+def discover_smoke_sh(repo: Path, override: Path | None = None) -> Path | None:
+    """Resolve a smoke.sh: override (if a file) → {repo}/smoke.sh → {repo}/scripts/smoke.sh."""
+    if override is not None and override.is_file():
+        return override
+    for candidate in (repo / "smoke.sh", repo / "scripts" / "smoke.sh"):
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def run_smoke(smoke_sh: Path, repo: Path, timeout: int) -> tuple[int, str]:
+    """Run `bash <smoke_sh>` in cwd=repo. Return (exit_code, combined output).
+
+    A TimeoutExpired is mapped to a non-zero exit so the caller treats it as a
+    FAIL. OSError (e.g. bash missing) is propagated for the caller's exit-2 path.
+    """
+    try:
+        proc = subprocess.run(
+            ["bash", str(smoke_sh)],
+            cwd=repo,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as exc:
+        out = (exc.stdout or "") + (exc.stderr or "")
+        return 124, f"{out}\nsmoke.sh timed out after {timeout}s"
+    return proc.returncode, proc.stdout + proc.stderr
+
+
+def _report(obs: set[str], smoke_sh: Path | None, result: tuple[int, str] | None) -> None:
+    listed = ", ".join(sorted(obs))
+    if not obs:
+        print("smoke: no runnable surface detected — runtime_smoke: n/a")
+        return
+    if smoke_sh is None:
+        print(
+            f"smoke: OBLIGATION [{listed}] but no smoke.sh found — "
+            "run ad-hoc and record runtime_smoke; recipe below:"
+        )
+        if SmokeObligation.BACKEND_HTTP.value in obs:
+            print(BACKEND_HTTP_RECIPE)
+        return
+    code, out = result if result is not None else (0, "")
+    if code == 0:
+        print(f"smoke: PASS via {smoke_sh} (obligations: {listed})")
+    else:
+        print(f"smoke: FAIL via {smoke_sh} (exit {code}) (obligations: {listed})")
+    if out.strip():
+        print(out.rstrip())
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        prog="runtime_smoke_gate", description=__doc__.splitlines()[0]
+    )
+    ap.add_argument("--diff-range", default="origin/main...HEAD")
+    ap.add_argument("--repo", type=Path, default=Path("."))
+    ap.add_argument("--smoke-sh", type=Path, default=None)
+    ap.add_argument("--timeout", type=int, default=60)
+    args = ap.parse_args(argv)
+
+    repo = args.repo.resolve()
+    try:
+        cs = changeset_from_git(repo, args.diff_range)
+    except DiffError as exc:
+        print(f"smoke: ERROR — {exc}", file=sys.stderr)
+        return 2
+
+    obs = obligations(cs)
+    if not obs:
+        _report(obs, None, None)
+        return 0
+
+    smoke_sh = discover_smoke_sh(repo, args.smoke_sh)
+    if smoke_sh is None:
+        _report(obs, None, None)
+        return 1
+
+    try:
+        code, out = run_smoke(smoke_sh, repo, args.timeout)
+    except OSError as exc:
+        print(f"smoke: ERROR — could not run {smoke_sh}: {exc}", file=sys.stderr)
+        return 2
+
+    _report(obs, smoke_sh, (code, out))
+    return 0 if code == 0 else 3
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/claude-config/scripts/runtime_smoke_gate.py
+++ b/claude-config/scripts/runtime_smoke_gate.py
@@ -62,8 +62,16 @@ _FRONTEND_PATH_RE = re.compile(r"(^|/)(pages|routes|app)/")
 _FRONTEND_EXT_RE = re.compile(r"\.(tsx|jsx)$")
 
 # --- content patterns (added lines / file text) ------------------------------
+# BACKEND_HTTP detection is FastAPI-biased and intentionally so for this
+# iteration: it matches FastAPI()/APIRouter() construction, add_api_route(),
+# and route decorators on `app`, `router`, or any `*router`-suffixed identifier
+# (e.g. @api_router.get, @v1_router.post). DOCUMENTED LIMITATION — Flask
+# (@app.route) and Django (urls.py) routes are NOT detected; downstream
+# projects relying on those frameworks should ship a project-local `smoke.sh`.
 _BACKEND_CONTENT_RE = re.compile(
-    r"FastAPI\(|@(app|router)\.(get|post|put|delete|patch)\b"
+    r"FastAPI\(|APIRouter\(|add_api_route\(|"
+    r"@(app|\w*router)\.(get|post|put|delete|patch|head|options)\b",
+    re.IGNORECASE,
 )
 # WORKER content marker fires on a lifespan/service DEFINITION or REGISTRATION
 # (not a bare prose/comment/regex mention) so docs and this tool's own source
@@ -72,9 +80,17 @@ _BACKEND_CONTENT_RE = re.compile(
 #   - `lifespan=`                            (FastAPI lifespan kwarg wiring)
 #   - `ServiceContainer(`                    (instantiating the container)
 #   - `_workers[`                            (registering in the worker dict)
+#   - `Celery(`                              (instantiating a Celery app)
+#   - `@<ident>.task`                        (a Celery task decorator)
+#   - `.add_job(`                            (APScheduler job registration)
 _WORKER_CONTENT_RE = re.compile(
-    r"\b(async\s+)?def\s+lifespan\b|\blifespan\s*=|\bServiceContainer\s*\(|\b_workers\["
+    r"\b(async\s+)?def\s+lifespan\b|\blifespan\s*=|\bServiceContainer\s*\(|"
+    r"\b_workers\[|\bCelery\s*\(|@\w+\.task\b|\.add_job\("
 )
+# CLI content marker: a Click command/group decorator anywhere in added .py.
+_CLI_CONTENT_RE = re.compile(r"@click\.(command|group)\b")
+# pyproject/setup CLI entrypoint markers (added lines only).
+_CONSOLE_SCRIPTS_RE = re.compile(r"\[project\.scripts\]|console_scripts")
 
 
 # Test files are exercised by the test runner, never booted as a runnable
@@ -114,9 +130,21 @@ def _backend_http_hit(cs: ChangeSet, path: str) -> bool:
     this repo's own ``claude-config/scripts/*.py`` from resolving to
     BACKEND_HTTP (the central anti-false-positive design point).
     """
-    if not _BACKEND_PATH_RE.search(path):
+    if not _BACKEND_PATH_RE.search(path) or _is_self_source(path):
         return False
     return _content_matches(cs, path, _BACKEND_CONTENT_RE)
+
+
+# This helper's own source file. Its module text legitimately contains the
+# very marker strings it scans for (regex literals like `@click.command`,
+# `console_scripts`, `Celery(`), so it must be excluded from CONTENT-based
+# obligation detection to avoid self-dogfood false positives. Path-token rules
+# don't match this file's name, so only the content scanners need the guard.
+_SELF_SOURCE = "runtime_smoke_gate.py"
+
+
+def _is_self_source(path: str) -> bool:
+    return path.endswith(_SELF_SOURCE)
 
 
 def _worker_hit(cs: ChangeSet, path: str) -> bool:
@@ -125,9 +153,23 @@ def _worker_hit(cs: ChangeSet, path: str) -> bool:
     # Content marker is a secondary trigger: only on Python source, and only on
     # ADDED lines (no whole-file fallback) — a worker entrypoint is being added,
     # not merely mentioned in a doc or comment elsewhere in the file.
-    if not path.endswith(".py"):
+    if not path.endswith(".py") or _is_self_source(path):
         return False
     return bool(_WORKER_CONTENT_RE.search(_added_text(cs, path)))
+
+
+def _cli_hit(cs: ChangeSet, path: str) -> bool:
+    """CLI obligation: path token, console-scripts entrypoint, or @click decorator."""
+    if _CLI_RE.search(path):
+        return True
+    if _is_self_source(path):
+        return False
+    name = path.rsplit("/", 1)[-1]
+    if name in ("pyproject.toml", "setup.py"):
+        return bool(_CONSOLE_SCRIPTS_RE.search(_added_text(cs, path)))
+    if path.endswith(".py"):
+        return bool(_CLI_CONTENT_RE.search(_added_text(cs, path)))
+    return False
 
 
 def _frontend_hit(path: str) -> bool:
@@ -142,7 +184,7 @@ def obligations(cs: ChangeSet) -> set[str]:
             continue
         if _backend_http_hit(cs, path):
             obs.add(SmokeObligation.BACKEND_HTTP.value)
-        if _CLI_RE.search(path):
+        if _cli_hit(cs, path):
             obs.add(SmokeObligation.CLI.value)
         if _worker_hit(cs, path):
             obs.add(SmokeObligation.WORKER.value)
@@ -161,11 +203,22 @@ def discover_smoke_sh(repo: Path, override: Path | None = None) -> Path | None:
     return None
 
 
+def _to_text(value: object) -> str:
+    """Normalize subprocess stdout/stderr to str (None→"", bytes→utf-8 decode)."""
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return str(value)
+
+
 def run_smoke(smoke_sh: Path, repo: Path, timeout: int) -> tuple[int, str]:
     """Run `bash <smoke_sh>` in cwd=repo. Return (exit_code, combined output).
 
     A TimeoutExpired is mapped to a non-zero exit so the caller treats it as a
     FAIL. OSError (e.g. bash missing) is propagated for the caller's exit-2 path.
+    TimeoutExpired.stdout/.stderr may be bytes even under text=True, so both are
+    normalized via _to_text to avoid a TypeError on concatenation.
     """
     try:
         proc = subprocess.run(
@@ -176,7 +229,7 @@ def run_smoke(smoke_sh: Path, repo: Path, timeout: int) -> tuple[int, str]:
             timeout=timeout,
         )
     except subprocess.TimeoutExpired as exc:
-        out = (exc.stdout or "") + (exc.stderr or "")
+        out = _to_text(exc.stdout) + _to_text(exc.stderr)
         return 124, f"{out}\nsmoke.sh timed out after {timeout}s"
     return proc.returncode, proc.stdout + proc.stderr
 
@@ -225,7 +278,12 @@ def main(argv: list[str] | None = None) -> int:
         _report(obs, None, None)
         return 0
 
-    smoke_sh = discover_smoke_sh(repo, args.smoke_sh)
+    # Resolve a relative --smoke-sh against --repo (not the process cwd) for
+    # predictability; absolute paths are used as-is.
+    override = args.smoke_sh
+    if override is not None and not override.is_absolute():
+        override = repo / override
+    smoke_sh = discover_smoke_sh(repo, override)
     if smoke_sh is None:
         _report(obs, None, None)
         return 1

--- a/claude-config/tests/test_runtime_smoke_gate.py
+++ b/claude-config/tests/test_runtime_smoke_gate.py
@@ -99,6 +99,123 @@ def test_comment_only_worker_marker_ignored(tmp_path):
     assert R.obligations(cs) == set()
 
 
+# ---------- broadened BACKEND_HTTP detection (codex review #463) ----------
+
+def test_backend_apirouter_construction(tmp_path):
+    cs = _cs(tmp_path, {"app/routers/x.py": [
+        (1, "api_router = APIRouter()"),
+        (2, "@api_router.get('/x')"),
+    ]})
+    assert R.obligations(cs) == {"backend_http"}
+
+
+def test_backend_add_api_route(tmp_path):
+    cs = _cs(tmp_path, {"app/main.py": [
+        (1, "app.add_api_route('/x', handler)"),
+    ]})
+    assert R.obligations(cs) == {"backend_http"}
+
+
+def test_backend_router_suffixed_identifier_decorator(tmp_path):
+    # A non-app/router identifier ending in `router` must still fire.
+    cs = _cs(tmp_path, {"app/routers/v1.py": [
+        (1, "@v1_router.post('/y')"),
+    ]})
+    assert R.obligations(cs) == {"backend_http"}
+
+
+def test_backend_path_no_fastapi_still_empty(tmp_path):
+    # No-false-positive guard still holds with the broadened content regex.
+    cs = _cs(tmp_path, {"app/util.py": [(1, "x = 1"), (2, "def helper(): ...")]})
+    assert R.obligations(cs) == set()
+
+
+# ---------- broadened CLI detection (codex review #463) ----------
+
+def test_pyproject_console_scripts_is_cli(tmp_path):
+    cs = _cs(tmp_path, {"pyproject.toml": [
+        (10, "[project.scripts]"),
+        (11, "mytool = 'pkg.cli:main'"),
+    ]})
+    assert R.obligations(cs) == {"cli"}
+
+
+def test_click_command_is_cli(tmp_path):
+    cs = _cs(tmp_path, {"tools/cmd.py": [
+        (1, "@click.command()"),
+        (2, "def run(): ..."),
+    ]})
+    assert R.obligations(cs) == {"cli"}
+
+
+# ---------- broadened WORKER detection (codex review #463) ----------
+
+def test_celery_task_decorator_is_worker(tmp_path):
+    cs = _cs(tmp_path, {"app/tasks.py": [
+        (1, "@celery_app.task"),
+        (2, "def crunch(): ..."),
+    ]})
+    assert R.obligations(cs) == {"worker"}
+
+
+def test_add_job_scheduler_is_worker(tmp_path):
+    cs = _cs(tmp_path, {"jobs/scheduler.py": [
+        (1, "scheduler.add_job(crunch, 'interval', seconds=30)"),
+    ]})
+    assert R.obligations(cs) == {"worker"}
+
+
+# ---------- path-boundary lock (codex review #463) ----------
+
+def test_test_path_boundary_does_not_swallow_lookalikes(tmp_path):
+    # `contests/` and `latest/` must NOT be treated as test paths — they remain
+    # eligible for obligations. A genuine `tests/test_*.py` IS excluded.
+    cs = _cs(tmp_path, {
+        "contests/foo.py": [(1, "@click.command()")],
+        "latest/foo.py": [(1, "@click.group()")],
+        "tests/test_x.py": [(1, "@click.command()")],
+    })
+    # Both lookalikes fire CLI; the real test path contributes nothing.
+    assert R.obligations(cs) == {"cli"}
+
+
+# ---------- self-source guard (codex review #463) ----------
+
+def test_self_source_not_self_dogfood_false_positive(tmp_path):
+    # The helper's own source contains marker string literals; it must not
+    # self-fire on content rules.
+    cs = _cs(tmp_path, {"claude-config/scripts/runtime_smoke_gate.py": [
+        (1, "_CLI_CONTENT_RE = re.compile(r'@click.command')"),
+        (2, "_CONSOLE_SCRIPTS_RE = re.compile(r'console_scripts')"),
+        (3, "r'Celery\\\\('"),
+    ]})
+    assert R.obligations(cs) == set()
+
+
+# ---------- timeout normalization (codex review #463) ----------
+
+def test_run_smoke_timeout_no_crash(tmp_path):
+    # A smoke.sh that sleeps past the timeout maps cleanly to a non-zero exit
+    # (no TypeError from bytes stdout/stderr concatenation).
+    sh = _write_smoke(tmp_path, "sleep 5")
+    code, out = R.run_smoke(sh, tmp_path, timeout=1)
+    assert code == 124
+    assert "timed out" in out
+
+
+def test_main_timeout_exit_3(tmp_path, monkeypatch):
+    _write_smoke(tmp_path, "sleep 5")
+    cs = _cs(tmp_path, {"services/x.py": [(1, "def run(): ...")]})
+    monkeypatch.setattr(R, "changeset_from_git", lambda *a, **k: cs)
+    assert R.main(["--repo", str(tmp_path), "--timeout", "1"]) == 3
+
+
+def test_to_text_normalizes(tmp_path):
+    assert R._to_text(None) == ""
+    assert R._to_text(b"hi") == "hi"
+    assert R._to_text("hi") == "hi"
+
+
 # ---------- smoke.sh discovery ----------
 
 def test_discover_none(tmp_path):

--- a/claude-config/tests/test_runtime_smoke_gate.py
+++ b/claude-config/tests/test_runtime_smoke_gate.py
@@ -1,0 +1,171 @@
+"""Tests for the runtime-smoke obligation helper (issue #463, AC5 of #458)."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+import runtime_smoke_gate as R  # noqa: E402
+from evals.common import ChangeSet  # noqa: E402
+
+
+def _cs(tmp_path, added):
+    return ChangeSet(repo=tmp_path, added=added)
+
+
+# ---------- obligation mapping matrix ----------
+
+def test_backend_route_with_fastapi_content(tmp_path):
+    cs = _cs(tmp_path, {"app/routers/jobs.py": [
+        (1, "from fastapi import APIRouter"),
+        (5, "@router.get('/x')"),
+    ]})
+    assert R.obligations(cs) == {"backend_http"}
+
+
+def test_backend_path_without_fastapi_content_no_false_positive(tmp_path):
+    # Load-bearing: backend-shaped paths with NO FastAPI content must NOT fire.
+    cs = _cs(tmp_path, {
+        "claude-config/scripts/some_tool.py": [(1, "import argparse")],
+        "app/util.py": [(1, "x = 1")],
+    })
+    assert R.obligations(cs) == set()
+
+
+def test_bin_path_is_cli(tmp_path):
+    cs = _cs(tmp_path, {"bin/foo": [(1, "#!/usr/bin/env python")]})
+    assert R.obligations(cs) == {"cli"}
+
+
+def test_services_path_is_worker(tmp_path):
+    cs = _cs(tmp_path, {"services/x.py": [(1, "def run(): ...")]})
+    assert R.obligations(cs) == {"worker"}
+
+
+def test_pages_tsx_is_frontend(tmp_path):
+    cs = _cs(tmp_path, {"frontend/pages/Home.tsx": [(1, "export default Home")]})
+    assert R.obligations(cs) == {"frontend"}
+
+
+def test_docs_only_is_na(tmp_path):
+    cs = _cs(tmp_path, {"README.md": [(1, "# hi")]})
+    assert R.obligations(cs) == set()
+
+
+def test_mixed_change_is_union(tmp_path):
+    cs = _cs(tmp_path, {
+        "app/routers/jobs.py": [(1, "from fastapi import APIRouter"),
+                                (2, "@router.post('/y')")],
+        "bin/cli.py": [(1, "import argparse")],
+    })
+    assert R.obligations(cs) == {"backend_http", "cli"}
+
+
+def test_backend_http_via_file_text_fallback(tmp_path):
+    # No content in added lines, but the working-tree file has FastAPI() —
+    # exercise the file_text fallback path.
+    mod = tmp_path / "app" / "main.py"
+    mod.parent.mkdir(parents=True)
+    mod.write_text("from fastapi import FastAPI\napp = FastAPI()\n", encoding="utf-8")
+    cs = _cs(tmp_path, {"app/main.py": [(3, "# comment-only added line")]})
+    assert "backend_http" in R.obligations(cs)
+
+
+def test_worker_via_lifespan_content(tmp_path):
+    cs = _cs(tmp_path, {"core/boot.py": [(1, "async def lifespan(app): ...")]})
+    assert R.obligations(cs) == {"worker"}
+
+
+def test_test_files_excluded(tmp_path):
+    # A test file whose fixtures contain route/worker example strings is NOT a
+    # runnable surface — it must contribute no obligations (the dogfood case).
+    cs = _cs(tmp_path, {
+        "tests/test_thing.py": [
+            (1, "cs = {'app/routers/x.py': '@router.get()'}"),
+            (2, "async def lifespan(app): ..."),
+        ],
+        "app/__main__.py": [(1, "# in a test tree? no — but bin pattern still excluded under tests/")],
+    })
+    # tests/ path excluded entirely; only the non-test app/__main__.py is a CLI.
+    assert R.obligations(cs) == {"cli"}
+
+
+def test_comment_only_worker_marker_ignored(tmp_path):
+    # A comment mentioning the markers must not fire the worker content rule.
+    cs = _cs(tmp_path, {"core/util.py": [
+        (1, "# this module talks to the ServiceContainer( and def lifespan"),
+        (2, "x = 1"),
+    ]})
+    assert R.obligations(cs) == set()
+
+
+# ---------- smoke.sh discovery ----------
+
+def test_discover_none(tmp_path):
+    assert R.discover_smoke_sh(tmp_path) is None
+
+
+def test_discover_root_smoke(tmp_path):
+    sh = tmp_path / "smoke.sh"
+    sh.write_text("#!/bin/bash\nexit 0\n")
+    assert R.discover_smoke_sh(tmp_path) == sh
+
+
+def test_discover_scripts_fallback(tmp_path):
+    (tmp_path / "scripts").mkdir()
+    sh = tmp_path / "scripts" / "smoke.sh"
+    sh.write_text("#!/bin/bash\nexit 0\n")
+    assert R.discover_smoke_sh(tmp_path) == sh
+
+
+def test_discover_override(tmp_path):
+    custom = tmp_path / "custom_smoke.sh"
+    custom.write_text("#!/bin/bash\nexit 0\n")
+    assert R.discover_smoke_sh(tmp_path, custom) == custom
+
+
+# ---------- runner + exit codes ----------
+
+def _write_smoke(tmp_path, body):
+    sh = tmp_path / "smoke.sh"
+    sh.write_text(f"#!/bin/bash\n{body}\n")
+    return sh
+
+
+def test_run_smoke_pass(tmp_path):
+    sh = _write_smoke(tmp_path, "echo ok; exit 0")
+    code, out = R.run_smoke(sh, tmp_path, timeout=10)
+    assert code == 0
+    assert "ok" in out
+
+
+def test_run_smoke_fail(tmp_path):
+    sh = _write_smoke(tmp_path, "echo boom; exit 3")
+    code, _ = R.run_smoke(sh, tmp_path, timeout=10)
+    assert code != 0
+
+
+def test_main_smoke_present_and_passes_exit_0(tmp_path, monkeypatch):
+    _write_smoke(tmp_path, "exit 0")
+    cs = _cs(tmp_path, {"services/x.py": [(1, "def run(): ...")]})
+    monkeypatch.setattr(R, "changeset_from_git", lambda *a, **k: cs)
+    assert R.main(["--repo", str(tmp_path)]) == 0
+
+
+def test_main_obligation_no_smoke_exit_1(tmp_path, monkeypatch):
+    cs = _cs(tmp_path, {"services/x.py": [(1, "def run(): ...")]})
+    monkeypatch.setattr(R, "changeset_from_git", lambda *a, **k: cs)
+    assert R.main(["--repo", str(tmp_path)]) == 1
+
+
+def test_main_smoke_fails_exit_3(tmp_path, monkeypatch):
+    _write_smoke(tmp_path, "exit 1")
+    cs = _cs(tmp_path, {"services/x.py": [(1, "def run(): ...")]})
+    monkeypatch.setattr(R, "changeset_from_git", lambda *a, **k: cs)
+    assert R.main(["--repo", str(tmp_path)]) == 3
+
+
+def test_main_no_obligation_exit_0(tmp_path, monkeypatch):
+    cs = _cs(tmp_path, {"README.md": [(1, "# hi")]})
+    monkeypatch.setattr(R, "changeset_from_git", lambda *a, **k: cs)
+    assert R.main(["--repo", str(tmp_path)]) == 0


### PR DESCRIPTION
## Summary
Closes #463 (AC5 of umbrella #458). Adds the shared smoke harness PROVE calls to determine/run Level 5 runtime obligations.

- New `claude-config/scripts/runtime_smoke_gate.py`: pure `obligations(changeset)` maps changed files → `{BACKEND_HTTP, CLI, WORKER, FRONTEND}` (reusing `evals/common.ChangeSet`). BACKEND_HTTP requires path **and** FastAPI content (no false positives on tooling repos). Discovers + runs a repo `smoke.sh` (or `scripts/smoke.sh`); embeds the post-merge uvicorn/health recipe as the backend default. Exit codes: 0 = n/a or smoke passed; 1 = obligation but no smoke.sh (advisory); 2 = DiffError; 3 = smoke.sh failed. Helper only — `prove_gate` (#460) owns enforcement.
- `prove.md` Level 5 now points PROVE at the tool.
- Broad doc reconciliation (git-process.md, code-quality-standards.md, eval-file-mapping.md) is **#464**.

## Test Plan
- `pytest test_runtime_smoke_gate.py` → **34 passed** (full obligation matrix incl. no-false-positive + path-boundary locks); collateral `test_prove_gate.py`+`test_evals.py` → 52. ruff clean.
- Self-dogfood on this branch → exit 0 / `runtime_smoke: n/a` (tooling+tests+docs, no runnable surface) — validates the no-false-positive design on the repo itself.

## Review
- PROVE: PASS, 4/4 ACs; verified the PATCH deviation (test-path exclusion is path-anchored, real routes/workers still fire).
- Codex adversarial review (gpt-5.5), 2 rounds: round 1 found 4 in-scope false-negatives (APIRouter/non-`app` router names, `add_api_route`, `[project.scripts]`/`@click.command` CLI, Celery workers) + a timeout `TimeoutExpired.stdout`-bytes crash. Round 2 broadened the heuristics + `_to_text` normalizer + a `_is_self_source` guard (so broadened regexes don't match the helper's own marker literals) + 12 new tests. Independently re-verified: new patterns fire, `contests/`/`latest/` not over-matched, self-dogfood still exit 0. Flask/Django remain a documented FastAPI-bias limitation.

Refs #458