### PR TITLE
feat(google): contacts read-write (add/delete) via reauth — new-email triage

### DIFF
--- a/claude-config/rules/google-mail.md
+++ b/claude-config/rules/google-mail.md
@@ -22,7 +22,8 @@ on this machine — work machines do not have it. Mirrors the M365 gate
 
 ## Authorized scopes (one superset token covers all agents)
 
-`gmail.send`, `gmail.modify`, `calendar`, `tasks`, `contacts.readonly`.
+`gmail.send`, `gmail.modify`, `calendar`, `tasks`, `contacts` (read-write since
+the 2026-06-27 reauth).
 Validated live 2026-06-26 on this laptop: Gmail (account
 `jasonwadejob@gmail.com`), Calendar (read/write), Google Tasks all OK.
 
@@ -36,7 +37,7 @@ Validated live 2026-06-26 on this laptop: Gmail (account
 | **Calendar read/write** (CLI) | `~/agents/google/gcal.py` (`calendars`/`agenda`/`add`/`quickadd`/`delete`) |
 | **Gmail read/search** (CLI) | `~/agents/google/gmail_read.py` (`unread`/`search`/`read`) |
 | **Gmail label/triage** (CLI) | `~/agents/google/gmail_label.py` (`list`/`add`/`remove`; `gmail.modify`) |
-| **Contacts lookup** (CLI, read-only) | `~/agents/google/contacts.py` (`search "<name>"` → email/phone) |
+| **Contacts read/write** (CLI) | `~/agents/google/contacts.py` (`search`/`add`/`delete`) |
 | Full reference | `~/agents/google/README.md` |
 
 ### Send mail (CLI)
@@ -87,15 +88,16 @@ $PY ~/agents/google/gmail_label.py remove <message_id> "Follow up"
 Uses `gmail.modify` (already granted) — no re-auth. Message ids come from
 `gmail_read.py`.
 
-### Contacts lookup (CLI, read-only)
+### Contacts read/write (CLI)
 
 ```bash
 PY=~/agents/.venv/bin/python
 $PY ~/agents/google/contacts.py search "Bob Smith"      # name -> email/phone
+$PY ~/agents/google/contacts.py add "Bob Smith" --email bob@x.com --phone 555-1234
+$PY ~/agents/google/contacts.py delete people/c123...   # resourceName from add/search
 ```
-Read-only (`contacts.readonly` scope). **Creating/editing contacts is NOT
-possible** with the current token — that needs the `contacts` (read-write) scope
-added to `auth.py:SCOPES` + a `reauth.py` re-consent.
+Read **and** write (`contacts` scope, granted via reauth 2026-06-27). Pairs with
+email triage — look up or save a sender after reading a new message.
 
 ### Google Tasks (no ready-made CLI yet)
 

--- a/claude-config/skills/google-workspace/SKILL.md
+++ b/claude-config/skills/google-workspace/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: google-workspace
 version: 1.0
-description: Read/search/send/label email via Gmail, read/write Google Calendar, and look up Google Contacts (name -> email/phone) on personal machines, using the shared ~/agents/google OAuth (gmail_read.py / send_mail.py / gmail_label.py / gcal.py / contacts.py). Use whenever asked to read/search the inbox, send/draft an email, label or triage a message, check the calendar, add/move/delete an event, or find someone's email/phone. You ARE authorized here — do not claim you lack Gmail access without checking for the token first.
+description: Read/search/send/label email via Gmail, read/write Google Calendar, and look up or add Google Contacts (name -> email/phone) on personal machines, using the shared ~/agents/google OAuth (gmail_read.py / send_mail.py / gmail_label.py / gcal.py / contacts.py). Use whenever asked to read/search the inbox, send/draft an email, label or triage a message, check the calendar, add/move/delete an event, or find/save someone's contact. You ARE authorized here — do not claim you lack Gmail access without checking for the token first.
 ---
 
 # google-workspace
@@ -52,16 +52,19 @@ $PY ~/agents/google/gcal.py delete --event-id <id>
 ```
 Timezone auto-detects from the calendar; `--calendar` defaults to `primary`.
 
-## Look up a contact (name → email/phone)
+## Contacts (look up / add)
 ```
-$PY ~/agents/google/contacts.py search "Bob Smith"
+$PY ~/agents/google/contacts.py search "Bob Smith"                       # name -> email/phone
+$PY ~/agents/google/contacts.py add "Bob Smith" --email bob@x.com --phone 555-1234
+$PY ~/agents/google/contacts.py delete people/c123...                    # resourceName from add/search
 ```
-Read-only. Handy to resolve a recipient before `send_mail.py`.
+Read/write (`contacts` scope). Pairs with email triage: after reading a new
+message, look up the sender or `add` them.
 
 ## Notes
 - This shared token is canonical — **never hand-roll a sender/reader or a second token.**
-- Read + send + calendar + contacts all run off this one token (scopes:
-  gmail.modify, gmail.send, calendar, contacts.readonly). No MCP needed for these.
+- Read + send + label + calendar + contacts all run off this one token (scopes:
+  gmail.modify, gmail.send, calendar, tasks, contacts). No MCP needed for these.
 - Google Tasks has no CLI yet: build a client off
   `~/agents/google/auth.py:load_credentials()`.
 - Full detail + per-machine gate: `~/.claude/rules/google-mail.md`.

--- a/google/auth.py
+++ b/google/auth.py
@@ -26,7 +26,7 @@ SCOPES = [
     "https://www.googleapis.com/auth/gmail.modify",
     "https://www.googleapis.com/auth/calendar",
     "https://www.googleapis.com/auth/tasks",
-    "https://www.googleapis.com/auth/contacts.readonly",
+    "https://www.googleapis.com/auth/contacts",
 ]
 
 

--- a/google/contacts.py
+++ b/google/contacts.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python3
-"""Google Contacts lookup (read-only) on the shared ~/agents/google token.
+"""Google Contacts read/write on the shared ~/agents/google token (`contacts` scope).
 
-Resolve a name -> email / phone (e.g. before sending mail with send_mail.py).
-Uses the token's existing `contacts.readonly` scope — no re-auth. People API.
+Look up a name -> email/phone (e.g. before send_mail.py), and create/delete
+contacts (e.g. add a sender after triaging a new email). People API.
 
     PY=~/agents/.venv/bin/python
     $PY ~/agents/google/contacts.py search "Bob Smith"
-    $PY ~/agents/google/contacts.py search bob --max 5
+    $PY ~/agents/google/contacts.py add "Bob Smith" --email bob@x.com --phone 555-1234
+    $PY ~/agents/google/contacts.py delete people/c1234567890   # resourceName from add/search
 """
 
 from __future__ import annotations
@@ -47,21 +48,48 @@ def search(svc, query: str, maxn: int) -> list[dict]:
     return [r.get("person", {}) for r in resp.get("results", [])]
 
 
+def create_contact(svc, name: str, emails: list[str], phones: list[str]) -> dict:
+    parts = name.split()
+    person = {"names": [{"givenName": parts[0], "familyName": " ".join(parts[1:])}]}
+    if emails:
+        person["emailAddresses"] = [{"value": e} for e in emails]
+    if phones:
+        person["phoneNumbers"] = [{"value": p} for p in phones]
+    return svc.people().createContact(body=person).execute()
+
+
+def delete_contact(svc, resource_name: str) -> None:
+    svc.people().deleteContact(resourceName=resource_name).execute()
+
+
 def main() -> int:
-    ap = argparse.ArgumentParser(description="Google Contacts lookup (read-only)")
+    ap = argparse.ArgumentParser(description="Google Contacts (read/write)")
     sub = ap.add_subparsers(dest="cmd", required=True)
     ps = sub.add_parser("search")
     ps.add_argument("query")
     ps.add_argument("--max", type=int, default=10, dest="maxn")
+    pa = sub.add_parser("add")
+    pa.add_argument("name")
+    pa.add_argument("--email", action="append", default=[])
+    pa.add_argument("--phone", action="append", default=[])
+    pd = sub.add_parser("delete")
+    pd.add_argument("resource_name", help="e.g. people/c123... (from add/search)")
     a = ap.parse_args()
 
     svc = service()
-    people = search(svc, a.query, a.maxn)
-    if not people:
-        print(f"(no contacts match {a.query!r})")
-        return 0
-    for p in people:
-        print(_fmt(p))
+    if a.cmd == "search":
+        people = search(svc, a.query, a.maxn)
+        if not people:
+            print(f"(no contacts match {a.query!r})")
+            return 0
+        for p in people:
+            print(f"{_fmt(p)}  [{p.get('resourceName', '')}]")
+    elif a.cmd == "add":
+        created = create_contact(svc, a.name, a.email, a.phone)
+        print(f"ADDED: {_fmt(created)}  [{created.get('resourceName', '')}]")
+    elif a.cmd == "delete":
+        delete_contact(svc, a.resource_name)
+        print(f"DELETED {a.resource_name}")
     return 0
 
 


### PR DESCRIPTION
## Summary
Enable adding a sender to contacts (the other half of new-email triage). Swapped `contacts.readonly` → `contacts` in `auth.py:SCOPES` and re-authorized (browser consent 2026-06-27). `contacts.py` gains `add`/`delete`; folded into the `google-workspace` skill + rule. Token is a strict superset → buddy (shared token) unaffected.

## Test Plan
- add → delete round-trip self-cleaned (no residue) ✅
- gmail_read + gcal still work post-reauth ✅
- ruff clean; budgets 198/200 + 399/450; budget + 10 parity tests pass ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)