### PR TITLE
docs(verification): reconcile git-process + code-quality-standards with enforced runtime gate

### DIFF
--- a/claude-config/rules/code-quality-standards.md
+++ b/claude-config/rules/code-quality-standards.md
@@ -56,6 +56,14 @@ explanation and passes.
 |---|---|
 | No credentials in the diff | E15 via the evals runner (part of the command above) |
 
+## Runtime Smoke
+
+| Standard | Check |
+|---|---|
+| Any change with a runnable surface must record a passing runtime smoke | `python3 ~/agents/claude-config/scripts/runtime_smoke_gate.py --diff-range origin/main...HEAD` (advisory helper: maps changed files to obligations, runs `smoke.sh` if present; exits 0 = no obligation or passed, 1 = obligation but no `smoke.sh` found) |
+| PROVE Level 5 `runtime_smoke` block required in artifact frontmatter | `python3 ~/agents/claude-config/scripts/prove_gate.py --issue <N>` — exit 6 (`GATE_SMOKE_VIOLATION`) when `runtime_smoke` is absent, FAIL, or malformed on a PASS artifact |
+| Escape hatch for non-runnable surfaces | `runtime_smoke: {status: "n/a", evidence: "no runnable surface"}` — docs, config, and rename-only changes qualify |
+
 ## How the pipeline applies this
 
 - **PATCH** captures the coverage baseline before changes and records the
@@ -64,6 +72,12 @@ explanation and passes.
 - **PROVE** treats an unexplained coverage decrease, any lint failure on
   changed files, or a mechanical-eval finding as an `ac_audit`-level issue —
   which makes it FAIL-able via AC-FORBIDS-APPROVE and enforced at merge by
-  `prove_gate.py` (#360).
+  `prove_gate.py` (#360). For runnable surfaces, PROVE Level 5 runtime smoke
+  is mandatory; a PASS artifact without a valid `runtime_smoke` block triggers
+  `GATE_SMOKE_VIOLATION` (exit 6, fail-closed). See
+  `docs/orchestrate-verification-gap.md` for the full gap analysis (#458).
+- **agent-git readiness/ship** require a fresh `--validation-log` (file exists,
+  newer than HEAD, contains a command) for runnable changes; docs and config
+  changes accept prose evidence.
 - **/quick** applies the eval gate on risk triggers (quick.md §2.5); lint
   on touched areas is already mandatory there.

--- a/docs/git-process.md
+++ b/docs/git-process.md
@@ -192,10 +192,20 @@ Same-file work must serialize unless the user explicitly approves overlap.
 
 Each project defines its own commands, but agents must follow the same ladder:
 
-1. Static or formatting checks, if present.
-2. Unit tests for touched code, if present.
-3. Integration or smoke tests for touched workflows, if present.
-4. Manual verification when automation does not exist.
+1. Static or formatting checks (`ruff check`, `npm run lint`).
+2. Unit tests for touched code (`pytest -q`, `npm run build`).
+3. **Runtime smoke — mandatory for any change with a runnable surface (PROVE
+   Level 5).** Boot the changed entrypoint and confirm it starts and responds
+   without error. PROVE records the result as `runtime_smoke {status, command,
+   evidence}` in its artifact frontmatter; `prove_gate.py` fails closed
+   (exit 6 `GATE_SMOKE_VIOLATION`) when this field is absent or reports
+   failure. Escape hatch: `runtime_smoke: {status: n/a, evidence: "no runnable
+   surface"}`. See `claude-config/scripts/runtime_smoke_gate.py` for the
+   obligation-mapping helper and recipe guidance, and
+   `docs/orchestrate-verification-gap.md` for the gap analysis that motivated
+   this gate.
+4. Manual verification when automation does not exist and no runnable surface
+   is present.
 
 The PR must state exactly what ran and what failed or was skipped. "Not run" is
 acceptable only with a concrete reason.
@@ -208,7 +218,13 @@ An issue is not complete merely because files were added. Each issue must prove:
 - **Wired:** behavior is reachable from the installer, command, workflow, agent
   instruction, CI job, or user-facing entrypoint that should invoke it.
 - **Exercised:** at least one automated or manual test runs through that
-  entrypoint.
+  entrypoint. For runnable surfaces (backend HTTP, CLI, worker, frontend),
+  PROVE Level 5 runtime smoke is required and mechanically enforced: the
+  PROVE artifact must record a passing `runtime_smoke` block, or the
+  `prove_gate.py` merge gate blocks with `GATE_SMOKE_VIOLATION` (exit 6).
+  `agent-git readiness`/`ship` also require a fresh `--validation-log` (exists
+  + newer than HEAD + contains a command) for runnable changes. Docs and config
+  changes may satisfy this with prose evidence.
 - **Observed:** the PR includes command output summary, artifact, check result,
   or fixture evidence.
 - **Documented:** user or agent-facing docs explain operational behavior.


### PR DESCRIPTION
## Summary
Closes #464 (AC6 of umbrella #458) — the final slice. Updates the docs to describe the now-ENFORCED runtime gate instead of aspirational prose.

- `docs/git-process.md`: Validation Ladder + "Exercised" gate now reference PROVE Level 5 RUNTIME (mandatory for runnable surfaces), the structured `runtime_smoke` frontmatter, `prove_gate.py` fail-closed (`GATE_SMOKE_VIOLATION`, exit 6), `agent-git --validation-log` (runnable changes; docs/config prose-OK), and the `runtime_smoke_gate.py` advisory helper. All "if present" language removed.
- `claude-config/rules/code-quality-standards.md`: new "Runtime Smoke" command-checkable standard (advisory helper vs hard gate vs escape hatch) + pipeline-application bullets.
- Both cross-link `docs/orchestrate-verification-gap.md`.

## Test Plan
- Docs-only; PROVE cross-checked **every claim against live code** (exit 6, advisory helper, Level 5 mandatory, validation-log runnable-only, escape-hatch shape) → zero inaccuracies, no "if present" remaining.
- Evals CLEAN; markdown sanity OK; cross-link resolves.
- Loop-closing dogfood: `runtime_smoke_gate.py` on this docs PR → exit 0 / `n/a` (correctly classifies its own docs change as no runnable surface).

Codex skipped per docs-only routing (no enforcement logic; the gates landed with Codex review in #460–463).

Refs #458