### PR TITLE
feat(skills): add spec-coherence-pass and adversarial-review-gated

### DIFF
--- a/claude-config/skills/adversarial-review-gated/SKILL.md
+++ b/claude-config/skills/adversarial-review-gated/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: adversarial-review-gated
+description: Run an adversarial review as a non-blocking pipeline gate — try Codex first, and on any Codex fault (rate-limit, timeout, auth, sandbox/runtime error) fall back to a fresh-context internal adversarial review. NEVER block the pipeline on Codex availability; always write a verdict to a writable path and return RISK + PROCEED/REVISE. Use in autonomous/orchestrate runs where review must happen but Codex may be unavailable.
+---
+
+# adversarial-review-gated
+
+`/codex:adversarial-review` is review-only and assumes Codex is reachable: it
+runs Codex and returns the output verbatim. It has **no fallback** — if Codex
+is rate-limited, timing out, unauthenticated, or sandbox-denied, the review
+step stalls or fails, which in an autonomous pipeline silently drops the review
+gate. This skill wraps that gap: Codex-first, internal-fallback, never-block,
+always-emit-a-verdict.
+
+Use this instead of calling `/codex:adversarial-review` directly when:
+
+- You are in an autonomous / `/orchestrate` / scheduled run where a human is not
+  watching to retry Codex.
+- The change is risk-class (auth, payments, migrations, data-loss, secrets,
+  contracts) and a review MUST be on record before merge — but Codex outages
+  must not block shipping.
+- Codex is known-down or rate-limited (e.g. the buddy "Codex resets <date>"
+  windows) and you still need an adversarial pass.
+
+If you are at a normal interactive keyboard and Codex is up, just use
+`/codex:adversarial-review` — this skill's only added value is the
+fallback + non-blocking gate + persisted verdict.
+
+## The gate (procedure)
+
+1. **Pick a writable verdict path.** Codex's sandbox denies writes under
+   `.agents/outputs/`. Write verdicts to a repo-writable path instead — default
+   `.codex-verdicts/<issue-or-slug>-<UTC-timestamp>.md`. Create the dir if
+   absent; ensure it is gitignored or intended-to-commit per the repo.
+
+2. **Try Codex first.**
+   ```bash
+   /codex:adversarial-review --wait --base origin/main <focus text>
+   ```
+   Treat as a Codex FAULT (→ fallback) any of: non-zero exit, rate-limit /
+   quota message, timeout, auth failure, empty output, or a sandbox/runtime
+   error. A real review verdict (even REQUEST_CHANGES) is NOT a fault — that is
+   a successful review; record it and act on findings.
+
+3. **On fault, run a fresh-context internal adversarial review.** Spawn a
+   subagent with NO inheritance from the implementation discussion (a fresh
+   reviewer, e.g. the `claude` or `Explore`-then-review agent) and the prompt
+   skeleton below. In-house adversarial review is a legitimate stand-in — in
+   the buddy thinker work it caught 3 real bugs in P3 and 2 BLOCKING SSE gaps
+   in P4 while Codex was rate-limited.
+
+4. **Always write the verdict file** with: source (`codex` | `internal`),
+   `RISK: N/10`, an `ac_audit` array (`implemented|partial|missing|deferred|n/a`
+   per AC), `new_concerns` (scope-freeze escape hatch — do NOT drift into
+   REQUEST_CHANGES on out-of-scope items), and the decision.
+
+5. **Return a structured result and NEVER block on Codex availability:**
+   `RISK: N/10` + `PROCEED` (no blocking findings) or `REVISE` (blocking
+   findings, listed). The pipeline continues either way — `REVISE` means fix
+   then re-gate, not "stop and wait for Codex to come back."
+
+## Reusable prompt skeleton (internal fallback reviewer)
+
+```
+FRESH-CONTEXT ADVERSARIAL REVIEW (Codex unavailable — internal fallback).
+You have NO context from how this was implemented. Review the DIFF against the
+issue/spec as a skeptic whose job is to find why this is WRONG.
+
+Diff scope: <git diff origin/main...HEAD, or paths>
+Issue / spec + acceptance criteria: <paste ACs>
+Risk class: <auth|payments|migration|data-loss|secrets|contract|none>
+
+Challenge the APPROACH, not just defects: Is this the right design? What
+assumptions does it depend on? Where does it fail under real-world load,
+concurrency, partial failure, or malicious input? For risk-class changes,
+explicitly check the named hazard (tenant isolation, money math, reversibility,
+secret exposure, enum/contract drift).
+
+Output EXACTLY this shape:
+  source: internal
+  RISK: N/10
+  ac_audit:
+    - ac: "<criterion>"
+      status: implemented|partial|missing|deferred|n/a
+      evidence: "<file:line or why>"
+  blocking_findings: [ ... tied to concrete changed code ... ]
+  new_concerns: [ ... out-of-scope observations, NOT blockers ... ]
+  decision: PROCEED | REVISE
+A reviewer that APPROVEs on partial AC coverage is wrong — the per-AC shape
+forbids it.
+```
+
+## Notes
+
+- The fallback is a stand-in, not a replacement: when Codex is back, a risk-class
+  change still benefits from a real Codex pass before merge. Note in the PR which
+  source produced the gating verdict.
+- Verdict path default `.codex-verdicts/` exists precisely because Codex's
+  sandbox cannot write under `.agents/outputs/` — do not target that path.
+- Classify findings (BLOCKING / NON-BLOCKING / CLEAN) per
+  `~/.claude/rules/implementation-routing.md` Step 3 before acting; don't let
+  speculative findings expand scope.

