### PR TITLE
fix(install): make install-all cross-platform (macOS, Ubuntu, WSL)

### DIFF
--- a/install-all.sh
+++ b/install-all.sh
@@ -70,9 +70,11 @@ detect_profile() {
             ;;
     esac
 
-    # Auto-detect by platform
+    # Auto-detect by platform. macOS is the "personal" (MacBook) profile;
+    # the scheduler is platform-detected at post-install time, so this only
+    # picks which config.toml/env.template to seed.
     if [[ "$(uname)" == "Darwin" ]]; then
-        echo "work"
+        echo "personal"
         return
     fi
 
@@ -205,7 +207,9 @@ if [ "$SKIP_PROFILE" = false ] && [ -n "$PROFILE" ]; then
         echo ""
         echo "  Running post-install for $PROFILE..."
         echo ""
-        "$PROFILE_DIR/post-install.sh"
+        # Non-fatal: base config (Claude + Codex) already installed above; a
+        # profile automation hiccup must not fail the whole install.
+        "$PROFILE_DIR/post-install.sh" || echo "  ⚠ post-install reported a problem — base install is still complete."
     fi
 else
     echo "[3/3] Skipped machine profile"

--- a/machines/lib/post-install-common.sh
+++ b/machines/lib/post-install-common.sh
@@ -1,0 +1,146 @@
+#!/bin/bash
+# Shared, platform-aware post-install logic for all machine profiles.
+#
+# A machine *profile* (work/personal) selects config.toml + env.template only.
+# The automation *scheduler* is chosen by the ACTUAL detected platform — NOT by
+# the profile name — so any profile is safe to run on macOS, Ubuntu/Linux, or
+# WSL:
+#
+#   macOS              → launchd
+#   Linux (systemd)    → systemd --user timer + cron
+#   Linux (no systemd) → cron only
+#   WSL  (systemd on)  → systemd --user timer + cron
+#   WSL  (no systemd)  → cron only (warns; enable systemd in /etc/wsl.conf)
+#
+# Sourced by machines/<profile>/post-install.sh, which then calls:
+#   run_profile_post_install "$REPO_DIR" "<profile-name>"
+#
+# Callers run with `set -e`; every function here degrades gracefully (warn,
+# never abort the whole install) when a scheduler or dependency is missing.
+
+# ─── Platform detection ──────────────────────────────────────────────────────
+
+detect_platform() {
+    if [[ "$(uname)" == "Darwin" ]]; then
+        echo "macos"
+    elif grep -qi microsoft /proc/version 2>/dev/null; then
+        echo "wsl"
+    else
+        echo "linux"
+    fi
+}
+
+# Is a usable systemd --user instance present? (PID-1 systemd + reachable bus)
+systemd_user_available() {
+    command -v systemctl >/dev/null 2>&1 || return 1
+    [ -d /run/systemd/system ] || return 1
+    systemctl --user show-environment >/dev/null 2>&1
+}
+
+# ─── Obsidian agent automation (platform-aware) ──────────────────────────────
+
+setup_obsidian_automation() {
+    local repo_dir="$1"
+    local python_bin="$2"
+    local agent_dir="$repo_dir/obsidian-agent"
+
+    if [ ! -d "$agent_dir" ]; then
+        echo "  ⚠ obsidian-agent/ not found at $agent_dir — skipping automation"
+        return 0
+    fi
+    # python -m obsidian_agent resolves the package via the working directory.
+    cd "$agent_dir" || { echo "  ⚠ cannot cd to $agent_dir — skipping"; return 0; }
+
+    local platform
+    platform="$(detect_platform)"
+
+    case "$platform" in
+        macos)
+            echo "  Platform: macOS → launchd"
+            "$python_bin" -m obsidian_agent --install-launchd \
+                || echo "  ⚠ launchd setup failed (continuing without real-time automation)"
+            ;;
+        linux)
+            if systemd_user_available; then
+                echo "  Platform: Linux → systemd --user timer + cron"
+                "$python_bin" -m obsidian_agent --install-systemd \
+                    || echo "  ⚠ systemd timer setup failed (continuing)"
+            else
+                echo "  Platform: Linux (no systemd --user) → cron only"
+            fi
+            "$python_bin" -m obsidian_agent --install-cron \
+                || echo "  ⚠ cron setup failed (continuing)"
+            ;;
+        wsl)
+            if systemd_user_available; then
+                echo "  Platform: WSL (systemd enabled) → systemd --user timer + cron"
+                "$python_bin" -m obsidian_agent --install-systemd \
+                    || echo "  ⚠ systemd timer setup failed (continuing)"
+            else
+                echo "  Platform: WSL (no systemd) → cron only"
+                echo "    Tip: add '[boot]\\nsystemd=true' to /etc/wsl.conf for real-time updates."
+            fi
+            "$python_bin" -m obsidian_agent --install-cron \
+                || echo "  ⚠ cron setup failed (continuing — ensure the cron daemon is running)"
+            ;;
+    esac
+}
+
+# ─── Email helper dependencies (PEP 668 safe) ────────────────────────────────
+
+setup_email_deps() {
+    local python_bin="$1"
+
+    if "$python_bin" -c "import azure.identity, httpx" 2>/dev/null; then
+        echo "  ✓ azure-identity + httpx already installed"
+        return 0
+    fi
+
+    echo "  Installing azure-identity httpx..."
+    # Plain --user first; fall back to --break-system-packages for
+    # externally-managed interpreters (Ubuntu 24.04+, PEP 668).
+    "$python_bin" -m pip install --user azure-identity httpx 2>/dev/null \
+        || "$python_bin" -m pip install --user --break-system-packages azure-identity httpx 2>/dev/null \
+        || echo "  ⚠ Failed to install email deps — install manually (pipx, a venv, or: pip install azure-identity httpx)"
+}
+
+# ─── Entry point ─────────────────────────────────────────────────────────────
+
+run_profile_post_install() {
+    local repo_dir="$1"
+    local profile_name="${2:-unknown}"
+
+    local platform
+    platform="$(detect_platform)"
+
+    echo "=== Post-Install (profile: $profile_name, platform: $platform) ==="
+    echo ""
+
+    local python_bin
+    python_bin="$(command -v python3 || command -v python || true)"
+    if [ -z "$python_bin" ]; then
+        echo "  ⚠ python3 not found — skipping obsidian-agent automation + email deps."
+        echo "    Install Python 3 and re-run: ./install-all.sh --profile $profile_name"
+        return 0
+    fi
+
+    echo "Setting up obsidian-agent automation..."
+    setup_obsidian_automation "$repo_dir" "$python_bin"
+    echo ""
+
+    echo "Checking email helper dependencies..."
+    setup_email_deps "$python_bin"
+    echo ""
+
+    echo "=== Post-install complete ($profile_name / $platform) ==="
+    case "$platform" in
+        macos)
+            echo "  Check status:  launchctl list | grep obsidian-agent"
+            echo "  View logs:     ~/Library/Logs/obsidian-agent/" ;;
+        linux|wsl)
+            echo "  Check timer:   systemctl --user status obsidian-agent-watcher.timer 2>/dev/null || echo '(cron only)'"
+            echo "  Check cron:    crontab -l | grep obsidian-agent" ;;
+    esac
+    echo "  Email: configure credentials in ~/.claude/.env"
+    echo ""
+}

