### PR TITLE
feat(skills): google-workspace skill + actionable CLAUDE.md row (cross-session discovery)

### DIFF
--- a/claude-config/CLAUDE.md
+++ b/claude-config/CLAUDE.md
@@ -149,7 +149,7 @@ configured here.
 | `spec-new-substrate-domain-sweep.md` | Auto-loads on `specs/**` — 5-question domain check for NEW substrates |
 | `post-merge-verification.md` | After `/pr --merge` |
 | `m365-graph.md` | On-demand — mail + SharePoint client docs via Microsoft Graph |
-| `google-mail.md` | On-demand — Gmail/Calendar/Tasks via the central `~/agents/google` token (personal machines) |
+| `google-mail.md` | Gmail send + Calendar r/w (personal machines): `~/agents/google/send_mail.py` / `gcal.py` — or the `google-workspace` skill; details on-demand |
 | `ms-todo.md` | On-demand — Microsoft To Do (personal MS account) read/write via Graph (personal machines) |
 | `memory-promotion.md` | On-demand — promoting a project lesson to a global rule |
 

--- a/claude-config/skills/google-workspace/SKILL.md
+++ b/claude-config/skills/google-workspace/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: google-workspace
+version: 1.0
+description: Send email via Gmail and read/write Google Calendar on personal machines, using the shared ~/agents/google OAuth (send_mail.py / gcal.py). Use whenever asked to send/draft an email, check the calendar, or add/move/delete a calendar event. You ARE authorized here — do not claim you lack Gmail access without checking for the token first.
+---
+
+# google-workspace
+
+On personal machines you **are** authorized for Gmail + Google Calendar via a
+shared OAuth token at `~/agents/google/token.json` — **no MCP or extra login
+needed.** Do not tell the user you lack Gmail/Calendar access without first
+checking that token file exists. If it is absent, the capability isn't set up on
+*this* machine (e.g. a work machine) — say that instead of guessing.
+
+```
+PY=~/agents/.venv/bin/python
+```
+
+## Send email
+```
+$PY ~/agents/google/send_mail.py --to a@b.com --subject "Hi" --body "Hello" [--attach file.pdf]
+```
+`--to` / `--cc` / `--bcc` / `--attach` repeat; `--body -` reads stdin. Sends from
+the authorized account (currently jasonwadejob@gmail.com); prints sender +
+message id. Attachments up to 25 MB.
+
+## Calendar (read/write)
+```
+$PY ~/agents/google/gcal.py agenda --days 7
+$PY ~/agents/google/gcal.py add --title "Lunch" --start "2026-06-28 12:30" --end "2026-06-28 13:30"
+$PY ~/agents/google/gcal.py quickadd --text "Dentist Thursday 3pm"
+$PY ~/agents/google/gcal.py calendars
+$PY ~/agents/google/gcal.py delete --event-id <id>
+```
+Timezone auto-detects from the calendar; `--calendar` defaults to `primary`.
+
+## Notes
+- This shared token is canonical — **never hand-roll a sender or a second token.**
+- Tasks / Contacts / reading Gmail have no CLI yet: build a client off
+  `~/agents/google/auth.py:load_credentials()`.
+- Full detail + per-machine gate: `~/.claude/rules/google-mail.md`.
+- Microsoft To Do is a separate capability: `~/agents/m365-todo/todo.py`
+  (see `~/.claude/rules/ms-todo.md`).


### PR DESCRIPTION
## Summary
Fix cross-session discoverability of the Google (Gmail + Calendar) capability. A session not working in `**/google/**` paths never auto-loaded `google-mail.md`, and the only always-loaded hint was a passive pointer row — so a cold session would claim "no Gmail authorization" when the capability is in fact fully implemented and authorized (token present, validated live).

- **New `google-workspace` skill** — skills appear in *every* session's system context, so any agent now sees the capability exists without reading a rule. The skill body gives the exact commands and explicitly says "you ARE authorized; check the token before claiming otherwise." Portable (passes the portability lint); mirrored into `~/.codex/skills` + `~/.agents/skills` like every other portable skill.
- **Tightened the CLAUDE.md reference row** to name the entry points (`send_mail.py` / `gcal.py` / the skill) instead of just pointing at the rule. Still one line; CLAUDE.md stays 198/200.

No new logic — this is purely a discoverability layer over the existing CLI.

## Test Plan
- `check-skill-portability.sh` → portable (exit 0) ✅
- Skill visible at `~/.claude/skills/google-workspace` ✅
- `test_check_context_budgets::test_real_tree_passes` + `test_agent_parity::test_cli_json_runs_against_current_repo` → pass ✅
- `agent-parity check --repo . --home ~` → `skill_parity: pass`, `ok: True` ✅
- CLAUDE.md 198/200 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