--- a/claude-config/skills/spec-coherence-pass/SKILL.md
+++ b/claude-config/skills/spec-coherence-pass/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: spec-coherence-pass
+description: When a spec plateaus across adversarial-review rounds — RISK stays flat and per-finding surgical fixes keep introducing cross-section drift — stop the surgical loop and do ONE whole-spec coherence pass (read end-to-end, build truth tables for contested contracts, reconcile every section + AC to one story), then run one final review.
+---
+
+# spec-coherence-pass
+
+This is the spec equivalent of "stop debugging line-by-line and re-read the
+whole function." Use it when round-by-round surgical fixes are no longer
+converging a spec. It complements — does not replace — `/spec-review`
+(which is about turning a *locked* spec into GitHub issues). This skill is
+about *getting the spec to lock* when the review loop has stalled.
+
+## When to use (trigger conditions)
+
+Invoke a coherence pass when ANY of these hold during spec adversarial review:
+
+- **RISK plateau** — Codex `RISK: N/10` is flat across rounds (e.g. 6 → 6 → 6).
+  Reviewers are sampling, not exhausting.
+- **RISK rising** — a "fix" introduced new errors or surfaced latent ones
+  (e.g. 5 → 7). STOP surgical fixes immediately.
+- **Drift symptom** — each per-finding edit fixes one section but contradicts
+  another (an enum, a state value, a column, a timeout, a default flips between
+  §A and §C).
+- **At R4** — you are about to do a fourth round of pure surgical fixes. Don't.
+  The owner_onboarding spec took 8 surgical rounds (~7 hours). The coherence
+  pass exists to never repeat that.
+
+Authority for the convergence/stop rules: `~/.claude/rules/spec-review-workflow.md`
+§4.2 (risk trajectory), §4.3 (lock signal), §4.4 (stop conditions). This skill
+operationalizes §4.4 option (a) "full hygiene pass."
+
+## The procedure
+
+1. **Stop the surgical loop.** Do not open the review tool. Do not make another
+   one-line edit. Announce: "Spec plateaued at RISK N — switching to a
+   whole-spec coherence pass."
+
+2. **Read the spec end-to-end, once, in order.** No jumping to the contested
+   section. You are reconstructing the single intended story, not patching.
+
+3. **Build explicit truth tables for every contested contract.** A contested
+   contract is anything that appears in 2+ sections and has drifted: enums,
+   status/role values, state machines, column names + types, default values,
+   timeouts, flag names, who-writes-what. One table per contract. Columns:
+   `value/state | section(s) that define it | every section + AC that consumes it | conflict?`.
+   The table is the single source of truth; the prose sections must conform to
+   it, not the reverse.
+
+4. **Reconcile every section AND every AC to the tables.** Walk the whole spec
+   and the acceptance criteria. Any sentence or AC that disagrees with a truth
+   table is edited to match. Resolve genuine ambiguities by reading the actual
+   code/migrations/docs (5 min max per call) — do not let the spec assert a
+   contract the codebase can't honor. Document the decision inline.
+
+5. **One final review round.** Submit ONE adversarial review of the
+   now-coherent spec (`/codex:adversarial-review`, or the gated wrapper). If it
+   does not lock, route to §4.4 (b) architectural rethink or (c) lock with a
+   "Known V1 implementation gaps" addendum — NOT another surgical round.
+
+## Reusable prompt skeleton
+
+Paste-ready prompt for the coherence pass itself (run it on yourself or hand to
+a fresh-context agent):
+
+```
+WHOLE-SPEC COHERENCE PASS — spec has plateaued in adversarial review.
+
+Spec: <path> (current commit <sha>)
+Manifest / code-reality doc: <path or "none">
+Review history: RISK trajectory <e.g. 7 → 6 → 6>; recurring finding class: <e.g.
+  "status enum value disagrees between §4 and the AC table">.
+
+Do NOT make per-finding surgical edits. Instead:
+
+1. Read the ENTIRE spec end-to-end in order. Reconstruct the single intended
+   story.
+2. Build an explicit truth table for EACH contested contract (any value that
+   appears in 2+ sections and has drifted: enums, states, columns+types,
+   defaults, timeouts, flag names, write-ownership). Table columns:
+     value/state | defined-in section(s) | consumed-by section(s) + AC(s) | conflict?
+3. For every conflict, pick ONE truth. If the truth depends on actual code,
+   read the code/migrations/docs (cite file:line) before choosing. Document
+   each decision.
+4. Reconcile EVERY section and EVERY acceptance criterion to the truth tables.
+   Edit any prose/AC that disagrees.
+5. Output: (a) the truth tables, (b) a list of every section/AC you changed and
+   why, (c) the reconciled spec, (d) a readiness call: LOCK / NEEDS-FINAL-REVIEW
+   / ARCHITECTURAL-RETHINK with reasoning.
+
+Convergence/stop rules: ~/.claude/rules/spec-review-workflow.md §4.2–§4.4.
+```
+
+## After the pass
+
+- If LOCK or final review passes → proceed to `/spec-review` for issue creation.
+- If still not converging → §4.4 (b) rethink the premise, or (c) lock with a
+  known-gaps addendum. R4+ of surgical fixes is almost never right.


