### PR TITLE
feat(google): contacts.py read-only lookup (name -> email/phone)

### DIFF
--- a/claude-config/rules/google-mail.md
+++ b/claude-config/rules/google-mail.md
@@ -35,6 +35,7 @@ Validated live 2026-06-26 on this laptop: Gmail (account
 | **Send mail** (CLI) | `~/agents/google/send_mail.py` |
 | **Calendar read/write** (CLI) | `~/agents/google/gcal.py` (`calendars`/`agenda`/`add`/`quickadd`/`delete`) |
 | **Gmail read/search** (CLI) | `~/agents/google/gmail_read.py` (`unread`/`search`/`read`) |
+| **Contacts lookup** (CLI, read-only) | `~/agents/google/contacts.py` (`search "<name>"` → email/phone) |
 | Full reference | `~/agents/google/README.md` |
 
 ### Send mail (CLI)
@@ -74,20 +75,29 @@ $PY ~/agents/google/gmail_read.py read <message_id>
 Uses the token's `gmail.modify` scope (read included) — no re-auth. `search`
 takes normal Gmail query syntax; `read` prints headers + plain-text body.
 
-### Tasks / Contacts (no ready-made CLI yet)
+### Contacts lookup (CLI, read-only)
 
-For Google Tasks or Contacts, use the shared auth directly — the same token
-already authorizes them:
+```bash
+PY=~/agents/.venv/bin/python
+$PY ~/agents/google/contacts.py search "Bob Smith"      # name -> email/phone
+```
+Read-only (`contacts.readonly` scope). **Creating/editing contacts is NOT
+possible** with the current token — that needs the `contacts` (read-write) scope
+added to `auth.py:SCOPES` + a `reauth.py` re-consent.
+
+### Google Tasks (no ready-made CLI yet)
+
+For Google Tasks, use the shared auth directly (the token already authorizes it):
 
 ```python
 import sys; sys.path.insert(0, "/Users/jasonjob/agents/google")
 from auth import load_credentials
 from googleapiclient.discovery import build
-svc = build("tasks", "v1", credentials=load_credentials())   # or "people"
+svc = build("tasks", "v1", credentials=load_credentials())
 ```
 
 If you find yourself repeating one, promote it to a `~/agents/google/` CLI helper
-(mirroring `send_mail.py` / `gcal.py` / `gmail_read.py`) rather than re-pasting.
+(mirroring `send_mail.py` / `gcal.py` / `gmail_read.py` / `contacts.py`).
 
 ## Relationship to the claude.ai MCP connectors
 

--- a/claude-config/skills/google-workspace/SKILL.md
+++ b/claude-config/skills/google-workspace/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: google-workspace
 version: 1.0
-description: Read, search, and send email via Gmail and read/write Google Calendar on personal machines, using the shared ~/agents/google OAuth (gmail_read.py / send_mail.py / gcal.py). Use whenever asked to read/search the inbox, send/draft an email, check the calendar, or add/move/delete a calendar event. You ARE authorized here — do not claim you lack Gmail access without checking for the token first.
+description: Read/search/send email via Gmail, read/write Google Calendar, and look up Google Contacts (name -> email/phone) on personal machines, using the shared ~/agents/google OAuth (gmail_read.py / send_mail.py / gcal.py / contacts.py). Use whenever asked to read/search the inbox, send/draft an email, check the calendar, add/move/delete an event, or find someone's email/phone. You ARE authorized here — do not claim you lack Gmail access without checking for the token first.
 ---
 
 # google-workspace
@@ -44,11 +44,17 @@ $PY ~/agents/google/gcal.py delete --event-id <id>
 ```
 Timezone auto-detects from the calendar; `--calendar` defaults to `primary`.
 
+## Look up a contact (name → email/phone)
+```
+$PY ~/agents/google/contacts.py search "Bob Smith"
+```
+Read-only. Handy to resolve a recipient before `send_mail.py`.
+
 ## Notes
 - This shared token is canonical — **never hand-roll a sender/reader or a second token.**
-- Read + send + calendar all run off this one token (scopes: gmail.modify,
-  gmail.send, calendar). The claude.ai Gmail MCP is no longer needed for reading.
-- Google Tasks / Contacts have no CLI yet: build a client off
+- Read + send + calendar + contacts all run off this one token (scopes:
+  gmail.modify, gmail.send, calendar, contacts.readonly). No MCP needed for these.
+- Google Tasks has no CLI yet: build a client off
   `~/agents/google/auth.py:load_credentials()`.
 - Full detail + per-machine gate: `~/.claude/rules/google-mail.md`.
 - Microsoft To Do (the user's real task lists) is a separate capability —

--- a/google/contacts.py
+++ b/google/contacts.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Google Contacts lookup (read-only) on the shared ~/agents/google token.
+
+Resolve a name -> email / phone (e.g. before sending mail with send_mail.py).
+Uses the token's existing `contacts.readonly` scope — no re-auth. People API.
+
+    PY=~/agents/.venv/bin/python
+    $PY ~/agents/google/contacts.py search "Bob Smith"
+    $PY ~/agents/google/contacts.py search bob --max 5
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+sys.path.insert(0, "/Users/jasonjob/agents/google")
+from auth import load_credentials  # noqa: E402
+from googleapiclient.discovery import build  # noqa: E402
+
+READ_MASK = "names,emailAddresses,phoneNumbers"
+
+
+def service():
+    return build("people", "v1", credentials=load_credentials(), cache_discovery=False)
+
+
+def _fmt(person: dict) -> str:
+    name = (person.get("names") or [{}])[0].get("displayName", "(no name)")
+    emails = [e["value"] for e in person.get("emailAddresses", []) if e.get("value")]
+    phones = [p["value"] for p in person.get("phoneNumbers", []) if p.get("value")]
+    line = name
+    if emails:
+        line += "  <" + ", ".join(emails) + ">"
+    if phones:
+        line += "  tel " + ", ".join(phones)
+    return line
+
+
+def search(svc, query: str, maxn: int) -> list[dict]:
+    # People API recommends a warmup request before searchContacts.
+    try:
+        svc.people().searchContacts(query="", readMask="names").execute()
+    except Exception:  # noqa: BLE001 — warmup is best-effort; ignore failures
+        pass
+    resp = svc.people().searchContacts(query=query, readMask=READ_MASK, pageSize=maxn).execute()
+    return [r.get("person", {}) for r in resp.get("results", [])]
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Google Contacts lookup (read-only)")
+    sub = ap.add_subparsers(dest="cmd", required=True)
+    ps = sub.add_parser("search")
+    ps.add_argument("query")
+    ps.add_argument("--max", type=int, default=10, dest="maxn")
+    a = ap.parse_args()
+
+    svc = service()
+    people = search(svc, a.query, a.maxn)
+    if not people:
+        print(f"(no contacts match {a.query!r})")
+        return 0
+    for p in people:
+        print(_fmt(p))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
Add `google/contacts.py` — resolve a contact by name to email/phone (read-only) before sending mail. Uses the token's existing `contacts.readonly` scope; no re-auth. Folded into the `google-workspace` skill; `google-mail.md` documents it and notes that **creating** contacts would need the `contacts` read-write scope + reauth (not granted).

## Test Plan
- `contacts.py search` returned real name→email/phone results ✅
- ruff clean; budgets 198/200 + 399/450 ✅
- budget + all agent_parity tests (10) pass ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)