### PR TITLE
feat(m365-todo): requirements, README, tests, --due (buddy#2625)

### DIFF
--- a/m365-todo/README.md
+++ b/m365-todo/README.md
@@ -1,0 +1,105 @@
+# Microsoft To Do for agents (`~/agents/m365-todo`)
+
+Read/write the user's **Microsoft To Do** task lists from any agent (and the
+Buddy resident) via Microsoft Graph with a **delegated** token (device-code
+flow, public client). Mirrors the `~/agents/google` pattern: committed code, a
+git-ignored per-machine credential file, one shared loader.
+
+This is separate from Google Tasks and from the work M365 **mail** app (see
+`../m365/`) — different identity, different auth model.
+
+## Layout
+
+| File | Tracked in git? | What it is |
+|---|---|---|
+| `todo.py` | ✅ | CLI over Graph `me/todo/*` — `lists`, `tasks`, `add`, `complete`. |
+| `auth.py` | ✅ | Shared loader — `get_token()` returns a valid access token (silent refresh). |
+| `authorize.py` | ✅ | One-time device-code authorization (`start` then `finish`). |
+| `config.example.json` | ✅ | Template for the per-machine identity profile. |
+| `requirements.txt` | ✅ | `msal`, `requests`. |
+| `test_todo.py` | ✅ | Mocked-Graph unit tests (no network). |
+| `config.json` | ❌ (git-ignored) | This machine's identity profile (client_id / authority / account). |
+| `token.json` | ❌ (git-ignored) | The MSAL token cache (refresh token). **Secret. Per-machine, chmod 600.** |
+
+The capability is **active only where BOTH `config.json` and `token.json`
+exist** — otherwise `auth.get_token()` fails closed with a clear message.
+
+## Everyday use
+
+```bash
+PY=~/agents/.venv/bin/python
+$PY ~/agents/m365-todo/todo.py lists                       # all task lists
+$PY ~/agents/m365-todo/todo.py tasks "Groceries"           # open tasks (--all incl. completed)
+$PY ~/agents/m365-todo/todo.py add "Groceries" "Milk"      # create
+$PY ~/agents/m365-todo/todo.py add "Groceries" "Rent" --due 2026-07-05
+$PY ~/agents/m365-todo/todo.py complete "Groceries" "Milk" # mark done
+```
+
+In Python (any agent):
+
+```python
+import sys; sys.path.insert(0, "/Users/jasonjob/agents/m365-todo")
+from auth import get_token
+headers = {"Authorization": f"Bearer {get_token()}"}
+# GET https://graph.microsoft.com/v1.0/me/todo/lists
+```
+
+## Auth provisioning — how to activate on a new machine (e.g. jns)
+
+> **This is the manual step the code cannot do for you.** The `.py` files arrive
+> via git; the credentials do not (git-ignored). You provision them once per
+> machine. Until both `config.json` and `token.json` exist, the capability is
+> inert.
+
+### 1. Register (or reuse) an Entra app with delegated `Tasks.ReadWrite`
+
+- **Personal Microsoft account** (the user's `jasonwadejob@gmail.com` To Do):
+  Azure Portal → **Microsoft Entra ID → App registrations → New registration**.
+  - Supported account types: **Personal Microsoft accounts** (or
+    "Accounts in any org directory and personal MS accounts").
+  - Authentication → **Allow public client flows → Yes** (device-code needs this).
+  - API permissions → **Microsoft Graph → Delegated → `Tasks.ReadWrite`**. No
+    secret and no admin consent are required for a personal-account public client.
+  - Copy the **Application (client) ID**.
+- **Work tenant** (optional): register the app in the work tenant with delegated
+  `Tasks.ReadWrite`; use the tenant id/domain as the authority (not `consumers`).
+  Some tenants require admin consent.
+
+### 2. Create `config.json` on the machine
+
+```bash
+cp ~/agents/m365-todo/config.example.json ~/agents/m365-todo/config.json
+# then edit config.json:
+#   "client_id": "<the Application (client) ID from step 1>"
+#   "authority": "https://login.microsoftonline.com/consumers"   # personal
+#                (or ".../<work-tenant-id-or-domain>" for a work profile)
+#   "scopes":    ["Tasks.ReadWrite"]
+#   "account":   "jasonwadejob@gmail.com"
+```
+
+### 3. Authorize (device-code — works headless / over SSH)
+
+```bash
+PY=~/agents/.venv/bin/python
+$PY ~/agents/m365-todo/authorize.py start    # prints a URL + code, exits immediately
+# open the URL in ANY browser, enter the code, approve as the target account
+$PY ~/agents/m365-todo/authorize.py finish   # blocks until approved, writes token.json
+```
+
+`token.json` is written chmod 600 and refreshes silently thereafter. To move an
+existing authorization to another machine, copy `config.json` + `token.json`
+(the refresh token is portable for the same app registration).
+
+### 4. Install deps on the new box
+
+```bash
+~/agents/.venv/bin/pip install -r ~/agents/m365-todo/requirements.txt
+```
+
+## Status
+
+- **Laptop (personal profile):** validated live 2026-06-26 — full read + write.
+- **jns (the Buddy resident):** **NOT yet provisioned** — no Graph credentials on
+  the server. Provisioning is steps 1–4 above (Jason's action). This is the
+  intended stop point; the resident gains To Do access only after `config.json` +
+  `token.json` exist on jns and are verified live.

--- a/m365-todo/requirements.txt
+++ b/m365-todo/requirements.txt
@@ -1,0 +1,2 @@
+msal>=1.24
+requests>=2.28

--- a/m365-todo/test_todo.py
+++ b/m365-todo/test_todo.py
@@ -1,0 +1,131 @@
+"""Mocked-Graph unit tests for todo.py — no network, no credentials.
+
+Verify each CLI operation builds the correct Graph URL/payload and parses the
+response. `get_token` and `requests` are stubbed so nothing touches Graph.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import todo  # noqa: E402
+
+GRAPH = "https://graph.microsoft.com/v1.0"
+LISTS = {"value": [{"id": "L1", "displayName": "Groceries", "wellknownListName": "defaultList"}]}
+
+
+class _Resp:
+    def __init__(self, payload: dict):
+        self._payload = payload
+
+    def json(self) -> dict:
+        return self._payload
+
+    def raise_for_status(self) -> None:
+        return None
+
+
+class _FakeRequests:
+    """Records calls and returns URL-routed canned responses."""
+
+    def __init__(self, tasks: dict | None = None):
+        self.tasks = tasks or {"value": []}
+        self.calls: list[tuple[str, str, dict | None]] = []
+
+    def get(self, url, headers=None, timeout=None):
+        self.calls.append(("GET", url, None))
+        if url.endswith("/me/todo/lists"):
+            return _Resp(LISTS)
+        return _Resp(self.tasks)
+
+    def post(self, url, headers=None, json=None, timeout=None):
+        self.calls.append(("POST", url, json))
+        return _Resp({"id": "T99", "title": json.get("title", "")})
+
+    def patch(self, url, headers=None, json=None, timeout=None):
+        self.calls.append(("PATCH", url, json))
+        return _Resp({"id": "T1", "title": "Milk", "status": "completed"})
+
+
+@pytest.fixture
+def fake(monkeypatch):
+    monkeypatch.setattr(todo, "get_token", lambda: "FAKE_TOKEN")
+    fr = _FakeRequests()
+    monkeypatch.setattr(todo, "requests", fr)
+    return fr
+
+
+def test_get_lists_url_and_parse(fake):
+    lists = todo.get_lists()
+    assert fake.calls[0] == ("GET", f"{GRAPH}/me/todo/lists", None)
+    assert lists[0]["displayName"] == "Groceries"
+
+
+def test_resolve_list_id_matches_by_name(fake):
+    assert todo._resolve_list_id("groceries") == "L1"  # case-insensitive
+
+
+def test_resolve_list_id_unknown_raises(fake):
+    with pytest.raises(SystemExit):
+        todo._resolve_list_id("Nope")
+
+
+def test_get_tasks_url_and_filters_completed(fake):
+    fake.tasks = {"value": [
+        {"id": "T1", "title": "Milk", "status": "notStarted"},
+        {"id": "T2", "title": "Old", "status": "completed"},
+    ]}
+    open_tasks = todo.get_tasks("Groceries")
+    # last GET is the tasks call against the resolved list id
+    assert fake.calls[-1][1] == f"{GRAPH}/me/todo/lists/L1/tasks"
+    assert [t["title"] for t in open_tasks] == ["Milk"]  # completed filtered out
+
+
+def test_get_tasks_include_done(fake):
+    fake.tasks = {"value": [
+        {"id": "T1", "title": "Milk", "status": "notStarted"},
+        {"id": "T2", "title": "Old", "status": "completed"},
+    ]}
+    all_tasks = todo.get_tasks("Groceries", include_done=True)
+    assert len(all_tasks) == 2
+
+
+def test_add_task_payload(fake):
+    todo.add_task("Groceries", "Bread")
+    method, url, body = fake.calls[-1]
+    assert method == "POST"
+    assert url == f"{GRAPH}/me/todo/lists/L1/tasks"
+    assert body == {"title": "Bread"}  # no dueDateTime when due omitted
+
+
+def test_add_task_with_due(fake):
+    todo.add_task("Groceries", "Rent", due="2026-07-05")
+    _, _, body = fake.calls[-1]
+    assert body["title"] == "Rent"
+    assert body["dueDateTime"] == {
+        "dateTime": "2026-07-05T00:00:00",
+        "timeZone": "Pacific Standard Time",
+    }
+
+
+def test_complete_task_patches_resolved_task(fake):
+    fake.tasks = {"value": [{"id": "T1", "title": "Milk", "status": "notStarted"}]}
+    todo.complete_task("Groceries", "milk")  # case-insensitive title match
+    method, url, body = fake.calls[-1]
+    assert method == "PATCH"
+    assert url == f"{GRAPH}/me/todo/lists/L1/tasks/T1"
+    assert body == {"status": "completed"}
+
+
+def test_complete_task_not_found_raises(fake):
+    fake.tasks = {"value": [{"id": "T1", "title": "Milk", "status": "notStarted"}]}
+    with pytest.raises(SystemExit):
+        todo.complete_task("Groceries", "Nonexistent")
+
+
+def test_headers_carry_bearer_token(fake):
+    assert todo._headers()["Authorization"] == "Bearer FAKE_TOKEN"

--- a/m365-todo/todo.py
+++ b/m365-todo/todo.py
@@ -5,6 +5,7 @@ Usage:
     $PY ~/agents/m365-todo/todo.py lists
     $PY ~/agents/m365-todo/todo.py tasks "Tasks"            # list name (default list is "Tasks")
     $PY ~/agents/m365-todo/todo.py add "Tasks" "Buy milk"
+    $PY ~/agents/m365-todo/todo.py add "Tasks" "Pay rent" --due 2026-07-05
     $PY ~/agents/m365-todo/todo.py complete "Tasks" "Buy milk"
 """
 
@@ -18,6 +19,9 @@ import requests
 from auth import get_token
 
 GRAPH = "https://graph.microsoft.com/v1.0"
+
+# Windows time-zone id Graph accepts; covers both PST and PDT (project runs Pacific).
+DEFAULT_TIMEZONE = "Pacific Standard Time"
 
 
 def _headers() -> dict:
@@ -50,12 +54,16 @@ def get_tasks(list_name: str, include_done: bool = False) -> list[dict]:
     return items
 
 
-def add_task(list_name: str, title: str) -> dict:
+def add_task(list_name: str, title: str, due: str | None = None) -> dict:
     lid = _resolve_list_id(list_name)
+    body: dict = {"title": title}
+    if due:
+        # Graph expects an ISO local dateTime + a time zone; a bare date starts at midnight.
+        body["dueDateTime"] = {"dateTime": f"{due}T00:00:00", "timeZone": DEFAULT_TIMEZONE}
     r = requests.post(
         f"{GRAPH}/me/todo/lists/{lid}/tasks",
         headers=_headers(),
-        json={"title": title},
+        json=body,
         timeout=30,
     )
     r.raise_for_status()
@@ -87,6 +95,7 @@ def main() -> int:
     p_add = sub.add_parser("add")
     p_add.add_argument("list")
     p_add.add_argument("title")
+    p_add.add_argument("--due", help="due date, YYYY-MM-DD (Pacific)")
     p_done = sub.add_parser("complete")
     p_done.add_argument("list")
     p_done.add_argument("title")
@@ -101,7 +110,7 @@ def main() -> int:
             mark = "x" if t.get("status") == "completed" else " "
             print(f"[{mark}] {t['title']}")
     elif a.cmd == "add":
-        t = add_task(a.list, a.title)
+        t = add_task(a.list, a.title, due=a.due)
         print(f"ADDED: {t['title']}  [{t['id']}]")
     elif a.cmd == "complete":
         t = complete_task(a.list, a.title)


### PR DESCRIPTION
## Summary

Completes the Microsoft To Do agent helper for **buddy#2625** (M365/To Do task access for agents + the resident).

**Verification finding:** the core CLI + MSAL device-code auth the issue describes **already shipped** in #496 (`m365-todo/todo.py`, `auth.py`, `authorize.py`, `config.example.json`), documented in `claude-config/rules/ms-todo.md`, and was live-validated 2026-06-26. Rather than create a duplicate `m365/` To Do CLI (broken window), this PR fills the remaining acceptance-criteria gaps in the existing `m365-todo/` dir:

- `requirements.txt` — `msal`, `requests`
- `README.md` — auth-provisioning steps (Entra app registration, delegated `Tasks.ReadWrite`, device-code flow, jns provisioning) — the explicit STOP point for activating the resident
- `test_todo.py` — 10 mocked-Graph unit tests (no network, no creds): URL/payload construction + response parsing for `lists`/`tasks`/`add`/`complete`
- `todo.py` — optional `--due YYYY-MM-DD` on `add` (builds `dueDateTime`, Pacific)

**STOPS at auth-provisioning** — jns has no Graph credentials; provisioning is Jason's action (README steps 1-4). No duplicate CLI created.

## Test Plan

- `python3 -m venv .venv && .venv/bin/pip install -r m365-todo/requirements.txt` (msal, requests)
- `.venv/bin/python -m pytest m365-todo/test_todo.py -q` → **10 passed** (mocked Graph HTTP, no live call)
- `ruff check m365-todo/` → clean (CI standard)
- `py_compile` clean on all m365-todo/*.py

Scope: `m365-todo/` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)