### PR DESCRIPTION
## Summary

Extract two reusable prompt patterns that proved valuable in a long spec/memory session into global Claude Code skills. Both are net-new value over existing surfaces (verified via dedup pass below).

### `spec-coherence-pass`
When a spec plateaus across adversarial-review rounds (RISK flat/rising, surgical per-finding fixes keep introducing cross-section drift), stop the surgical loop and do ONE whole-spec coherence pass: read end-to-end, build truth tables for contested contracts, reconcile every section + AC to one story, then one final review. Operationalizes `spec-review-workflow.md` §4.4(a). **Distinct from `/spec-review`** (which is issue-creation from a *locked* spec — this is about *getting it to lock*).

### `adversarial-review-gated`
Codex-first, internal-fallback, never-block review gate: try `/codex:adversarial-review`; on any Codex fault (rate-limit/timeout/auth/sandbox) fall back to a fresh-context internal adversarial review; always write a verdict to a writable path (`.codex-verdicts/`, since Codex sandbox denies writes under `.agents/outputs/`); return RISK + PROCEED/REVISE; never block the pipeline. **Adds the fallback that `/codex:adversarial-review` lacks** — that command is review-only and assumes Codex is reachable.

## Dedup pass
- `spec-review` → issue creation, not spec-convergence. No overlap.
- `/codex:adversarial-review` → review-only, no fallback/never-block/verdict-persistence. This skill composes on top.
- `deep-research` → already covers fan-out → cited synthesis, so the research-synthesis candidate was SKIPPED.

## Test plan
- Skills are prompt/doc artifacts (no runnable surface). Frontmatter matches existing skill style (`dashboard/SKILL.md`).
- `description` lines load into the Skill registry (confirmed: both appear in available-skills list after creation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NvaazFvGUNCwSuKCryUDhx