### PR TITLE
docs(skills): harden adversarial-review skeleton with bypass-hunt + integrity

### DIFF
--- a/claude-config/skills/adversarial-review-gated/SKILL.md
+++ b/claude-config/skills/adversarial-review-gated/SKILL.md
@@ -76,6 +76,32 @@ concurrency, partial failure, or malicious input? For risk-class changes,
 explicitly check the named hazard (tenant isolation, money math, reversibility,
 secret exposure, enum/contract drift).
 
+BYPASS HUNT (required for risk-class diffs — migrations, auth, money,
+contracts): for every constraint, guard, trigger, index, check, or idempotency
+mechanism in the diff, NAME the input or path that DEFEATS it. If you cannot
+state why a bypass is impossible, that is a finding. Known classes that get
+approved while leaving a hole:
+- A partial UNIQUE / generated-column / filtered index is evaded by NULL or
+  missing source fields — the row drops out of the index. Require the linkage
+  be NOT NULL (CHECK), not merely indexed.
+- A row-level trigger (BEFORE UPDATE OR DELETE) does NOT fire on statement-level
+  ops (TRUNCATE) or COPY; a conditional REVOKE no-ops if the role is absent.
+  Enumerate EVERY mutation path, not just the obvious one.
+- Idempotency: IF NOT EXISTS on CREATE TABLE/INDEX but not on ADD COLUMN /
+  CREATE TRIGGER → re-apply after a partial failure breaks. Every statement
+  must converge on re-run.
+- ON CONFLICT keyed on a column whose unique index is partial (WHERE col IS NOT
+  NULL) silently no-ops its dedup when the key is NULL → duplicate accumulation.
+- Roles: protection that holds for the app role but not for table-owner /
+  superuser / migration roles is incomplete.
+- Fail-open error handling that swallows a failure so the caller proceeds on
+  empty/half-built state and reports a misleading success.
+
+REVIEW INTEGRITY: capture the diff and the full content of changed files at the
+START of the review — do not rely on re-reading the live working tree, which can
+change mid-review under parallel agents/worktrees. If the issue/ACs are not
+fetchable, derive ACs from the referenced spec sections and SAY SO explicitly.
+
 Output EXACTLY this shape:
   source: internal
   RISK: N/10


### PR DESCRIPTION
## Summary
Hardens the `adversarial-review-gated` skill's reusable prompt skeleton with two additions, grounded in a real miss during a buddy migration review (#2131):

- **BYPASS HUNT** — for every constraint/guard/trigger/index/idempotency mechanism, name the input that defeats it. Enumerates the classes that get approved while leaving a hole: NULL-key/partial-index evasion, statement-level TRUNCATE/COPY bypassing row triggers, `ADD COLUMN`/`CREATE TRIGGER` idempotency gaps, `ON CONFLICT` on a partial unique index, role gaps, swallowed fail-open.
- **REVIEW INTEGRITY** — capture the diff + changed-file content up front (don't rely on the live working tree, which can change mid-review under parallel agents/worktrees); derive ACs from the spec when the issue isn't fetchable, and say so.

## Why
In the #2131 review the migration's append-only contract had three bypasses (TRUNCATE past the row trigger, NULL key escaping the partial unique index, partial idempotency) that the generic skeleton didn't prompt for. The reviewer only caught them by hunting independently. This bakes that hunt into the skeleton.

## Test Plan
Docs/prompt-only change. Deployed to `~/.claude/` via `install.sh`. No code paths affected.