### PR TITLE
chore(hooks): wire project_event emit hooks (defensive, per-repo, flag-gated)

### DIFF
--- a/claude-config/settings.json
+++ b/claude-config/settings.json
@@ -84,6 +84,10 @@
           {
             "type": "command",
             "command": "python3 ~/.claude/hooks/precompact_checkpoint.py"
+          },
+          {
+            "type": "command",
+            "command": "sh -c 'set -a; [ -f \"$HOME/.buddy/emit-env.sh\" ] && . \"$HOME/.buddy/emit-env.sh\"; [ -f \"$PWD/.buddy-emit-project\" ] && BUDDY_EMIT_PROJECT_ID=\"$(cat \"$PWD/.buddy-emit-project\")\"; [ -f \"$HOME/projects/buddy/scripts/hooks/project_event_session.py\" ] && PYTHONPATH=\"$HOME/projects/buddy/src\" python3 \"$HOME/projects/buddy/scripts/hooks/project_event_session.py\" || true'"
           }
         ]
       }
@@ -138,6 +142,10 @@
           {
             "type": "command",
             "command": "python3 ~/.claude/hooks/capture_session_telemetry.py"
+          },
+          {
+            "type": "command",
+            "command": "sh -c 'set -a; [ -f \"$HOME/.buddy/emit-env.sh\" ] && . \"$HOME/.buddy/emit-env.sh\"; [ -f \"$PWD/.buddy-emit-project\" ] && BUDDY_EMIT_PROJECT_ID=\"$(cat \"$PWD/.buddy-emit-project\")\"; [ -f \"$HOME/projects/buddy/scripts/hooks/project_event_session.py\" ] && PYTHONPATH=\"$HOME/projects/buddy/src\" python3 \"$HOME/projects/buddy/scripts/hooks/project_event_session.py\" || true'"
           }
         ]
       }
@@ -153,6 +161,10 @@
           {
             "type": "command",
             "command": "python3 ~/.claude/hooks/edit_quality_feedback.py"
+          },
+          {
+            "type": "command",
+            "command": "sh -c 'set -a; [ -f \"$HOME/.buddy/emit-env.sh\" ] && . \"$HOME/.buddy/emit-env.sh\"; [ -f \"$PWD/.buddy-emit-project\" ] && BUDDY_EMIT_PROJECT_ID=\"$(cat \"$PWD/.buddy-emit-project\")\"; [ -f \"$HOME/projects/buddy/scripts/hooks/project_event_posttooluse.py\" ] && PYTHONPATH=\"$HOME/projects/buddy/src\" python3 \"$HOME/projects/buddy/scripts/hooks/project_event_posttooluse.py\" || true'"
           }
         ]
       }


### PR DESCRIPTION
Wires the buddy #2583 project_event emit hooks into the shared settings.json (PostToolUse Tier-1 acts + Stop/PreCompact Tier-2 digest). Each command is a defensive no-op unless: the buddy checkout exists AND ~/.buddy/emit-env.sh arms it (BUDDY_EVENT_EMISSION_ENABLED + ingress + token) AND the repo has a .buddy-emit-project file (per-repo stream). Safe on all machines/repos by default (opt-in per repo). Personal jns only; work-buddy is a separate independent instance.