--- a/machines/personal/post-install.sh
+++ b/machines/personal/post-install.sh
@@ -1,39 +1,17 @@
 #!/bin/bash
-# Post-install for Personal machine (macOS)
-# Sets up launchd agents for obsidian-agent automation
+# Post-install for the "personal" machine profile.
+#
+# The profile selects config.toml + env.template only. The automation scheduler
+# is chosen by the ACTUAL detected platform (macOS→launchd, Linux→systemd+cron,
+# WSL→cron[/systemd]) via machines/lib/post-install-common.sh — so this profile
+# runs cleanly on macOS, Ubuntu/Linux, or WSL.
 
 set -e
 
-REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-PYTHON_BIN="$(command -v python3)"
+PROFILE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$PROFILE_DIR/../.." && pwd)"
 
-echo "=== Personal Machine Post-Install ==="
-echo "  Platform: macOS"
-echo ""
+# shellcheck source=../lib/post-install-common.sh
+source "$REPO_DIR/machines/lib/post-install-common.sh"
 
-# ─── Obsidian Agent: launchd (real-time updates + scheduled rollups) ──────
-echo "Setting up launchd agents..."
-cd "$REPO_DIR/obsidian-agent"
-"$PYTHON_BIN" -m obsidian_agent --install-launchd
-echo ""
-
-# ─── Email helper dependencies ────────────────────────────────────────────
-echo "Checking email helper dependencies..."
-if "$PYTHON_BIN" -c "import azure.identity; import httpx" 2>/dev/null; then
-    echo "  ✓ azure-identity + httpx already installed"
-else
-    echo "  Installing azure-identity httpx..."
-    "$PYTHON_BIN" -m pip install azure-identity httpx 2>/dev/null || \
-    echo "  ⚠ Failed to install email deps — install manually: pip3 install azure-identity httpx"
-fi
-echo ""
-
-echo "=== Personal machine setup complete ==="
-echo ""
-echo "  launchd watcher: active (60s polling)"
-echo "  launchd rollups: daily 11 PM (includes weekly/monthly)"
-echo "  Email: deps installed (configure credentials in ~/.claude/.env)"
-echo ""
-echo "  Check status:  launchctl list | grep obsidian-agent"
-echo "  View logs:     ~/Library/Logs/obsidian-agent/"
-echo ""
+run_profile_post_install "$REPO_DIR" "personal"

