### PR TITLE
feat(google): gmail_read attachments subcommand + PDF text extraction

### DIFF
--- a/google/gmail_read.py
+++ b/google/gmail_read.py
@@ -9,12 +9,14 @@ claude.ai Gmail MCP's read tools, so reading no longer depends on an MCP connect
     $PY ~/agents/google/gmail_read.py unread --max 10
     $PY ~/agents/google/gmail_read.py search "from:boss@x.com newer_than:7d" --max 20
     $PY ~/agents/google/gmail_read.py read <message_id>
+    $PY ~/agents/google/gmail_read.py attachments <message_id>
 """
 
 from __future__ import annotations
 
 import argparse
 import base64
+import io
 import sys
 
 sys.path.insert(0, "/Users/jasonjob/agents/google")
@@ -90,6 +92,57 @@ def read_msg(svc, mid: str) -> dict:
     }
 
 
+def _iter_attachments(payload: dict):
+    """Yield attachment descriptors from a full-format message payload.
+
+    A MIME part is treated as an attachment when it carries a non-empty
+    ``filename``. Small attachments arrive inline as ``body.data``; larger ones
+    only carry ``body.attachmentId`` and must be fetched separately.
+    """
+    def walk(p: dict):
+        body = p.get("body", {}) or {}
+        if p.get("filename"):
+            yield {
+                "filename": p["filename"],
+                "mime": p.get("mimeType", ""),
+                "size": body.get("size", 0),
+                "data": body.get("data"),
+                "attachment_id": body.get("attachmentId"),
+            }
+        for sub in p.get("parts", []) or []:
+            yield from walk(sub)
+
+    yield from walk(payload)
+
+
+def _download_attachment(svc, mid: str, att: dict) -> bytes:
+    """Return the decoded bytes for an attachment (inline or fetched by id)."""
+    raw = att.get("data")
+    if not raw:
+        resp = (
+            svc.users()
+            .messages()
+            .attachments()
+            .get(userId="me", messageId=mid, id=att["attachment_id"])
+            .execute()
+        )
+        raw = resp.get("data", "")
+    return base64.urlsafe_b64decode(raw)
+
+
+def extract_pdf_text(pdf_bytes: bytes) -> str:
+    """Extract text from PDF bytes using pypdf. Pure/testable — no Gmail."""
+    from pypdf import PdfReader
+
+    reader = PdfReader(io.BytesIO(pdf_bytes))
+    return "\n".join((page.extract_text() or "") for page in reader.pages)
+
+
+def list_attachments(svc, mid: str) -> list[dict]:
+    msg = svc.users().messages().get(userId="me", id=mid, format="full").execute()
+    return list(_iter_attachments(msg.get("payload", {})))
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description="Gmail read/search CLI (shared token)")
     sub = ap.add_subparsers(dest="cmd", required=True)
@@ -100,6 +153,8 @@ def main() -> int:
     pu.add_argument("--max", type=int, default=10, dest="maxn")
     pr = sub.add_parser("read")
     pr.add_argument("id")
+    pa = sub.add_parser("attachments")
+    pa.add_argument("id")
     a = ap.parse_args()
 
     svc = service()
@@ -117,6 +172,22 @@ def main() -> int:
         m = read_msg(svc, a.id)
         print(f"From: {m['from']}\nTo: {m['to']}\nDate: {m['date']}\nSubject: {m['subject']}\n")
         print(m["body"][:4000])
+    elif a.cmd == "attachments":
+        atts = list_attachments(svc, a.id)
+        if not atts:
+            print("(no attachments)")
+            return 0
+        for i, att in enumerate(atts, 1):
+            print(f"[{i}] {att['filename']}  ({att['mime']}, {att['size']} bytes)")
+        for att in atts:
+            if att["mime"] == "application/pdf" or att["filename"].lower().endswith(".pdf"):
+                print(f"\n--- PDF text: {att['filename']} ---")
+                try:
+                    text = extract_pdf_text(_download_attachment(svc, a.id, att))
+                except Exception as exc:  # noqa: BLE001 - report, keep other attachments
+                    print(f"(failed to extract text: {exc})")
+                    continue
+                print(text.strip() or "(no extractable text — likely a scanned image)")
     return 0
 
 

--- a/google/requirements.txt
+++ b/google/requirements.txt
@@ -1,3 +1,4 @@
 google-auth>=2.0
 google-auth-oauthlib>=1.0
 google-api-python-client>=2.0
+pypdf>=4.0

--- a/google/test_gmail_read.py
+++ b/google/test_gmail_read.py
@@ -1,0 +1,109 @@
+"""Deterministic tests for gmail_read attachment + PDF-text extraction (buddy#2626).
+
+No live Gmail: the PDF is a tiny embedded fixture and the Gmail service is mocked.
+Run: ~/agents/.venv/bin/python -m pytest google/test_gmail_read.py -q
+"""
+
+from __future__ import annotations
+
+import base64
+from unittest import mock
+
+import gmail_read
+
+# A tiny ReportLab-generated PDF whose text is "Fluent Home Invoice #495213 /
+# Amount Due: $189.00". Embedded so the test needs only pypdf at runtime.
+_FIXTURE_PDF_B64 = (
+    "JVBERi0xLjMKJZOMi54gUmVwb3J0TGFiIEdlbmVyYXRlZCBQREYgZG9jdW1lbnQgKG9wZW5zb3Vy"
+    "Y2UpCjEgMCBvYmoKPDwKL0YxIDIgMCBSCj4+CmVuZG9iagoyIDAgb2JqCjw8Ci9CYXNlRm9udCAv"
+    "SGVsdmV0aWNhIC9FbmNvZGluZyAvV2luQW5zaUVuY29kaW5nIC9OYW1lIC9GMSAvU3VidHlwZSAv"
+    "VHlwZTEgL1R5cGUgL0ZvbnQKPj4KZW5kb2JqCjMgMCBvYmoKPDwKL0NvbnRlbnRzIDcgMCBSIC9N"
+    "ZWRpYUJveCBbIDAgMCA1OTUuMjc1NiA4NDEuODg5OCBdIC9QYXJlbnQgNiAwIFIgL1Jlc291cmNl"
+    "cyA8PAovRm9udCAxIDAgUiAvUHJvY1NldCBbIC9QREYgL1RleHQgL0ltYWdlQiAvSW1hZ2VDIC9J"
+    "bWFnZUkgXQo+PiAvUm90YXRlIDAgL1RyYW5zIDw8Cgo+PiAKICAvVHlwZSAvUGFnZQo+PgplbmRv"
+    "YmoKNCAwIG9iago8PAovUGFnZU1vZGUgL1VzZU5vbmUgL1BhZ2VzIDYgMCBSIC9UeXBlIC9DYXRh"
+    "bG9nCj4+CmVuZG9iago1IDAgb2JqCjw8Ci9BdXRob3IgKGFub255bW91cykgL0NyZWF0aW9uRGF0"
+    "ZSAoRDoyMDI2MDcwMTE4MDYyNC0wNycwMCcpIC9DcmVhdG9yIChhbm9ueW1vdXMpIC9LZXl3b3Jk"
+    "cyAoKSAvTW9kRGF0ZSAoRDoyMDI2MDcwMTE4MDYyNC0wNycwMCcpIC9Qcm9kdWNlciAoUmVwb3J0"
+    "TGFiIFBERiBMaWJyYXJ5IC0gXChvcGVuc291cmNlXCkpIAogIC9TdWJqZWN0ICh1bnNwZWNpZmll"
+    "ZCkgL1RpdGxlICh1bnRpdGxlZCkgL1RyYXBwZWQgL0ZhbHNlCj4+CmVuZG9iago2IDAgb2JqCjw8"
+    "Ci9Db3VudCAxIC9LaWRzIFsgMyAwIFIgXSAvVHlwZSAvUGFnZXMKPj4KZW5kb2JqCjcgMCBvYmoK"
+    "PDwKL0ZpbHRlciBbIC9BU0NJSTg1RGVjb2RlIC9GbGF0ZURlY29kZSBdIC9MZW5ndGggMTUxCj4+"
+    "CnN0cmVhbQpHYXBRaDBFPUYsMFVcSDNUXHBOWVReUUtrP3RjPklQLDtXI1UxXjIzaWhQRU1fP0NX"
+    "NEtJU2k8IVs3YCNPQl9xdVwiKG1yXUZrQy9yN2s2VGNiLVJdYmlEXyxBSjdeOCw9PnM4S29kaj4m"
+    "MW9HWiUzVHM7RjdXJVVIPGotQVhWPV9DL00tUSclJDoqMER1ZnJmKyFZaH4+ZW5kc3RyZWFtCmVu"
+    "ZG9iagp4cmVmCjAgOAowMDAwMDAwMDAwIDY1NTM1IGYgCjAwMDAwMDAwNjEgMDAwMDAgbiAKMDAw"
+    "MDAwMDA5MiAwMDAwMCBuIAowMDAwMDAwMTk5IDAwMDAwIG4gCjAwMDAwMDA0MDIgMDAwMDAgbiAK"
+    "MDAwMDAwMDQ3MCAwMDAwMCBuIAowMDAwMDAwNzMxIDAwMDAwIG4gCjAwMDAwMDA3OTAgMDAwMDAg"
+    "biAKdHJhaWxlcgo8PAovSUQgCls8MzllOTY4YzhjZGRiZDNkMjExNGE5NzQ1NzBmNTU0ODY+PDM5"
+    "ZTk2OGM4Y2RkYmQzZDIxMTRhOTc0NTcwZjU1NDg2Pl0KJSBSZXBvcnRMYWIgZ2VuZXJhdGVkIFBE"
+    "RiBkb2N1bWVudCAtLSBkaWdlc3QgKG9wZW5zb3VyY2UpCgovSW5mbyA1IDAgUgovUm9vdCA0IDAg"
+    "UgovU2l6ZSA4Cj4+CnN0YXJ0eHJlZgoxMDMxCiUlRU9GCg=="
+)
+
+FIXTURE_PDF = base64.b64decode(_FIXTURE_PDF_B64)
+
+
+def test_extract_pdf_text_returns_invoice_content():
+    text = gmail_read.extract_pdf_text(FIXTURE_PDF)
+    assert "495213" in text
+    assert "189.00" in text
+    assert "Fluent Home" in text
+
+
+def test_iter_attachments_walks_nested_parts():
+    payload = {
+        "mimeType": "multipart/mixed",
+        "parts": [
+            {"mimeType": "text/plain", "filename": "", "body": {"data": "aGk="}},
+            {
+                "mimeType": "application/pdf",
+                "filename": "invoice.pdf",
+                "body": {"size": 4096, "attachmentId": "att-1"},
+            },
+        ],
+    }
+    atts = list(gmail_read._iter_attachments(payload))
+    assert len(atts) == 1
+    assert atts[0]["filename"] == "invoice.pdf"
+    assert atts[0]["mime"] == "application/pdf"
+    assert atts[0]["size"] == 4096
+    assert atts[0]["attachment_id"] == "att-1"
+
+
+def test_download_attachment_fetches_by_id_when_not_inline():
+    """No inline data -> attachments().get() is called and decoded."""
+    b64 = base64.urlsafe_b64encode(FIXTURE_PDF).decode()
+    svc = mock.MagicMock()
+    svc.users().messages().attachments().get().execute.return_value = {"data": b64}
+
+    att = {"filename": "invoice.pdf", "mime": "application/pdf",
+           "size": len(FIXTURE_PDF), "data": None, "attachment_id": "att-1"}
+    raw = gmail_read._download_attachment(svc, "msg-123", att)
+    assert raw == FIXTURE_PDF
+    # And it round-trips through extraction.
+    assert "495213" in gmail_read.extract_pdf_text(raw)
+
+
+def test_download_attachment_uses_inline_data_without_fetch():
+    b64 = base64.urlsafe_b64encode(b"hello").decode()
+    svc = mock.MagicMock()
+    att = {"filename": "note.txt", "mime": "text/plain", "size": 5,
+           "data": b64, "attachment_id": None}
+    raw = gmail_read._download_attachment(svc, "msg-123", att)
+    assert raw == b"hello"
+    svc.users().messages().attachments().get.assert_not_called()
+
+
+def test_list_attachments_uses_full_format():
+    svc = mock.MagicMock()
+    svc.users().messages().get().execute.return_value = {
+        "payload": {
+            "parts": [
+                {"mimeType": "application/pdf", "filename": "invoice.pdf",
+                 "body": {"size": 10, "attachmentId": "a1"}},
+            ]
+        }
+    }
+    atts = gmail_read.list_attachments(svc, "msg-1")
+    assert [a["filename"] for a in atts] == ["invoice.pdf"]


### PR DESCRIPTION
## Summary
Implements Gmail attachment listing + PDF text extraction for the shared `google/` CLI tooling (buddy#2626). `read <id>` only returns body/snippet — invoice PDFs (e.g. Fluent Home #495213) were unreachable.

- New subcommand `gmail_read.py attachments <message_id>`: lists attachments (filename, mime, size); for PDFs, downloads bytes via `users().messages().attachments().get()` (base64url) and prints extracted text via `pypdf`.
- Reuses existing service/auth + token path; matches argparse/CLI style.
- Adds `pypdf>=4.0` to `google/requirements.txt`.

## Test Plan
Deterministic, no live Gmail (`google/test_gmail_read.py`, 5 tests):
- `extract_pdf_text` against an embedded fixture PDF → asserts `495213`, `189.00`, `Fluent Home`.
- `_iter_attachments` walks nested MIME parts.
- `_download_attachment` fetches by id when not inline, uses inline data otherwise (no fetch).
- `list_attachments` uses `format=full`.

`pytest` 5 passed · `py_compile` OK · `ruff check` clean.

Live real-invoice extraction is coordinator server-side verify.

Refs buddy#2626

🤖 Generated with [Claude Code](https://claude.com/claude-code)