### PR TITLE
feat(google): gmail_label.py — label/triage emails (gmail.modify, no re-auth)

### DIFF
--- a/claude-config/rules/google-mail.md
+++ b/claude-config/rules/google-mail.md
@@ -35,6 +35,7 @@ Validated live 2026-06-26 on this laptop: Gmail (account
 | **Send mail** (CLI) | `~/agents/google/send_mail.py` |
 | **Calendar read/write** (CLI) | `~/agents/google/gcal.py` (`calendars`/`agenda`/`add`/`quickadd`/`delete`) |
 | **Gmail read/search** (CLI) | `~/agents/google/gmail_read.py` (`unread`/`search`/`read`) |
+| **Gmail label/triage** (CLI) | `~/agents/google/gmail_label.py` (`list`/`add`/`remove`; `gmail.modify`) |
 | **Contacts lookup** (CLI, read-only) | `~/agents/google/contacts.py` (`search "<name>"` → email/phone) |
 | Full reference | `~/agents/google/README.md` |
 
@@ -74,6 +75,17 @@ $PY ~/agents/google/gmail_read.py read <message_id>
 
 Uses the token's `gmail.modify` scope (read included) — no re-auth. `search`
 takes normal Gmail query syntax; `read` prints headers + plain-text body.
+
+### Label / triage mail (CLI)
+
+```bash
+PY=~/agents/.venv/bin/python
+$PY ~/agents/google/gmail_label.py list
+$PY ~/agents/google/gmail_label.py add <message_id> "Follow up" --create
+$PY ~/agents/google/gmail_label.py remove <message_id> "Follow up"
+```
+Uses `gmail.modify` (already granted) — no re-auth. Message ids come from
+`gmail_read.py`.
 
 ### Contacts lookup (CLI, read-only)
 

--- a/claude-config/skills/google-workspace/SKILL.md
+++ b/claude-config/skills/google-workspace/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: google-workspace
 version: 1.0
-description: Read/search/send email via Gmail, read/write Google Calendar, and look up Google Contacts (name -> email/phone) on personal machines, using the shared ~/agents/google OAuth (gmail_read.py / send_mail.py / gcal.py / contacts.py). Use whenever asked to read/search the inbox, send/draft an email, check the calendar, add/move/delete an event, or find someone's email/phone. You ARE authorized here — do not claim you lack Gmail access without checking for the token first.
+description: Read/search/send/label email via Gmail, read/write Google Calendar, and look up Google Contacts (name -> email/phone) on personal machines, using the shared ~/agents/google OAuth (gmail_read.py / send_mail.py / gmail_label.py / gcal.py / contacts.py). Use whenever asked to read/search the inbox, send/draft an email, label or triage a message, check the calendar, add/move/delete an event, or find someone's email/phone. You ARE authorized here — do not claim you lack Gmail access without checking for the token first.
 ---
 
 # google-workspace
@@ -25,6 +25,14 @@ $PY ~/agents/google/gmail_read.py read <message_id>
 `search` takes the normal Gmail query syntax. `unread`/`search` print id + from +
 subject + snippet; `read` prints headers + the plain-text body. This is the
 token path — **no MCP needed to read.**
+
+## Label / triage an email
+```
+$PY ~/agents/google/gmail_label.py list
+$PY ~/agents/google/gmail_label.py add <message_id> "Follow up" [--create]
+$PY ~/agents/google/gmail_label.py remove <message_id> "Follow up"
+```
+Uses `gmail.modify` (no re-auth). Get the message id from `gmail_read.py`.
 
 ## Send email
 ```

--- a/google/gmail_label.py
+++ b/google/gmail_label.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Gmail label management on the shared ~/agents/google token (gmail.modify scope).
+
+Add / remove labels on a message (e.g. triage a new email) — no re-auth needed.
+
+    PY=~/agents/.venv/bin/python
+    $PY ~/agents/google/gmail_label.py list
+    $PY ~/agents/google/gmail_label.py add <message_id> "Follow up" [--create]
+    $PY ~/agents/google/gmail_label.py remove <message_id> "Follow up"
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+sys.path.insert(0, "/Users/jasonjob/agents/google")
+from auth import load_credentials  # noqa: E402
+from googleapiclient.discovery import build  # noqa: E402
+
+
+def service():
+    return build("gmail", "v1", credentials=load_credentials(), cache_discovery=False)
+
+
+def _labels(svc) -> list[dict]:
+    return svc.users().labels().list(userId="me").execute().get("labels", [])
+
+
+def _resolve(svc, name: str, create: bool = False) -> str:
+    for label in _labels(svc):
+        if label["name"].lower() == name.lower():
+            return label["id"]
+    if create:
+        made = (
+            svc.users()
+            .labels()
+            .create(
+                userId="me",
+                body={
+                    "name": name,
+                    "labelListVisibility": "labelShow",
+                    "messageListVisibility": "show",
+                },
+            )
+            .execute()
+        )
+        return made["id"]
+    existing = [label["name"] for label in _labels(svc) if label.get("type") == "user"]
+    raise SystemExit(f"Label not found: {name!r} (pass --create to make it). Existing: {existing}")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Gmail label management (shared token)")
+    sub = ap.add_subparsers(dest="cmd", required=True)
+    sub.add_parser("list")
+    pa = sub.add_parser("add")
+    pa.add_argument("message_id")
+    pa.add_argument("label")
+    pa.add_argument("--create", action="store_true", help="create the label if it doesn't exist")
+    pr = sub.add_parser("remove")
+    pr.add_argument("message_id")
+    pr.add_argument("label")
+    a = ap.parse_args()
+
+    svc = service()
+    if a.cmd == "list":
+        for label in sorted(_labels(svc), key=lambda x: x["name"].lower()):
+            tag = "" if label.get("type") == "user" else "  (system)"
+            print(f"{label['name']}{tag}")
+    elif a.cmd == "add":
+        lid = _resolve(svc, a.label, create=a.create)
+        svc.users().messages().modify(
+            userId="me", id=a.message_id, body={"addLabelIds": [lid]}
+        ).execute()
+        print(f"ADDED label {a.label!r} to message {a.message_id}")
+    elif a.cmd == "remove":
+        lid = _resolve(svc, a.label)
+        svc.users().messages().modify(
+            userId="me", id=a.message_id, body={"removeLabelIds": [lid]}
+        ).execute()
+        print(f"REMOVED label {a.label!r} from message {a.message_id}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
Add `google/gmail_label.py` to label/triage emails (`list`/`add`/`remove`) on the token's existing `gmail.modify` scope — **no re-auth**. Folded into the `google-workspace` skill + `google-mail.md`. This is half of the new-email triage use case; adding the sender to contacts is the other half and needs the contacts read-write scope + reauth (tracked separately).

## Test Plan
- Self-cleaning add/remove round-trip on a real message ✅ (label created, applied, removed, deleted — no residue)
- ruff clean; budgets 198/200 + 399/450; budget + 10 parity tests pass ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)