### PR TITLE
feat(google): gmail_read.py + read in google-workspace skill + ms-todo skill (token-only, drop Gmail MCP)

### DIFF
--- a/claude-config/rules/google-mail.md
+++ b/claude-config/rules/google-mail.md
@@ -34,6 +34,7 @@ Validated live 2026-06-26 on this laptop: Gmail (account
 | Re-authorize ("reauth google") | `~/agents/.venv/bin/python ~/agents/google/reauth.py` |
 | **Send mail** (CLI) | `~/agents/google/send_mail.py` |
 | **Calendar read/write** (CLI) | `~/agents/google/gcal.py` (`calendars`/`agenda`/`add`/`quickadd`/`delete`) |
+| **Gmail read/search** (CLI) | `~/agents/google/gmail_read.py` (`unread`/`search`/`read`) |
 | Full reference | `~/agents/google/README.md` |
 
 ### Send mail (CLI)
@@ -61,32 +62,44 @@ Timezone auto-detects from the calendar (override with `--tz`); `--calendar`
 defaults to `primary`. Note the file is `gcal.py`, **not** `calendar.py` (that
 would shadow the stdlib `calendar` module).
 
-### Tasks / Contacts / read-Gmail (no ready-made CLI yet)
+### Read / search mail (CLI)
 
-For Google Tasks, Contacts, or reading Gmail, use the shared auth directly — the
-same token already authorizes them:
+```bash
+PY=~/agents/.venv/bin/python
+$PY ~/agents/google/gmail_read.py unread --max 10
+$PY ~/agents/google/gmail_read.py search "from:x@y.com newer_than:7d" --max 20
+$PY ~/agents/google/gmail_read.py read <message_id>
+```
+
+Uses the token's `gmail.modify` scope (read included) — no re-auth. `search`
+takes normal Gmail query syntax; `read` prints headers + plain-text body.
+
+### Tasks / Contacts (no ready-made CLI yet)
+
+For Google Tasks or Contacts, use the shared auth directly — the same token
+already authorizes them:
 
 ```python
 import sys; sys.path.insert(0, "/Users/jasonjob/agents/google")
 from auth import load_credentials
 from googleapiclient.discovery import build
-svc = build("tasks", "v1", credentials=load_credentials())   # or "gmail"/"people"
+svc = build("tasks", "v1", credentials=load_credentials())   # or "people"
 ```
 
-If you find yourself repeating one of these, promote it to a `~/agents/google/`
-CLI helper (mirroring `send_mail.py` / `gcal.py`) rather than re-pasting.
+If you find yourself repeating one, promote it to a `~/agents/google/` CLI helper
+(mirroring `send_mail.py` / `gcal.py` / `gmail_read.py`) rather than re-pasting.
 
 ## Relationship to the claude.ai MCP connectors
 
-The claude.ai **Gmail / Calendar / Drive** MCP connectors overlap with this
-token. Migration status toward dropping them:
+Goal: **no MCP** for Google. Status — the token CLI now covers everything except Drive:
 
-- **Calendar** — ✅ covered by `gcal.py` (read/write). The claude.ai Calendar MCP
-  is now redundant and can be disconnected.
-- **Google Tasks** — only reachable via this token (no Tasks MCP).
-- **Gmail send** — covered by `send_mail.py`. **Gmail read/search** has no CLI
-  helper yet — keep the claude.ai Gmail MCP until one exists, or you lose
-  read/search ergonomics.
-- **Drive** — still MCP-only; no `~/agents/google/` helper.
+- **Gmail read/search** — ✅ `gmail_read.py`. The claude.ai Gmail MCP is now
+  **redundant and can be disconnected.**
+- **Gmail send** — ✅ `send_mail.py` (the MCP never could send anyway).
+- **Calendar read/write** — ✅ `gcal.py`. The claude.ai Calendar MCP is redundant.
+- **Google Tasks / Contacts** — token-authorized; no CLI yet (use `auth.py`).
+- **Drive** — still MCP-only; no `~/agents/google/` helper (only remaining reason
+  to keep any claude.ai Google connector).
 
-There is no longer a local `gmail-send` MCP — that path is retired.
+There is no longer a local `gmail-send` MCP. Prefer the token CLIs above over any
+MCP for Gmail/Calendar.

--- a/claude-config/skills/google-workspace/SKILL.md
+++ b/claude-config/skills/google-workspace/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: google-workspace
 version: 1.0
-description: Send email via Gmail and read/write Google Calendar on personal machines, using the shared ~/agents/google OAuth (send_mail.py / gcal.py). Use whenever asked to send/draft an email, check the calendar, or add/move/delete a calendar event. You ARE authorized here — do not claim you lack Gmail access without checking for the token first.
+description: Read, search, and send email via Gmail and read/write Google Calendar on personal machines, using the shared ~/agents/google OAuth (gmail_read.py / send_mail.py / gcal.py). Use whenever asked to read/search the inbox, send/draft an email, check the calendar, or add/move/delete a calendar event. You ARE authorized here — do not claim you lack Gmail access without checking for the token first.
 ---
 
 # google-workspace
@@ -15,6 +15,16 @@ checking that token file exists. If it is absent, the capability isn't set up on
 ```
 PY=~/agents/.venv/bin/python
 ```
+
+## Read / search email
+```
+$PY ~/agents/google/gmail_read.py unread --max 10
+$PY ~/agents/google/gmail_read.py search "from:boss@x.com newer_than:7d" --max 20
+$PY ~/agents/google/gmail_read.py read <message_id>
+```
+`search` takes the normal Gmail query syntax. `unread`/`search` print id + from +
+subject + snippet; `read` prints headers + the plain-text body. This is the
+token path — **no MCP needed to read.**
 
 ## Send email
 ```
@@ -35,9 +45,11 @@ $PY ~/agents/google/gcal.py delete --event-id <id>
 Timezone auto-detects from the calendar; `--calendar` defaults to `primary`.
 
 ## Notes
-- This shared token is canonical — **never hand-roll a sender or a second token.**
-- Tasks / Contacts / reading Gmail have no CLI yet: build a client off
+- This shared token is canonical — **never hand-roll a sender/reader or a second token.**
+- Read + send + calendar all run off this one token (scopes: gmail.modify,
+  gmail.send, calendar). The claude.ai Gmail MCP is no longer needed for reading.
+- Google Tasks / Contacts have no CLI yet: build a client off
   `~/agents/google/auth.py:load_credentials()`.
 - Full detail + per-machine gate: `~/.claude/rules/google-mail.md`.
-- Microsoft To Do is a separate capability: `~/agents/m365-todo/todo.py`
-  (see `~/.claude/rules/ms-todo.md`).
+- Microsoft To Do (the user's real task lists) is a separate capability —
+  use the `ms-todo` skill / `~/agents/m365-todo/todo.py` (see `rules/ms-todo.md`).

--- a/claude-config/skills/ms-todo/SKILL.md
+++ b/claude-config/skills/ms-todo/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: ms-todo
+version: 1.0
+description: Read and write the user's Microsoft To Do task lists (their real task manager) on personal machines, via ~/agents/m365-todo/todo.py. Use whenever asked about tasks, to-dos, "my list", adding/completing a task, or reviewing what needs doing. You ARE authorized here — don't claim you lack task access without checking the token first.
+---
+
+# ms-todo
+
+The user's **real task lists live in Microsoft To Do** (not Google Tasks). On
+personal machines you **are** authorized via a delegated Graph token under
+`~/agents/m365-todo/` — **no MCP, no extra login.** Don't say you can't see the
+user's tasks without first checking that the token exists. If it's absent, the
+capability isn't set up on *this* machine (e.g. a work machine) — say so.
+
+```
+PY=~/agents/.venv/bin/python
+```
+
+## Use it
+```
+$PY ~/agents/m365-todo/todo.py lists                       # all task lists
+$PY ~/agents/m365-todo/todo.py tasks "Groceries"           # open tasks (--all for completed)
+$PY ~/agents/m365-todo/todo.py add "Groceries" "Buy milk"
+$PY ~/agents/m365-todo/todo.py complete "Groceries" "Buy milk"
+```
+
+For anything beyond these (due dates, reminders, delete), call Graph directly
+with the shared token: `sys.path.insert(0,"/Users/jasonjob/agents/m365-todo");
+from auth import get_token` → `Authorization: Bearer {get_token()}` against
+`https://graph.microsoft.com/v1.0/me/todo/lists[/{id}/tasks]`.
+
+## Profiles & re-auth
+- **Personal** profile is active here (config + token under `~/agents/m365-todo/`).
+  **Work** is a *separate* profile (different tenant app + token) set up
+  per-machine — see `~/.claude/rules/ms-todo.md`.
+- Re-authorize if the token is lost: `$PY ~/agents/m365-todo/authorize.py start`
+  then `$PY ~/agents/m365-todo/authorize.py finish`.
+- Don't confuse with Google Tasks — that's a different system; tasks live here.

--- a/google/gmail_read.py
+++ b/google/gmail_read.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Gmail read/search CLI on the shared ~/agents/google token.
+
+Uses the token's existing `gmail.modify` scope (which includes read) — no extra
+auth. Mirrors send_mail.py / gcal.py. This is the token-based replacement for the
+claude.ai Gmail MCP's read tools, so reading no longer depends on an MCP connector.
+
+    PY=~/agents/.venv/bin/python
+    $PY ~/agents/google/gmail_read.py unread --max 10
+    $PY ~/agents/google/gmail_read.py search "from:boss@x.com newer_than:7d" --max 20
+    $PY ~/agents/google/gmail_read.py read <message_id>
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import sys
+
+sys.path.insert(0, "/Users/jasonjob/agents/google")
+from auth import load_credentials  # noqa: E402
+from googleapiclient.discovery import build  # noqa: E402
+
+
+def service():
+    return build("gmail", "v1", credentials=load_credentials(), cache_discovery=False)
+
+
+def _hdr(headers: list[dict], name: str) -> str:
+    for h in headers:
+        if h.get("name", "").lower() == name.lower():
+            return h.get("value", "")
+    return ""
+
+
+def search(svc, query: str, maxn: int) -> list[dict]:
+    resp = svc.users().messages().list(userId="me", q=query, maxResults=maxn).execute()
+    out = []
+    for m in resp.get("messages", []):
+        msg = (
+            svc.users()
+            .messages()
+            .get(
+                userId="me",
+                id=m["id"],
+                format="metadata",
+                metadataHeaders=["From", "Subject", "Date"],
+            )
+            .execute()
+        )
+        h = msg.get("payload", {}).get("headers", [])
+        out.append(
+            {
+                "id": m["id"],
+                "from": _hdr(h, "From"),
+                "subject": _hdr(h, "Subject"),
+                "date": _hdr(h, "Date"),
+                "snippet": msg.get("snippet", ""),
+            }
+        )
+    return out
+
+
+def _extract_body(payload: dict) -> str:
+    """Walk MIME parts for text/plain; fall back to the top-level body."""
+    def walk(p: dict) -> str:
+        if p.get("mimeType") == "text/plain" and p.get("body", {}).get("data"):
+            return base64.urlsafe_b64decode(p["body"]["data"]).decode("utf-8", "replace")
+        for sub in p.get("parts", []) or []:
+            found = walk(sub)
+            if found:
+                return found
+        return ""
+
+    body = walk(payload)
+    if not body and payload.get("body", {}).get("data"):
+        body = base64.urlsafe_b64decode(payload["body"]["data"]).decode("utf-8", "replace")
+    return body
+
+
+def read_msg(svc, mid: str) -> dict:
+    msg = svc.users().messages().get(userId="me", id=mid, format="full").execute()
+    h = msg.get("payload", {}).get("headers", [])
+    return {
+        "from": _hdr(h, "From"),
+        "to": _hdr(h, "To"),
+        "subject": _hdr(h, "Subject"),
+        "date": _hdr(h, "Date"),
+        "body": _extract_body(msg.get("payload", {})),
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Gmail read/search CLI (shared token)")
+    sub = ap.add_subparsers(dest="cmd", required=True)
+    ps = sub.add_parser("search")
+    ps.add_argument("query", help="Gmail search query (same syntax as the Gmail search box)")
+    ps.add_argument("--max", type=int, default=10, dest="maxn")
+    pu = sub.add_parser("unread")
+    pu.add_argument("--max", type=int, default=10, dest="maxn")
+    pr = sub.add_parser("read")
+    pr.add_argument("id")
+    a = ap.parse_args()
+
+    svc = service()
+    if a.cmd in ("search", "unread"):
+        q = a.query if a.cmd == "search" else "is:unread"
+        rows = search(svc, q, a.maxn)
+        if not rows:
+            print("(no matching messages)")
+        for m in rows:
+            print(f"[{m['id']}] {m['date']}")
+            print(f"  From: {m['from']}")
+            print(f"  Subj: {m['subject']}")
+            print(f"  {m['snippet'][:160]}\n")
+    elif a.cmd == "read":
+        m = read_msg(svc, a.id)
+        print(f"From: {m['from']}\nTo: {m['to']}\nDate: {m['date']}\nSubject: {m['subject']}\n")
+        print(m["body"][:4000])
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
Close the Gmail-read gap and make tasks as discoverable as email/calendar — all on the existing tokens, no MCP, no re-auth.

- **`google/gmail_read.py`** — Gmail read/search on the shared token's `gmail.modify` scope (`unread` / `search "<gmail query>"` / `read <id>`). Validated live. This is the token replacement for the claude.ai Gmail MCP's read tools.
- **`google-workspace` skill** — now covers **read + send + calendar** (added the read commands; description updated).
- **`ms-todo` skill (new)** — wraps `m365-todo/todo.py` so the user's real task lists are discoverable in every session, same as Gmail/Calendar. Personal profile; work is a separate per-machine profile.
- **`rules/google-mail.md`** — documents `gmail_read.py`; updates the MCP section: Gmail (read+send) and Calendar are now fully token-covered → the claude.ai Gmail/Calendar MCPs are redundant (only Drive still needs an MCP).

No new authorization required — existing token scopes (`gmail.modify`, `gmail.send`, `calendar`; MS `Tasks.ReadWrite`) already cover all of it.

## Test Plan
- `gmail_read.py unread` returned live unread mail (token read path works) ✅
- `ruff check` clean on `gmail_read.py` ✅
- Both skills pass the portability lint; mirrored into `~/.codex/skills` + `~/.agents/skills` ✅
- `test_check_context_budgets` + all `test_agent_parity` (10) pass ✅
- `agent-parity --home ~`: `skill_parity: pass`, `ok: True` ✅
- Budgets: CLAUDE.md 198/200, always-load 399/450 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