--- a/machines/work/post-install.sh
+++ b/machines/work/post-install.sh
@@ -1,42 +1,17 @@
 #!/bin/bash
-# Post-install for Work machine (WSL/Linux)
-# Sets up systemd timer + cron for obsidian-agent automation
+# Post-install for the "work" machine profile.
+#
+# The profile selects config.toml + env.template only. The automation scheduler
+# is chosen by the ACTUAL detected platform (macOS→launchd, Linux→systemd+cron,
+# WSL→cron[/systemd]) via machines/lib/post-install-common.sh — so this profile
+# runs cleanly on macOS, Ubuntu/Linux, or WSL.
 
 set -e
 
-REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-PYTHON_BIN="$(command -v python3)"
+PROFILE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$PROFILE_DIR/../.." && pwd)"
 
-echo "=== Work Machine Post-Install ==="
-echo "  Platform: Linux/WSL"
-echo ""
+# shellcheck source=../lib/post-install-common.sh
+source "$REPO_DIR/machines/lib/post-install-common.sh"
 
-# ─── Obsidian Agent: systemd timer (real-time updates) ────────────────────
-echo "Setting up systemd timer..."
-cd "$REPO_DIR/obsidian-agent"
-"$PYTHON_BIN" -m obsidian_agent --install-systemd
-echo ""
-
-# ─── Obsidian Agent: cron (scheduled rollups) ─────────────────────────────
-echo "Setting up cron entries..."
-"$PYTHON_BIN" -m obsidian_agent --install-cron
-echo ""
-
-# ─── Email helper dependencies ────────────────────────────────────────────
-echo "Checking email helper dependencies..."
-if "$PYTHON_BIN" -c "import azure.identity; import httpx" 2>/dev/null; then
-    echo "  ✓ azure-identity + httpx already installed"
-else
-    echo "  Installing azure-identity httpx..."
-    "$PYTHON_BIN" -m pip install --user azure-identity httpx 2>/dev/null || \
-    "$PYTHON_BIN" -m pip install --user --break-system-packages azure-identity httpx 2>/dev/null || \
-    echo "  ⚠ Failed to install email deps — install manually: pip3 install azure-identity httpx"
-fi
-echo ""
-
-echo "=== Work machine setup complete ==="
-echo ""
-echo "  Systemd timer: active (60s polling)"
-echo "  Cron: nightly daily rollup, weekly, monthly"
-echo "  Email: deps installed (configure credentials in ~/.claude/.env)"
-echo ""
+run_profile_post_install "$REPO_DIR" "work"


### PR DESCRIPTION
## Summary

`install-all.sh` failed on this Ubuntu box because machine *profiles* were hard-coupled to a platform's scheduler (`personal`→launchd, `work`→systemd). With the `personal` profile saved on Linux, the installer ran macOS `launchctl` → `FileNotFoundError: launchctl` → `set -e` aborted the entire install.

This decouples profile from scheduler. A profile now only seeds `config.toml`/`env.template`; the scheduler is chosen by **detected platform**.

| Platform | Scheduler |
|---|---|
| macOS | launchd |
| Linux (systemd) | systemd `--user` timer + cron |
| Linux (no systemd) | cron only |
| WSL (systemd on) | systemd + cron |
| WSL (no systemd) | cron only (warns) |

### Changes
- **`machines/lib/post-install-common.sh`** (new) — platform detection + graceful scheduler setup (warns, never aborts) + PEP 668-safe email deps (`--break-system-packages` fallback for Ubuntu 24.04).
- **`machines/{work,personal}/post-install.sh`** — thin wrappers delegating to the shared logic.
- **`install-all.sh`** — fixed backwards `Darwin→work` auto-detect (now `→personal`); profile post-install step made non-fatal.

## Test Plan
- ✅ Reproduced original `launchctl` crash, then confirmed gone
- ✅ `./install-all.sh --profile personal` on Ubuntu 24.04 → exit 0; idempotent on re-run
- ✅ systemd `--user` timer active; timed job ran to completion (wrote `DASHBOARD.md`, not failed)
- ✅ cron entries installed; `azure-identity`/`httpx` installed
- ✅ All 4 scripts pass `bash -n`
- ✅ Base install (`--skip-profile`) clean; post-merge-hook `--skip-profile` invariant untouched
- ⚠️ macOS/WSL paths not executable here, but driven by the same `uname`/`/proc/version` detection