### PR TITLE
feat(ops): /ops hardened pipeline skill + ops_spawn_guard hook

### DIFF
--- a/claude-config/hooks/ops_spawn_guard.py
+++ b/claude-config/hooks/ops_spawn_guard.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""PreToolUse hook: bound ops-flavored agent spawns.
+
+The mechanical backstop for the ops-hang failure mode (buddy
+`feedback-ad-hoc-agent-hangs.md`): raw Agent/Task spawns on open-ended ops/data
+work hang because they carry no termination condition + no done-oracle. Code
+work is protected by `/orchestrate` (the test suite is a universal oracle); ops
+work has no such pipeline, so this hook enforces the bound at the harness layer
+instead of relying on a rule that is "loaded != followed".
+
+Policy: an *ops-flavored* spawn MUST declare a bounded-execution contract in its
+prompt:
+
+    OPS-BOUNDED: timeout=<N>s oracle="<deterministic done-check>"
+
+The `/ops` skill emits this automatically. A raw spawn that omits it is blocked
+with an actionable message. This proves BOTH a timeout and a postcondition
+oracle were declared before any live-infra agent runs.
+
+A spawn is "ops-flavored" when EITHER:
+  - subagent_type == "ops"  (the explicit prod-write worker), OR
+  - the prompt/description contains a high-confidence prod-execution signal
+    (ssh to a known host + mutation, systemctl start/restart, dbmate up,
+    pg_dump/pg_restore/pg_basebackup, psql against $DATABASE_URL, crontab/
+    launchctl install, secret rotation). The signal list is deliberately
+    execution-oriented to keep false positives near zero — a code agent that
+    merely *mentions* psql is not caught.
+
+Exit 2 blocks the tool call (Anthropic hook spec); exit 0 allows. Fails OPEN on
+any parse/internal error — this hook must never block legitimate work because of
+its own bug.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import sys
+from pathlib import Path
+
+_log_file = Path.home() / ".claude" / "hooks.log"
+try:
+    _log_file.parent.mkdir(parents=True, exist_ok=True)
+    logging.basicConfig(
+        filename=str(_log_file),
+        level=logging.WARNING,
+        format="%(asctime)s [ops_spawn_guard] %(levelname)s: %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+except OSError:
+    pass  # logging is best-effort; never block on it
+
+SPAWN_TOOLS = {"Agent", "Task"}
+
+# The bounded-execution contract the prompt must carry. Requires an explicit
+# integer-second timeout AND a non-empty oracle string. Case-insensitive on the
+# label so OPS-BOUNDED / ops-bounded both pass.
+OPS_BOUNDED_RE = re.compile(
+    r"OPS-BOUNDED:\s*timeout=\s*\d+\s*s\s+oracle=\s*[\"']?\S",
+    re.IGNORECASE,
+)
+
+# High-confidence prod-EXECUTION signals (not mere mentions). Each implies the
+# agent will mutate or directly operate live infra.
+PROD_EXEC_SIGNALS = [
+    re.compile(r"\bssh\s+jns(?:-server)?\b"),  # the home server
+    re.compile(r"\bsystemctl\s+(?:restart|start|stop|enable|disable)\b"),
+    re.compile(r"\bdbmate\s+up\b"),
+    re.compile(r"\bpg_dump\b"),
+    re.compile(r"\bpg_restore\b"),
+    re.compile(r"\bpg_basebackup\b"),
+    re.compile(r"\bpsql\b[^\n]*\$?\{?DATABASE_URL"),  # psql against prod DSN
+    re.compile(r"\bcrontab\s+-", re.IGNORECASE),
+    re.compile(r"\blaunchctl\s+(?:load|bootstrap|enable)\b"),
+    re.compile(r"\brotat\w*\s+(?:the\s+)?secret", re.IGNORECASE),
+    re.compile(r"\bsupabase\b[^\n]*\b(?:db|migration)\b", re.IGNORECASE),
+]
+
+
+def _matched_signal(text: str) -> str | None:
+    for pat in PROD_EXEC_SIGNALS:
+        if pat.search(text):
+            return pat.pattern
+    return None
+
+
+def is_ops_flavored(subagent_type: str, text: str) -> tuple[bool, str]:
+    """Return (is_ops, reason). reason names why it was classified ops."""
+    if subagent_type.strip().lower() == "ops":
+        return True, "subagent_type=ops"
+    sig = _matched_signal(text)
+    if sig:
+        return True, f"prod-execution signal /{sig}/"
+    return False, ""
+
+
+def deny(reason: str) -> None:
+    """Block the spawn (exit 2 + stderr per Anthropic hook spec)."""
+    logging.warning("BLOCKED: %s", reason)
+    sys.stderr.write(
+        "[ops_spawn_guard] Blocked an ops-flavored agent spawn that is not "
+        "bounded.\n"
+        f"  Why classified as ops: {reason}\n"
+        "  Add a bounded-execution contract to the agent prompt:\n"
+        '      OPS-BOUNDED: timeout=<N>s oracle="<deterministic done-check>"\n'
+        '  e.g. OPS-BOUNDED: timeout=120s oracle="systemctl is-active '
+        'buddy-server == active AND curl -sf localhost:17789/health"\n'
+        "  Or run the task through the /ops skill, which emits this and wraps "
+        "every blocking call in `timeout`.\n"
+        "  If this is genuinely NOT an ops task, drop subagent_type=ops / "
+        "rephrase the prod-execution command out of the prompt.\n"
+    )
+    sys.exit(2)
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError) as e:
+        logging.warning("could not parse stdin JSON: %s", e)
+        return 0  # fail open
+
+    tool_name = payload.get("tool_name", "")
+    if tool_name not in SPAWN_TOOLS:
+        return 0
+
+    tool_input = payload.get("tool_input", {}) or {}
+    subagent_type = str(tool_input.get("subagent_type", "") or "")
+    prompt = str(tool_input.get("prompt", "") or "")
+    description = str(tool_input.get("description", "") or "")
+    text = f"{description}\n{prompt}"
+
+    ops, reason = is_ops_flavored(subagent_type, text)
+    if not ops:
+        return 0
+
+    if OPS_BOUNDED_RE.search(text):
+        return 0  # bounded — allow
+
+    deny(reason)
+    return 0  # unreachable (deny exits), but keep the contract explicit
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/claude-config/settings.json
+++ b/claude-config/settings.json
@@ -57,6 +57,17 @@
     "defaultMode": "auto"
   },
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Agent|Task",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ~/.claude/hooks/ops_spawn_guard.py"
+          }
+        ]
+      }
+    ],
     "PreCompact": [
       {
         "matcher": "",
@@ -162,5 +173,6 @@
   "tui": "fullscreen",
   "skipDangerousModePermissionPrompt": true,
   "skipWorkflowUsageWarning": true,
-  "theme": "dark"
+  "theme": "dark",
+  "agentPushNotifEnabled": true
 }

--- a/claude-config/skills/ops/SKILL.md
+++ b/claude-config/skills/ops/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: ops
+description: "Hardened pipeline for OPS/infra/data work — the missing /orchestrate-equivalent for non-code tasks (DB backup/restore, migrations, systemd/deploy, data slicing, secret ops). Forces a deterministic done-oracle to exist BEFORE execution, wraps every blocking call in `timeout`, verifies the postcondition, and routes irreversible work to supervised-only. Use whenever you'd spawn an agent (or run commands) against live infra. Loads fresh at invocation (decay-proof) and is enforced by the ops_spawn_guard PreToolUse hook."
+---
+
+# /ops — Bounded, Verified Ops Execution
+
+**Why this exists.** `/orchestrate` is hardened because every code task reduces
+to one universal oracle: the test suite (green = done). **Ops work has no
+universal oracle** — each task has a *bespoke* postcondition — so raw Agent/Task
+spawns on ops/data work hang: open-ended task + no definition-of-done + no
+stop-after-N on live infra. This skill supplies the missing structure: it cannot
+*invent* the oracle (it's bespoke), so it **forces you to declare one** and
+refuses to execute without it. Companion enforcement: the `ops_spawn_guard`
+PreToolUse hook blocks any ops-flavored spawn lacking the `OPS-BOUNDED:` contract
+this skill emits. Provenance: buddy `feedback-ad-hoc-agent-hangs.md` (ops agents
+hung 3× in one session under rules-only guidance — "loaded ≠ followed").
+
+Policy: `rules/agent-delegation-contract.md` (ops flavor), `rules/orchestration-concurrency.md`.
+
+## Usage
+```
+/ops "back up the jns buddy db and verify the dump"
+/ops "deploy the frontend build to jns and confirm the site serves"
+/ops "slice locomo10.json to a 1-conversation canary fixture"
+```
+For a read-only status check, this is overkill — just run it. Use `/ops` for any
+task that **writes to or operates live infra**, or any data-wrangling an agent
+could loop on without a stop condition.
+
+## Deterministic workflow
+
+### Step 1 — Classify risk (sets the route)
+| Class | Examples | Route |
+|-------|----------|-------|
+| **READ-ONLY** | status, audit, `SELECT`, `is-active`, log read | autonomous, light oracle |
+| **REVERSIBLE** | backup, deploy, restart, data-slice, additive migration | autonomous-bounded (Steps 2–6) |
+| **IRREVERSIBLE** | prod `DROP`/`TRUNCATE`/`DELETE`, restore-OVER-prod, secret rotation, destructive migration | **SUPERVISED ONLY** — STOP, do not autonomously spawn |
+
+IRREVERSIBLE → present the plan + oracle to the human and run it **step-by-step
+with them present**. Never fire it through a background agent. (Matches the
+`autonomous-run` stop-gate + delegation-contract "confirm before hard-to-reverse".)
+
+### Step 2 — PREFLIGHT (fail fast; most hangs are missing prereqs)
+Before any execution, assert — and STOP with a clear report if any fails:
+- Target reachable (`ssh <host> true`, DB `SELECT 1`, endpoint `curl -sf`).
+- Every input/fixture present (the canary hang was a missing/ malformed input).
+- Required tools installed on the target (`command -v pg_dump`, etc.).
+- For writes: confirm you are pointed at the **intended** resource (echo the DSN
+  host / systemd unit / target path) — never discover it mid-run.
+
+### Step 3 — DECLARE THE ORACLE (the gate — no oracle, no run)
+Write the **deterministic postcondition** that means "done." It must be a
+command-checkable boolean, not a vibe. If you cannot write one, that is the
+signal to **supervise, not automate** — fall back to Step 1 IRREVERSIBLE handling.
+Examples:
+- Backup → `pg_restore --list dump | grep -c TABLE` == source table count **AND** `stat -c%s dump` > floor.
+- Restore-to-scratch → scratch schema hash == prod schema hash; row counts within tolerance. **NEVER restore over prod.**
+- Deploy → `systemctl is-active <unit>` == `active` **AND** `curl -sf <health>` == 200 **AND** artifact mtime > deploy-start.
+- Data slice → output validates against the **handed-in** schema **AND** `count(sessions)` == expected.
+- Migration → `dbmate status` shows applied **AND** a `SELECT` on the new object succeeds.
+
+### Step 4 — EXECUTE (bounded; delegate REVERSIBLE, supervise IRREVERSIBLE)
+For READ-ONLY / REVERSIBLE, dispatch the **`ops` typed agent** (carries the
+prod-write quality contract: single-owner, soft-delete-not-destructive,
+verify-after-write). The dispatch prompt MUST:
+- Wrap **every** blocking call in `timeout <N>` (ssh, psql, pg_dump, curl,
+  long evals) — the #1 hang fix.
+- Carry an **iteration cap + STOP-condition** ("if X fails in 2 tries, STOP and
+  report"); never an open loop.
+- Hand the agent the **exact target spec/shape** — never make it *discover* a
+  data shape or schema.
+- Include the bounded-execution contract line (this is what satisfies the
+  `ops_spawn_guard` hook):
+  ```
+  OPS-BOUNDED: timeout=<N>s oracle="<the Step 3 postcondition>"
+  ```
+
+**Dispatch (REVERSIBLE):**
+```
+subagent_type: ops
+run_in_background: true            # background by default; stay available
+prompt: <PREFLIGHT results + exact commands (each timeout-wrapped) +
+         the Step 3 oracle + iteration cap + OPS-BOUNDED line>
+```
+IRREVERSIBLE → do NOT dispatch; walk the human through it one step at a time.
+
+### Step 5 — VERIFY (run the oracle; this is the terminal condition)
+Re-read/re-query the resource and evaluate the Step 3 oracle deterministically.
+PASS = done. FAIL = report what diverged + the evidence; do **not** silently
+retry past the iteration cap. Verification is the stop — not "the agent said it
+finished."
+
+### Step 6 — REPORT
+Compact verdict: class, oracle, PASS/FAIL + the evidence (command output), and
+prod-state confirmation. Never a log dump.
+
+## Liveness tripwire (standing, all `/ops` dispatches)
+Watch the background agent's output-file mtime. Stale (no progress past the
+declared timeout window) + no matching process → **kill it and finish
+deterministically** (its committed work survives). A hung ops agent is the exact
+failure this skill prevents — don't wait it out.
+
+## Hard rules (what this skill enforces)
+- **No oracle, no run.** Step 3 is a gate, not a formality.
+- **Every blocking call wrapped in `timeout`.** Open loops on live infra hang.
+- **Hand the shape, never discover it.** Exact target spec into the prompt.
+- **IRREVERSIBLE = supervised only.** Never background a destructive op.
+- **Soft-delete / additive over destructive** (delegation-contract ops flavor);
+  `is_active=false`/archive over `DELETE`/`DROP`.
+- **Verify after writing**, single-owner per resource, sequential writes.
+- The `OPS-BOUNDED:` line is mandatory on every ops dispatch — the
+  `ops_spawn_guard` hook blocks the spawn without it.


### PR DESCRIPTION
## Summary
The missing `/orchestrate`-equivalent for **ops/data/infra** work. Code tasks reduce to one universal oracle (tests green); ops tasks have a *bespoke* postcondition, so raw Agent/Task spawns on live infra hang (open-ended + no done-oracle + no stop-after-N). Three ops agents hung in one session under rules-only guidance — *loaded ≠ followed* — so this adds **structural** enforcement.

**A — `/ops` skill** (`claude-config/skills/ops/SKILL.md`): PREFLIGHT → DECLARE-ORACLE (gate: no oracle, no run) → timeout-wrapped EXECUTE → VERIFY → REPORT. Risk router: read-only / reversible (autonomous-bounded) / **irreversible (supervised-only — never backgrounded)**. Emits the `OPS-BOUNDED:` contract line on every dispatch; reuses the `ops` typed agent.

**B — `ops_spawn_guard.py` PreToolUse hook** (matcher `Agent|Task`): blocks any *ops-flavored* spawn (`subagent_type=ops`, or a high-confidence prod-exec signal: `ssh jns`, `systemctl restart`, `dbmate up`, `pg_dump/restore`, `psql $DATABASE_URL`, …) lacking `OPS-BOUNDED: timeout=<N>s oracle=...`. The harness enforces it whether or not the skill is invoked — closing the 'skill only helps if you remember to call it' gap. **Fails open** on parse error. Registers the first `PreToolUse` block in settings.json (also carries a harness-set `agentPushNotifEnabled` toggle).

## Test Plan
- 7/7 block/allow matrix (ops no-sentinel → block; ops+sentinel → allow; gp+`ssh jns systemctl restart` → block; `impl` mentioning psql → allow; non-spawn tool → allow; sentinel-missing-timeout → block; malformed JSON → allow/fail-open).
- `ruff check` + `ruff format --check` clean; `validate-hooks.py` ✓ (paths resolve); `py_compile` OK.
- **Activates next session** (hooks load at session start) — post-merge verify = next session blocks an unbounded ops spawn.

Provenance: buddy `feedback-ad-hoc-agent-hangs.md`; companion to `orchestration-concurrency.md` + `/coordinate`.